### PR TITLE
add default fortran flags set in configure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,54 @@
 *.o
 *.mod
 *.s
-Makefile*
 pathnames*
+
+Makefile
+# From https://github.com/github/gitignore/blob/master/Autotools.gitignore
+# http://www.gnu.org/software/automake
+Makefile.in
+/ar-lib
+/mdate-sh
+/py-compile
+/test-driver
+/ylwrap
+*.log
+*.trs
+
+# http://www.gnu.org/software/autoconf
+autom4te.cache
+/autoscan.log
+/autoscan-*.log
+/aclocal.m4
+/compile
+/config.guess
+/config.h.in
+/config.log
+/config.status
+/config.sub
+/configure
+/configure.scan
+/depcomp
+/install-sh
+/missing
+/stamp-h1
+.deps
+
+# https://www.gnu.org/software/libtool/
+libtool
+/ltmain.sh
+*.lo
+*.la
+.libs
+
+# http://www.gnu.org/software/texinfo
+/texinfo.tex
+
+# http://www.gnu.org/software/m4/
+m4/libtool.m4
+m4/ltoptions.m4
+m4/ltsugar.m4
+m4/ltversion.m4
+m4/lt~obsolete.m4
+
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,44 @@
+# This Travis-CI file for testing the build, and eventually the
+# functionality of the libfms library.
+#
+# This Travis-CI file was created based off the NOAA-GFDL/MOM6
+# Travis-CI file.
+
+# FMS is not a c-language project, although there are a few c-language
+# sources.  However, this is the best choice.
+language: c
+dist: trusty
+sudo: false
+
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - pkg-config netcdf-bin libnetcdf-dev openmpi-bin libopenmpi-dev gfortran
+
+before_install:
+  - test -n $CC && unset CC
+  - test -n $FC && unset FC
+  - test -n $CPPFLAGS && unset CPPFLAGS
+  - test -n FCFLAGS && unset FCFLAGS
+
+before_script:
+  - export CC=mpicc
+  - export FC=mpif90
+  - export CPPFLAGS='-I/usr/include'
+  - export FCFLAGS='-fcray-pointer -fdefault-double-8 -fdefault-real-8 -Waliasing -ffree-line-length-none -fno-range-check'
+
+env:
+  global:
+    - CC=mpicc
+    - FC=mpif90
+    - CPPFLAGS='-I/usr/include'
+    - FCFLAGS='-fcray-pointer -fdefault-double-8 -fdefault-real-8 -Waliasing -ffree-line-length-none -fno-range-check'
+    - LDFLAGS='-L/usr/lib'
+  
+script:
+  - autoreconf -i
+  - ./configure
+  - make -j distcheck
+ 

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,0 +1,16 @@
+# This is the main automake file for FMS.
+# Ed Hartnett 2/21/2019
+
+# This directory stores libtool macros, put there by aclocal.
+ACLOCAL_AMFLAGS = -I m4
+
+# Make targets will be run in each subdirectory. Order is significant.
+SUBDIRS = include platform constants tridiagonal mpp memutils fms	\
+mosaic time_manager diag_manager drifters axis_utils horiz_interp	\
+time_interp diag_integral column_diagnostics block_control		\
+data_override astronomy field_manager coupler monin_obukhov		\
+interpolator fft amip_interp oda_tools exchange topography		\
+tracer_manager station_data sat_vapor_pres random_numbers libFMS	\
+test_fms
+
+EXTRA_DIST = README.md

--- a/amip_interp/Makefile.am
+++ b/amip_interp/Makefile.am
@@ -1,0 +1,27 @@
+# This is an automake file for the amip_interp directory of the FMS
+# package.
+
+# Ed Hartnett 2/22/19
+
+# Include .h and .mod files.
+AM_CPPFLAGS = -I${top_srcdir}/include
+AM_CPPFLAGS += -I${top_builddir}/time_interp
+AM_CPPFLAGS += -I${top_builddir}/time_manager
+AM_CPPFLAGS += -I${top_builddir}/mpp
+AM_CPPFLAGS += -I${top_builddir}/horiz_interp
+AM_CPPFLAGS += -I${top_builddir}/fms
+AM_CPPFLAGS += -I${top_builddir}/constants
+AM_CPPFLAGS += -I${top_builddir}/platform
+
+# Build this uninstalled convenience library.
+noinst_LTLIBRARIES = libamip_interp.la
+
+# The convenience library depends on its source.
+libamip_interp_la_SOURCES = amip_interp.F90
+
+# Mod file depends on its o file, is built and then installed.
+amip_interp_mod.mod: amip_interp.$(OBJEXT)
+BUILT_SOURCES = amip_interp_mod.mod
+include_HEADERS = amip_interp_mod.mod
+
+CLEANFILES = *.mod

--- a/amip_interp/Makefile.am
+++ b/amip_interp/Makefile.am
@@ -3,6 +3,9 @@
 
 # Ed Hartnett 2/22/19
 
+# Use any Fortran flags set by configure.
+AM_FCFLAGS = ${FMS_FCFLAGS}
+
 # Include .h and .mod files.
 AM_CPPFLAGS = -I${top_srcdir}/include
 AM_CPPFLAGS += -I${top_builddir}/time_interp

--- a/astronomy/Makefile.am
+++ b/astronomy/Makefile.am
@@ -1,0 +1,26 @@
+# This is an automake file for the astronomy directory of the FMS
+# package.
+
+# Ed Hartnett 2/22/19
+
+# Include .h and .mod files.
+AM_CPPFLAGS = -I${top_srcdir}/include
+AM_CPPFLAGS += -I${top_builddir}/fms
+AM_CPPFLAGS += -I${top_builddir}/time_manager
+AM_CPPFLAGS += -I${top_builddir}/constants
+AM_CPPFLAGS += -I${top_builddir}/mpp
+
+# Build this uninstalled convenience library.
+noinst_LTLIBRARIES = libastronomy.la
+
+# The convenience library depends on its source.
+libastronomy_la_SOURCES = astronomy.F90
+
+# Mod file depends on its o file, is built and then installed.
+astronomy_mod.mod: astronomy.$(OBJEXT)
+BUILT_SOURCES = astronomy_mod.mod
+include_HEADERS = astronomy_mod.mod
+
+EXTRA_DIST = astronomy.tech.ps
+
+CLEANFILES = *.mod

--- a/astronomy/Makefile.am
+++ b/astronomy/Makefile.am
@@ -3,6 +3,9 @@
 
 # Ed Hartnett 2/22/19
 
+# Use any Fortran flags set by configure.
+AM_FCFLAGS = ${FMS_FCFLAGS}
+
 # Include .h and .mod files.
 AM_CPPFLAGS = -I${top_srcdir}/include
 AM_CPPFLAGS += -I${top_builddir}/fms

--- a/axis_utils/Makefile.am
+++ b/axis_utils/Makefile.am
@@ -1,0 +1,23 @@
+# This is an automake file for the axis_utils directory of the FMS
+# package.
+
+# Ed Hartnett 2/22/19
+
+# Include .h and .mod files.
+AM_CPPFLAGS = -I${top_srcdir}/include
+AM_CPPFLAGS += -I${top_builddir}/mpp
+AM_CPPFLAGS += -I${top_builddir}/fms
+AM_CPPFLAGS += -I${top_builddir}/constants
+
+# Build this uninstalled convenience library.
+noinst_LTLIBRARIES = libaxis_utils.la
+
+# The convenience library depends on its source.
+libaxis_utils_la_SOURCES = axis_utils.F90
+
+# Mod file depends on its o file, is built and then installed.
+axis_utils_mod.mod: axis_utils.$(OBJEXT)
+include_HEADERS = axis_utils_mod.mod
+BUILT_SOURCES = axis_utils_mod.mod
+
+CLEANFILES = *.mod

--- a/axis_utils/Makefile.am
+++ b/axis_utils/Makefile.am
@@ -3,6 +3,9 @@
 
 # Ed Hartnett 2/22/19
 
+# Use any Fortran flags set by configure.
+AM_FCFLAGS = ${FMS_FCFLAGS}
+
 # Include .h and .mod files.
 AM_CPPFLAGS = -I${top_srcdir}/include
 AM_CPPFLAGS += -I${top_builddir}/mpp

--- a/block_control/Makefile.am
+++ b/block_control/Makefile.am
@@ -1,0 +1,21 @@
+# This is an automake file for the block_control directory of the FMS
+# package.
+
+# Ed Hartnett 2/22/19
+
+# Include .h and .mod files.
+AM_CPPFLAGS = -I${top_srcdir}/include
+AM_CPPFLAGS += -I${top_builddir}/mpp
+
+# Build this uninstalled convenience library.
+noinst_LTLIBRARIES = libblock_control.la
+
+# The convenience library depends on its source.
+libblock_control_la_SOURCES = block_control.F90
+
+# Mod file depends on its o file, is built and then installed.
+block_control_mod.mod: block_control.$(OBJEXT)
+BUILT_SOURCES = block_control_mod.mod
+include_HEADERS = block_control_mod.mod
+
+CLEANFILES = *.mod

--- a/block_control/Makefile.am
+++ b/block_control/Makefile.am
@@ -3,6 +3,9 @@
 
 # Ed Hartnett 2/22/19
 
+# Use any Fortran flags set by configure.
+AM_FCFLAGS = ${FMS_FCFLAGS}
+
 # Include .h and .mod files.
 AM_CPPFLAGS = -I${top_srcdir}/include
 AM_CPPFLAGS += -I${top_builddir}/mpp

--- a/column_diagnostics/Makefile.am
+++ b/column_diagnostics/Makefile.am
@@ -1,0 +1,24 @@
+# This is an automake file for the column_diagnostics directory of the FMS
+# package.
+
+# Ed Hartnett 2/22/19
+
+# Include .h and .mod files.
+AM_CPPFLAGS = -I${top_srcdir}/include
+AM_CPPFLAGS += -I${top_builddir}/mpp
+AM_CPPFLAGS += -I${top_builddir}/fms
+AM_CPPFLAGS += -I${top_builddir}/time_manager
+AM_CPPFLAGS += -I${top_builddir}/constants
+
+# Build this uninstalled convenience library.
+noinst_LTLIBRARIES = libcolumn_diagnostics.la
+
+# The convenience library depends on its source.
+libcolumn_diagnostics_la_SOURCES = column_diagnostics.F90
+
+# Mod file depends on its o file, is built and then installed.
+column_diagnostics_mod.mod: column_diagnostics.$(OBJEXT)
+BUILT_SOURCES = column_diagnostics_mod.mod
+include_HEADERS = column_diagnostics_mod.mod
+
+CLEANFILES = *.mod

--- a/column_diagnostics/Makefile.am
+++ b/column_diagnostics/Makefile.am
@@ -3,6 +3,9 @@
 
 # Ed Hartnett 2/22/19
 
+# Use any Fortran flags set by configure.
+AM_FCFLAGS = ${FMS_FCFLAGS}
+
 # Include .h and .mod files.
 AM_CPPFLAGS = -I${top_srcdir}/include
 AM_CPPFLAGS += -I${top_builddir}/mpp

