### PR TITLE
Update FV3 GFS build scripts - feature/warsaw_201803_fv3gfs_make

### DIFF
--- a/fv3gfs/make.rules
+++ b/fv3gfs/make.rules
@@ -1,0 +1,30 @@
+.SUFFIXES:
+.SUFFIXES: .F90 .f90 .F .f .o .c
+
+.F90.f90:
+	$(CPP) $(CPPFLAGS) $< > $*.f90
+
+.F.f:
+	$(CPP) $(CPPFLAGS) $< > $*.f
+
+.f.o:
+	$(FC) $(FFLAGS) $(OTHER_FFLAGS) -c $< -o $@
+
+.f90.o:
+	$(FC) $(FFLAGS) $(OTHER_FFLAGS) -c $< -o $@
+
+.F.o:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) $(OTHER_FFLAGS) -c $< -o $@
+
+.F90.o:
+	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) $(OTHER_FFLAGS) -c $< -o $@
+
+.c.o:
+	$(CC) $(CPPDEFS) $(CPPFLAGS) $(CFLAGS) $(OTHERFLAGS) $(OTHER_CFLAGS) -c $< -o $@
+
+depend: $(DEPEND_FILES) makefile
+	@echo "Building dependencies ..."
+	@ls -1 $(DEPEND_FILES) > Srcfiles
+	@echo "." > Filepath
+	@$(MKDEPENDS) -m Filepath Srcfiles > depend
+	@$(RM) -f Filepath Srcfiles

--- a/fv3gfs/makefile
+++ b/fv3gfs/makefile
@@ -158,7 +158,10 @@ $(LIBRARY): $(OBJS)
 clean:
 	@echo "Cleaning fms ... "
 	@echo
-	$(RM) -f $(LIBRARY) *__genmod.f90 *.o */*.o *.mod *.lst *.i depend ../*/*.o
+	cd .. ; \
+	ls -1 */*.a */*.o */*.mod */depend \
+	  | grep -vE 'INSTALL|\.git' | xargs rm -f ; \
+	rm -rf FMS_INSTALL
 
 MKDEPENDS = ./mkDepends.pl
 include ./make.rules

--- a/fv3gfs/makefile
+++ b/fv3gfs/makefile
@@ -160,8 +160,8 @@ clean:
 	@echo
 	cd .. ; \
 	ls -1 */*.a */*.o */*.mod */depend \
-	  | grep -vE 'INSTALL|\.git' | xargs rm -f ; \
-	rm -rf FMS_INSTALL
+	  | grep -vE 'INSTALL|\.git' | xargs rm -f || true ; \
+	rm -rf FMS_INSTALL || true
 
 MKDEPENDS = ./mkDepends.pl
 include ./make.rules

--- a/fv3gfs/makefile
+++ b/fv3gfs/makefile
@@ -20,122 +20,110 @@
 
 SHELL = /bin/sh
 
-inside_nems := $(wildcard ../../../conf/configure.nems)
-ifneq ($(strip $(inside_nems)),)
-    include ../../../conf/configure.nems
-else
-    exist_configure_fv3 := $(wildcard ../conf/configure.fv3)
-    ifneq ($(strip $(exist_configure_fv3)),)
-        include ../conf/configure.fv3
-    else
-        $(error "../conf/configure.fv3 file is missing. Run ./configure")
-    endif
-    $(info )
-    $(info Build standalone FV3 fms ...)
-    $(info )
-endif
+include ../../NEMS/src/conf/configure.nems
 
 LIBRARY  = libfms.a
+FMS_INSTALL=$(realpath $(PWD)/..)/FMS_INSTALL
 
-FFLAGS   += -I./include -I./mpp/include -I./fms
+FFLAGS   += -I../include -I../mpp/include -I../fms
 
 SRCS_f   =
 
 SRCS_f90 = \
-		   ./oda_tools/xbt_drop_rate_adjust.f90
+		   ../oda_tools/xbt_drop_rate_adjust.f90
 
 SRCS_F   =
 
 SRCS_F90 = \
