### PR TITLE
User/jml/default data fix overload r8

### DIFF
--- a/fms/fms_io.F90
+++ b/fms/fms_io.F90
@@ -1741,7 +1741,7 @@ function register_restart_field_r2d8(fileObj, filename, fieldname, data, domain,
   else
      call setup_one_field(fileObj, filename, fieldname, (/size(data,1), size(data,2), 1, 1/), &
                           index_field, domain, mandatory, no_domain, is_compressed, &
-                          position, tile_count, longname=longname, units=units, compress_axis=compressed_axis, &
+                          position, tile_count, longname=longname, units=units, compressed_axis=compressed_axis, &
                           read_only=read_only, owns_data=restart_owns_data)
   endif
   

--- a/fms/fms_io.F90
+++ b/fms/fms_io.F90
@@ -1733,7 +1733,7 @@ function register_restart_field_r2d8(fileObj, filename, fieldname, data, domain,
   is_compressed = .false.
   if(present(compressed)) is_compressed=compressed
   if(present(data_default)) then
-     data_default_r4=data_default
+     data_default_r4=REAL(data_default, FLOAT_KIND)
      call setup_one_field(fileObj, filename, fieldname, (/size(data,1), size(data,2), 1, 1/), &
                           index_field, domain, mandatory, no_domain, is_compressed, &
                           position, tile_count, data_default_r4, longname, units, compressed_axis, &
@@ -1782,7 +1782,7 @@ function register_restart_field_r3d8(fileObj, filename, fieldname, data, domain,
   is_compressed = .false.
   if(present(compressed)) is_compressed=compressed
   if(present(data_default)) then
-     data_default_r4=data_default
+     data_default_r4=REAL(data_default, FLOAT_KIND)
      call setup_one_field(fileObj, filename, fieldname, (/size(data,1), size(data,2), size(data,3), 1/), &
                           index_field, domain, mandatory, no_domain, is_compressed, &
                           position, tile_count, data_default_r4, longname, units, compressed_axis, &

--- a/fms/fms_io.F90
+++ b/fms/fms_io.F90
@@ -1732,11 +1732,20 @@ function register_restart_field_r2d8(fileObj, filename, fieldname, data, domain,
   if(.not.module_is_initialized) call mpp_error(FATAL,'fms_io(register_restart_field_r2d8): need to call fms_io_init')
   is_compressed = .false.
   if(present(compressed)) is_compressed=compressed
-  if(present(data_default)) data_default_r4=data_default
-  call setup_one_field(fileObj, filename, fieldname, (/size(data,1), size(data,2), 1, 1/), &
-                       index_field, domain, mandatory, no_domain, is_compressed, &
-                       position, tile_count, data_default_r4, longname, units, compressed_axis, &
-                       read_only=read_only, owns_data=restart_owns_data)
+  if(present(data_default)) then
+     data_default_r4=data_default
+     call setup_one_field(fileObj, filename, fieldname, (/size(data,1), size(data,2), 1, 1/), &
+                          index_field, domain, mandatory, no_domain, is_compressed, &
+                          position, tile_count, data_default_r4, longname, units, compressed_axis, &
+                          read_only=read_only, owns_data=restart_owns_data)
+  else
+     call setup_one_field(fileObj, filename, fieldname, (/size(data,1), size(data,2), 1, 1/), &
+                          index_field, domain, mandatory, no_domain, is_compressed, &
+                          position, tile_count, longname=longname, units=units, compress_axis=compressed_axis, &
+                          read_only=read_only, owns_data=restart_owns_data)
+  endif
+  
+  
   fileObj%p2dr8(fileObj%var(index_field)%siz(4), index_field)%p => data
   fileObj%var(index_field)%ndim = 2
   register_restart_field_r2d8 = index_field
@@ -1772,11 +1781,19 @@ function register_restart_field_r3d8(fileObj, filename, fieldname, data, domain,
   if(.not.module_is_initialized) call mpp_error(FATAL,'fms_io(register_restart_field_r3d8): need to call fms_io_init')
   is_compressed = .false.
   if(present(compressed)) is_compressed=compressed
-  if(present(data_default)) data_default_r4=data_default
-  call setup_one_field(fileObj, filename, fieldname, (/size(data,1), size(data,2), size(data,3), 1/), &
-                       index_field, domain, mandatory, no_domain, is_compressed, &
-                       position, tile_count, data_default_r4, longname, units, compressed_axis, &
-                       read_only=read_only, owns_data=restart_owns_data)
+  if(present(data_default)) then
+     data_default_r4=data_default
+     call setup_one_field(fileObj, filename, fieldname, (/size(data,1), size(data,2), size(data,3), 1/), &
+                          index_field, domain, mandatory, no_domain, is_compressed, &
+                          position, tile_count, data_default_r4, longname, units, compressed_axis, &
+                          read_only=read_only, owns_data=restart_owns_data)
+  else
+     call setup_one_field(fileObj, filename, fieldname, (/size(data,1), size(data,2), size(data,3), 1/), &
+                          index_field, domain, mandatory, no_domain, is_compressed, &
+                          position, tile_count, longname=longname, units=units, compressed_axis=compressed_axis, &
+                          read_only=read_only, owns_data=restart_owns_data)
+  endif
+  
   fileObj%p3dr8(fileObj%var(index_field)%siz(4), index_field)%p => data
   fileObj%var(index_field)%ndim = 3
   register_restart_field_r3d8 = index_field


### PR DESCRIPTION
@menzel-gfdl 
@bensonr 
Added conditional statements in register_restart_field_r3d8 and register_restart_field_r2d8 that only pass the optional 'data_default_r4' argument to 'setup_one_field' if data_default is initially passed to the register_restart_field interface. These modifications allow 'setup_one_field' to set the variable attribute 'default_data' to MPP_FILL_DOUBLE. 

The current code passes data_default_r4, and uninitialized real variable, to setup_one_field regardless of whether it is defined or not. Since the fv3gfs_io register_restart_field calls do not define data_default, the uninitialized data_default_r4 is passed to setup_one_field. Setup_one_field sees that data_default is present, and sets the variable attribute 'default_data' to the uninitialized value, a NaN, which is trapped in the call to mpp_write by save_default_restart in the debug-compiled executable.

This fix was tested on Gaea C3 with Intel 16. 
