### PR TITLE
Update .travis.yml for new MPI directive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,10 @@
 *.o
 *.mod
 *.s
+*.out
 pathnames*
+/*.zip
+/*.tar.gz
 
 Makefile
 # From https://github.com/github/gitignore/blob/master/Autotools.gitignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,36 +7,26 @@
 # FMS is not a c-language project, although there are a few c-language
 # sources.  However, this is the best choice.
 language: c
-dist: trusty
-sudo: false
+dist: xenial 
 
 addons:
   apt:
     sources:
     - ubuntu-toolchain-r-test
     packages:
-    - pkg-config netcdf-bin libnetcdf-dev openmpi-bin libopenmpi-dev gfortran
+    - pkg-config netcdf-bin libnetcdf-dev libnetcdff-dev openmpi-bin libopenmpi-dev gfortran
 
+# Travis sets CC to gcc, but we need to ensure it is not set, so we can use mpicc
 before_install:
-  - test -n $CC && unset CC
-  - test -n $FC && unset FC
-  - test -n $CPPFLAGS && unset CPPFLAGS
-  - test -n FCFLAGS && unset FCFLAGS
+  - test -n "$CC" && unset CC
 
 before_script:
   - export CC=mpicc
   - export FC=mpif90
-  - export CPPFLAGS='-I/usr/include'
+  - export CPPFLAGS='-I/usr/include -Duse_LARGEFILE -DMAXFIELDMETHODS_=500'
   - export FCFLAGS='-fcray-pointer -fdefault-double-8 -fdefault-real-8 -Waliasing -ffree-line-length-none -fno-range-check'
+  - export LDFLAGS='-L/usr/lib'
 
-env:
-  global:
-    - CC=mpicc
-    - FC=mpif90
-    - CPPFLAGS='-I/usr/include'
-    - FCFLAGS='-fcray-pointer -fdefault-double-8 -fdefault-real-8 -Waliasing -ffree-line-length-none -fno-range-check'
-    - LDFLAGS='-L/usr/lib'
-  
 script:
   - autoreconf -i
   - ./configure

--- a/libFMS/Makefile.am
+++ b/libFMS/Makefile.am
@@ -66,6 +66,7 @@ libFMS_la_LIBADD += ${top_builddir}/column_diagnostics/libcolumn_diagnostics.la
 libFMS_la_LIBADD += ${top_builddir}/block_control/libblock_control.la
 libFMS_la_LIBADD += ${top_builddir}/astronomy/libastronomy.la
 libFMS_la_LIBADD += ${top_builddir}/field_manager/libfield_manager.la
+libFMS_la_LIBADD += ${top_builddir}/field_manager/libfm_util.la
 libFMS_la_LIBADD += ${top_builddir}/monin_obukhov/libmonin_obukhov.la
 libFMS_la_LIBADD += ${top_builddir}/monin_obukhov/libmonin_obukhov_kernel.la
 libFMS_la_LIBADD += ${top_builddir}/interpolator/libinterpolator.la

--- a/test_fms/Makefile.am
+++ b/test_fms/Makefile.am
@@ -6,6 +6,7 @@
 # Find the fms_mod.mod file.
 AM_CPPFLAGS = -I${top_builddir}/fms
 AM_CPPFLAGS += -I${top_builddir}/constants
+LDADD = ${top_builddir}/libFMS/.libs/libFMS.la
 
 # Build this test program.
 check_PROGRAMS = tst_fms1

--- a/test_fms/tst_fms1.F90
+++ b/test_fms/tst_fms1.F90
@@ -1,13 +1,16 @@
 ! This is a sample test program for the FMS library.
 
       program tst_fms1
-      use fms_mod
+      use constants_mod
       implicit none
 
       print *, ''
       print *,'*** Testing FMS library...'
 
       ! Insert test code here.
+      ! constanst_init is a no-op routine.  This is just to ensure the library
+      ! can be linked into an executable
+      call constants_init()
 
       print *,'*** SUCCESS!'
       end


### PR DESCRIPTION
The previous travis environment used an outdated openMPI the
did not have a new MPI API element.  The travis enviornment
now uses xenial with an openMPI library with the missing
API.

Other travis.yml cleanup was also done.

Also found that fm_util.o file was not included in the final
libFMS library.  This has been corrected.

The base test did not link in the library, added a no-op
libFMS call to constants_init(), and modified the test
Makefile.am to link in the library.

Fixes #90
Fixes #91 
Fixes #92