### PR TITLE
+Added name prefix argument to CT_register_restarts

### DIFF
--- a/coupler/coupler_types.F90
+++ b/coupler/coupler_types.F90
@@ -3475,12 +3475,18 @@ end subroutine CT_register_restarts_2d
 
 !> This subroutine registers the fields in a coupler_2d_bc_type to be saved
 !! in the specified restart file.
-subroutine CT_register_restarts_to_file_2d(var, file_name, rest_file, mpp_domain)
+subroutine CT_register_restarts_to_file_2d(var, file_name, rest_file, mpp_domain, &
+                                           varname_prefix)
   type(coupler_2d_bc_type), intent(inout) :: var  !< BC_type structure to be registered for restarts
   character(len=*),         intent(in)    :: file_name !< The name of the restart file
   type(restart_file_type),  pointer       :: rest_file !< A (possibly associated) structure describing the restart file
   type(domain2D),           intent(in)    :: mpp_domain !< The FMS domain to use for this registration call
+  character(len=*), optional, intent(in)  :: varname_prefix !< A prefix for the variable name
+                                                  !! in the restart file, intended to allow
+                                                  !! multiple BC_type variables to use the
+                                                  !! same restart files.
 
+  character(len=128) :: var_name
   integer :: n, m
 
   ! Register the fields with the restart file
@@ -3490,8 +3496,10 @@ subroutine CT_register_restarts_to_file_2d(var, file_name, rest_file, mpp_domain
 
     var%bc(n)%rest_type => rest_file
     do m = 1, var%bc(n)%num_fields
+      var_name = trim(var%bc(n)%field(m)%name)
+      if (present(varname_prefix)) var_name = trim(varname_prefix)//trim(var_name)
       var%bc(n)%field(m)%id_rest = register_restart_field(rest_file, &
-              file_name, var%bc(n)%field(m)%name, var%bc(n)%field(m)%values, &
+              file_name, var_name, var%bc(n)%field(m)%values, &
               mpp_domain, mandatory=.not.var%bc(n)%field(m)%may_init )
     enddo
   enddo
@@ -3553,12 +3561,19 @@ end subroutine CT_register_restarts_3d
 
 !> This subroutine registers the fields in a coupler_3d_bc_type to be saved
 !! in the specified restart file.
-subroutine CT_register_restarts_to_file_3d(var, file_name, rest_file, mpp_domain)
+subroutine CT_register_restarts_to_file_3d(var, file_name, rest_file, mpp_domain, &
+                                           varname_prefix)
   type(coupler_3d_bc_type), intent(inout) :: var  !< BC_type structure to be registered for restarts
   character(len=*),         intent(in)  :: file_name !< The name of the restart file
   type(restart_file_type),  pointer     :: rest_file !< A (possibly associated) structure describing the restart file
   type(domain2D),           intent(in)  :: mpp_domain     !< The FMS domain to use for this registration call
 
+  character(len=*), optional, intent(in)  :: varname_prefix !< A prefix for the variable name
+                                                  !! in the restart file, intended to allow
+                                                  !! multiple BC_type variables to use the
+                                                  !! same restart files.
+
+  character(len=128) :: var_name
   integer :: n, m
 
   ! Register the fields with the restart file
@@ -3568,8 +3583,10 @@ subroutine CT_register_restarts_to_file_3d(var, file_name, rest_file, mpp_domain
 
     var%bc(n)%rest_type => rest_file
     do m = 1, var%bc(n)%num_fields
+      var_name = trim(var%bc(n)%field(m)%name)
+      if (present(varname_prefix)) var_name = trim(varname_prefix)//trim(var_name)
       var%bc(n)%field(m)%id_rest = register_restart_field(rest_file, &
-              file_name, var%bc(n)%field(m)%name, var%bc(n)%field(m)%values, &
+              file_name, var_name, var%bc(n)%field(m)%values, &
               mpp_domain, mandatory=.not.var%bc(n)%field(m)%may_init )
     enddo
   enddo


### PR DESCRIPTION
  Added a new optional argument, varname_prefix, to the variants of
coupler_type_register_restarts that use a specified restart file, so that
multiple coupler_type variables can use the same restart file.  All existing
answers are bitwise identical, but this new capability is required for the
concurrent ice version of SIS2 to save fluxes by category and their weighted
averages in the restart files.