### PR TITLE
diag_integral output includes ensemble number

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,8 +7,8 @@ ACLOCAL_AMFLAGS = -I m4
 # Make targets will be run in each subdirectory. Order is significant.
 SUBDIRS = include platform constants tridiagonal mpp memutils fms	\
 mosaic time_manager diag_manager drifters axis_utils horiz_interp	\
-time_interp diag_integral column_diagnostics block_control		\
-data_override astronomy field_manager coupler monin_obukhov		\
+time_interp column_diagnostics block_control data_override		\
+astronomy field_manager coupler diag_integral monin_obukhov		\
 interpolator fft amip_interp oda_tools exchange topography		\
 tracer_manager station_data sat_vapor_pres random_numbers libFMS	\
 test_fms

--- a/configure.ac
+++ b/configure.ac
@@ -83,13 +83,13 @@ AC_CONFIG_FILES([Makefile
         exchange/Makefile
         drifters/Makefile
         diag_manager/Makefile
-        diag_integral/Makefile
         data_override/Makefile
         column_diagnostics/Makefile
         block_control/Makefile
         axis_utils/Makefile
         astronomy/Makefile
         coupler/Makefile
+        diag_integral/Makefile
         sat_vapor_pres/Makefile
         random_numbers/Makefile
         libFMS/Makefile

--- a/diag_integral/Makefile.am
+++ b/diag_integral/Makefile.am
@@ -9,6 +9,7 @@ AM_CPPFLAGS += -I${top_builddir}/time_manager
 AM_CPPFLAGS += -I${top_builddir}/mpp
 AM_CPPFLAGS += -I${top_builddir}/fms
 AM_CPPFLAGS += -I${top_builddir}/constants
+AM_CPPFLAGS += -I${top_builddir}/coupler
 
 # Build this uninstalled convenience library.
 noinst_LTLIBRARIES = libdiag_integral.la

--- a/diag_integral/diag_integral.F90
+++ b/diag_integral/diag_integral.F90
@@ -1527,6 +1527,7 @@ real, dimension (size(data,1),size(data,2)) :: data2
 
 end function vert_diag_integral
 
+!> \brief Adds .ens_## to the diag_integral.out file name 
 function ensemble_file_name(fname) result(updated_file_name)
      character (len=mxch), intent(inout) :: fname
      character (len=mxch) :: updated_file_name
@@ -1534,7 +1535,7 @@ function ensemble_file_name(fname) result(updated_file_name)
      character(len=7) :: ensemble_suffix
      character(len=2) :: ensemble_id_char 
      integer :: i
-     !> Make sure the file name short enough ti handle adding the ensemble number
+     !> Make sure the file name short enough to handle adding the ensemble number
      if (len(trim(fname)) > mxch-7) call error_mesg ('diag_integral_mod :: ensemble_file_name',  &
           trim(fname)//" is too long and can not support adding ens_XX.  Please shorten the "//&
           "file_name in the diag_integral_nml", FATAL)


### PR DESCRIPTION
Resolves #111
When an ensemble is run, the diag_integral.out file will be named diag_integral.ens_##.out where ## is a 2-digit number designated to the ensemble number.  This also resolves autotools compilation errors.