-		   ./amip_interp/amip_interp.F90                                     \
-		   ./astronomy/astronomy.F90                                         \
-		   ./axis_utils/axis_utils.F90                                       \
-		   ./block_control/block_control.F90                                 \
-		   ./column_diagnostics/column_diagnostics.F90                       \
-		   ./coupler/atmos_ocean_fluxes.F90                                  \
-		   ./coupler/coupler_types.F90                                       \
-		   ./coupler/ensemble_manager.F90                                    \
-		   ./data_override/data_override.F90                                 \
-		   ./diag_manager/diag_axis.F90                                      \
-		   ./diag_manager/diag_data.F90                                      \
-		   ./diag_manager/diag_grid.F90                                      \
-		   ./diag_manager/diag_manifest.F90                                  \
-		   ./diag_manager/diag_manager.F90                                   \
-		   ./diag_manager/diag_output.F90                                    \
-		   ./diag_manager/diag_table.F90                                     \
-		   ./diag_manager/diag_util.F90                                      \
-		   ./drifters/cloud_interpolator.F90                                 \
-		   ./drifters/drifters.F90                                           \
-		   ./drifters/drifters_comm.F90                                      \
-		   ./drifters/drifters_core.F90                                      \
-		   ./drifters/drifters_input.F90                                     \
-		   ./drifters/drifters_io.F90                                        \
-		   ./drifters/quicksort.F90                                          \
-		   ./exchange/stock_constants.F90                                    \
-		   ./exchange/test_xgrid.F90                                         \
-		   ./exchange/xgrid.F90                                              \
-		   ./fft/fft.F90                                                     \
-		   ./fft/fft99.F90                                                   \
-		   ./field_manager/field_manager.F90                                 \
-		   ./field_manager/fm_util.F90                                       \
-		   ./fms/fms.F90                                                     \
-		   ./fms/fms_io.F90                                                  \
-		   ./fms/test_fms_io.F90                                             \
-		   ./constants/constants.F90                                         \
-		   ./horiz_interp/horiz_interp.F90                                   \
-		   ./horiz_interp/horiz_interp_bicubic.F90                           \
-		   ./horiz_interp/horiz_interp_bilinear.F90                          \
-		   ./horiz_interp/horiz_interp_conserve.F90                          \
-		   ./horiz_interp/horiz_interp_spherical.F90                         \
-		   ./horiz_interp/horiz_interp_type.F90                              \
-		   ./horiz_interp/test_horiz_interp.F90                              \
-		   ./interpolator/interpolator.F90                                   \
-		   ./memutils/memutils.F90                                           \
-		   ./mosaic/gradient.F90                                             \
-		   ./mosaic/grid.F90                                                 \
-		   ./mosaic/mosaic.F90                                               \
-		   ./mpp/mpp.F90                                                     \
-		   ./mpp/mpp_data.F90                                                \
-		   ./mpp/mpp_domains.F90                                             \
-		   ./mpp/mpp_efp.F90                                                 \
-		   ./mpp/mpp_io.F90                                                  \
-		   ./mpp/mpp_memutils.F90                                            \
-		   ./mpp/mpp_parameter.F90                                           \
-		   ./mpp/mpp_pset.F90                                                \
-		   ./mpp/mpp_utilities.F90                                           \
-		   ./mpp/test_mpp.F90                                                \
-		   ./mpp/test_mpp_domains.F90                                        \
-		   ./mpp/test_mpp_io.F90                                             \
-		   ./mpp/test_mpp_pset.F90                                           \
-		   ./oda_tools/oda_core.F90                                          \
-		   ./oda_tools/oda_core_ecda.F90                                     \
-		   ./oda_tools/oda_types.F90                                         \
-		   ./oda_tools/write_ocean_data.F90                                  \
-		   ./platform/platform.F90                                           \
-		   ./random_numbers/MersenneTwister.F90                              \
-		   ./random_numbers/random_numbers.F90                               \
-		   ./sat_vapor_pres/sat_vapor_pres.F90                               \
-		   ./sat_vapor_pres/sat_vapor_pres_k.F90                             \
-		   ./station_data/station_data.F90                                   \
-		   ./time_interp/time_interp.F90                                     \
-		   ./time_interp/time_interp_external.F90                            \
-		   ./time_manager/get_cal_time.F90                                   \
-		   ./time_manager/time_manager.F90                                   \
-		   ./topography/gaussian_topog.F90                                   \
-		   ./topography/topography.F90                                       \
-		   ./tracer_manager/tracer_manager.F90                               \
-		   ./tridiagonal/tridiagonal.F90
+		   ../amip_interp/amip_interp.F90                                     \
+		   ../astronomy/astronomy.F90                                         \
+		   ../axis_utils/axis_utils.F90                                       \
+		   ../block_control/block_control.F90                                 \
+		   ../column_diagnostics/column_diagnostics.F90                       \
+		   ../coupler/atmos_ocean_fluxes.F90                                  \
+		   ../coupler/coupler_types.F90                                       \
+		   ../coupler/ensemble_manager.F90                                    \
+		   ../data_override/data_override.F90                                 \
+		   ../diag_manager/diag_axis.F90                                      \
+		   ../diag_manager/diag_data.F90                                      \
+		   ../diag_manager/diag_grid.F90                                      \
+		   ../diag_manager/diag_manifest.F90                                  \
+		   ../diag_manager/diag_manager.F90                                   \
+		   ../diag_manager/diag_output.F90                                    \
+		   ../diag_manager/diag_table.F90                                     \
+		   ../diag_manager/diag_util.F90                                      \
+		   ../drifters/cloud_interpolator.F90                                 \
+		   ../drifters/drifters.F90                                           \
+		   ../drifters/drifters_comm.F90                                      \
+		   ../drifters/drifters_core.F90                                      \
+		   ../drifters/drifters_input.F90                                     \
+		   ../drifters/drifters_io.F90                                        \
+		   ../drifters/quicksort.F90                                          \
+		   ../exchange/stock_constants.F90                                    \
+		   ../exchange/test_xgrid.F90                                         \
+		   ../exchange/xgrid.F90                                              \
+		   ../fft/fft.F90                                                     \
+		   ../fft/fft99.F90                                                   \
+		   ../field_manager/field_manager.F90                                 \
+		   ../field_manager/fm_util.F90                                       \
+		   ../fms/fms.F90                                                     \
+		   ../fms/fms_io.F90                                                  \
+		   ../fms/test_fms_io.F90                                             \
+		   ../constants/constants.F90                                         \
+		   ../horiz_interp/horiz_interp.F90                                   \
+		   ../horiz_interp/horiz_interp_bicubic.F90                           \
+		   ../horiz_interp/horiz_interp_bilinear.F90                          \
+		   ../horiz_interp/horiz_interp_conserve.F90                          \
+		   ../horiz_interp/horiz_interp_spherical.F90                         \
+		   ../horiz_interp/horiz_interp_type.F90                              \
+		   ../horiz_interp/test_horiz_interp.F90                              \
+		   ../interpolator/interpolator.F90                                   \
+		   ../memutils/memutils.F90                                           \
+		   ../mosaic/gradient.F90                                             \
+		   ../mosaic/grid.F90                                                 \
+		   ../mosaic/mosaic.F90                                               \
+		   ../mpp/mpp.F90                                                     \
+		   ../mpp/mpp_data.F90                                                \
+		   ../mpp/mpp_domains.F90                                             \
+		   ../mpp/mpp_efp.F90                                                 \
+		   ../mpp/mpp_io.F90                                                  \
+		   ../mpp/mpp_memutils.F90                                            \
+		   ../mpp/mpp_parameter.F90                                           \
+		   ../mpp/mpp_pset.F90                                                \
+		   ../mpp/mpp_utilities.F90                                           \
+		   ../mpp/test_mpp.F90                                                \
+		   ../mpp/test_mpp_domains.F90                                        \
+		   ../mpp/test_mpp_io.F90                                             \
+		   ../mpp/test_mpp_pset.F90                                           \
+		   ../oda_tools/oda_core.F90                                          \
+		   ../oda_tools/oda_core_ecda.F90                                     \
+		   ../oda_tools/oda_types.F90                                         \
+		   ../oda_tools/write_ocean_data.F90                                  \
+		   ../platform/platform.F90                                           \
+		   ../random_numbers/MersenneTwister.F90                              \
+		   ../random_numbers/random_numbers.F90                               \
+		   ../sat_vapor_pres/sat_vapor_pres.F90                               \
+		   ../sat_vapor_pres/sat_vapor_pres_k.F90                             \
+		   ../station_data/station_data.F90                                   \
+		   ../time_interp/time_interp.F90                                     \
+		   ../time_interp/time_interp_external.F90                            \
+		   ../time_manager/get_cal_time.F90                                   \
+		   ../time_manager/time_manager.F90                                   \
+		   ../topography/gaussian_topog.F90                                   \
+		   ../topography/topography.F90                                       \
+		   ../tracer_manager/tracer_manager.F90                               \
+		   ../tridiagonal/tridiagonal.F90
 
 SRCS_c   = \
