### PR TITLE
Bugfix for Intel 18 compiler in mpp/include/mpp_gather.h

### DIFF
--- a/mpp/include/mpp_gather.h
+++ b/mpp/include/mpp_gather.h
@@ -143,7 +143,7 @@ subroutine MPP_GATHER_PELIST_3D_(is, ie, js, je, nk, pelist, array_seg, data, is
    type array3D
      MPP_TYPE_, dimension(:,:,:), allocatable :: data
    endtype array3D
-   type(array3d), dimension(size(pelist)) :: temp
+   type(array3d), dimension(:), allocatable :: temp
 
    if (.not.ANY(mpp_pe().eq.pelist(:))) return
 
@@ -178,6 +178,7 @@ subroutine MPP_GATHER_PELIST_3D_(is, ie, js, je, nk, pelist, array_seg, data, is
 
 ! gather indices into global index on root_pe
    if (is_root_pe) then
+     allocate(temp(1:size(pelist)))
      do i = 1, size(pelist)
 ! root_pe data copy - no send to self
        if (pelist(i).eq.root_pe) then
@@ -229,6 +230,7 @@ subroutine MPP_GATHER_PELIST_3D_(is, ie, js, je, nk, pelist, array_seg, data, is
          deallocate(temp(i)%data)
        endif
      enddo
+     deallocate(temp)
    else
 !    non root_pe's send data to root_pe
      msgsize = (my_ind(2)-my_ind(1)+1) * (my_ind(4)-my_ind(3)+1) * nk


### PR DESCRIPTION
Using the Intel 18 compiler on Cheyenne, NEMSfv3gfs crashes at the end of routine MPP_GATHER_PELIST_3D_. This is related to the object temp defined as

`type(array3d), dimension(size(pelist)) :: temp`

in the original code. Processors/MPI tasks for which `is_root_pe==.false.` do not make use of this derived data type and as such do not allocate members `temp(i)%data`. The crash does not happen if the code is compiled without optimization (NEMSfv3gfs's DEBUG mode), and it also does not happen with Intel 17, i.e. it is clearly a compiler bug.

This PR solves the problem by making temp an allocatable data structure and allocate/deallocate it inside the `is_root_pe` if-blocks. The proposed solution does not change the results, does not increase the runtime and does not increase the memory footprint.
