### PR TITLE
Added coupler_type_extract_data and coupler_type_set_data

### DIFF
--- a/coupler/coupler_types.F90
+++ b/coupler/coupler_types.F90
@@ -1,22 +1,6 @@
 module coupler_types_mod
 !-----------------------------------------------------------------------
-!                   GNU General Public License
-! This file is a part of MOM.
-!
-! MOM is free software; you can redistribute it and/or modify it and
-! are expected to follow the terms of the GNU General Public License
-! as published by the Free Software Foundation; either version 2 of
-! the License, or (at your option) any later version.
-!
-! MOM is distributed in the hope that it will be useful, but WITHOUT
-! ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
-! or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
-! License for more details.
-!
-! For the full text of the GNU General Public License,
-! write to: Free Software Foundation, Inc.,
-!           675 Mass Ave, Cambridge, MA 02139, USA.
-! or see:   http://www.gnu.org/licenses/gpl.html
+! This file is part of MOM6. See LICENSE.md for the license.
 !-----------------------------------------------------------------------
 !
 !> \brief This module contains type declarations for the coupler.
@@ -189,27 +173,21 @@ implicit none ; private
 !-----------------------------------------------------------------------
 
 public  coupler_types_init
-public  coupler_type_copy, coupler_type_spawn, coupler_type_set_diags
-public  coupler_type_write_chksums, coupler_type_send_data, coupler_type_data_override
-public  coupler_type_register_restarts, coupler_type_restore_state
-public  coupler_type_increment_data, coupler_type_rescale_data
-public  coupler_type_copy_data, coupler_type_redistribute_data
-public  coupler_type_destructor, coupler_type_initialized
-
-public  coupler_type_copy_1d_2d
-public  coupler_type_copy_1d_3d
-
-!
-!----------------------------------------------------------------------
-!
-
 character(len=48), parameter                    :: mod_name = 'coupler_types_mod'
+public coupler_type_copy, coupler_type_spawn, coupler_type_set_diags
+public coupler_type_write_chksums, coupler_type_send_data, coupler_type_data_override
+public coupler_type_register_restarts, coupler_type_restore_state
+public coupler_type_increment_data, coupler_type_rescale_data
+public coupler_type_copy_data, coupler_type_redistribute_data
+public coupler_type_destructor, coupler_type_initialized
+public coupler_type_extract_data, coupler_type_set_data
 
+public coupler_type_copy_1d_2d
+public coupler_type_copy_1d_3d
 
 !
 !       3-d fields
 !
-
 type, public :: coupler_3d_values_type
   character(len=48)       :: name = ' '  !< The diagnostic name for this array
   real, pointer, contiguous, dimension(:,:,:) :: values => NULL() !< The pointer to the
@@ -257,7 +235,6 @@ end type coupler_3d_bc_type
 !
 !       2-d fields
 !
-
 type, public    :: coupler_2d_values_type
   character(len=48)       :: name = ' '  !< The diagnostic name for this array
   real, pointer, contiguous, dimension(:,:) :: values => NULL() !< The pointer to the
@@ -304,7 +281,6 @@ end type coupler_2d_bc_type
 !
 !       1-d fields
 !
-
 type, public    :: coupler_1d_values_type
   character(len=48)           :: name = ' '  !< The diagnostic name for this array
   real, pointer, dimension(:) :: values => NULL() !< The pointer to the array of values
@@ -341,7 +317,6 @@ type, public    :: coupler_1d_bc_type
   logical    :: set = .false.       !< If true, this type has been initialized
 end type coupler_1d_bc_type
 
-!
 !----------------------------------------------------------------------
 !   The following public parameters can help in selecting the sub-elements of a
 ! coupler type.  There are duplicate values because different boundary
@@ -401,6 +376,16 @@ end interface coupler_type_rescale_data
 interface coupler_type_increment_data
   module procedure CT_increment_data_2d_2d, CT_increment_data_3d_3d, CT_increment_data_2d_3d
 end interface coupler_type_increment_data
+
+!> This is the interface to extract a field in a coupler_bc_type into an array.
+interface coupler_type_extract_data
+  module procedure CT_extract_data_2d, CT_extract_data_3d, CT_extract_data_3d_2d
+end interface coupler_type_extract_data
+
+!> This is the interface to set a field in a coupler_bc_type from an array.
+interface coupler_type_set_data
+  module procedure CT_set_data_2d, CT_set_data_3d, CT_set_data_2d_3d
+end interface coupler_type_set_data
 
 !> This is the interface to set diagnostics for the arrays in a coupler_bc_type.
 interface coupler_type_set_diags
