### PR TITLE
Add 'sum' time operation to the diagnostic manager

### DIFF
--- a/diag_manager/diag_data.F90
+++ b/diag_manager/diag_data.F90
@@ -487,6 +487,7 @@ MODULE diag_data_mod
      LOGICAL :: static
      LOGICAL :: time_max ! true if the output field is maximum over time interval
      LOGICAL :: time_min ! true if the output field is minimum over time interval
+     LOGICAL :: time_sum ! true if the output field is summed over time interval
      LOGICAL :: time_ops ! true if any of time_min, time_max, time_rms or time_average is true
      INTEGER  :: pack
      INTEGER :: pow_value !< Power value to use for mean_pow(n) calculations

--- a/diag_manager/diag_util.F90
+++ b/diag_manager/diag_util.F90
@@ -1491,6 +1491,7 @@ CONTAINS
     output_fields(out_num)%time_rms = .FALSE.
     output_fields(out_num)%time_min = .FALSE.
     output_fields(out_num)%time_max = .FALSE.
+    output_fields(out_num)%time_sum = .FALSE.
     output_fields(out_num)%time_ops = .FALSE.
     output_fields(out_num)%written_once = .FALSE.
 
@@ -1566,6 +1567,8 @@ CONTAINS
        CASE ( 'sum', 'cumsum' )
           output_fields(out_num)%time_sum = .TRUE.
           l1 = LEN_TRIM(output_fields(out_num)%output_name)
+          IF ( output_fields(out_num)%output_name(l1-2:l1) /= 'sum' )&
+               & output_fields(out_num)%output_name = TRIM(output_name)//'_sum'
           method_selected = method_selected+1
           t_method = 'sum'
        END SELECT

--- a/diag_manager/diag_util.F90
+++ b/diag_manager/diag_util.F90
@@ -1576,7 +1576,7 @@ CONTAINS
 
     ! reconcile logical flags
     output_fields(out_num)%time_ops = output_fields(out_num)%time_min.OR.output_fields(out_num)%time_max&
-         & .OR.output_fields(out_num)%time_average .OR.output_fields(out_num)%time_average
+         & .OR.output_fields(out_num)%time_average .OR. output_fields(out_num)%time_sum
 
     output_fields(out_num)%phys_window = .FALSE.
     ! need to initialize grid_type = -1(start, end, l_start_indx,l_end_indx etc...)

--- a/diag_manager/diag_util.F90
+++ b/diag_manager/diag_util.F90
@@ -1563,12 +1563,17 @@ CONTAINS
                & output_fields(out_num)%output_name = TRIM(output_name)//'_min'
           method_selected = method_selected+1
           t_method = 'min'
+       CASE ( 'sum', 'cumsum' )
+          output_fields(out_num)%time_sum = .TRUE.
+          l1 = LEN_TRIM(output_fields(out_num)%output_name)
+          method_selected = method_selected+1
+          t_method = 'sum'
        END SELECT
     END IF
 
     ! reconcile logical flags
     output_fields(out_num)%time_ops = output_fields(out_num)%time_min.OR.output_fields(out_num)%time_max&
-         & .OR.output_fields(out_num)%time_average
+         & .OR.output_fields(out_num)%time_average .OR.output_fields(out_num)%time_average
 
     output_fields(out_num)%phys_window = .FALSE.
     ! need to initialize grid_type = -1(start, end, l_start_indx,l_end_indx etc...)


### PR DESCRIPTION
Adds the option of outputting a diagnostic that is summed over the output interval. This is intended for quantities which represent accumulated quantities, for example 'ea' or 'eb' in MOM6. To specify this option in the diag_table, set the time_avg filed to 'sum' or 'cumsum'. Variables using this time operation have the '_sum' suffix appended.

This feature was test using the MOM6 Baltic case. Fields were saved both as snapshots at the end of each timestep and also summed using the diag_manager. 