### PR TITLE
Fixes the intent of argument updated by inner call to data_override

### DIFF
--- a/coupler/coupler_types.F90
+++ b/coupler/coupler_types.F90
@@ -3730,9 +3730,9 @@ end subroutine CT_restore_state_3d
 
 !> This subroutine potentially overrides the values in a coupler_2d_bc_type
 subroutine CT_data_override_2d(gridname, var, Time)
-  character(len=3),         intent(in) :: gridname !< 3-character long model grid ID
-  type(coupler_2d_bc_type), intent(in) :: var  !< BC_type structure to override
-  type(time_type),          intent(in) :: time !< The current model time
+  character(len=3),         intent(in)    :: gridname !< 3-character long model grid ID
+  type(coupler_2d_bc_type), intent(inout) :: var  !< BC_type structure to override
+  type(time_type),          intent(in)    :: time !< The current model time
 
   integer :: m, n
 
@@ -3744,9 +3744,9 @@ end subroutine CT_data_override_2d
 
 !> This subroutine potentially overrides the values in a coupler_3d_bc_type
 subroutine CT_data_override_3d(gridname, var, Time)
-  character(len=3),         intent(in) :: gridname !< 3-character long model grid ID
-  type(coupler_3d_bc_type), intent(in) :: var  !< BC_type structure to override
-  type(time_type),          intent(in) :: time !< The current model time
+  character(len=3),         intent(in)    :: gridname !< 3-character long model grid ID
+  type(coupler_3d_bc_type), intent(inout) :: var  !< BC_type structure to override
+  type(time_type),          intent(in)    :: time !< The current model time
 
   integer :: m, n
 


### PR DESCRIPTION
- In CT_data_override_2d() and CT_data_override_3d(), a call to data_override()
  updates a dummy argument with intent(in). This commit changes it to intent(inout).
- Related to NOAA-GFDL/MOM6#651.
- Closes NOAA-GFDL/FMS#41.
- Reported by @jiandewang.