### PR TITLE
History files name fix

### DIFF
--- a/diag_manager/diag_output.F90
+++ b/diag_manager/diag_output.F90
@@ -196,7 +196,7 @@ CONTAINS
     endif
 !> If there is a .nc suffix on the file name, remove the .nc
     if (len(trim(fname_no_tile)) > 3 ) then
-       checkNC: do i = 3,len_file_name
+       checkNC: do i = 3,len(fname_no_tile)
          if (fname_no_tile(i-2:i) == ".nc") then
             fname_no_tile(i-2:i) = "   "
             exit checkNC

--- a/diag_manager/diag_output.F90
+++ b/diag_manager/diag_output.F90
@@ -196,7 +196,7 @@ CONTAINS
     endif
 !> If there is a .nc suffix on the file name, remove the .nc
     if (len(trim(fname_no_tile)) > 3 ) then
-       checkNC: do i = 3,len(fname_no_tile)
+       checkNC: do i = 3,len(trim(fname_no_tile))
          if (fname_no_tile(i-2:i) == ".nc") then
             fname_no_tile(i-2:i) = "   "
             exit checkNC


### PR DESCRIPTION
https://github.com/thomas-robinson/FMS/pull/7 fixed an issue where the names of the history files were coming out with an extra .nc suffix

I got a crash in a different test case because the length of the string fname_no_tile was less than len_file_name since in this test case it got into the L182-196 where "tile" was removed from the file name. 

I fixed it so that the loop goes from 1 to the length of fname_no_tile instead