-		   ./memutils/memuse.c                                               \
-		   ./mosaic/create_xgrid.c                                           \
-		   ./mosaic/gradient_c2l.c                                           \
-		   ./mosaic/interp.c                                                 \
-		   ./mosaic/mosaic_util.c                                            \
-		   ./mosaic/read_mosaic.c                                            \
-		   ./mpp/affinity.c                                                  \
-		   ./mpp/nsclock.c                                                   \
-		   ./mpp/threadloc.c
+		   ../memutils/memuse.c                                               \
+		   ../mosaic/create_xgrid.c                                           \
+		   ../mosaic/gradient_c2l.c                                           \
+		   ../mosaic/interp.c                                                 \
+		   ../mosaic/mosaic_util.c                                            \
+		   ../mosaic/read_mosaic.c                                            \
+		   ../mpp/affinity.c                                                  \
+		   ../mpp/nsclock.c                                                   \
+		   ../mpp/threadloc.c
 
 DEPEND_FILES = $(SRCS_f) $(SRCS_f90) $(SRCS_F) $(SRCS_F90)
 
@@ -147,19 +135,33 @@ OBJS_c   = $(SRCS_c:.c=.o)
 
 OBJS = $(OBJS_f) $(OBJS_f90) $(OBJS_F) $(OBJS_F90) $(OBJS_c)
 