@@ -931,9 +916,8 @@ subroutine coupler_type_copy_1d_2d(var_in, var_out, is, ie, js, je,     &
   type(time_type), intent(in)             :: time !< model time variable for registering diagnostic field
   character(len=*), intent(in), optional  :: suffix !< optional suffix to make the name identifier unique
 
-  character(len=64), parameter    :: sub_name = 'coupler_type_copy_1d_2d'
-  character(len=256), parameter   :: error_header =                               &
-       '==>Error from ' // trim(mod_name) // '(' // trim(sub_name) // '):'
+  character(len=256), parameter :: error_header = &
+       '==>Error from coupler_types_mod (coupler_type_copy_1d_2d):'
   character(len=400)      :: error_msg
   integer                 :: m, n
 
@@ -981,9 +965,8 @@ subroutine coupler_type_copy_1d_3d(var_in, var_out, is, ie, js, je, kd, &
   type(time_type), intent(in)             :: time !< model time variable for registering diagnostic field
   character(len=*), intent(in), optional  :: suffix !< optional suffix to make the name identifier unique
 
-  character(len=64), parameter    :: sub_name = 'coupler_type_copy_1d_3d'
-  character(len=256), parameter   :: error_header =                               &
-     '==>Error from ' // trim(mod_name) // '(' // trim(sub_name) // '):'
+  character(len=256), parameter :: error_header = &
+     '==>Error from coupler_types_mod (coupler_type_copy_1d_3d):'
   character(len=400)      :: error_msg
   integer                 :: m, n
 
@@ -1025,9 +1008,8 @@ subroutine coupler_type_copy_2d_2d(var_in, var_out, is, ie, js, je,     &
   type(time_type), intent(in)             :: time !< model time variable for registering diagnostic field
   character(len=*), intent(in), optional  :: suffix !< optional suffix to make the name identifier unique
 
-  character(len=64), parameter    :: sub_name = 'coupler_type_copy_2d_2d'
-  character(len=256), parameter   :: error_header =                               &
-       '==>Error from ' // trim(mod_name) // '(' // trim(sub_name) // '):'
+  character(len=256), parameter :: error_header = &
+       '==>Error from coupler_types_mod (coupler_type_copy_2d_2d):'
   character(len=400)      :: error_msg
   integer                 :: m, n
 
@@ -1075,9 +1057,8 @@ subroutine coupler_type_copy_2d_3d(var_in, var_out, is, ie, js, je, kd, &
   type(time_type), intent(in)             :: time !< model time variable for registering diagnostic field
   character(len=*), intent(in), optional  :: suffix !< optional suffix to make the name identifier unique
 
-  character(len=64), parameter    :: sub_name = 'coupler_type_copy_2d_3d'
-  character(len=256), parameter   :: error_header =                               &
-     '==>Error from ' // trim(mod_name) // '(' // trim(sub_name) // '):'
+  character(len=256), parameter :: error_header = &
+     '==>Error from coupler_types_mod (coupler_type_copy_2d_3d):'
   character(len=400)      :: error_msg
   integer                 :: m, n
 
@@ -1119,9 +1100,8 @@ subroutine coupler_type_copy_3d_2d(var_in, var_out, is, ie, js, je,     &
   type(time_type), intent(in)             :: time !< model time variable for registering diagnostic field
   character(len=*), intent(in), optional  :: suffix !< optional suffix to make the name identifier unique
 
-  character(len=64), parameter    :: sub_name = 'coupler_type_copy_3d_2d'
-  character(len=256), parameter   :: error_header =                               &
-       '==>Error from ' // trim(mod_name) // '(' // trim(sub_name) // '):'
+  character(len=256), parameter :: error_header = &
+       '==>Error from coupler_types_mod (coupler_type_copy_3d_2d):'
   character(len=400)      :: error_msg
   integer                 :: m, n
 
@@ -1169,9 +1149,8 @@ subroutine coupler_type_copy_3d_3d(var_in, var_out, is, ie, js, je, kd, &
   type(time_type), intent(in)             :: time !< model time variable for registering diagnostic field
   character(len=*), intent(in), optional  :: suffix !< optional suffix to make the name identifier unique
 
-  character(len=64), parameter    :: sub_name = 'coupler_type_copy_3d_3d'
-  character(len=256), parameter   :: error_header =                               &
-     '==>Error from ' // trim(mod_name) // '(' // trim(sub_name) // '):'
+  character(len=256), parameter :: error_header = &
+     '==>Error from coupler_types_mod (coupler_type_copy_3d_3d):'
   character(len=400)      :: error_msg
   integer                 :: m, n
 
@@ -1216,9 +1195,8 @@ subroutine CT_spawn_1d_2d(var_in, var, idim, jdim, suffix, as_needed)
   logical,          optional, intent(in)  :: as_needed !< Only do the spawn if the target type (var)
                                                      !! is not set and the parent type (var_in) is set.
 
-  character(len=64), parameter    :: sub_name = 'CT_spawn_1d_2d'
-  character(len=256), parameter   :: error_header =                               &
-       '==>Error from ' // trim(mod_name) // '(' // trim(sub_name) // '):'
+  character(len=256), parameter :: error_header = &
+       '==>Error from coupler_types_mod (CT_spawn_1d_2d):'
   character(len=400)      :: error_msg
   integer                 :: m, n
 
@@ -1318,9 +1296,8 @@ subroutine CT_spawn_1d_3d(var_in, var, idim, jdim, kdim, suffix, as_needed)
   logical,          optional, intent(in)  :: as_needed !< Only do the spawn if the target type (var)
                                                      !! is not set and the parent type (var_in) is set.
 
-  character(len=64), parameter    :: sub_name = 'CT_spawn_1d_3d'
-  character(len=256), parameter   :: error_header =                               &
-     '==>Error from ' // trim(mod_name) // '(' // trim(sub_name) // '):'
+  character(len=256), parameter :: error_header = &
+     '==>Error from coupler_types_mod (CT_spawn_1d_3d):'
   character(len=400)      :: error_msg
   integer                 :: m, n
 
@@ -1424,9 +1401,8 @@ subroutine CT_spawn_2d_2d(var_in, var, idim, jdim, suffix, as_needed)
   logical,          optional, intent(in)  :: as_needed !< Only do the spawn if the target type (var)
                                                      !! is not set and the parent type (var_in) is set.
 
-  character(len=64), parameter    :: sub_name = 'CT_spawn_2d_2d'
-  character(len=256), parameter   :: error_header =                               &
-       '==>Error from ' // trim(mod_name) // '(' // trim(sub_name) // '):'
+  character(len=256), parameter :: error_header = &
+       '==>Error from coupler_types_mod (CT_spawn_2d_2d):'
   character(len=400)      :: error_msg
   integer                 :: m, n
 
@@ -1526,9 +1502,8 @@ subroutine CT_spawn_2d_3d(var_in, var, idim, jdim, kdim, suffix, as_needed)
   logical,          optional, intent(in)  :: as_needed !< Only do the spawn if the target type (var)
                                                      !! is not set and the parent type (var_in) is set.
 
-  character(len=64), parameter    :: sub_name = 'CT_spawn_2d_3d'
-  character(len=256), parameter   :: error_header =                               &
-     '==>Error from ' // trim(mod_name) // '(' // trim(sub_name) // '):'
+  character(len=256), parameter :: error_header = &
+     '==>Error from coupler_types_mod (CT_spawn_2d_3d):'
   character(len=400)      :: error_msg
   integer                 :: m, n
 
@@ -1632,9 +1607,8 @@ subroutine CT_spawn_3d_2d(var_in, var, idim, jdim, suffix, as_needed)
   logical,          optional, intent(in)  :: as_needed !< Only do the spawn if the target type (var)
                                                      !! is not set and the parent type (var_in) is set.
 
-  character(len=64), parameter    :: sub_name = 'CT_spawn_1d_2d'
-  character(len=256), parameter   :: error_header =                               &
-       '==>Error from ' // trim(mod_name) // '(' // trim(sub_name) // '):'
+  character(len=256), parameter :: error_header = &
+       '==>Error from coupler_types_mod (CT_spawn_3d_2d):'
   character(len=400)      :: error_msg
   integer                 :: m, n
 
@@ -1734,9 +1708,8 @@ subroutine CT_spawn_3d_3d(var_in, var, idim, jdim, kdim, suffix, as_needed)
   logical,          optional, intent(in)  :: as_needed !< Only do the spawn if the target type (var)
                                                      !! is not set and the parent type (var_in) is set.
 
-  character(len=64), parameter    :: sub_name = 'CT_spawn_3d_3d'
-  character(len=256), parameter   :: error_header =                               &
-     '==>Error from ' // trim(mod_name) // '(' // trim(sub_name) // '):'
+  character(len=256), parameter :: error_header = &
+     '==>Error from coupler_types_mod (CT_spawn_3d_3d):'
   character(len=400)      :: error_msg
   integer                 :: m, n
 
@@ -2360,7 +2333,7 @@ end subroutine CT_rescale_data_3d
 !> This subroutine does a direct increment of the data in all elements of one
 !! coupler_2d_bc_type into another.  Both must have the same array sizes.
 subroutine CT_increment_data_2d_2d(var_in, var, halo_size, bc_index, field_index, &
-                           scale_factor, exclude_flux_type, only_flux_type, pass_through_ice)
+                           scale_factor, scale_prev, exclude_flux_type, only_flux_type, pass_through_ice)
   type(coupler_2d_bc_type),   intent(in)    :: var_in  !< BC_type structure with the data to add to the other type
   type(coupler_2d_bc_type),   intent(inout) :: var !< The BC_type structure whose fields are being incremented
   integer,          optional, intent(in)    :: halo_size !< The extent of the halo to increment; 0 by default
@@ -2369,16 +2342,18 @@ subroutine CT_increment_data_2d_2d(var_in, var, halo_size, bc_index, field_index
   integer,          optional, intent(in)    :: field_index !< The index of the field in the
                                                        !! boundary condition that is being copied
   real,             optional, intent(in)    :: scale_factor  !< A scaling factor for the data that is being added
+  real,             optional, intent(in)    :: scale_prev    !< A scaling factor for the data that is already here
   character(len=*), optional, intent(in)    :: exclude_flux_type !< A string describing which types of fluxes to exclude from this increment.
   character(len=*), optional, intent(in)    :: only_flux_type    !< A string describing which types of fluxes to include from this increment.
   logical,          optional, intent(in)    :: pass_through_ice !< If true, only increment BCs whose
                                                        !! value of pass_through ice matches this
 
-  real :: scale
+  real :: scale, sc_prev
   logical :: increment_bc
   integer :: i, j, m, n, n1, n2, halo, i_off, j_off
 
   scale = 1.0 ; if (present(scale_factor)) scale = scale_factor
+  sc_prev = 1.0 ; if (present(scale_prev)) sc_prev = scale_prev
 
   if (present(bc_index)) then
     if (bc_index > var_in%num_bcs) &
@@ -2429,7 +2404,7 @@ subroutine CT_increment_data_2d_2d(var_in, var, halo_size, bc_index, field_index
       if (present(field_index)) then ; if (m /= field_index) cycle ; endif
       if ( associated(var%bc(n)%field(m)%values) ) then
         do j=var%jsc-halo,var%jec+halo ; do i=var%isc-halo,var%iec+halo
-          var%bc(n)%field(m)%values(i,j) =  var%bc(n)%field(m)%values(i,j) + &
+          var%bc(n)%field(m)%values(i,j) = sc_prev * var%bc(n)%field(m)%values(i,j) + &
                           scale * var_in%bc(n)%field(m)%values(i+i_off,j+j_off)
         enddo ; enddo
       endif
@@ -2442,7 +2417,7 @@ end subroutine CT_increment_data_2d_2d
 !> This subroutine does a direct increment of the data in all elements of one
 !! coupler_3d_bc_type into another.  Both must have the same array sizes.
 subroutine CT_increment_data_3d_3d(var_in, var, halo_size, bc_index, field_index, &
-                           scale_factor, exclude_flux_type, only_flux_type, pass_through_ice)
+                           scale_factor, scale_prev, exclude_flux_type, only_flux_type, pass_through_ice)
   type(coupler_3d_bc_type),   intent(in)    :: var_in  !< BC_type structure with the data to add to the other type
   type(coupler_3d_bc_type),   intent(inout) :: var !< The BC_type structure whose fields are being incremented
   integer,          optional, intent(in)    :: halo_size !< The extent of the halo to copy; 0 by default
@@ -2451,16 +2426,18 @@ subroutine CT_increment_data_3d_3d(var_in, var, halo_size, bc_index, field_index
   integer,          optional, intent(in)    :: field_index !< The index of the field in the
                                                        !! boundary condition that is being copied
   real,             optional, intent(in)    :: scale_factor  !< A scaling factor for the data that is being added
+  real,             optional, intent(in)    :: scale_prev    !< A scaling factor for the data that is already here
   character(len=*), optional, intent(in)    :: exclude_flux_type !< A string describing which types of fluxes to exclude from this increment.
   character(len=*), optional, intent(in)    :: only_flux_type    !< A string describing which types of fluxes to include from this increment.
   logical,          optional, intent(in)    :: pass_through_ice !< If true, only increment BCs whose
                                                        !! value of pass_through ice matches this
 
-  real :: scale
+  real :: scale, sc_prev
   logical :: increment_bc
   integer :: i, j, k, m, n, n1, n2, halo, i_off, j_off, k_off
 
   scale = 1.0 ; if (present(scale_factor)) scale = scale_factor
+  sc_prev = 1.0 ; if (present(scale_prev)) sc_prev = scale_prev
 
   if (present(bc_index)) then
     if (bc_index > var_in%num_bcs) &
@@ -2513,7 +2490,7 @@ subroutine CT_increment_data_3d_3d(var_in, var, halo_size, bc_index, field_index
       if (present(field_index)) then ; if (m /= field_index) cycle ; endif
       if ( associated(var%bc(n)%field(m)%values) ) then
         do k=var%ks,var%ke ; do j=var%jsc-halo,var%jec+halo ; do i=var%isc-halo,var%iec+halo
-          var%bc(n)%field(m)%values(i,j,k) = var%bc(n)%field(m)%values(i,j,k) + &
+          var%bc(n)%field(m)%values(i,j,k) = sc_prev * var%bc(n)%field(m)%values(i,j,k) + &
                        scale * var_in%bc(n)%field(m)%values(i+i_off,j+j_off,k+k_off)
         enddo ; enddo ; enddo
       endif
@@ -2527,7 +2504,7 @@ end subroutine CT_increment_data_3d_3d
 !! the same horizontal array sizes and the normalized weight array must match the
 !! array sizes of the coupler_3d_bc_type.
 subroutine CT_increment_data_2d_3d(var_in, weights, var, halo_size, bc_index, field_index, &
-                           scale_factor, exclude_flux_type, only_flux_type, pass_through_ice)
+                           scale_factor, scale_prev, exclude_flux_type, only_flux_type, pass_through_ice)
   type(coupler_3d_bc_type),   intent(in)    :: var_in  !< BC_type structure with the data to add to the other type
   real, dimension(:,:,:),     intent(in)    :: weights !< An array of normalized weights for the 3d-data to
                                                        !! increment the 2d-data.  There is no renormalization,
@@ -2540,17 +2517,19 @@ subroutine CT_increment_data_2d_3d(var_in, weights, var, halo_size, bc_index, fi
   integer,          optional, intent(in)    :: field_index !< The index of the field in the
                                                        !! boundary condition that is being copied
   real,             optional, intent(in)    :: scale_factor  !< A scaling factor for the data that is being added
+  real,             optional, intent(in)    :: scale_prev    !< A scaling factor for the data that is already here
   character(len=*), optional, intent(in)    :: exclude_flux_type !< A string describing which types of fluxes to exclude from this increment.
   character(len=*), optional, intent(in)    :: only_flux_type    !< A string describing which types of fluxes to include from this increment.
   logical,          optional, intent(in)    :: pass_through_ice !< If true, only increment BCs whose
                                                        !! value of pass_through ice matches this
 
-  real :: scale
+  real :: scale, sc_prev
   logical :: increment_bc
   integer :: i, j, k, m, n, n1, n2, halo
   integer :: io1, jo1, iow, jow, kow  ! Offsets to account for different index conventions.
 
   scale = 1.0 ; if (present(scale_factor)) scale = scale_factor
+  sc_prev = 1.0 ; if (present(scale_prev)) sc_prev = scale_prev
 
   if (present(bc_index)) then
     if (bc_index > var_in%num_bcs) &
@@ -2622,7 +2601,7 @@ subroutine CT_increment_data_2d_3d(var_in, weights, var, halo_size, bc_index, fi
       if (present(field_index)) then ; if (m /= field_index) cycle ; endif
       if ( associated(var%bc(n)%field(m)%values) ) then
         do k=var_in%ks,var_in%ke ; do j=var%jsc-halo,var%jec+halo ; do i=var%isc-halo,var%iec+halo
-          var%bc(n)%field(m)%values(i,j) = var%bc(n)%field(m)%values(i,j) + &
+          var%bc(n)%field(m)%values(i,j) = sc_prev * var%bc(n)%field(m)%values(i,j) + &
                      (scale * weights(i+iow,j+jow,k+kow)) * var_in%bc(n)%field(m)%values(i+io1,j+io1,k)
         enddo ; enddo ; enddo
       endif
@@ -2630,6 +2609,737 @@ subroutine CT_increment_data_2d_3d(var_in, weights, var, halo_size, bc_index, fi
   enddo
 
 end subroutine CT_increment_data_2d_3d
+
+
+!> This subroutine extracts a single 2-d field from a coupler_2d_bc_type into
+!! a two-dimensional array.
+subroutine CT_extract_data_2d(var_in, bc_index, field_index, array_out, &
+                              scale_factor, halo_size, idim, jdim)
+  type(coupler_2d_bc_type),   intent(in)    :: var_in    !< BC_type structure with the data to extract
+  integer,                    intent(in)    :: bc_index  !< The index of the boundary condition
+                                                         !! that is being copied
+  integer,                    intent(in)    :: field_index !< The index of the field in the
+                                                         !! boundary condition that is being copied
+  real, dimension(1:,1:),     intent(out)   :: array_out !< The recipient array for the field; its size
+                                                         !! must match the size of the data being copied
+                                                         !! unless idim and jdim are supplied.
+  real,             optional, intent(in)    :: scale_factor !< A scaling factor for the data that is being added
+  integer,          optional, intent(in)    :: halo_size !< The extent of the halo to copy; 0 by default
+  integer, dimension(4), optional, intent(in) :: idim    !< The data and computational domain extents of
+                                                         !! the first dimension of the output array
+                                                         !! in a non-decreasing list
+  integer, dimension(4), optional, intent(in) :: jdim    !< The data and computational domain extents of
+                                                         !! the second dimension of the output array
+                                                         !! in a non-decreasing list
+  character(len=256), parameter :: error_header = &
+     '==>Error from coupler_types_mod (CT_extract_data_2d):'
+  character(len=400)      :: error_msg
+
+  real :: scale
+  integer :: i, j, halo, i_off, j_off
+
+  if (bc_index <= 0) then
+    array_out(:,:) = 0.0
+    return
+  endif
+
+  halo = 0 ; if (present(halo_size)) halo = halo_size
+  scale = 1.0 ; if (present(scale_factor)) scale = scale_factor
+
+  if ((var_in%isc-var_in%isd < halo) .or. (var_in%ied-var_in%iec < halo)) &
+    call mpp_error(FATAL, trim(error_header)//" Excessive i-direction halo size for the input structure.")
+  if ((var_in%jsc-var_in%jsd < halo) .or. (var_in%jed-var_in%jec < halo)) &
+    call mpp_error(FATAL, trim(error_header)//" Excessive j-direction halo size for the input structure.")
+
+  if (bc_index > var_in%num_bcs) &
+    call mpp_error(FATAL, trim(error_header)//" bc_index exceeds var_in%num_bcs.")
+  if (field_index > var_in%bc(bc_index)%num_fields) &
+    call mpp_error(FATAL, trim(error_header)//" field_index exceeds num_fields for" //&
+                   trim(var_in%bc(bc_index)%name) )
+
+  ! Do error checking on the i-dimension and determine the array offsets.
+  if (present(idim)) then
+    if ((idim(1) > idim(2)) .or. (idim(3) > idim(4))) then
+      write (error_msg, *) trim(error_header), ' Disordered i-dimension index bound list ', idim
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if (size(array_out,1) /= (1+idim(4)-idim(1))) then
+      write (error_msg, *) trim(error_header), ' The declared i-dimension size of ', &
+            (1+idim(4)-idim(1)), ' does not match the actual size of ', size(array_out,1)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if ((var_in%iec-var_in%isc) /= (idim(3)-idim(2))) &
+      call mpp_error(FATAL, trim(error_header)//" There is an i-direction computional domain size mismatch.")
+    if ((idim(2)-idim(1) < halo) .or. (idim(4)-idim(3) < halo)) &
+      call mpp_error(FATAL, trim(error_header)//" Excessive i-direction halo size for the output array.")
+    if (size(array_out,1) < 2*halo + 1 + var_in%iec - var_in%isc) then
+      write (error_msg, *) trim(error_header), ' The target array with i-dimension size ', &
+            (1+idim(4)-idim(1)), ' is too small to match the data of size ', &
+            (2*halo + 1 + var_in%iec - var_in%isc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+
+    i_off = (1-idim(1)) + (idim(2)-var_in%isc)
+  else
+    if (size(array_out,1) < 2*halo + 1 + var_in%iec - var_in%isc) then
+      write (error_msg, *) trim(error_header), ' The target array with i-dimension size ', &
+            size(array_out,1), ' does not match the data of size ', &
+            (2*halo + 1 + var_in%iec - var_in%isc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    i_off = 1 - (var_in%isc-halo)  
+  endif
+
+  ! Do error checking on the j-dimension and determine the array offsets.
+  if (present(jdim)) then
+    if ((jdim(1) > jdim(2)) .or. (jdim(3) > jdim(4))) then
+      write (error_msg, *) trim(error_header), ' Disordered j-dimension index bound list ', jdim
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if (size(array_out,2) /= (1+jdim(4)-jdim(1))) then
+      write (error_msg, *) trim(error_header), ' The declared j-dimension size of ', &
+            (1+jdim(4)-jdim(1)), ' does not match the actual size of ', size(array_out,2)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if ((var_in%jec-var_in%jsc) /= (jdim(3)-jdim(2))) &
+      call mpp_error(FATAL, trim(error_header)//" There is an j-direction computional domain size mismatch.")
+    if ((jdim(2)-jdim(1) < halo) .or. (jdim(4)-jdim(3) < halo)) &
+      call mpp_error(FATAL, trim(error_header)//" Excessive j-direction halo size for the output array.")
+    if (size(array_out,2) < 2*halo + 1 + var_in%jec - var_in%jsc) then
+      write (error_msg, *) trim(error_header), ' The target array with j-dimension size ', &
+            (1+jdim(4)-jdim(1)), ' is too small to match the data of size ', &
+            (2*halo + 1 + var_in%jec - var_in%jsc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+
+    j_off = (1-jdim(1)) + (jdim(2)-var_in%jsc)
+  else
+    if (size(array_out,2) < 2*halo + 1 + var_in%jec - var_in%jsc) then
+      write (error_msg, *) trim(error_header), ' The target array with j-dimension size ', &
+            size(array_out,2), ' does not match the data of size ', &
+            (2*halo + 1 + var_in%jec - var_in%jsc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    j_off = 1 - (var_in%jsc-halo)  
+  endif
+
+  do j=var_in%jsc-halo,var_in%jec+halo ; do i=var_in%isc-halo,var_in%iec+halo
+    array_out(i+i_off,j+j_off) = scale * var_in%bc(bc_index)%field(field_index)%values(i,j)
+  enddo ; enddo
+
+end subroutine CT_extract_data_2d
+
+!> This subroutine extracts a single k-level of a 3-d field from a coupler_3d_bc_type
+!! into a two-dimensional array.
+subroutine CT_extract_data_3d_2d(var_in, bc_index, field_index, k_in, array_out, &
+                                 scale_factor, halo_size, idim, jdim)
+  type(coupler_3d_bc_type),   intent(in)    :: var_in    !< BC_type structure with the data to extract
+  integer,                    intent(in)    :: bc_index  !< The index of the boundary condition
+                                                         !! that is being copied
+  integer,                    intent(in)    :: field_index !< The index of the field in the
+                                                         !! boundary condition that is being copied
+  integer,                    intent(in)    :: k_in      !< The k-index to extract
+  real, dimension(1:,1:),     intent(out)   :: array_out !< The recipient array for the field; its size
+                                                         !! must match the size of the data being copied
+                                                         !! unless idim and jdim are supplied.
+  real,             optional, intent(in)    :: scale_factor !< A scaling factor for the data that is being added
+  integer,          optional, intent(in)    :: halo_size !< The extent of the halo to copy; 0 by default
+  integer, dimension(4), optional, intent(in) :: idim    !< The data and computational domain extents of
+                                                         !! the first dimension of the output array
+                                                         !! in a non-decreasing list
+  integer, dimension(4), optional, intent(in) :: jdim    !< The data and computational domain extents of
+                                                         !! the second dimension of the output array
+                                                         !! in a non-decreasing list
+  character(len=256), parameter :: error_header = &
+     '==>Error from coupler_types_mod (CT_extract_data_3d_2d):'
+  character(len=400)      :: error_msg
+
+  real :: scale
+  integer :: i, j, k, halo, i_off, j_off
+
+  if (bc_index <= 0) then
+    array_out(:,:) = 0.0
+    return
+  endif
+
+  halo = 0 ; if (present(halo_size)) halo = halo_size
+  scale = 1.0 ; if (present(scale_factor)) scale = scale_factor
+
+  if ((var_in%isc-var_in%isd < halo) .or. (var_in%ied-var_in%iec < halo)) &
+    call mpp_error(FATAL, trim(error_header)//" Excessive i-direction halo size for the input structure.")
+  if ((var_in%jsc-var_in%jsd < halo) .or. (var_in%jed-var_in%jec < halo)) &
+    call mpp_error(FATAL, trim(error_header)//" Excessive j-direction halo size for the input structure.")
+
+  if (bc_index > var_in%num_bcs) &
+    call mpp_error(FATAL, trim(error_header)//" bc_index exceeds var_in%num_bcs.")
+  if (field_index > var_in%bc(bc_index)%num_fields) &
+    call mpp_error(FATAL, trim(error_header)//" field_index exceeds num_fields for" //&
+                   trim(var_in%bc(bc_index)%name) )
+
+  ! Do error checking on the i-dimension and determine the array offsets.
+  if (present(idim)) then
+    if ((idim(1) > idim(2)) .or. (idim(3) > idim(4))) then
+      write (error_msg, *) trim(error_header), ' Disordered i-dimension index bound list ', idim
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if (size(array_out,1) /= (1+idim(4)-idim(1))) then
+      write (error_msg, *) trim(error_header), ' The declared i-dimension size of ', &
+            (1+idim(4)-idim(1)), ' does not match the actual size of ', size(array_out,1)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if ((var_in%iec-var_in%isc) /= (idim(3)-idim(2))) &
+      call mpp_error(FATAL, trim(error_header)//" There is an i-direction computional domain size mismatch.")
+    if ((idim(2)-idim(1) < halo) .or. (idim(4)-idim(3) < halo)) &
+      call mpp_error(FATAL, trim(error_header)//" Excessive i-direction halo size for the output array.")
+    if (size(array_out,1) < 2*halo + 1 + var_in%iec - var_in%isc) then
+      write (error_msg, *) trim(error_header), ' The target array with i-dimension size ', &
+            (1+idim(4)-idim(1)), ' is too small to match the data of size ', &
+            (2*halo + 1 + var_in%iec - var_in%isc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+
+    i_off = (1-idim(1)) + (idim(2)-var_in%isc)
+  else
+    if (size(array_out,1) < 2*halo + 1 + var_in%iec - var_in%isc) then
+      write (error_msg, *) trim(error_header), ' The target array with i-dimension size ', &
+            size(array_out,1), ' does not match the data of size ', &
+            (2*halo + 1 + var_in%iec - var_in%isc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    i_off = 1 - (var_in%isc-halo)  
+  endif
+
+  ! Do error checking on the j-dimension and determine the array offsets.
+  if (present(jdim)) then
+    if ((jdim(1) > jdim(2)) .or. (jdim(3) > jdim(4))) then
+      write (error_msg, *) trim(error_header), ' Disordered j-dimension index bound list ', jdim
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if (size(array_out,2) /= (1+jdim(4)-jdim(1))) then
+      write (error_msg, *) trim(error_header), ' The declared j-dimension size of ', &
+            (1+jdim(4)-jdim(1)), ' does not match the actual size of ', size(array_out,2)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if ((var_in%jec-var_in%jsc) /= (jdim(3)-jdim(2))) &
+      call mpp_error(FATAL, trim(error_header)//" There is an j-direction computional domain size mismatch.")
+    if ((jdim(2)-jdim(1) < halo) .or. (jdim(4)-jdim(3) < halo)) &
+      call mpp_error(FATAL, trim(error_header)//" Excessive j-direction halo size for the output array.")
+    if (size(array_out,2) < 2*halo + 1 + var_in%jec - var_in%jsc) then
+      write (error_msg, *) trim(error_header), ' The target array with j-dimension size ', &
+            (1+jdim(4)-jdim(1)), ' is too small to match the data of size ', &
+            (2*halo + 1 + var_in%jec - var_in%jsc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+
+    j_off = (1-jdim(1)) + (jdim(2)-var_in%jsc)
+  else
+    if (size(array_out,2) < 2*halo + 1 + var_in%jec - var_in%jsc) then
+      write (error_msg, *) trim(error_header), ' The target array with j-dimension size ', &
+            size(array_out,2), ' does not match the data of size ', &
+            (2*halo + 1 + var_in%jec - var_in%jsc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    j_off = 1 - (var_in%jsc-halo)  
+  endif
+
+  if ((k_in > var_in%ke) .or. (k_in < var_in%ks)) then
+    write (error_msg, *) trim(error_header), ' The extracted k-index of ', k_in, &
+           ' is outside of the valid range of ', var_in%ks, ' to ', var_in%ke
+    call mpp_error(FATAL, trim(error_msg))
+  endif
+
+  do j=var_in%jsc-halo,var_in%jec+halo ; do i=var_in%isc-halo,var_in%iec+halo
+    array_out(i+i_off,j+j_off) = scale * var_in%bc(bc_index)%field(field_index)%values(i,j,k_in)
+  enddo ; enddo
+
+end subroutine CT_extract_data_3d_2d
+
+!> This subroutine extracts a single 3-d field from a coupler_3d_bc_type into
+!! a three-dimensional array.
+subroutine CT_extract_data_3d(var_in, bc_index, field_index, array_out, &
+                              scale_factor, halo_size, idim, jdim)
+  type(coupler_3d_bc_type),   intent(in)    :: var_in    !< BC_type structure with the data to extract
+  integer,                    intent(in)    :: bc_index  !< The index of the boundary condition
+                                                         !! that is being copied
+  integer,                    intent(in)    :: field_index !< The index of the field in the
+                                                         !! boundary condition that is being copied
+  real, dimension(1:,1:,1:),  intent(out)   :: array_out !< The recipient array for the field; its size
+                                                         !! must match the size of the data being copied
+                                                         !! unless idim and jdim are supplied.
+  real,             optional, intent(in)    :: scale_factor !< A scaling factor for the data that is being added
+  integer,          optional, intent(in)    :: halo_size !< The extent of the halo to copy; 0 by default
+  integer, dimension(4), optional, intent(in) :: idim    !< The data and computational domain extents of
+                                                         !! the first dimension of the output array
+                                                         !! in a non-decreasing list
+  integer, dimension(4), optional, intent(in) :: jdim    !< The data and computational domain extents of
+                                                         !! the second dimension of the output array
+                                                         !! in a non-decreasing list
+  character(len=256), parameter :: error_header = &
+     '==>Error from coupler_types_mod (CT_extract_data_3d):'
+  character(len=400)      :: error_msg
+
+  real :: scale
+  integer :: i, j, k, halo, i_off, j_off, k_off
+
+  if (bc_index <= 0) then
+    array_out(:,:,:) = 0.0
+    return
+  endif
+
+  halo = 0 ; if (present(halo_size)) halo = halo_size
+  scale = 1.0 ; if (present(scale_factor)) scale = scale_factor
+
+  if ((var_in%isc-var_in%isd < halo) .or. (var_in%ied-var_in%iec < halo)) &
+    call mpp_error(FATAL, trim(error_header)//" Excessive i-direction halo size for the input structure.")
+  if ((var_in%jsc-var_in%jsd < halo) .or. (var_in%jed-var_in%jec < halo)) &
+    call mpp_error(FATAL, trim(error_header)//" Excessive j-direction halo size for the input structure.")
+
+  if (bc_index > var_in%num_bcs) &
+    call mpp_error(FATAL, trim(error_header)//" bc_index exceeds var_in%num_bcs.")
+  if (field_index > var_in%bc(bc_index)%num_fields) &
+    call mpp_error(FATAL, trim(error_header)//" field_index exceeds num_fields for" //&
+                   trim(var_in%bc(bc_index)%name) )
+
+  ! Do error checking on the i-dimension and determine the array offsets.
+  if (present(idim)) then
+    if ((idim(1) > idim(2)) .or. (idim(3) > idim(4))) then
+      write (error_msg, *) trim(error_header), ' Disordered i-dimension index bound list ', idim
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if (size(array_out,1) /= (1+idim(4)-idim(1))) then
+      write (error_msg, *) trim(error_header), ' The declared i-dimension size of ', &
+            (1+idim(4)-idim(1)), ' does not match the actual size of ', size(array_out,1)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if ((var_in%iec-var_in%isc) /= (idim(3)-idim(2))) &
+      call mpp_error(FATAL, trim(error_header)//" There is an i-direction computional domain size mismatch.")
+    if ((idim(2)-idim(1) < halo) .or. (idim(4)-idim(3) < halo)) &
+      call mpp_error(FATAL, trim(error_header)//" Excessive i-direction halo size for the output array.")
+    if (size(array_out,1) < 2*halo + 1 + var_in%iec - var_in%isc) then
+      write (error_msg, *) trim(error_header), ' The target array with i-dimension size ', &
+            (1+idim(4)-idim(1)), ' is too small to match the data of size ', &
+            (2*halo + 1 + var_in%iec - var_in%isc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+
+    i_off = (1-idim(1)) + (idim(2)-var_in%isc)
+  else
+    if (size(array_out,1) < 2*halo + 1 + var_in%iec - var_in%isc) then
+      write (error_msg, *) trim(error_header), ' The target array with i-dimension size ', &
+            size(array_out,1), ' does not match the data of size ', &
+            (2*halo + 1 + var_in%iec - var_in%isc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    i_off = 1 - (var_in%isc-halo)  
+  endif
+
+  ! Do error checking on the j-dimension and determine the array offsets.
+  if (present(jdim)) then
+    if ((jdim(1) > jdim(2)) .or. (jdim(3) > jdim(4))) then
+      write (error_msg, *) trim(error_header), ' Disordered j-dimension index bound list ', jdim
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if (size(array_out,2) /= (1+jdim(4)-jdim(1))) then
+      write (error_msg, *) trim(error_header), ' The declared j-dimension size of ', &
+            (1+jdim(4)-jdim(1)), ' does not match the actual size of ', size(array_out,2)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if ((var_in%jec-var_in%jsc) /= (jdim(3)-jdim(2))) &
+      call mpp_error(FATAL, trim(error_header)//" There is an j-direction computional domain size mismatch.")
+    if ((jdim(2)-jdim(1) < halo) .or. (jdim(4)-jdim(3) < halo)) &
+      call mpp_error(FATAL, trim(error_header)//" Excessive j-direction halo size for the output array.")
+    if (size(array_out,2) < 2*halo + 1 + var_in%jec - var_in%jsc) then
+      write (error_msg, *) trim(error_header), ' The target array with j-dimension size ', &
+            (1+jdim(4)-jdim(1)), ' is too small to match the data of size ', &
+            (2*halo + 1 + var_in%jec - var_in%jsc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+
+    j_off = (1-jdim(1)) + (jdim(2)-var_in%jsc)
+  else
+    if (size(array_out,2) < 2*halo + 1 + var_in%jec - var_in%jsc) then
+      write (error_msg, *) trim(error_header), ' The target array with j-dimension size ', &
+            size(array_out,2), ' does not match the data of size ', &
+            (2*halo + 1 + var_in%jec - var_in%jsc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    j_off = 1 - (var_in%jsc-halo)  
+  endif
+
+  if (size(array_out,3) /= 1 + var_in%ke - var_in%ks) then
+    write (error_msg, *) trim(error_header), ' The target array with k-dimension size ', &
+          size(array_out,3), ' does not match the data of size ', &
+          (1 + var_in%ke - var_in%ks)
+    call mpp_error(FATAL, trim(error_msg))
+  endif
+  k_off = 1 - var_in%ks
+
+  do k=var_in%ks,var_in%ke ; do j=var_in%jsc-halo,var_in%jec+halo ; do i=var_in%isc-halo,var_in%iec+halo
+    array_out(i+i_off,j+j_off,k+k_off) = scale * var_in%bc(bc_index)%field(field_index)%values(i,j,k)
+  enddo ; enddo ; enddo
+
+end subroutine CT_extract_data_3d
+
+
+!> This subroutine sets a single 2-d field in a coupler_3d_bc_type from
+!! a two-dimensional array.
+subroutine CT_set_data_2d(array_in, bc_index, field_index, var, &
+                          scale_factor, halo_size, idim, jdim)
+  real, dimension(1:,1:),     intent(in)   :: array_in   !< The source array for the field; its size
+                                                         !! must match the size of the data being copied
+                                                         !! unless idim and jdim are supplied.
+  integer,                    intent(in)    :: bc_index  !< The index of the boundary condition
+                                                         !! that is being copied
+  integer,                    intent(in)    :: field_index !< The index of the field in the
+                                                         !! boundary condition that is being copied
+  type(coupler_2d_bc_type),   intent(inout) :: var       !< BC_type structure with the data to set
+  real,             optional, intent(in)    :: scale_factor !< A scaling factor for the data that is being added
+  integer,          optional, intent(in)    :: halo_size !< The extent of the halo to copy; 0 by default
+  integer, dimension(4), optional, intent(in) :: idim    !< The data and computational domain extents of
+                                                         !! the first dimension of the output array
+                                                         !! in a non-decreasing list
+  integer, dimension(4), optional, intent(in) :: jdim    !< The data and computational domain extents of
+                                                         !! the second dimension of the output array
+                                                         !! in a non-decreasing list
+  character(len=256), parameter :: error_header = &
+     '==>Error from coupler_types_mod (CT_set_data_2d):'
+  character(len=400)      :: error_msg
+
+  real :: scale
+  integer :: i, j, halo, i_off, j_off
+
+  if (bc_index <= 0) return
+
+  halo = 0 ; if (present(halo_size)) halo = halo_size
+  scale = 1.0 ; if (present(scale_factor)) scale = scale_factor
+
+  if ((var%isc-var%isd < halo) .or. (var%ied-var%iec < halo)) &
+    call mpp_error(FATAL, trim(error_header)//" Excessive i-direction halo size for the input structure.")
+  if ((var%jsc-var%jsd < halo) .or. (var%jed-var%jec < halo)) &
+    call mpp_error(FATAL, trim(error_header)//" Excessive j-direction halo size for the input structure.")
+
+  if (bc_index > var%num_bcs) &
+    call mpp_error(FATAL, trim(error_header)//" bc_index exceeds var%num_bcs.")
+  if (field_index > var%bc(bc_index)%num_fields) &
+    call mpp_error(FATAL, trim(error_header)//" field_index exceeds num_fields for" //&
+                   trim(var%bc(bc_index)%name) )
+
+  ! Do error checking on the i-dimension and determine the array offsets.
+  if (present(idim)) then
+    if ((idim(1) > idim(2)) .or. (idim(3) > idim(4))) then
+      write (error_msg, *) trim(error_header), ' Disordered i-dimension index bound list ', idim
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if (size(array_in,1) /= (1+idim(4)-idim(1))) then
+      write (error_msg, *) trim(error_header), ' The declared i-dimension size of ', &
+            (1+idim(4)-idim(1)), ' does not match the actual size of ', size(array_in,1)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if ((var%iec-var%isc) /= (idim(3)-idim(2))) &
+      call mpp_error(FATAL, trim(error_header)//" There is an i-direction computional domain size mismatch.")
+    if ((idim(2)-idim(1) < halo) .or. (idim(4)-idim(3) < halo)) &
+      call mpp_error(FATAL, trim(error_header)//" Excessive i-direction halo size for the output array.")
+    if (size(array_in,1) < 2*halo + 1 + var%iec - var%isc) then
+      write (error_msg, *) trim(error_header), ' The target array with i-dimension size ', &
+            (1+idim(4)-idim(1)), ' is too small to match the data of size ', &
+            (2*halo + 1 + var%iec - var%isc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+
+    i_off = (1-idim(1)) + (idim(2)-var%isc)
+  else
+    if (size(array_in,1) < 2*halo + 1 + var%iec - var%isc) then
+      write (error_msg, *) trim(error_header), ' The target array with i-dimension size ', &
+            size(array_in,1), ' does not match the data of size ', &
+            (2*halo + 1 + var%iec - var%isc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    i_off = 1 - (var%isc-halo)  
+  endif
+
+  ! Do error checking on the j-dimension and determine the array offsets.
+  if (present(jdim)) then
+    if ((jdim(1) > jdim(2)) .or. (jdim(3) > jdim(4))) then
+      write (error_msg, *) trim(error_header), ' Disordered j-dimension index bound list ', jdim
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if (size(array_in,2) /= (1+jdim(4)-jdim(1))) then
+      write (error_msg, *) trim(error_header), ' The declared j-dimension size of ', &
+            (1+jdim(4)-jdim(1)), ' does not match the actual size of ', size(array_in,2)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if ((var%jec-var%jsc) /= (jdim(3)-jdim(2))) &
+      call mpp_error(FATAL, trim(error_header)//" There is an j-direction computional domain size mismatch.")
+    if ((jdim(2)-jdim(1) < halo) .or. (jdim(4)-jdim(3) < halo)) &
+      call mpp_error(FATAL, trim(error_header)//" Excessive j-direction halo size for the output array.")
+    if (size(array_in,2) < 2*halo + 1 + var%jec - var%jsc) then
+      write (error_msg, *) trim(error_header), ' The target array with j-dimension size ', &
+            (1+jdim(4)-jdim(1)), ' is too small to match the data of size ', &
+            (2*halo + 1 + var%jec - var%jsc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+
+    j_off = (1-jdim(1)) + (jdim(2)-var%jsc)
+  else
+    if (size(array_in,2) < 2*halo + 1 + var%jec - var%jsc) then
+      write (error_msg, *) trim(error_header), ' The target array with j-dimension size ', &
+            size(array_in,2), ' does not match the data of size ', &
+            (2*halo + 1 + var%jec - var%jsc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    j_off = 1 - (var%jsc-halo)  
+  endif
+
+  do j=var%jsc-halo,var%jec+halo ; do i=var%isc-halo,var%iec+halo
+    var%bc(bc_index)%field(field_index)%values(i,j) = scale * array_in(i+i_off,j+j_off)
+  enddo ; enddo
+
+end subroutine CT_set_data_2d
+
+!> This subroutine sets a one k-level of a single 3-d field in a
+!! coupler_3d_bc_type from a two-dimensional array.
+subroutine CT_set_data_2d_3d(array_in, bc_index, field_index, k_out, var, &
+                             scale_factor, halo_size, idim, jdim)
+  real, dimension(1:,1:),     intent(in)    :: array_in  !< The source array for the field; its size
+                                                         !! must match the size of the data being copied
+                                                         !! unless idim and jdim are supplied.
+  integer,                    intent(in)    :: bc_index  !< The index of the boundary condition
+                                                         !! that is being copied
+  integer,                    intent(in)    :: field_index !< The index of the field in the
+                                                         !! boundary condition that is being copied
+  integer,                    intent(in)    :: k_out     !< The k-index to set
+  type(coupler_3d_bc_type),   intent(inout) :: var       !< BC_type structure with the data to be set
+  real,             optional, intent(in)    :: scale_factor !< A scaling factor for the data that is being added
+  integer,          optional, intent(in)    :: halo_size !< The extent of the halo to copy; 0 by default
+  integer, dimension(4), optional, intent(in) :: idim    !< The data and computational domain extents of
+                                                         !! the first dimension of the output array
+                                                         !! in a non-decreasing list
+  integer, dimension(4), optional, intent(in) :: jdim    !< The data and computational domain extents of
+                                                         !! the second dimension of the output array
+                                                         !! in a non-decreasing list
+  character(len=256), parameter :: error_header = &
+     '==>Error from coupler_types_mod (CT_set_data_3d_2d):'
+  character(len=400)      :: error_msg
+
+  real :: scale
+  integer :: i, j, halo, i_off, j_off
+
+  if (bc_index <= 0) return
+
+  halo = 0 ; if (present(halo_size)) halo = halo_size
+  scale = 1.0 ; if (present(scale_factor)) scale = scale_factor
+
+  if ((var%isc-var%isd < halo) .or. (var%ied-var%iec < halo)) &
+    call mpp_error(FATAL, trim(error_header)//" Excessive i-direction halo size for the input structure.")
+  if ((var%jsc-var%jsd < halo) .or. (var%jed-var%jec < halo)) &
+    call mpp_error(FATAL, trim(error_header)//" Excessive j-direction halo size for the input structure.")
+
+  if (bc_index > var%num_bcs) &
+    call mpp_error(FATAL, trim(error_header)//" bc_index exceeds var%num_bcs.")
+  if (field_index > var%bc(bc_index)%num_fields) &
+    call mpp_error(FATAL, trim(error_header)//" field_index exceeds num_fields for" //&
+                   trim(var%bc(bc_index)%name) )
+
+  ! Do error checking on the i-dimension and determine the array offsets.
+  if (present(idim)) then
+    if ((idim(1) > idim(2)) .or. (idim(3) > idim(4))) then
+      write (error_msg, *) trim(error_header), ' Disordered i-dimension index bound list ', idim
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if (size(array_in,1) /= (1+idim(4)-idim(1))) then
+      write (error_msg, *) trim(error_header), ' The declared i-dimension size of ', &
+            (1+idim(4)-idim(1)), ' does not match the actual size of ', size(array_in,1)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if ((var%iec-var%isc) /= (idim(3)-idim(2))) &
+      call mpp_error(FATAL, trim(error_header)//" There is an i-direction computional domain size mismatch.")
+    if ((idim(2)-idim(1) < halo) .or. (idim(4)-idim(3) < halo)) &
+      call mpp_error(FATAL, trim(error_header)//" Excessive i-direction halo size for the output array.")
+    if (size(array_in,1) < 2*halo + 1 + var%iec - var%isc) then
+      write (error_msg, *) trim(error_header), ' The target array with i-dimension size ', &
+            (1+idim(4)-idim(1)), ' is too small to match the data of size ', &
+            (2*halo + 1 + var%iec - var%isc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+
+    i_off = (1-idim(1)) + (idim(2)-var%isc)
+  else
+    if (size(array_in,1) < 2*halo + 1 + var%iec - var%isc) then
+      write (error_msg, *) trim(error_header), ' The target array with i-dimension size ', &
+            size(array_in,1), ' does not match the data of size ', &
+            (2*halo + 1 + var%iec - var%isc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    i_off = 1 - (var%isc-halo)  
+  endif
+
+  ! Do error checking on the j-dimension and determine the array offsets.
+  if (present(jdim)) then
+    if ((jdim(1) > jdim(2)) .or. (jdim(3) > jdim(4))) then
+      write (error_msg, *) trim(error_header), ' Disordered j-dimension index bound list ', jdim
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if (size(array_in,2) /= (1+jdim(4)-jdim(1))) then
+      write (error_msg, *) trim(error_header), ' The declared j-dimension size of ', &
+            (1+jdim(4)-jdim(1)), ' does not match the actual size of ', size(array_in,2)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if ((var%jec-var%jsc) /= (jdim(3)-jdim(2))) &
+      call mpp_error(FATAL, trim(error_header)//" There is an j-direction computional domain size mismatch.")
+    if ((jdim(2)-jdim(1) < halo) .or. (jdim(4)-jdim(3) < halo)) &
+      call mpp_error(FATAL, trim(error_header)//" Excessive j-direction halo size for the output array.")
+    if (size(array_in,2) < 2*halo + 1 + var%jec - var%jsc) then
+      write (error_msg, *) trim(error_header), ' The target array with j-dimension size ', &
+            (1+jdim(4)-jdim(1)), ' is too small to match the data of size ', &
+            (2*halo + 1 + var%jec - var%jsc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+
+    j_off = (1-jdim(1)) + (jdim(2)-var%jsc)
+  else
+    if (size(array_in,2) < 2*halo + 1 + var%jec - var%jsc) then
+      write (error_msg, *) trim(error_header), ' The target array with j-dimension size ', &
+            size(array_in,2), ' does not match the data of size ', &
+            (2*halo + 1 + var%jec - var%jsc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    j_off = 1 - (var%jsc-halo)  
+  endif
+
+  if ((k_out > var%ke) .or. (k_out < var%ks)) then
+    write (error_msg, *) trim(error_header), ' The seted k-index of ', k_out, &
+           ' is outside of the valid range of ', var%ks, ' to ', var%ke
+    call mpp_error(FATAL, trim(error_msg))
+  endif
+
+  do j=var%jsc-halo,var%jec+halo ; do i=var%isc-halo,var%iec+halo
+    var%bc(bc_index)%field(field_index)%values(i,j,k_out) = scale * array_in(i+i_off,j+j_off)
+  enddo ; enddo
+
+end subroutine CT_set_data_2d_3d
+
+!> This subroutine sets a single 3-d field in a coupler_3d_bc_type from
+!! a three-dimensional array.
+subroutine CT_set_data_3d(array_in, bc_index, field_index, var, &
+                          scale_factor, halo_size, idim, jdim)
+  real, dimension(1:,1:,1:),  intent(in)    :: array_in  !< The source array for the field; its size
+                                                         !! must match the size of the data being copied
+                                                         !! unless idim and jdim are supplied.
+  integer,                    intent(in)    :: bc_index  !< The index of the boundary condition
+                                                         !! that is being copied
+  integer,                    intent(in)    :: field_index !< The index of the field in the
+                                                         !! boundary condition that is being copied
+  type(coupler_3d_bc_type),   intent(inout) :: var       !< BC_type structure with the data to be set
+  real,             optional, intent(in)    :: scale_factor !< A scaling factor for the data that is being added
+  integer,          optional, intent(in)    :: halo_size !< The extent of the halo to copy; 0 by default
+  integer, dimension(4), optional, intent(in) :: idim    !< The data and computational domain extents of
+                                                         !! the first dimension of the output array
+                                                         !! in a non-decreasing list
+  integer, dimension(4), optional, intent(in) :: jdim    !< The data and computational domain extents of
+                                                         !! the second dimension of the output array
+                                                         !! in a non-decreasing list
+  character(len=256), parameter :: error_header = &
+     '==>Error from coupler_types_mod (CT_set_data_3d):'
+  character(len=400)      :: error_msg
+
+  real :: scale
+  integer :: i, j, k, halo, i_off, j_off, k_off
+
+  if (bc_index <= 0) return
+
+  halo = 0 ; if (present(halo_size)) halo = halo_size
+  scale = 1.0 ; if (present(scale_factor)) scale = scale_factor
+
+  if ((var%isc-var%isd < halo) .or. (var%ied-var%iec < halo)) &
+    call mpp_error(FATAL, trim(error_header)//" Excessive i-direction halo size for the input structure.")
+  if ((var%jsc-var%jsd < halo) .or. (var%jed-var%jec < halo)) &
+    call mpp_error(FATAL, trim(error_header)//" Excessive j-direction halo size for the input structure.")
+
+  if (bc_index > var%num_bcs) &
+    call mpp_error(FATAL, trim(error_header)//" bc_index exceeds var%num_bcs.")
+  if (field_index > var%bc(bc_index)%num_fields) &
+    call mpp_error(FATAL, trim(error_header)//" field_index exceeds num_fields for" //&
+                   trim(var%bc(bc_index)%name) )
+
+  ! Do error checking on the i-dimension and determine the array offsets.
+  if (present(idim)) then
+    if ((idim(1) > idim(2)) .or. (idim(3) > idim(4))) then
+      write (error_msg, *) trim(error_header), ' Disordered i-dimension index bound list ', idim
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if (size(array_in,1) /= (1+idim(4)-idim(1))) then
+      write (error_msg, *) trim(error_header), ' The declared i-dimension size of ', &
+            (1+idim(4)-idim(1)), ' does not match the actual size of ', size(array_in,1)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if ((var%iec-var%isc) /= (idim(3)-idim(2))) &
+      call mpp_error(FATAL, trim(error_header)//" There is an i-direction computional domain size mismatch.")
+    if ((idim(2)-idim(1) < halo) .or. (idim(4)-idim(3) < halo)) &
+      call mpp_error(FATAL, trim(error_header)//" Excessive i-direction halo size for the output array.")
+    if (size(array_in,1) < 2*halo + 1 + var%iec - var%isc) then
+      write (error_msg, *) trim(error_header), ' The target array with i-dimension size ', &
+            (1+idim(4)-idim(1)), ' is too small to match the data of size ', &
+            (2*halo + 1 + var%iec - var%isc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+
+    i_off = (1-idim(1)) + (idim(2)-var%isc)
+  else
+    if (size(array_in,1) < 2*halo + 1 + var%iec - var%isc) then
+      write (error_msg, *) trim(error_header), ' The target array with i-dimension size ', &
+            size(array_in,1), ' does not match the data of size ', &
+            (2*halo + 1 + var%iec - var%isc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    i_off = 1 - (var%isc-halo)  
+  endif
+
+  ! Do error checking on the j-dimension and determine the array offsets.
+  if (present(jdim)) then
+    if ((jdim(1) > jdim(2)) .or. (jdim(3) > jdim(4))) then
+      write (error_msg, *) trim(error_header), ' Disordered j-dimension index bound list ', jdim
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if (size(array_in,2) /= (1+jdim(4)-jdim(1))) then
+      write (error_msg, *) trim(error_header), ' The declared j-dimension size of ', &
+            (1+jdim(4)-jdim(1)), ' does not match the actual size of ', size(array_in,2)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    if ((var%jec-var%jsc) /= (jdim(3)-jdim(2))) &
+      call mpp_error(FATAL, trim(error_header)//" There is an j-direction computional domain size mismatch.")
+    if ((jdim(2)-jdim(1) < halo) .or. (jdim(4)-jdim(3) < halo)) &
+      call mpp_error(FATAL, trim(error_header)//" Excessive j-direction halo size for the output array.")
+    if (size(array_in,2) < 2*halo + 1 + var%jec - var%jsc) then
+      write (error_msg, *) trim(error_header), ' The target array with j-dimension size ', &
+            (1+jdim(4)-jdim(1)), ' is too small to match the data of size ', &
+            (2*halo + 1 + var%jec - var%jsc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+
+    j_off = (1-jdim(1)) + (jdim(2)-var%jsc)
+  else
+    if (size(array_in,2) < 2*halo + 1 + var%jec - var%jsc) then
+      write (error_msg, *) trim(error_header), ' The target array with j-dimension size ', &
+            size(array_in,2), ' does not match the data of size ', &
+            (2*halo + 1 + var%jec - var%jsc)
+      call mpp_error(FATAL, trim(error_msg))
+    endif
+    j_off = 1 - (var%jsc-halo)  
+  endif
+
+  if (size(array_in,3) /= 1 + var%ke - var%ks) then
+    write (error_msg, *) trim(error_header), ' The target array with k-dimension size ', &
+          size(array_in,3), ' does not match the data of size ', &
+          (1 + var%ke - var%ks)
+    call mpp_error(FATAL, trim(error_msg))
+  endif
+  k_off = 1 - var%ks
+
+  do k=var%ks,var%ke ; do j=var%jsc-halo,var%jec+halo ; do i=var%isc-halo,var%iec+halo
+    var%bc(bc_index)%field(field_index)%values(i,j,k) = scale * array_in(i+i_off,j+j_off,k+k_off) 
+  enddo ; enddo ; enddo
+
+end subroutine CT_set_data_3d
 
 
 !> This routine registers the diagnostics of a coupler_2d_bc_type.
@@ -2644,7 +3354,7 @@ subroutine CT_set_diags_2d(var, diag_name, axes, time)
   if (diag_name == ' ') return
 
   if (size(axes) < 2) then
-    call mpp_error(FATAL, '==>Error from ' // trim(mod_name) //&
+    call mpp_error(FATAL, '==>Error from coupler_types_mod' //&
              '(coupler_types_set_diags_3d): axes has less than 2 elements')
   endif
 
@@ -2670,7 +3380,7 @@ subroutine CT_set_diags_3d(var, diag_name, axes, time)
   if (diag_name == ' ') return
 
   if (size(axes) < 3) then
-    call mpp_error(FATAL, '==>Error from ' // trim(mod_name) //&
+    call mpp_error(FATAL, '==>Error from coupler_types_mod' //&
              '(coupler_types_set_diags_3d): axes has less than 3 elements')
   endif
 


### PR DESCRIPTION
  Added two new interfaces, coupler_type_extract_data and coupler_type_set_data,
to exchange fields between coupler_bc_types and arrays.  Also added a new
optional argument, scale_prev, to the coupler_type_increment_data routines,
which allows for a weighted running average with a single call. In addition,
some lines setting up the text for error messages were simplified.  All answers
are bitwise identical.