--- a/configure.ac
+++ b/configure.ac
@@ -1,0 +1,98 @@
+# This is the main configure file for the FMS package.
+# Ed Hartnett 2/21/2019
+
+AC_PREREQ([2.59])
+
+# Initialize with name, version, and support email address.
+AC_INIT([FMS], [2.0-development], [])
+
+# Find out about the host we're building on.
+AC_CANONICAL_HOST
+
+# Find out about the target we're building for.
+AC_CANONICAL_TARGET
+
+AM_INIT_AUTOMAKE([foreign dist-zip subdir-objects])
+
+# Keep libtool macros in an m4 directory.
+AC_CONFIG_MACRO_DIR([m4])
+
+# Set up libtool.
+LT_PREREQ([2.4])
+LT_INIT()
+
+# Find the C compiler.
+AC_PROG_CC
+AM_PROG_CC_C_O
+AC_C_CONST
+AC_PROG_CPP
+
+# Find the Fortran compiler.
+AC_PROG_FC
+AC_PROG_F77
+
+# Find the install program.
+AC_PROG_INSTALL
+
+# Check to see if any macros must be set to enable large (>2GB) files.
+AC_SYS_LARGEFILE
+
+# Require MPI.
+AC_CHECK_FUNC([MPI_Init], [], [AC_MSG_ERROR([MPI C library required to build FMS])])
+
+# Check for netCDF C library.
+AC_SEARCH_LIBS([nc_create], [netcdf], [],
+                            [AC_MSG_ERROR([Can't find or link to the netcdf C library, set CPPFLAGS/LDFLAGS.])])
+
+# Check for netCDF Fortran library.
+AC_LANG_PUSH(Fortran)
+AC_SEARCH_LIBS([nf_create], [netcdff], [],
+                            [AC_MSG_ERROR([Can't find or link to the netcdf Fortran library, set CPPFLAGS/LDFLAGS.])])
+AC_LANG_POP(Fortran)
+
+# Require netCDF.
+#AC_CHECK_FUNC([nf_open], [], [AC_MSG_ERROR([NetCDF Fortran library required to build FMS])])
+
+# These defines are required for the build.
+AC_DEFINE([use_netCDF], [1])
+AC_DEFINE([use_libMPI], [1])
+
+# These files will be created when the configure script is run.
+AC_CONFIG_FILES([Makefile
+        include/Makefile
+        amip_interp/Makefile
+        time_interp/Makefile
+        time_manager/Makefile
+        constants/Makefile
+        platform/Makefile
+        fms/Makefile
+        mpp/Makefile
+        mpp/include/Makefile
+        tridiagonal/Makefile
+        tracer_manager/Makefile
+        topography/Makefile
+        station_data/Makefile
+        oda_tools/Makefile
+        mosaic/Makefile
+        monin_obukhov/Makefile
+        memutils/Makefile
+        interpolator/Makefile
+        horiz_interp/Makefile
+        field_manager/Makefile
+        fft/Makefile
+        exchange/Makefile
+        drifters/Makefile
+        diag_manager/Makefile
+        diag_integral/Makefile
+        data_override/Makefile
+        column_diagnostics/Makefile
+        block_control/Makefile
+        axis_utils/Makefile
+        astronomy/Makefile
+        coupler/Makefile
+        sat_vapor_pres/Makefile
+        random_numbers/Makefile
+        libFMS/Makefile
+        test_fms/Makefile
+        ])
+AC_OUTPUT()

--- a/configure.ac
+++ b/configure.ac
@@ -63,12 +63,13 @@ AC_DEFINE([use_libMPI], [1])
 
 # It's a bad idea for the build system to set flags for the
 # user. However, this is a replacement for a build system that did
-# exactly that, so we will reproduce existing functionality.
+# exactly that, so we will reproduce existing functionality. Whatever
+# the user sets as FCFLAGS will be appended to these flags.
 AC_MSG_CHECKING([what Fortran flags should be used])
 if test "$enable_fortran_flags" = yes; then
    AC_SUBST([FMS_FCFLAGS], ["-fcray-pointer -fdefault-double-8 -fdefault-real-8 -ffree-line-length-none -fno-range-check"])
 fi
-AC_MSG_RESULT([$FMS_FCFLAGS])
+AC_MSG_RESULT([$FMS_FCFLAGS $FCFLAGS])
 
 # These files will be created when the configure script is run.
 AC_CONFIG_FILES([Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -37,6 +37,13 @@ AC_PROG_INSTALL
 # Check to see if any macros must be set to enable large (>2GB) files.
 AC_SYS_LARGEFILE
 
+# Does the user want to turn off flags?
+AC_MSG_CHECKING([whether we should set fortran flags])
+AC_ARG_ENABLE([fortran-flags], [AS_HELP_STRING([--disable-fortran-flags],
+              [do not attempt to set any Fortran flags])])
+test "x$enable_fortran_flags" = xno || enable_fortran_flags=yes
+AC_MSG_RESULT([$enable_fortran_flags])
+
 # Require MPI.
 AC_CHECK_FUNC([MPI_Init], [], [AC_MSG_ERROR([MPI C library required to build FMS])])
 
@@ -50,12 +57,18 @@ AC_SEARCH_LIBS([nf_create], [netcdff], [],
                             [AC_MSG_ERROR([Can't find or link to the netcdf Fortran library, set CPPFLAGS/LDFLAGS.])])
 AC_LANG_POP(Fortran)
 
-# Require netCDF.
-#AC_CHECK_FUNC([nf_open], [], [AC_MSG_ERROR([NetCDF Fortran library required to build FMS])])
-
 # These defines are required for the build.
 AC_DEFINE([use_netCDF], [1])
 AC_DEFINE([use_libMPI], [1])
+
+# It's a bad idea for the build system to set flags for the
+# user. However, this is a replacement for a build system that did
+# exactly that, so we will reproduce existing functionality.
+AC_MSG_CHECKING([what Fortran flags should be used])
+if test "$enable_fortran_flags" = yes; then
+   AC_SUBST([FMS_FCFLAGS], ["-fcray-pointer -fdefault-double-8 -fdefault-real-8 -ffree-line-length-none -fno-range-check"])
+fi
+AC_MSG_RESULT([$FMS_FCFLAGS])
 
 # These files will be created when the configure script is run.
 AC_CONFIG_FILES([Makefile

--- a/constants/Makefile.am
+++ b/constants/Makefile.am
@@ -1,0 +1,21 @@
+# This is an automake file for the constants directory of the FMS
+# package.
+
+# Ed Hartnett 2/22/19
+
+# Include .h and .mod files.
+AM_CPPFLAGS = -I${top_srcdir}/include
+AM_CPPFLAGS += -I${top_builddir}/platform
+
+# Build this uninstalled convenience library.
+noinst_LTLIBRARIES = libconstants.la
+
+# The convenience library depends on its source.
+libconstants_la_SOURCES = constants.F90
+
+# Mod file depends on its o file, is built and then installed.
+constants_mod.mod: constants.$(OBJEXT)
+BUILT_SOURCES = constants_mod.mod
+include_HEADERS = constants_mod.mod
+
+CLEANFILES = *.mod

--- a/constants/Makefile.am
+++ b/constants/Makefile.am
@@ -3,6 +3,9 @@
 
 # Ed Hartnett 2/22/19
 
+# Use any Fortran flags set by configure.
+AM_FCFLAGS = ${FMS_FCFLAGS}
+
 # Include .h and .mod files.
 AM_CPPFLAGS = -I${top_srcdir}/include
 AM_CPPFLAGS += -I${top_builddir}/platform

--- a/coupler/Makefile.am
+++ b/coupler/Makefile.am
@@ -1,0 +1,39 @@
+# This is an automake file for the coupler directory of the FMS
+# package.
+
+# Ed Hartnett 2/22/19
+
+# Include .h and .mod files.
+AM_CPPFLAGS = -I${top_srcdir}/include
+AM_CPPFLAGS += -I${top_builddir}/constants
+AM_CPPFLAGS += -I${top_builddir}/fms
+AM_CPPFLAGS += -I${top_builddir}/mpp
+AM_CPPFLAGS += -I${top_builddir}/time_manager
+AM_CPPFLAGS += -I${top_builddir}/diag_manager
+AM_CPPFLAGS += -I${top_builddir}/data_override
+AM_CPPFLAGS += -I${top_builddir}/field_manager
+
+# Build these uninstalled convenience libraries.
+noinst_LTLIBRARIES = libcoupler_types.la libensemble_manager.la	\
+libatmos_ocean_fluxes.la
+
+# Each convenience library depends on its source.
+libcoupler_types_la_SOURCES = coupler_types.F90
+libensemble_manager_la_SOURCES = ensemble_manager.F90
+libatmos_ocean_fluxes_la_SOURCES = atmos_ocean_fluxes.F90
+
+# Each mod file depends on the .o file.
+coupler_types_mod.mod: coupler_types.$(OBJEXT)
+ensemble_manager_mod.mod: ensemble_manager.$(OBJEXT)
+atmos_ocean_fluxes_mod.mod: atmos_ocean_fluxes.$(OBJEXT)
+
+# Some mods are dependant on other mods in this dir.
+atmos_ocean_fluxes.$(OBJEXT): coupler_types_mod.mod
+
+# Mod files are built and then installed as headers.
+MODFILES = coupler_types_mod.mod ensemble_manager_mod.mod	\
+atmos_ocean_fluxes_mod.mod
+include_HEADERS = $(MODFILES)
+BUILT_SOURCES = $(MODFILES)
+
+CLEANFILES = *.mod

--- a/coupler/Makefile.am
+++ b/coupler/Makefile.am
@@ -3,6 +3,9 @@
 
 # Ed Hartnett 2/22/19
 
+# Use any Fortran flags set by configure.
+AM_FCFLAGS = ${FMS_FCFLAGS}
+
 # Include .h and .mod files.
 AM_CPPFLAGS = -I${top_srcdir}/include
 AM_CPPFLAGS += -I${top_builddir}/constants

--- a/data_override/Makefile.am
+++ b/data_override/Makefile.am
@@ -1,0 +1,28 @@
+# This is an automake file for the data_override directory of the FMS
+# package.
+
+# Ed Hartnett 2/22/19
+
+# Include .h and .mod files.
+AM_CPPFLAGS = -I${top_srcdir}/include
+AM_CPPFLAGS += -I${top_builddir}/platform
+AM_CPPFLAGS += -I${top_builddir}/constants
+AM_CPPFLAGS += -I${top_builddir}/mpp
+AM_CPPFLAGS += -I${top_builddir}/horiz_interp
+AM_CPPFLAGS += -I${top_builddir}/time_interp
+AM_CPPFLAGS += -I${top_builddir}/time_manager
+AM_CPPFLAGS += -I${top_builddir}/fms
+AM_CPPFLAGS += -I${top_builddir}/axis_utils
+
+# Build this uninstalled convenience library.
+noinst_LTLIBRARIES = libdata_override.la
+
+# The convenience library depends on its source.
+libdata_override_la_SOURCES = data_override.F90
+
+# Mod file depends on its o file, is built and then installed.
+data_override_mod.mod: data_override.$(OBJEXT)
+BUILT_SOURCES = data_override_mod.mod
+include_HEADERS = data_override_mod.mod
+
+CLEANFILES = *.mod

--- a/data_override/Makefile.am
+++ b/data_override/Makefile.am
@@ -3,6 +3,9 @@
 
 # Ed Hartnett 2/22/19
 
+# Use any Fortran flags set by configure.
+AM_FCFLAGS = ${FMS_FCFLAGS}
+
 # Include .h and .mod files.
 AM_CPPFLAGS = -I${top_srcdir}/include
 AM_CPPFLAGS += -I${top_builddir}/platform

--- a/diag_integral/Makefile.am
+++ b/diag_integral/Makefile.am
@@ -1,0 +1,26 @@
+# This is an automake file for the diag_integral directory of the FMS
+# package.
+
+# Ed Hartnett 2/22/19
+
+# Include .h and .mod files.
+AM_CPPFLAGS = -I${top_srcdir}/include
+AM_CPPFLAGS += -I${top_builddir}/time_manager
+AM_CPPFLAGS += -I${top_builddir}/mpp
+AM_CPPFLAGS += -I${top_builddir}/fms
+AM_CPPFLAGS += -I${top_builddir}/constants
+
+# Build this uninstalled convenience library.
+noinst_LTLIBRARIES = libdiag_integral.la
+
+# The convenience library depends on its source.
+libdiag_integral_la_SOURCES = diag_integral.F90
+
+# Mod file depends on its o file, is built and then installed.
+diag_integral_mod.mod: diag_integral.$(OBJEXT)
+include_HEADERS = diag_integral_mod.mod
+BUILT_SOURCES = diag_integral_mod.mod
+
+EXTRA_DIST = diag_integral.html
+
+CLEANFILES = *.mod

--- a/diag_integral/Makefile.am
+++ b/diag_integral/Makefile.am
@@ -3,6 +3,9 @@
 
 # Ed Hartnett 2/22/19
 
+# Use any Fortran flags set by configure.
+AM_FCFLAGS = ${FMS_FCFLAGS}
+
 # Include .h and .mod files.
 AM_CPPFLAGS = -I${top_srcdir}/include
 AM_CPPFLAGS += -I${top_builddir}/time_manager

--- a/diag_manager/Makefile.am
+++ b/diag_manager/Makefile.am
@@ -1,0 +1,53 @@
+# This is an automake file for the diag_manager directory of the FMS
+# package.
+
+# Ed Hartnett 2/22/19
+
+# Include .h and .mod files.
+AM_CPPFLAGS = -I${top_srcdir}/include
+AM_CPPFLAGS += -I${top_builddir}/mpp
+AM_CPPFLAGS += -I${top_builddir}/fms
+AM_CPPFLAGS += -I${top_builddir}/time_manager
+AM_CPPFLAGS += -I${top_builddir}/constants
+
+# Build these uninstalled convenience libraries.
+noinst_LTLIBRARIES = libdiag_data.la libdiag_axis.la libdiag_grid.la	\
+libdiag_output.la libdiag_util.la libdiag_manifest.la			\
+libdiag_table.la libdiag_manager.la
+
+# Each convenience library depends on its source.
+libdiag_axis_la_SOURCES = diag_axis.F90
+libdiag_data_la_SOURCES = diag_data.F90
+libdiag_grid_la_SOURCES = diag_grid.F90
+libdiag_manager_la_SOURCES = diag_manager.F90
+libdiag_manifest_la_SOURCES = diag_manifest.F90
+libdiag_output_la_SOURCES = diag_output.F90
+libdiag_table_la_SOURCES = diag_table.F90
+libdiag_util_la_SOURCES = diag_util.F90
+
+# Each mod file depends on the .o file.
+diag_axis_mod.mod: diag_axis.$(OBJEXT)
+diag_grid_mod.mod: diag_grid.$(OBJEXT)
+diag_manifest_mod.mod: diag_manifest.$(OBJEXT)
+diag_table_mod.mod: diag_table.$(OBJEXT)
+diag_data_mod.mod: diag_data.$(OBJEXT)
+diag_manager_mod.mod: diag_manager.$(OBJEXT)
+diag_output_mod.mod: diag_output.$(OBJEXT)
+diag_util_mod.mod: diag_util.$(OBJEXT)
+
+# Some mods are dependant on other mods in this dir.
+diag_axis.$(OBJEXT): diag_data_mod.mod
+diag_manifest.$(OBJEXT): diag_data_mod.mod
+diag_output.$(OBJEXT): diag_axis_mod.mod diag_data_mod.mod
+diag_util.$(OBJEXT): diag_data_mod.mod diag_axis_mod.mod diag_output_mod.mod diag_grid_mod.mod
+diag_table.$(OBJEXT): diag_data_mod.mod diag_util_mod.mod
+diag_manager.$(OBJEXT): diag_axis_mod.mod diag_data_mod.mod diag_util_mod.mod diag_output_mod.mod diag_grid_mod.mod diag_table_mod.mod diag_manifest_mod.mod
+
+# Mod files are built and then installed as headers.
+MODFILES = diag_data_mod.mod diag_axis_mod.mod diag_grid_mod.mod	\
+diag_output_mod.mod diag_util_mod.mod diag_manifest_mod.mod		\
+diag_table_mod.mod diag_manager_mod.mod
+include_HEADERS = $(MODFILES)
+BUILT_SOURCES = $(MODFILES)
+
+CLEANFILES = *.mod

--- a/diag_manager/Makefile.am
+++ b/diag_manager/Makefile.am
@@ -3,6 +3,9 @@
 
 # Ed Hartnett 2/22/19
 
+# Use any Fortran flags set by configure.
+AM_FCFLAGS = ${FMS_FCFLAGS}
+
 # Include .h and .mod files.
 AM_CPPFLAGS = -I${top_srcdir}/include
 AM_CPPFLAGS += -I${top_builddir}/mpp

--- a/drifters/Makefile.am
+++ b/drifters/Makefile.am
@@ -1,0 +1,46 @@
+# This is an automake file for the drifters directory of the FMS
+# package.
+
+# Ed Hartnett 2/22/19
+
+# Turn off parallel builds in this directory.
+.NOTPARALLEL:
+
+# Include .h and .mod files.
+AM_CPPFLAGS = -I${top_srcdir}/include
+AM_CPPFLAGS += -I${top_builddir}/mpp
+
+# Build these uninstalled convenience libraries.
+noinst_LTLIBRARIES = libdrifters_core.la libdrifters_input.la	\
+libdrifters_comm.la libdrifters_io.la libcloud_interpolator.la	\
+libdrifters.la libquicksort.la
+
+# Each convenience library depends on its source.
+libdrifters_la_SOURCES = drifters.F90
+libdrifters_core_la_SOURCES = drifters_core.F90
+libdrifters_comm_la_SOURCES = drifters_comm.F90
+libdrifters_input_la_SOURCES = drifters_input.F90
+libdrifters_io_la_SOURCES = drifters_io.F90
+libcloud_interpolator_la_SOURCES = cloud_interpolator.F90
+libquicksort_la_SOURCES = quicksort.F90
+
+# These headers are in the drifters directory.
+DRIFTERS_HDRS = drifters_compute_k.h drifters_push.h	\
+drifters_set_field.h fms_switches.h
+
+# Each mod file depends on the .o file.
+drifters_core_mod.mod: drifters_core.$(OBJEXT)
+drifters_input_mod.mod: drifters_input.$(OBJEXT)
+drifters_comm_mod.mod: drifters_comm.$(OBJEXT)
+drifters_io_mod.mod: drifters_io.$(OBJEXT)
+cloud_interpolator_mod.mod: cloud_interpolator.$(OBJEXT)
+drifters_mod.mod: drifters.$(OBJEXT)
+
+# Mod files are built and then installed as headers.
+MODFILES = drifters_core_mod.mod drifters_input_mod.mod			\
+drifters_comm_mod.mod drifters_io_mod.mod cloud_interpolator_mod.mod	\
+drifters_mod.mod
+include_HEADERS = $(MODFILES) $(DRIFTERS_HDRS)
+BUILT_SOURCES = $(MODFILES)
+
+CLEANFILES = *.mod

--- a/drifters/Makefile.am
+++ b/drifters/Makefile.am
@@ -3,6 +3,9 @@
 
 # Ed Hartnett 2/22/19
 
+# Use any Fortran flags set by configure.
+AM_FCFLAGS = ${FMS_FCFLAGS}
+
 # Turn off parallel builds in this directory.
 .NOTPARALLEL:
 

--- a/exchange/Makefile.am
+++ b/exchange/Makefile.am
@@ -1,0 +1,34 @@
+# This is an automake file for the exchange directory of the FMS
+# package.
+
+# Ed Hartnett 2/22/19
+
+# Include .h and .mod files.
+AM_CPPFLAGS = -I${top_srcdir}/include
+AM_CPPFLAGS += -I${top_builddir}/mpp
+AM_CPPFLAGS += -I${top_builddir}/fms
+AM_CPPFLAGS += -I${top_builddir}/time_manager
+AM_CPPFLAGS += -I${top_builddir}/diag_manager
+AM_CPPFLAGS += -I${top_builddir}/constants
+AM_CPPFLAGS += -I${top_builddir}/mosaic
+
+# Build these uninstalled convenience libraries.
+noinst_LTLIBRARIES = libstock_constants.la libxgrid.la
+
+# Each convenience library depends on its source.
+libstock_constants_la_SOURCES = stock_constants.F90
+libxgrid_la_SOURCES = xgrid.F90 stock_constants_mod.mod
+
+# Each mod file depends on the .o file.
+stock_constants_mod.mod: stock_constants.$(OBJEXT)
+xgrid_mod.mod: xgrid.$(OBJEXT)
+
+# Some mods are dependant on other mods in this dir.
+xgrid.$(OBJEXT): stock_constants_mod.mod
+
+# Mod files are built and then installed as headers.
+MODFILES = stock_constants_mod.mod xgrid_mod.mod
+include_HEADERS = $(MODFILES)
+BUILT_SOURCES = $(MODFILES)
+
+CLEANFILES = *.mod

--- a/exchange/Makefile.am
+++ b/exchange/Makefile.am
@@ -3,6 +3,9 @@
 
 # Ed Hartnett 2/22/19
 
+# Use any Fortran flags set by configure.
+AM_FCFLAGS = ${FMS_FCFLAGS}
+
 # Include .h and .mod files.
 AM_CPPFLAGS = -I${top_srcdir}/include
 AM_CPPFLAGS += -I${top_builddir}/mpp

--- a/fft/Makefile.am
+++ b/fft/Makefile.am
@@ -1,0 +1,32 @@
+# This is an automake file for the fft directory of the FMS
+# package.
+
+# Ed Hartnett 2/22/19
+
+# Include .h and .mod files.
+AM_CPPFLAGS = -I${top_srcdir}/include
+AM_CPPFLAGS += -I${top_builddir}/fms
+AM_CPPFLAGS += -I${top_builddir}/platform
+AM_CPPFLAGS += -I${top_builddir}/constants
+AM_CPPFLAGS += -I${top_builddir}/mpp
+
+# Build these uninstalled convenience libraries.
+noinst_LTLIBRARIES = libfft99.la libfft.la
+
+# Each convenience library depends on its source.
+libfft_la_SOURCES = fft.F90
+libfft99_la_SOURCES = fft99.F90
+
+# Each mod file depends on the .o file.
+fft99_mod.mod: fft99.$(OBJEXT)
+fft_mod.mod: fft.$(OBJEXT)
+
+# Some mods are dependant on other mods in this dir.
+fft.$(OBJEXT): fft99_mod.mod
+
+# Mod files are built and then installed as headers.
+MODFILES = fft99_mod.mod fft_mod.mod
+include_HEADERS = $(MODFILES)
+BUILT_SOURCES = $(MODFILES)
+
+CLEANFILES = *.mod

--- a/fft/Makefile.am
+++ b/fft/Makefile.am
@@ -3,6 +3,9 @@
 
 # Ed Hartnett 2/22/19
 
+# Use any Fortran flags set by configure.
+AM_FCFLAGS = ${FMS_FCFLAGS}
+
 # Include .h and .mod files.
 AM_CPPFLAGS = -I${top_srcdir}/include
 AM_CPPFLAGS += -I${top_builddir}/fms

--- a/field_manager/Makefile.am
+++ b/field_manager/Makefile.am
@@ -1,0 +1,33 @@
+# This is an automake file for the field_manager directory of the FMS
+# package.
+
+# Ed Hartnett 2/22/19
+
+# Include .h and .mod files.
+AM_CPPFLAGS = -I${top_srcdir}/include
+AM_CPPFLAGS += -I${top_builddir}/constants
+AM_CPPFLAGS += -I${top_builddir}/mpp
+AM_CPPFLAGS += -I${top_builddir}/fms
+
+# Build these uninstalled convenience libraries.
+noinst_LTLIBRARIES = libfield_manager.la libfm_util.la
+
+# Each convenience library depends on its source.
+libfield_manager_la_SOURCES = field_manager.F90
+libfm_util_la_SOURCES = fm_util.F90
+
+# Each mod file depends on the .o file.
+field_manager_mod.mod: field_manager.$(OBJEXT)
+fm_util_mod.mod: fm_util.$(OBJEXT)
+
+# Some mods are dependant on other mods in this dir.
+fm_util.$(OBJEXT): field_manager_mod.mod
+
+# Mod files are built and then installed as headers.
+MODFILES = field_manager_mod.mod fm_util_mod.mod
+BUILT_SOURCES = $(MODFILES)
+include_HEADERS = $(MODFILES)
+
+EXTRA_DIST = parse.inc
+
+CLEANFILES = *.mod

--- a/field_manager/Makefile.am
+++ b/field_manager/Makefile.am
@@ -3,6 +3,9 @@
 
 # Ed Hartnett 2/22/19
 
+# Use any Fortran flags set by configure.
+AM_FCFLAGS = ${FMS_FCFLAGS}
+
 # Include .h and .mod files.
 AM_CPPFLAGS = -I${top_srcdir}/include
 AM_CPPFLAGS += -I${top_builddir}/constants

--- a/fms/Makefile.am
+++ b/fms/Makefile.am
@@ -1,0 +1,44 @@
+# This is an automake file for the fms directory of the FMS
+# package.
+
+# Ed Hartnett 2/22/19
+
+# Include .h and .mod files.
+AM_CPPFLAGS = -I${top_srcdir}/include
+AM_CPPFLAGS += -I${top_builddir}/constants
+AM_CPPFLAGS += -I${top_builddir}/mpp
+AM_CPPFLAGS += -I${top_builddir}/platform
+AM_CPPFLAGS += -I${top_builddir}/memutils
+
+# Build these uninstalled convenience libraries.
+noinst_LTLIBRARIES = libfms_io.la libfms.la
+
+# Each convenience library depends on its source.
+libfms_la_SOURCES = fms.F90
+libfms_io_la_SOURCES = fms_io.F90
+
+# These inc files are in the fms directory.
+FMS_INC_FILES = fms_io_unstructured_field_exist.inc			\
+fms_io_unstructured_get_file_name.inc					\
+fms_io_unstructured_register_restart_axis.inc				\
+fms_io_unstructured_setup_one_field.inc read_data_4d.inc		\
+fms_io_unstructured_file_unit.inc					\
+fms_io_unstructured_get_file_unit.inc					\
+fms_io_unstructured_register_restart_field.inc read_data_2d.inc		\
+write_data.inc fms_io_unstructured_get_field_size.inc			\
+fms_io_unstructured_read.inc fms_io_unstructured_save_restart.inc	\
+read_data_3d.inc
+
+# Each mod file depends on the .o file.
+fms_io_mod.mod: fms_io.$(OBJEXT)
+fms_mod.mod: fms.$(OBJEXT)
+
+# Some mods are dependant on other mods in this dir.
+fms.$(OBJEXT): fms_io_mod.mod
+
+# Mod files are built and then installed as headers.
+MODFILES = fms_io_mod.mod fms_mod.mod
+BUILT_SOURCES = $(MODFILES)
+include_HEADERS = $(MODFILES) $(FMS_INC_FILES)
+
+CLEANFILES = *.mod

--- a/fms/Makefile.am
+++ b/fms/Makefile.am
@@ -3,6 +3,9 @@
 
 # Ed Hartnett 2/22/19
 
+# Use any Fortran flags set by configure.
+AM_FCFLAGS = ${FMS_FCFLAGS}
+
 # Include .h and .mod files.
 AM_CPPFLAGS = -I${top_srcdir}/include
 AM_CPPFLAGS += -I${top_builddir}/constants

--- a/horiz_interp/Makefile.am
+++ b/horiz_interp/Makefile.am
@@ -1,0 +1,49 @@
+# This is an automake file for the horiz_interp directory of the FMS
+# package.
+
+# Ed Hartnett 2/22/19
+
+# Include .h and .mod files.
+AM_CPPFLAGS = -I${top_srcdir}/include
+AM_CPPFLAGS += -I${top_builddir}/mpp
+AM_CPPFLAGS += -I${top_builddir}/fms
+AM_CPPFLAGS += -I${top_builddir}/constants
+
+# Build these uninstalled convenience libraries.
+noinst_LTLIBRARIES = libhoriz_interp_type.la			\
+libhoriz_interp_bicubic.la libhoriz_interp_bilinear.la		\
+libhoriz_interp_conserve.la libhoriz_interp_spherical.la	\
+libhoriz_interp.la
+
+# Each convenience library depends on its source.
+libhoriz_interp_bicubic_la_SOURCES = horiz_interp_bicubic.F90
+libhoriz_interp_bilinear_la_SOURCES = horiz_interp_bilinear.F90
+libhoriz_interp_conserve_la_SOURCES = horiz_interp_conserve.F90
+libhoriz_interp_la_SOURCES = horiz_interp.F90
+libhoriz_interp_spherical_la_SOURCES = horiz_interp_spherical.F90
+libhoriz_interp_type_la_SOURCES = horiz_interp_type.F90
+
+# Each mod file depends on the .o file.
+horiz_interp_type_mod.mod: horiz_interp_type.$(OBJEXT)
+horiz_interp_bicubic_mod.mod: horiz_interp_bicubic.$(OBJEXT)
+horiz_interp_bilinear_mod.mod: horiz_interp_bilinear.$(OBJEXT)
+horiz_interp_conserve_mod.mod: horiz_interp_conserve.$(OBJEXT)
+horiz_interp_spherical_mod.mod: horiz_interp_spherical.$(OBJEXT)
+horiz_interp_mod.mod: horiz_interp.$(OBJEXT)
+
+# Some mods are dependant on other mods in this dir.
+horiz_interp_bicubic.$(OBJEXT): horiz_interp_type_mod.mod
+horiz_interp_bilinear.$(OBJEXT): horiz_interp_type_mod.mod
+horiz_interp_conserve.$(OBJEXT): horiz_interp_type_mod.mod
+horiz_interp_spherical.$(OBJEXT): horiz_interp_type_mod.mod
+horiz_interp.$(OBJEXT): horiz_interp_bicubic_mod.mod horiz_interp_type_mod.mod \
+	horiz_interp_bilinear_mod.mod horiz_interp_conserve_mod.mod horiz_interp_spherical_mod.mod
+
+# Mod files are built and then installed as headers.
+MODFILES = horiz_interp_type_mod.mod horiz_interp_bicubic_mod.mod	\
+horiz_interp_bilinear_mod.mod horiz_interp_conserve_mod.mod		\
+horiz_interp_spherical_mod.mod horiz_interp_mod.mod
+include_HEADERS = $(MODFILES)
+BUILT_SOURCES = $(MODFILES)
+
+CLEANFILES = *.mod

--- a/horiz_interp/Makefile.am
+++ b/horiz_interp/Makefile.am
@@ -3,6 +3,9 @@
 
 # Ed Hartnett 2/22/19
 
+# Use any Fortran flags set by configure.
+AM_FCFLAGS = ${FMS_FCFLAGS}
+
 # Include .h and .mod files.
 AM_CPPFLAGS = -I${top_srcdir}/include
 AM_CPPFLAGS += -I${top_builddir}/mpp

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -1,0 +1,6 @@
+# This is an automake file for the include directory of the FMS
+# package.
+
+# Ed Hartnett 2/26/19
+
+include_HEADERS = file_version.h fms_platform.h

--- a/interpolator/Makefile.am
+++ b/interpolator/Makefile.am
@@ -1,0 +1,27 @@
+# This is an automake file for the interpolator directory of the FMS
+# package.
+
+# Ed Hartnett 2/22/19
+
+# Include .h and .mod files.
+AM_CPPFLAGS = -I${top_srcdir}/include
+AM_CPPFLAGS += -I${top_builddir}/mpp
+AM_CPPFLAGS += -I${top_builddir}/diag_manager
+AM_CPPFLAGS += -I${top_builddir}/fms
+AM_CPPFLAGS += -I${top_builddir}/horiz_interp
+AM_CPPFLAGS += -I${top_builddir}/time_manager
+AM_CPPFLAGS += -I${top_builddir}/time_interp
+AM_CPPFLAGS += -I${top_builddir}/constants
+
+# Build this uninstalled convenience library.
+noinst_LTLIBRARIES = libinterpolator.la
+
+# The convenience library depends on its source.
+libinterpolator_la_SOURCES = interpolator.F90
+
+# Mod file depends on its o file, is built and then installed.
+interpolator_mod.mod: interpolator.$(OBJEXT)
+BUILT_SOURCES = interpolator_mod.mod
+include_HEADERS = interpolator_mod.mod
+
+CLEANFILES = *.mod

--- a/interpolator/Makefile.am
+++ b/interpolator/Makefile.am
@@ -3,6 +3,9 @@
 
 # Ed Hartnett 2/22/19
 
+# Use any Fortran flags set by configure.
+AM_FCFLAGS = ${FMS_FCFLAGS}
+
 # Include .h and .mod files.
 AM_CPPFLAGS = -I${top_srcdir}/include
 AM_CPPFLAGS += -I${top_builddir}/mpp

--- a/libFMS/BUILD_SYSTEM.md
+++ b/libFMS/BUILD_SYSTEM.md
@@ -1,0 +1,95 @@
+# Autotools Build System Documentation
+
+This document describes the autotools-based build system for FMS.
+
+## Introduction to Autotools
+
+Autoconf, automake, and libtool and the GNU/Linux standard build
+tools. When building a package based on autotools, the user does
+something like:
+
+./configure && make check install
+
+The configure step queries the system about many things, and contructs
+makefiles.
+
+The make step uses the generated Makefiles to build, test, and install
+the software.
+
+Standard environment variables and configure options can be used to
+control many aspects of the build. Custom configure options can easily
+be added to support additional needs.
+
+### Caution Concerning Generated Files
+
+Autotools creates many generated files, which should not be edited or
+checked into the repository. Simply ignore them. Do not try to edit
+generated Makefiles, do not move or rename any of the shell scripts
+that autoreconf puts in place to let autotools work. These files have
+been added to .gitignore and should never be added to the repo.
+
+# How to Build FMS
+
+Previously, everyone built FMS by checking out code from git. However,
+with the new build system, only those who want to contribute to the
+code base need check out the code from git.
+
+## As an FMS Developer
+
+All FMS developers will need a reasobably reacent version of tools
+autoconf, automake, and libtool. These are available on package
+management systems. (Ex. yum install automake autoconf libtool).
+
+The process of building FMS from the repo is:
+
+1. Clone repo and cd into repo directory.
+2. Run autoreconf -i to build the developer build system.
+3. Run ./configure to configure.
+4. Run make to build.
+
+## As an FMS User
+
+Users start with a tarball, not the git repo. They do not have to have
+any of the autotools installed. Thier build process is:
+
+1. Unpack the tarball and cd into the directory.
+2. Run ./configure --prefix=/my/installdir
+3. Run make install
+
+## Precious Flags for configure
+
+Some environment variables are important to the autotools build
+system, these are known as "precious" variables. One example is CC,
+which should be set to the C compiler.
+
+It's common to set some precious vars before the build. Commonly used
+ones include:
+* CC the C compiler
+* FC the Fortran compiler
+* CPPFLAGS C (and Fortran) pre-processor flags
+* FCFLAGS Fortran compiler flags
+* LDFLAGS Linker flags
+
+## Standard Configure Options
+
+The configure script has some standard options, including:
+* --prefix allows user to specify install directory
+* --disable-shared disables building of shared library
+* --help prints message showing all options
+
+## FMS Configure Options
+
+Currently there are not FMS specific configure options, but probably
+we will add some.
+
+## Standard Make Targets
+
+Some of the useful make targets include:
+* make or make all - build code
+* make install - build code (as needed) and install
+* make check - build code (as needed) and run tests
+* make clean - clean back build
+* make distclean - clean configure output and build
+* make dist - create a tarball for distribution
+* make distcheck - create a tarball, unpack it, build and run tests, then then clean it.
+

--- a/libFMS/Makefile.am
+++ b/libFMS/Makefile.am
@@ -1,0 +1,85 @@
+# This is an automake file for the libFMS directory of the FMS
+# package. This is the final packaging of the library.
+
+# Ed Hartnett 2/22/19
+
+# This builds the FMS library file.
+lib_LTLIBRARIES = libFMS.la
+
+# These linker flags specify libtool version info.
+# See http://www.gnu.org/software/libtool/manual/libtool.html#Libtool-versioning
+# for information regarding incrementing `-version-info`.
+libFMS_la_LDFLAGS = -version-info 2:0:0
+
+# Add the convenience libraries to the FMS library.
+libFMS_la_LIBADD = ${top_builddir}/platform/libplatform.la
+libFMS_la_LIBADD += ${top_builddir}/constants/libconstants.la
+libFMS_la_LIBADD += ${top_builddir}/tridiagonal/libtridiagonal.la
+libFMS_la_LIBADD += ${top_builddir}/mpp/libmpp_parameter.la
+libFMS_la_LIBADD += ${top_builddir}/mpp/libmpp.la
+libFMS_la_LIBADD += ${top_builddir}/mpp/libmpp_data.la
+libFMS_la_LIBADD += ${top_builddir}/mpp/libmpp_utilities.la
+libFMS_la_LIBADD += ${top_builddir}/mpp/libmpp_domains.la
+libFMS_la_LIBADD += ${top_builddir}/mpp/libmpp_io.la
+libFMS_la_LIBADD += ${top_builddir}/mpp/libmpp_pset.la
+libFMS_la_LIBADD += ${top_builddir}/mpp/libmpp_efp.la
+libFMS_la_LIBADD += ${top_builddir}/mpp/libmpp_c.la
+libFMS_la_LIBADD += ${top_builddir}/memutils/libmemutils.la
+libFMS_la_LIBADD += ${top_builddir}/fms/libfms_io.la
+libFMS_la_LIBADD += ${top_builddir}/fms/libfms.la
+libFMS_la_LIBADD += ${top_builddir}/mosaic/libmosaic.la
+libFMS_la_LIBADD += ${top_builddir}/mosaic/libgrid.la
+libFMS_la_LIBADD += ${top_builddir}/mosaic/libgradient.la
+libFMS_la_LIBADD += ${top_builddir}/mosaic/libmosaic_c.la
+libFMS_la_LIBADD += ${top_builddir}/coupler/libcoupler_types.la
+libFMS_la_LIBADD += ${top_builddir}/coupler/libensemble_manager.la
+libFMS_la_LIBADD += ${top_builddir}/coupler/libatmos_ocean_fluxes.la
+libFMS_la_LIBADD += ${top_builddir}/drifters/libdrifters_core.la
+libFMS_la_LIBADD += ${top_builddir}/drifters/libdrifters_input.la
+libFMS_la_LIBADD += ${top_builddir}/drifters/libdrifters_comm.la
+libFMS_la_LIBADD += ${top_builddir}/drifters/libdrifters_io.la
+libFMS_la_LIBADD += ${top_builddir}/drifters/libdrifters.la
+libFMS_la_LIBADD += ${top_builddir}/drifters/libcloud_interpolator.la
+libFMS_la_LIBADD += ${top_builddir}/drifters/libquicksort.la
+libFMS_la_LIBADD += ${top_builddir}/axis_utils/libaxis_utils.la
+libFMS_la_LIBADD += ${top_builddir}/horiz_interp/libhoriz_interp_type.la
+libFMS_la_LIBADD += ${top_builddir}/horiz_interp/libhoriz_interp_bicubic.la
+libFMS_la_LIBADD += ${top_builddir}/horiz_interp/libhoriz_interp_bilinear.la
+libFMS_la_LIBADD += ${top_builddir}/horiz_interp/libhoriz_interp_conserve.la
+libFMS_la_LIBADD += ${top_builddir}/horiz_interp/libhoriz_interp_spherical.la
+libFMS_la_LIBADD += ${top_builddir}/horiz_interp/libhoriz_interp.la
+libFMS_la_LIBADD += ${top_builddir}/time_manager/libtime_manager.la
+libFMS_la_LIBADD += ${top_builddir}/time_manager/libget_cal_time.la
+libFMS_la_LIBADD += ${top_builddir}/time_interp/libtime_interp.la
+libFMS_la_LIBADD += ${top_builddir}/time_interp/libtime_interp_external.la
+libFMS_la_LIBADD += ${top_builddir}/diag_manager/libdiag_data.la
+libFMS_la_LIBADD += ${top_builddir}/diag_manager/libdiag_axis.la
+libFMS_la_LIBADD += ${top_builddir}/diag_manager/libdiag_grid.la
+libFMS_la_LIBADD += ${top_builddir}/diag_manager/libdiag_output.la
+libFMS_la_LIBADD += ${top_builddir}/diag_manager/libdiag_util.la
+libFMS_la_LIBADD += ${top_builddir}/diag_manager/libdiag_manifest.la
+libFMS_la_LIBADD += ${top_builddir}/diag_manager/libdiag_table.la
+libFMS_la_LIBADD += ${top_builddir}/diag_manager/libdiag_manager.la
+libFMS_la_LIBADD += ${top_builddir}/diag_integral/libdiag_integral.la
+libFMS_la_LIBADD += ${top_builddir}/data_override/libdata_override.la
+libFMS_la_LIBADD += ${top_builddir}/column_diagnostics/libcolumn_diagnostics.la
+libFMS_la_LIBADD += ${top_builddir}/block_control/libblock_control.la
+libFMS_la_LIBADD += ${top_builddir}/astronomy/libastronomy.la
+libFMS_la_LIBADD += ${top_builddir}/field_manager/libfield_manager.la
+libFMS_la_LIBADD += ${top_builddir}/monin_obukhov/libmonin_obukhov.la
+libFMS_la_LIBADD += ${top_builddir}/monin_obukhov/libmonin_obukhov_kernel.la
+libFMS_la_LIBADD += ${top_builddir}/interpolator/libinterpolator.la
+libFMS_la_LIBADD += ${top_builddir}/fft/libfft99.la
+libFMS_la_LIBADD += ${top_builddir}/fft/libfft.la
+libFMS_la_LIBADD += ${top_builddir}/amip_interp/libamip_interp.la
+libFMS_la_LIBADD += ${top_builddir}/oda_tools/liboda_types.la
+libFMS_la_LIBADD += ${top_builddir}/oda_tools/liboda_core.la
+libFMS_la_LIBADD += ${top_builddir}/oda_tools/libwrite_ocean_data.la
+libFMS_la_LIBADD += ${top_builddir}/exchange/libstock_constants.la
+libFMS_la_LIBADD += ${top_builddir}/exchange/libxgrid.la
+libFMS_la_LIBADD += ${top_builddir}/topography/libtopography.la
+libFMS_la_LIBADD += ${top_builddir}/tracer_manager/libtracer_manager.la
+libFMS_la_LIBADD += ${top_builddir}/station_data/libstation_data.la
+
+# At least one source file must be included to please Automake.
+libFMS_la_SOURCES = ${top_builddir}/include/file_version.h

--- a/libFMS/Makefile.am
+++ b/libFMS/Makefile.am
@@ -3,6 +3,9 @@
 
 # Ed Hartnett 2/22/19
 
+# Use any Fortran flags set by configure.
+AM_FCFLAGS = ${FMS_FCFLAGS}
+
 # This builds the FMS library file.
 lib_LTLIBRARIES = libFMS.la
 

--- a/memutils/Makefile.am
+++ b/memutils/Makefile.am
@@ -1,0 +1,21 @@
+# This is an automake file for the memutils directory of the FMS
+# package.
+
+# Ed Hartnett 2/22/19
+
+# Include .h and .mod files.
+AM_CPPFLAGS = -I${top_srcdir}/include
+AM_CPPFLAGS += -I${top_builddir}/mpp
+
+# Build this uninstalled convenience library.
+noinst_LTLIBRARIES = libmemutils.la
+
+# The convenience library depends on its source.
+libmemutils_la_SOURCES = memutils.F90
+
+# Mod file depends on its o file, is built and then installed.
+memutils_mod.mod: memutils.$(OBJEXT)
+BUILT_SOURCES = memutils_mod.mod
+include_HEADERS = memutils_mod.mod
+
+CLEANFILES = *.mod

--- a/memutils/Makefile.am
+++ b/memutils/Makefile.am
@@ -3,6 +3,9 @@
 
 # Ed Hartnett 2/22/19
 
+# Use any Fortran flags set by configure.
+AM_FCFLAGS = ${FMS_FCFLAGS}
+
 # Include .h and .mod files.
 AM_CPPFLAGS = -I${top_srcdir}/include
 AM_CPPFLAGS += -I${top_builddir}/mpp

--- a/monin_obukhov/Makefile.am
+++ b/monin_obukhov/Makefile.am
@@ -1,0 +1,29 @@
+# This is an automake file for the monin_obukhov directory of the FMS
+# package.
+
+# Ed Hartnett 2/22/19
+
+AM_CPPFLAGS = -I${top_srcdir}/include
+AM_CPPFLAGS += -I${top_builddir}/mpp
+AM_CPPFLAGS += -I${top_builddir}/fms
+
+# Allow constants.mod to be found.
+AM_CPPFLAGS += -I${top_builddir}/constants
+
+noinst_LTLIBRARIES = libmonin_obukhov.la libmonin_obukhov_kernel.la
+
+libmonin_obukhov_la_SOURCES = monin_obukhov.F90
+libmonin_obukhov_kernel_la_SOURCES = monin_obukhov_kernel.F90
+
+# Note that the name of the mod is different from the name of the F90
+# code for monin_obukhov_kernel.F90. Also note that the mod file for
+# this one does not have "_mod" in the name.
+monin_obukhov_mod.mod: monin_obukhov.$(OBJEXT)
+monin_obukhov_inter.mod: monin_obukhov_kernel.$(OBJEXT)
+
+# Mod files are built and then installed as headers.
+MODFILES = monin_obukhov_mod.mod monin_obukhov_inter.mod
+include_HEADERS = $(MODFILES) monin_obukhov_interfaces.h
+BUILT_SOURCES = $(MODFILES)
+
+CLEANFILES = *.mod

--- a/monin_obukhov/Makefile.am
+++ b/monin_obukhov/Makefile.am
@@ -3,6 +3,9 @@
 
 # Ed Hartnett 2/22/19
 
+# Use any Fortran flags set by configure.
+AM_FCFLAGS = ${FMS_FCFLAGS}
+
 AM_CPPFLAGS = -I${top_srcdir}/include
 AM_CPPFLAGS += -I${top_builddir}/mpp
 AM_CPPFLAGS += -I${top_builddir}/fms

--- a/mosaic/Makefile.am
+++ b/mosaic/Makefile.am
@@ -1,0 +1,38 @@
+# This is an automake file for the mosaic directory of the FMS
+# package.
+
+# Ed Hartnett 2/22/19
+
+# Include .h and .mod files.
+AM_CPPFLAGS = -I${top_srcdir}/include
+AM_CPPFLAGS += -I${top_builddir}/mpp
+AM_CPPFLAGS += -I${top_builddir}/constants
+AM_CPPFLAGS += -I${top_builddir}/fms
+
+# Build these uninstalled convenience libraries.
+noinst_LTLIBRARIES = libmosaic.la libgrid.la libgradient.la	\
+libmosaic_c.la
+
+# Each convenience library depends on its source. Lump all the C code
+# into libmosaic_c.la.
+libmosaic_la_SOURCES = mosaic.F90
+libgrid_la_SOURCES = grid.F90
+libgradient_la_SOURCES = gradient.F90
+libmosaic_c_la_SOURCES = create_xgrid.c gradient_c2l.c interp.c		\
+mosaic_util.c read_mosaic.c constant.h create_xgrid.h gradient_c2l.h	\
+interp.h mosaic_util.h read_mosaic.h
+
+# Each mod file depends on the .o file.
+mosaic_mod.mod: mosaic.$(OBJEXT)
+grid_mod.mod: grid.$(OBJEXT)
+gradient_mod.mod: gradient.$(OBJEXT)
+
+# Some mods are dependant on other mods in this dir.
+grid.$(OBJEXT): mosaic_mod.mod
+
+# Mod files are built and then installed as headers.
+MODFILES = mosaic_mod.mod grid_mod.mod gradient_mod.mod
+include_HEADERS = $(MODFILES)
+BUILT_SOURCES = $(MODFILES)
+
+CLEANFILES = *.mod

--- a/mosaic/Makefile.am
+++ b/mosaic/Makefile.am
@@ -3,6 +3,9 @@
 
 # Ed Hartnett 2/22/19
 
+# Use any Fortran flags set by configure.
+AM_FCFLAGS = ${FMS_FCFLAGS}
+
 # Include .h and .mod files.
 AM_CPPFLAGS = -I${top_srcdir}/include
 AM_CPPFLAGS += -I${top_builddir}/mpp

--- a/mpp/Makefile.am
+++ b/mpp/Makefile.am
@@ -1,0 +1,59 @@
+# This is an automake file for the mpp directory of the MPP
+# package.
+
+# Ed Hartnett 2/22/19
+
+# Descend into include directory.
+SUBDIRS = include
+
+# Include .h and .mod files.
+AM_CPPFLAGS = -I${top_srcdir}/include
+AM_CPPFLAGS += -I${top_srcdir}/mpp/include
+
+# Build these uninstalled convenience libraries.
+noinst_LTLIBRARIES = libmpp_parameter.la libmpp_data.la libmpp.la	\
+libmpp_utilities.la libmpp_memutils.la libmpp_pset.la libmpp_efp.la	\
+libmpp_domains.la libmpp_io.la libmpp_c.la
+
+# Each convenience library depends on its source.
+libmpp_parameter_la_SOURCES = mpp_parameter.F90
+libmpp_la_SOURCES = mpp.F90
+libmpp_data_la_SOURCES = mpp_data.F90
+libmpp_utilities_la_SOURCES = mpp_utilities.F90
+libmpp_domains_la_SOURCES = mpp_domains.F90
+libmpp_io_la_SOURCES = mpp_io.F90
+libmpp_pset_la_SOURCES = mpp_pset.F90
+libmpp_efp_la_SOURCES = mpp_efp.F90
+libmpp_c_la_SOURCES = nsclock.c affinity.c threadloc.c
+libmpp_memutils_la_SOURCES = mpp_memutils.F90
+
+# Each mod file depends on the .o file.
+mpp_parameter_mod.mod: mpp_parameter.$(OBJEXT)
+mpp_data_mod.mod: mpp_data.$(OBJEXT)
+mpp_mod.mod: mpp.$(OBJEXT)
+mpp_pset_mod.mod: mpp_pset.$(OBJEXT)
+mpp_utilities_mod.mod: mpp_utilities.$(OBJEXT)
+mpp_memutils_mod.mod: mpp_memutils.$(OBJEXT)
+mpp_efp_mod.mod: mpp_efp.$(OBJEXT)
+mpp_domains_mod.mod: mpp_domains.$(OBJEXT)
+mpp_io_mod.mod: mpp_io.$(OBJEXT)
+
+# Some mods are dependant on other mods in this dir.
+mpp_data.$(OBJEXT): mpp_parameter_mod.mod
+mpp.$(OBJEXT): mpp_data_mod.mod
+mpp_utilities.$(OBJEXT): mpp_mod.mod mpp_efp_mod.mod
+mpp_memutils.$(OBJEXT): mpp_mod.mod
+mpp_pset.$(OBJEXT): mpp_mod.mod
+mpp_efp.$(OBJEXT): mpp_efp_mod.mod mpp_parameter_mod.mod mpp_mod.mod
+mpp_domains.$(OBJEXT): mpp_data_mod.mod mpp_parameter_mod.mod \
+	mpp_mod.mod mpp_memutils_mod.mod mpp_pset_mod.mod mpp_efp_mod.mod
+mpp_io.$(OBJEXT): mpp_parameter_mod.mod mpp_mod.mod mpp_domains_mod.mod
+
+# Mod files are built and then installed as headers.
+MODFILES = mpp_parameter_mod.mod mpp_data_mod.mod mpp_mod.mod	\
+mpp_utilities_mod.mod mpp_memutils_mod.mod mpp_pset_mod.mod	\
+mpp_efp_mod.mod mpp_domains_mod.mod mpp_io_mod.mod
+include_HEADERS = $(MODFILES)
+BUILT_SOURCES = $(MODFILES)
+
+CLEANFILES = *.mod

--- a/mpp/Makefile.am
+++ b/mpp/Makefile.am
@@ -3,6 +3,9 @@
 
 # Ed Hartnett 2/22/19
 
+# Use any Fortran flags set by configure.
+AM_FCFLAGS = ${FMS_FCFLAGS}
+
 # Descend into include directory.
 SUBDIRS = include
 

--- a/mpp/include/Makefile.am
+++ b/mpp/include/Makefile.am
@@ -1,0 +1,36 @@
+# This is an automake file for the mpp/include directory of the FMS
+# package.
+
+# Ed Hartnett 2/26/19
+
+include_HEADERS = mpp_alltoall_mpi.h mpp_do_get_boundary_ad.h		\
+mpp_do_update_nonblock.h mpp_gather.h mpp_global_sum.h			\
+mpp_reduce_sma.h mpp_transmit_sma.h mpp_update_nest_domains.h		\
+mpp_alltoall_nocomm.h mpp_do_get_boundary.h mpp_do_updateV_ad.h		\
+mpp_get_boundary_ad.h mpp_global_sum_tl.h mpp_scatter.h			\
+mpp_type_mpi.h mpp_write_2Ddecomp.h mpp_alltoall_sma.h			\
+mpp_do_global_field_ad.h mpp_do_updateV.h mpp_get_boundary.h		\
+mpp_group_update.h mpp_sum_mpi_ad.h mpp_type_nocomm.h			\
+mpp_write_compressed.h mpp_chksum.h mpp_do_global_field.h		\
+mpp_do_updateV_nonblock.h mpp_global_field_ad.h mpp_read_2Ddecomp.h	\
+mpp_sum_mpi.h mpp_type_sma.h mpp_write.h mpp_chksum_int.h		\
+mpp_do_redistribute.h mpp_error_a_a.h mpp_global_field.h		\
+mpp_read_compressed.h mpp_sum_nocomm.h mpp_unstruct_pass_data.h		\
+mpp_write_unlimited_axis.h mpp_chksum_scalar.h mpp_do_update_ad.h	\
+mpp_error_a_s.h mpp_global_field_ug.h mpp_read_distributed_ascii.h	\
+mpp_sum_sma.h mpp_update_domains2D_ad.h system_clock.h mpp_do_check.h	\
+mpp_do_update.h mpp_error_s_a.h mpp_global_reduce.h mpp_reduce_mpi.h	\
+mpp_transmit_mpi.h mpp_update_domains2D.h mpp_do_checkV.h		\
+mpp_do_update_nest.h mpp_error_s_s.h mpp_global_sum_ad.h		\
+mpp_reduce_nocomm.h mpp_transmit_nocomm.h				\
+mpp_update_domains2D_nonblock.h group_update_pack.inc			\
+mpp_comm_nocomm.inc mpp_data_sma.inc mpp_domains_misc.inc		\
+mpp_io_misc.inc mpp_io_util.inc mpp_sum.inc mpp_util_mpi.inc		\
+group_update_unpack.inc mpp_comm_sma.inc mpp_define_nest_domains.inc	\
+mpp_domains_reduce.inc mpp_io_read.inc mpp_io_write.inc			\
+mpp_transmit.inc mpp_util_nocomm.inc mpp_comm.inc mpp_data_mpi.inc	\
+mpp_domains_comm.inc mpp_domains_util.inc				\
+mpp_io_unstructured_read.inc mpp_read_distributed_ascii.inc		\
+mpp_unstruct_domain.inc mpp_util_sma.inc mpp_comm_mpi.inc		\
+mpp_data_nocomm.inc mpp_domains_define.inc mpp_io_connect.inc		\
+mpp_io_unstructured_write.inc mpp_sum_ad.inc mpp_util.inc

--- a/oda_tools/Makefile.am
+++ b/oda_tools/Makefile.am
@@ -1,0 +1,44 @@
+# This is an automake file for the oda_tools directory of the FMS
+# package.
+
+# Ed Hartnett 2/22/19
+
+# Include .h and .mod files.
+AM_CPPFLAGS = -I${top_srcdir}/include
+AM_CPPFLAGS += -I${top_builddir}/fms
+AM_CPPFLAGS += -I${top_builddir}/mpp
+AM_CPPFLAGS += -I${top_builddir}/time_manager
+AM_CPPFLAGS += -I${top_builddir}/axis_utils
+AM_CPPFLAGS += -I${top_builddir}/horiz_interp
+AM_CPPFLAGS += -I${top_builddir}/constants
+AM_CPPFLAGS += -I${top_builddir}/field_manager
+
+# Build these uninstalled convenience libraries.
+noinst_LTLIBRARIES = liboda_types.la libwrite_ocean_data.la	\
+liboda_core.la
+
+# Each convenience library depends on its source.
+liboda_types_la_SOURCES = oda_types.F90
+liboda_core_la_SOURCES = oda_core.F90
+libwrite_ocean_data_la_SOURCES = write_ocean_data.F90
+
+# This left deliberately uncompiled due to unresolved
+# dependancies. See github issue 66.
+# liboda_core_ecda_la_SOURCES = oda_core_ecda.F90
+
+# Each mod file depends on the .o file.
+oda_types_mod.mod: oda_types.$(OBJEXT)
+write_ocean_data_mod.mod: write_ocean_data.$(OBJEXT)
+oda_core_mod.mod: oda_core.$(OBJEXT)
+
+# Some mods are dependant on other mods in this dir.
+write_ocean_data.$(OBJEXT): oda_types_mod.mod
+oda_core.$(OBJEXT): oda_types_mod.mod write_ocean_data_mod.mod
+
+# Mod files are built and then installed as headers.
+MODFILES = oda_types_mod.mod write_ocean_data_mod.mod	\
+oda_core_mod.mod
+include_HEADERS = $(MODFILES)
+BUILT_SOURCES = $(MODFILES)
+
+CLEANFILES = *.mod

--- a/oda_tools/Makefile.am
+++ b/oda_tools/Makefile.am
@@ -3,6 +3,9 @@
 
 # Ed Hartnett 2/22/19
 
+# Use any Fortran flags set by configure.
+AM_FCFLAGS = ${FMS_FCFLAGS}
+
 # Include .h and .mod files.
 AM_CPPFLAGS = -I${top_srcdir}/include
 AM_CPPFLAGS += -I${top_builddir}/fms

--- a/platform/Makefile.am
+++ b/platform/Makefile.am
@@ -1,0 +1,20 @@
+# This is an automake file for the platform directory of the FMS
+# package.
+
+# Ed Hartnett 2/22/19
+
+# Include .h files.
+AM_CPPFLAGS = -I${top_srcdir}/include
+
+# Build this uninstalled convenience library.
+noinst_LTLIBRARIES = libplatform.la
+
+# The convenience library depends on its source.
+libplatform_la_SOURCES = platform.F90
+
+# Mod file depends on its o file, is built and then installed.
+platform_mod.mod: platform.$(OBJEXT)
+BUILT_SOURCES = platform_mod.mod
+include_HEADERS = platform_mod.mod
+
+CLEANFILES = *.mod

--- a/platform/Makefile.am
+++ b/platform/Makefile.am
@@ -3,6 +3,9 @@
 
 # Ed Hartnett 2/22/19
 
+# Use any Fortran flags set by configure.
+AM_FCFLAGS = ${FMS_FCFLAGS}
+
 # Include .h files.
 AM_CPPFLAGS = -I${top_srcdir}/include
 

--- a/random_numbers/Makefile.am
+++ b/random_numbers/Makefile.am
@@ -1,0 +1,29 @@
+# This is an automake file for the random_numbers directory of the FMS
+# package.
+
+# Ed Hartnett 2/28/19
+
+# Include .h and .mod files.
+AM_CPPFLAGS = -I${top_srcdir}/include
+AM_CPPFLAGS += -I${top_builddir}/time_manager
+
+# Build these uninstalled convenience library.
+noinst_LTLIBRARIES = libMersenneTwister.la librandom_numbers.la
+
+# Each convenience library depends on its source.
+librandom_numbers_la_SOURCES = random_numbers.F90
+libMersenneTwister_la_SOURCES = MersenneTwister.F90
+
+# Each mod file depends on the .o file.
+random_numbers_mod.mod: random_numbers.$(OBJEXT)
+mersennetwister_mod.mod: MersenneTwister.$(OBJEXT)
+
+# Some mods are dependant on other mods in this dir.
+random_numbers.$(OBJEXT): mersennetwister_mod.mod
+
+# Mod files are built and then installed as headers.
+MODFILES = mersennetwister_mod.mod random_numbers_mod.mod
+BUILT_SOURCES = $(MODFILES)
+include_HEADERS = $(MODFILES)
+
+CLEANFILES = *.mod

--- a/random_numbers/Makefile.am
+++ b/random_numbers/Makefile.am
@@ -3,6 +3,9 @@
 
 # Ed Hartnett 2/28/19
 
+# Use any Fortran flags set by configure.
+AM_FCFLAGS = ${FMS_FCFLAGS}
+
 # Include .h and .mod files.
 AM_CPPFLAGS = -I${top_srcdir}/include
 AM_CPPFLAGS += -I${top_builddir}/time_manager

--- a/sat_vapor_pres/Makefile.am
+++ b/sat_vapor_pres/Makefile.am
@@ -1,0 +1,31 @@
+# This is an automake file for the sat_vapor_pres directory of the FMS
+# package.
+
+# Ed Hartnett 2/28/19
+
+# Include .h and .mod files.
+AM_CPPFLAGS = -I${top_srcdir}/include
+AM_CPPFLAGS += -I${top_builddir}/constants
+AM_CPPFLAGS += -I${top_builddir}/fms
+AM_CPPFLAGS += -I${top_builddir}/mpp
+
+# Build these uninstalled convenience library.
+noinst_LTLIBRARIES = libsat_vapor_pres_k.la libsat_vapor_pres.la
+
+# Each convenience library depends on its source.
+libsat_vapor_pres_la_SOURCES = sat_vapor_pres.F90
+libsat_vapor_pres_k_la_SOURCES = sat_vapor_pres_k.F90
+
+# Each mod file depends on the .o file.
+sat_vapor_pres_mod.mod: sat_vapor_pres.$(OBJEXT)
+sat_vapor_pres_k_mod.mod: sat_vapor_pres_k.$(OBJEXT)
+
+# Some mods are dependant on other mods in this dir.
+sat_vapor_pres.$(OBJEXT): sat_vapor_pres_k_mod.mod
+
+# Mod files are built and then installed as headers.
+MODFILES = sat_vapor_pres_k_mod.mod sat_vapor_pres_mod.mod
+BUILT_SOURCES = $(MODFILES)
+include_HEADERS = $(MODFILES)
+
+CLEANFILES = *.mod

--- a/sat_vapor_pres/Makefile.am
+++ b/sat_vapor_pres/Makefile.am
@@ -3,6 +3,9 @@
 
 # Ed Hartnett 2/28/19
 
+# Use any Fortran flags set by configure.
+AM_FCFLAGS = ${FMS_FCFLAGS}
+
 # Include .h and .mod files.
 AM_CPPFLAGS = -I${top_srcdir}/include
 AM_CPPFLAGS += -I${top_builddir}/constants

--- a/station_data/Makefile.am
+++ b/station_data/Makefile.am
@@ -1,0 +1,26 @@
+# This is an automake file for the station_data directory of the FMS
+# package.
+
+# Ed Hartnett 2/22/19
+
+# Include .h and .mod files.
+AM_CPPFLAGS = -I${top_srcdir}/include
+AM_CPPFLAGS += -I${top_builddir}/axis_utils
+AM_CPPFLAGS += -I${top_builddir}/constants
+AM_CPPFLAGS += -I${top_builddir}/mpp
+AM_CPPFLAGS += -I${top_builddir}/fms
+AM_CPPFLAGS += -I${top_builddir}/diag_manager
+AM_CPPFLAGS += -I${top_builddir}/time_manager
+
+# Build this uninstalled convenience library.
+noinst_LTLIBRARIES = libstation_data.la
+
+# The convenience library depends on its source.
+libstation_data_la_SOURCES = station_data.F90
+
+# Mod file depends on its o file, is built and then installed.
+station_data_mod.mod: station_data.$(OBJEXT)
+BUILT_SOURCES = station_data_mod.mod
+include_HEADERS = station_data_mod.mod
+
+CLEANFILES = *.mod

--- a/station_data/Makefile.am
+++ b/station_data/Makefile.am
@@ -3,6 +3,9 @@
 
 # Ed Hartnett 2/22/19
 
+# Use any Fortran flags set by configure.
+AM_FCFLAGS = ${FMS_FCFLAGS}
+
 # Include .h and .mod files.
 AM_CPPFLAGS = -I${top_srcdir}/include
 AM_CPPFLAGS += -I${top_builddir}/axis_utils

--- a/test_fms/Makefile.am
+++ b/test_fms/Makefile.am
@@ -1,0 +1,17 @@
+# This is an automake file for the test_fms directory of the FMS
+# package.
+
+# Ed Hartnett 2/22/19
+
+# Find the fms_mod.mod file.
+AM_CPPFLAGS = -I${top_builddir}/fms
+AM_CPPFLAGS += -I${top_builddir}/constants
+
+# Build this test program.
+check_PROGRAMS = tst_fms1
+
+# This is the source code for the test.
+tst_fms1_SOURCES = tst_fms1.F90
+
+# Run the test program.
+TESTS = tst_fms1

--- a/test_fms/Makefile.am
+++ b/test_fms/Makefile.am
@@ -3,6 +3,9 @@
 
 # Ed Hartnett 2/22/19
 
+# Use any Fortran flags set by configure.
+AM_FCFLAGS = ${FMS_FCFLAGS}
+
 # Find the fms_mod.mod file.
 AM_CPPFLAGS = -I${top_builddir}/fms
 AM_CPPFLAGS += -I${top_builddir}/constants

--- a/test_fms/tst_fms1.F90
+++ b/test_fms/tst_fms1.F90
@@ -1,0 +1,13 @@
+! This is a sample test program for the FMS library.
+
+      program tst_fms1
+      use fms_mod
+      implicit none
+
+      print *, ''
+      print *,'*** Testing FMS library...'
+
+      ! Insert test code here.
+
+      print *,'*** SUCCESS!'
+      end

--- a/time_interp/Makefile.am
+++ b/time_interp/Makefile.am
@@ -1,0 +1,35 @@
+# This is an automake file for the time_interp directory of the FMS
+# package.
+
+# Ed Hartnett 2/22/19
+
+# Include .h and .mod files.
+AM_CPPFLAGS = -I${top_srcdir}/include
+AM_CPPFLAGS += -I${top_builddir}/time_manager
+AM_CPPFLAGS += -I${top_builddir}/constants
+AM_CPPFLAGS += -I${top_builddir}/fms
+AM_CPPFLAGS += -I${top_builddir}/mpp
+AM_CPPFLAGS += -I${top_builddir}/axis_utils
+AM_CPPFLAGS += -I${top_builddir}/platform
+AM_CPPFLAGS += -I${top_builddir}/horiz_interp
+
+# Build these uninstalled convenience libraries.
+noinst_LTLIBRARIES = libtime_interp.la libtime_interp_external.la
+
+# Each convenience library depends on its source.
+libtime_interp_la_SOURCES = time_interp.F90
+libtime_interp_external_la_SOURCES = time_interp_external.F90
+
+# Each mod file depends on the .o file.
+time_interp_mod.mod: time_interp.$(OBJEXT)
+time_interp_external_mod.mod: time_interp_external.$(OBJEXT)
+
+# Some mods are dependant on other mods in this dir.
+time_interp_external.$(OBJEXT):  time_interp_mod.mod
+
+# Mod files are built and then installed as headers.
+MODFILES = time_interp_mod.mod time_interp_external_mod.mod
+include_HEADERS = $(MODFILES)
+BUILT_SOURCES = $(MODFILES)
+
+CLEANFILES = *.mod

--- a/time_interp/Makefile.am
+++ b/time_interp/Makefile.am
@@ -3,6 +3,9 @@
 
 # Ed Hartnett 2/22/19
 
+# Use any Fortran flags set by configure.
+AM_FCFLAGS = ${FMS_FCFLAGS}
+
 # Include .h and .mod files.
 AM_CPPFLAGS = -I${top_srcdir}/include
 AM_CPPFLAGS += -I${top_builddir}/time_manager

--- a/time_manager/Makefile.am
+++ b/time_manager/Makefile.am
@@ -1,0 +1,31 @@
+# This is an automake file for the time_manager directory of the FMS
+# package.
+
+# Ed Hartnett 2/22/19
+
+# Include .h and .mod files.
+AM_CPPFLAGS = -I${top_srcdir}/include
+AM_CPPFLAGS += -I${top_builddir}/constants
+AM_CPPFLAGS += -I${top_builddir}/fms
+AM_CPPFLAGS += -I${top_builddir}/mpp
+
+# Build these uninstalled convenience libraries.
+noinst_LTLIBRARIES = libtime_manager.la libget_cal_time.la
+
+# Each convenience library depends on its source.
+libtime_manager_la_SOURCES = time_manager.F90
+libget_cal_time_la_SOURCES = get_cal_time.F90
+
+# Each mod file depends on the .o file.
+time_manager_mod.mod: time_manager.$(OBJEXT)
+get_cal_time_mod.mod: get_cal_time.$(OBJEXT)
+
+# Some mods are dependant on other mods in this dir.
+get_cal_time.$(OBJEXT): time_manager_mod.mod
+
+# Mod files are built and then installed as headers.
+MODFILES = time_manager_mod.mod get_cal_time_mod.mod
+include_HEADERS = $(MODFILES)
+BUILT_SOURCES = $(MODFILES)
+
+CLEANFILES = *.mod

--- a/time_manager/Makefile.am
+++ b/time_manager/Makefile.am
@@ -3,6 +3,9 @@
 
 # Ed Hartnett 2/22/19
 
+# Use any Fortran flags set by configure.
+AM_FCFLAGS = ${FMS_FCFLAGS}
+
 # Include .h and .mod files.
 AM_CPPFLAGS = -I${top_srcdir}/include
 AM_CPPFLAGS += -I${top_builddir}/constants

--- a/topography/Makefile.am
+++ b/topography/Makefile.am
@@ -1,0 +1,32 @@
+# This is an automake file for the topography directory of the FMS
+# package.
+
+# Ed Hartnett 2/22/19
+
+# Include .h and .mod files.
+AM_CPPFLAGS = -I${top_srcdir}/include
+AM_CPPFLAGS += -I${top_builddir}/fms
+AM_CPPFLAGS += -I${top_builddir}/constants
+AM_CPPFLAGS += -I${top_builddir}/mpp
+AM_CPPFLAGS += -I${top_builddir}/horiz_interp
+
+# Build these uninstalled convenience libraries.
+noinst_LTLIBRARIES = libgaussian_topog.la libtopography.la
+
+# Each convenience library depends on its source.
+libtopography_la_SOURCES = topography.F90
+libgaussian_topog_la_SOURCES = gaussian_topog.F90
+
+# Each mod file depends on the .o file.
+gaussian_topog_mod.mod: gaussian_topog.$(OBJEXT)
+topography_mod.mod: topography.$(OBJEXT)
+
+# Some mods are dependant on other mods in this dir.
+topography.$(OBJEXT): gaussian_topog_mod.mod
+
+# Mod files are built and then installed as headers.
+MODFILES = gaussian_topog_mod.mod topography_mod.mod
+include_HEADERS = $(MODFILES)
+BUILT_SOURCES = $(MODFILES)
+
+CLEANFILES = *.mod

--- a/topography/Makefile.am
+++ b/topography/Makefile.am
@@ -3,6 +3,9 @@
 
 # Ed Hartnett 2/22/19
 
+# Use any Fortran flags set by configure.
+AM_FCFLAGS = ${FMS_FCFLAGS}
+
 # Include .h and .mod files.
 AM_CPPFLAGS = -I${top_srcdir}/include
 AM_CPPFLAGS += -I${top_builddir}/fms

--- a/tracer_manager/Makefile.am
+++ b/tracer_manager/Makefile.am
@@ -1,0 +1,24 @@
+# This is an automake file for the tracer_manager directory of the FMS
+# package.
+
+# Ed Hartnett 2/22/19
+
+# Include .h and .mod files.
+AM_CPPFLAGS = -I${top_srcdir}/include
+AM_CPPFLAGS += -I${top_builddir}/constants
+AM_CPPFLAGS += -I${top_builddir}/mpp
+AM_CPPFLAGS += -I${top_builddir}/fms
+AM_CPPFLAGS += -I${top_builddir}/field_manager
+
+# Build this uninstalled convenience library.
+noinst_LTLIBRARIES = libtracer_manager.la
+
+# The convenience library depends on its source.
+libtracer_manager_la_SOURCES = tracer_manager.F90
+
+# Mod file depends on its o file, is built and then installed.
+tracer_manager_mod.mod: tracer_manager.$(OBJEXT)
+BUILT_SOURCES = tracer_manager_mod.mod
+include_HEADERS = tracer_manager_mod.mod
+
+CLEANFILES = *.mod

--- a/tracer_manager/Makefile.am
+++ b/tracer_manager/Makefile.am
@@ -3,6 +3,9 @@
 
 # Ed Hartnett 2/22/19
 
+# Use any Fortran flags set by configure.
+AM_FCFLAGS = ${FMS_FCFLAGS}
+
 # Include .h and .mod files.
 AM_CPPFLAGS = -I${top_srcdir}/include
 AM_CPPFLAGS += -I${top_builddir}/constants

--- a/tridiagonal/Makefile.am
+++ b/tridiagonal/Makefile.am
@@ -1,0 +1,21 @@
+# This is an automake file for the tridiagonal directory of the FMS
+# package.
+
+# Ed Hartnett 2/22/19
+
+# Include .h and .mod files.
+AM_CPPFLAGS = -I${top_srcdir}/include
+AM_CPPFLAGS += -I${top_builddir}/platform
+
+# Build this uninstalled convenience library.
+noinst_LTLIBRARIES = libtridiagonal.la
+
+# The convenience library depends on its source.
+libtridiagonal_la_SOURCES = tridiagonal.F90
+
+# Mod file depends on its o file, is built and then installed.
+tridiagonal_mod.mod: tridiagonal.$(OBJEXT)
+BUILT_SOURCES = tridiagonal_mod.mod
+include_HEADERS = tridiagonal_mod.mod
+
+CLEANFILES = *.mod

--- a/tridiagonal/Makefile.am
+++ b/tridiagonal/Makefile.am
@@ -3,6 +3,9 @@
 
 # Ed Hartnett 2/22/19
 
+# Use any Fortran flags set by configure.
+AM_FCFLAGS = ${FMS_FCFLAGS}
+
 # Include .h and .mod files.
 AM_CPPFLAGS = -I${top_srcdir}/include
 AM_CPPFLAGS += -I${top_builddir}/platform


### PR DESCRIPTION
Part of #73.

In this PR I add the setting of default fortran flags by configure. 

Setting of fortran flags can be disabled with --disable-fortran-flags. The FCFLAGS variable remains for the user to use, and any flags set in FCFLAGS will also be used (appended to the flags selected by configure).

Currently configure only sets flags for gfortran. If it seems good we can add other compilers as needed. If the user is using an unknown compiler, their best bet will be to use --disable-fortran-flags and figure out their own flags.

This is not a good thing to do - in fact it's a severe hack. But we will do it to help a smooth transition to the new build system. (The proper solution is for this code to be buildable without flags.)

Each currently-necessary flag that can be removed simplifies the build system and make build errors less likely, thus reducing maintenance and support for you. The ideal is a build-anywhere package which requires almost no support. netcdf-fortran has achieved this, so it is certainly possible for FMS.

I hope that this feature can be removed from the build system, after the code has been changed to reduce the dependence on fortran compiler flags.