### PR TITLE
fms_platform.h: correct preprocessor directives for quad precision computing

### DIFF
--- a/include/fms_platform.h
+++ b/include/fms_platform.h
@@ -92,8 +92,8 @@
 #define NF_GET_ATT_REAL nf_get_att_double
 #endif
 
-#if defined __CRAYXT_COMPUTE_LINUX_TARGET || defined __GFORTRAN__
-!Cray XT compilers do not support real*16 computation
+#if defined __CRAYXT_COMPUTE_LINUX_TARGET || defined __PGI
+!Cray XT and PGI compilers do not support real*16 computation
 !also known as 128-bit or quad precision
 #define NO_QUAD_PRECISION
 #endif


### PR DESCRIPTION
This PR corrects/updates the preprocessor directives in include/fms_platform.h.

As of version 4.6.0, the GNU compilers do support real*16 computations via libquadmath. However, the PGI compilers (as of today) still don't.

With the changes in this PR, FMS can be built with the PGI compilers, and GNU compilers can make use of real*16 computations. These changes were tested with gfortran 6.2.0 on Theia, gfortran 6.3.0 on Cheyenne, gfortran 6.2.0 and gfortran 8.1.0 on MacOSX, pgf90 17.7 on Theia, and pgf90 17.9 on Cheyenne.