### PR TITLE
Add default missing values for missing values handling in various codes 

### DIFF
--- a/constants/constants.F90
+++ b/constants/constants.F90
@@ -27,7 +27,7 @@ real :: realnumber
   ! Missing Value
 
   real, public, parameter :: xmissing= -9e+33        ! default missing value
-  real, public, parameter :: real_missing= -9e+33    ! default missing value for REAL
+  real, public, parameter :: real_missing= xmissing  ! default missing value for REAL
   integer, public, parameter :: int_missing= -99999  ! default missing value for INTEGER  
   
 


### PR DESCRIPTION
I am writing code for reading World Ocean Data. The data sets have missing values. I found in various codes. The missing values can be varied from code to code. Therefore, default missing values for real (real_missing) and for integer (int_missing) are suggested, here, in the FMS. Then, programmers can be shared with the same missing value. 