-all default: depend $(LIBRARY)
+all: esmf_make_fragment
+	cp -fp *.a *.mod ../include/*.h "$(FMS_INSTALL)"/.
+
+esmf_make_fragment: depend $(LIBRARY)
+	mkdir -p "$(FMS_INSTALL)"
+	@echo "# ESMF self-describing build dependency makefile fragment"              > fms.mk
+	@echo "# src location /lfs3/projects/hfv3gfs/Samuel.Trahan/fms-component/FV3" >> fms.mk
+	@echo ""                                                                      >> fms.mk
+	@echo "ESMF_DEP_FRONT     ="                                                  >> fms.mk
+	@echo "ESMF_DEP_INCPATH   = $(FMS_INSTALL)"                                   >> fms.mk
+	@echo "ESMF_DEP_CMPL_OBJS ="                                                  >> fms.mk
+	@echo "ESMF_DEP_LINK_OBJS = $(FMS_INSTALL)/libfms.a"                          >> fms.mk
+	@echo "ESMF_DEP_SHRD_PATH ="                                                  >> fms.mk
+	@echo "ESMF_DEP_SHRD_LIBS ="                                                  >> fms.mk
+	mv fms.mk "$(FMS_INSTALL)/."
 
 $(LIBRARY): $(OBJS)
 	$(AR) $(ARFLAGS) $@ $?
 
-.PHONY: clean
+.PHONY: clean esmf_make_fragment all
 clean:
 	@echo "Cleaning fms ... "
 	@echo
-	$(RM) -f $(LIBRARY) *__genmod.f90 *.o */*.o *.mod *.lst *.i depend
+	$(RM) -f $(LIBRARY) *__genmod.f90 *.o */*.o *.mod *.lst *.i depend ../*/*.o
 
-MKDEPENDS = ../mkDepends.pl
-include ../conf/make.rules
+MKDEPENDS = ./mkDepends.pl
+include ./make.rules
 
 # do not include 'depend' file if the target contains string 'clean'
 ifneq (clean,$(findstring clean,$(MAKECMDGOALS)))

