### PR TITLE
enable/disable affinity.c on macOS (APPLE)

### DIFF
--- a/mpp/affinity.c
+++ b/mpp/affinity.c
@@ -29,9 +29,14 @@
 
 static pid_t gettid(void)
 {
+#ifdef __APPLE__
+  return syscall(SYS_gettid);
+#else
   return syscall(__NR_gettid);
+#endif
 }
 
+#ifndef __APPLE__
 /*
  * Returns this thread's CPU affinity, if bound to a single core,
  * or else -1.
@@ -80,3 +85,4 @@ void set_cpu_affinity( int cpu )
 }
 
 void set_cpu_affinity_(int *cpu) { set_cpu_affinity(*cpu); }	/* Fortran interface */
+#endif


### PR DESCRIPTION
Simple bugfix to allow building on FMS on macOS.

Change-Id: Id17e31c82101c89b3d047c8d04a1027eb0b3dc03