### PR TITLE
affinity.c get_cpu_affinity only one return

### DIFF
--- a/mpp/affinity.c
+++ b/mpp/affinity.c
@@ -67,7 +67,7 @@ int get_cpu_affinity_(void) { return get_cpu_affinity(); }	/* Fortran interface 
 /*
  * Set CPU affinity to one core.
  */
-void set_cpu_affinity( int cpu )
+int set_cpu_affinity( int cpu )
 {
   cpu_set_t coremask;		/* core affinity mask */
 
@@ -79,4 +79,4 @@ void set_cpu_affinity( int cpu )
   return 0;
 }
 
-void set_cpu_affinity_(int *cpu) { return set_cpu_affinity(*cpu); }	/* Fortran interface */
+int set_cpu_affinity_(int *cpu) { return set_cpu_affinity(*cpu); }	/* Fortran interface */

--- a/mpp/affinity.c
+++ b/mpp/affinity.c
@@ -74,8 +74,9 @@ void set_cpu_affinity( int cpu )
   CPU_ZERO(&coremask);
   CPU_SET(cpu,&coremask);
   if (sched_setaffinity(gettid(),sizeof(cpu_set_t),&coremask) != 0) {
-    fprintf(stderr,"Unable to set thread %d affinity. %s\n",gettid(),strerror(errno));
+    return -1;
   }
+  return 0;
 }
 
-void set_cpu_affinity_(int *cpu) { set_cpu_affinity(*cpu); }	/* Fortran interface */
+void set_cpu_affinity_(int *cpu) { return set_cpu_affinity(*cpu); }	/* Fortran interface */

--- a/mpp/affinity.c
+++ b/mpp/affinity.c
@@ -58,8 +58,7 @@ int get_cpu_affinity(void)
     }
   }
 
-  if (last_cpu != -1) {return (first_cpu);}
-  return (last_cpu == -1) ? first_cpu : -1;
+  return first_cpu;
 }
 
 int get_cpu_affinity_(void) { return get_cpu_affinity(); }	/* Fortran interface */


### PR DESCRIPTION
The `get_cpu_affinity` function in `mpp/affinity.c` had two return lines
that essentially resulted in only one possible return value `first_cpu`.
This commite reduces the return statement to simply `return first_cpu`.

Resolves #62.

This needs to be merged at the same time as NOAA-GFDL/coupler#9.