--- a/fv3gfs/mkDepends.pl
+++ b/fv3gfs/mkDepends.pl
@@ -1,0 +1,357 @@
+#!/usr/bin/env perl
+
+# Modifications to Brian Eaton's original to relax the restrictions on
+# source file name matching module name and only one module per source
+# file.  See the new "-m" and "-d" options for details.
+#
+# One important limitation remains.  If your module is named "procedure",
+# this script will quietly ignore it.
+#
+#   Tom Henderson
+#   Global Systems Division, NOAA/OAR
+#   Mar 2011
+#
+# Brian Eaton's original comments follow:
+#
+# Generate dependencies in a form suitable for inclusion into a Makefile.
+# The source filenames are provided in a file, one per line.  Directories
+# to be searched for the source files and for their dependencies are provided
+# in another file, one per line.  Output is written to STDOUT.
+#
+# For CPP type dependencies (lines beginning with #include) the dependency
+# search is recursive.  Only dependencies that are found in the specified
+# directories are included.  So, for example, the standard include file
+# stdio.h would not be included as a dependency unless /usr/include were
+# one of the specified directories to be searched.
+#
+# For Fortran module USE dependencies (lines beginning with a case
+# insensitive "USE", possibly preceded by whitespace) the Fortran compiler
+# must be able to access the .mod file associated with the .o file that
+# contains the module.  In order to correctly generate these dependencies
+# two restrictions must be observed.
+# 1) All modules must be contained in files that have the same base name as
+#    the module, in a case insensitive sense.  This restriction implies that
+#    there can only be one module per file.
+# 2) All modules that are to be contained in the dependency list must be
+#    contained in one of the source files in the list provided on the command
+#    line.
+# The reason for the second restriction is that since the makefile doesn't
+# contain rules to build .mod files the dependency takes the form of the .o
+# file that contains the module.  If a module is being used for which the
+# source code is not available (e.g., a module from a library), then adding
+# a .o dependency for that module is a mistake because make will attempt to
+# build that .o file, and will fail if the source code is not available.
+#
+# Author: B. Eaton
+#         Climate Modelling Section, NCAR
+#         Feb 2001
+
+use Getopt::Std;
+use File::Basename;
+
+# Check for usage request.
+@ARGV >= 2                          or usage();
+
+# Process command line.
+my %opt = ();
+getopts( "t:wmd:", \%opt )        or usage();
+my $filepath_arg = shift()        or usage();
+my $srcfile_arg = shift()         or usage();
+@ARGV == 0                        or usage();  # Check that all args were processed.
+
+my $obj_dir;
+if ( defined $opt{'t'} ) { $obj_dir = $opt{'t'}; }
+
+my $additional_obj = "";
+if ( defined $opt{'d'} ) { $additional_obj = $opt{'d'}; }
+
+open(FILEPATH, $filepath_arg) or die "Can't open $filepath_arg: $!\n";
+open(SRCFILES, $srcfile_arg) or die "Can't open $srcfile_arg: $!\n";
+
+# Make list of paths to use when looking for files.
+# Prepend "." so search starts in current directory.  This default is for
+# consistency with the way GNU Make searches for dependencies.
+my @file_paths = <FILEPATH>;
+close(FILEPATH);
+chomp @file_paths;
+unshift(@file_paths,'.');
+foreach $dir (@file_paths) {  # (could check that directories exist here)
+    $dir =~ s!/?\s*$!!;  # remove / and any whitespace at end of directory name
+    ($dir) = glob $dir;  # Expand tildes in path names.
+}
+
+# Make list of files containing source code.
+my @src = <SRCFILES>;
+close(SRCFILES);
+chomp @src;
+
+my %module_files = ();
+
+#TODO:  DRY this out
+if ( defined $opt{'m'} ) {
+    # Attempt to parse each file for /^\s*module/ and extract module names
+    # for each file.
+    my ($f, $name, $path, $suffix, $mod);
+    my @suffixes = ('\.[fF]90', '\.[fF]' );
+    foreach $f (@src) {
+        ($name, $path, $suffix) = fileparse($f, @suffixes);
+        open(FH, $f)  or die "Can't open $f: $!\n";
+        while ( <FH> ) {
+            # Search for module definitions.
+            if ( /^\s*MODULE\s+(\w+)/i ) {
+                ($mod = $1) =~ tr/a-z/A-Z/;
+                # skip "module procedure foo" statements
+                if ( $mod ne "PROCEDURE" ) {
+                    if ( defined $module_files{$mod} ) {
+                        die "Duplicate definitions of module $mod in $module_files{$mod} and $name: $!\n";
+                    }
+                $module_files{$mod} = $path.$name;
+                }
+            }
+        }
+        close( FH );
+    }
+} else {
+    # For each file that may contain a Fortran module (*.[fF]90 *.[fF]) convert the
+    # file's basename to uppercase and use it as a hash key whose value is the file's
+    # basename.  This allows fast identification of the files that contain modules.
+    # The only restriction is that the file's basename and the module name must match
+    # in a case insensitive way.
+    my ($f, $name, $path, $suffix, $mod);
+    my @suffixes = ('\.[fF]90', '\.[fF]' );
+    foreach $f (@src) {
+        ($name, $path, $suffix) = fileparse($f, @suffixes);
+        ($mod = $name) =~ tr/a-z/A-Z/;
+        $module_files{$mod} = $path.$name;
+    }
+}
+
+#print STDERR "\%module_files\n";
+#while ( ($k,$v) = each %module_files ) {
+#    print STDERR "$k => $v\n";
+#}
+
+# Find module and include dependencies of the source files.
+my ($file_path, $rmods, $rincs);
+my %file_modules = ();
+my %file_includes = ();
+my @check_includes = ();
+foreach $f ( @src ) {
+
+    # Find the file in the seach path (@file_paths).
+    unless ($file_path = find_file($f)) {
+	if (defined $opt{'w'}) {print STDERR "$f not found\n";}
+	next;
+    }
+
+    # Find the module and include dependencies.
+    ($rmods, $rincs) = find_dependencies( $file_path );
+
+    # Remove redundancies (a file can contain multiple procedures that have
+    # the same dependencies).
+    $file_modules{$f} = rm_duplicates($rmods);
+    $file_includes{$f} = rm_duplicates($rincs);
+
+    # Make a list of all include files.
+    push @check_includes, @{$file_includes{$f}};
+}
+
+#print STDERR "\%file_modules\n";
+#while ( ($k,$v) = each %file_modules ) {
+#    print STDERR "$k => @$v\n";
+#}
+#print STDERR "\%file_includes\n";
+#while ( ($k,$v) = each %file_includes ) {
+#    print STDERR "$k => @$v\n";
+#}
+#print STDERR "\@check_includes\n";
+#print STDERR "@check_includes\n";
+
+# Find include file dependencies.
+my %include_depends = ();
+while (@check_includes) {
+    $f = shift @check_includes;
+    if (defined($include_depends{$f})) { next; }
+
+    # Mark files not in path so they can be removed from the dependency list.
+    unless ($file_path = find_file($f)) {
+	$include_depends{$f} = -1;
+	next;
+    }
+
+    # Find include file dependencies.
+    ($rmods, $include_depends{$f}) = find_dependencies($file_path);
+
+    # Add included include files to the back of the check_includes list so
+    # that their dependencies can be found.
+    push @check_includes, @{$include_depends{$f}};
+
+    # Add included modules to the include_depends list.
+    if ( @$rmods ) { push @{$include_depends{$f}}, @$rmods;  }
+}
+
+#print STDERR "\%include_depends\n";
+#while ( ($k,$v) = each %include_depends ) {
+#    print STDERR (ref $v ? "$k => @$v\n" : "$k => $v\n");
+#}
+
+# Remove include file dependencies that are not in the Filepath.
+my $i, $ii;
+foreach $f (keys %include_depends) {
+
+    unless (ref $include_depends{$f}) { next; }
+    $rincs = $include_depends{$f};
+    unless (@$rincs) { next; }
+    $ii = 0;
+    $num_incs = @$rincs;
+    for ($i = 0; $i < $num_incs; ++$i) {
+    	if ($include_depends{$$rincs[$ii]} == -1) {
+	    splice @$rincs, $ii, 1;
+	    next;
+	}
+    ++$ii;
+    }
+}
+
+# Substitute the include file dependencies into the %file_includes lists.
+foreach $f (keys %file_includes) {
+    my @expand_incs = ();
+
+    # Initialize the expanded %file_includes list.
+    my $i;
+    unless (@{$file_includes{$f}}) { next; }
+    foreach $i (@{$file_includes{$f}}) {
+	push @expand_incs, $i  unless ($include_depends{$i} == -1);
+    }
+    unless (@expand_incs) {
+	$file_includes{$f} = [];
+	next;
+    }
+
+    # Expand
+    for ($i = 0; $i <= $#expand_incs; ++$i) {
+	push @expand_incs, @{ $include_depends{$expand_incs[$i]} };
+    }
+
+    $file_includes{$f} = rm_duplicates(\@expand_incs);
+}
+
+#print STDERR "expanded \%file_includes\n";
+#while ( ($k,$v) = each %file_includes ) {
+#    print STDERR "$k => @$v\n";
+#}
+
+# Print dependencies to STDOUT.
+foreach $f (sort keys %file_modules) {
+    $f =~ /(.+)\./;
+    $target = "$1.o";
+    if ( defined $opt{'t'} ) { $target = "$opt{'t'}/$1.o"; }
+    push(@{$file_modules{$f}},$additional_obj);
+    print "$target : $f @{noncircular(@{$file_modules{$f}},$target)} @{noncircular(@{$file_includes{$f}},$target)}\n";
+}
+
+#--------------------------------------------------------------------------------------
+
+sub noncircular
+{
+  # Return an array identical to that represented by the first argument, except
+  # for the absence of the element specified by the second argument.
+  my @a=();
+  my $x=pop(@_);
+  foreach (@_) { unless ($_ eq $x) { push(@a,$_) } };
+  return \@a;
+}
+
+sub find_dependencies {
+
+    # Find dependencies of input file.
+    # Use'd Fortran 90 modules are returned in \@mods.
+    # Files that are "#include"d by the cpp preprocessor are returned in \@incs.
+
+    my( $file ) = @_;
+    my( @mods, @incs );
+
+    open(FH, $file)  or die "Can't open $file: $!\n";
+
+    while ( <FH> ) {
+	# Search for "#include" and strip filename when found.
+	if ( /^#include\s+[<"](.*)[>"]/ ) {
+	     push @incs, $1;
+	 }
+	# Search for module dependencies.
+	elsif ( /^\s*USE\s+(\w+)/i ) {
+	    # Return dependency in the form of a .o version of the file that contains
+	    # the module.
+	    ($module = $1) =~ tr/a-z/A-Z/;
+	    if ( defined $module_files{$module} ) {
+	        if ( defined $obj_dir ) {
+		    push @mods, "$obj_dir/$module_files{$module}.o";
+	        } else {
+	            push @mods, "$module_files{$module}.o";
+	        }
+	    }
+	}
+    }
+    close( FH );
+    return (\@mods, \@incs);
+}
+
+#--------------------------------------------------------------------------------------
+
+sub find_file {
+
+# Search for the specified file in the list of directories in the global
+# array @file_paths.  Return the first occurance found, or the null string if
+# the file is not found.
+
+    my($file) = @_;
+    my($dir, $fname);
+
+    foreach $dir (@file_paths) {
+	$fname = "$dir/$file";
+	if ( -f  $fname ) { return $fname; }
+    }
+    return '';  # file not found
+}
+
+#--------------------------------------------------------------------------------------
+
+sub rm_duplicates {
+
+# Return a list with duplicates removed.
+
+    my ($in) = @_;       # input arrary reference
+    my @out = ();
+    my $i;
+    my %h = ();
+    foreach $i (@$in) {
+	$h{$i} = '';
+    }
+    @out = keys %h;
+    return \@out;
+}
+
+#--------------------------------------------------------------------------------------
+
+sub usage {
+    ($ProgName = $0) =~ s!.*/!!;            # name of program
+    die <<EOF
+SYNOPSIS
+     $ProgName [-t dir] [-w] [-m] [-d objfile] Filepath Srcfiles
+OPTIONS
+     -t dir
+          Target directory.  If this option is set the .o files that are
+          targets in the dependency rules have the form dir/file.o.
+     -w   Print warnings to STDERR about files or dependencies not found.
+     -m   Search source files for module definitions instead of assuming
+          that module names match file base names.  With this option, more
+          than one module is allowed to reside in a single source file.
+     -d objfile
+          Additional object file to be added to every dependence.
+ARGUMENTS
+     Filepath is the name of a file containing the directories (one per
+     line) to be searched for dependencies.  Srcfiles is the name of a
+     file containing the names of files (one per line) for which
+     dependencies will be generated.
+EOF
+}


### PR DESCRIPTION
There is an fv3gfs/ directory with a build system that purports to be for the FV3 GFS.  The contents of that directory will not build from the FMS repository; they  have to be copied up to the FV3 repository and run there.  We need to build FMS outside FV3 within the GFS to support coupled modeling work, wherein FV3 and MOM6 are coupled within NEMS.  

These changes allow FMS to be built independently, using the fv3gfs/ makefiles.  It is set up to seamlessly integrate within NEMS applications.

The changes are entirely within the fv3gfs/ directory, so there is no chance of impacting other FMS work.  I am already working with the NEMS code manager and FV3 GFS code manager to ensure the NEMS is unaffected.  All FMS-using NEMS applications pass their regression tests.  The NEMS and FV3 GFS code managers are ready to commit once the FMS repository has these updates.

We will also need a warsaw_201803_fv3gfs_make tag, or some similar name of your choosing.