### PR TITLE
New_io: Fix in compressed_write where the incorrect compressed index was used

### DIFF
--- a/fms2_io/include/compressed_write.inc
+++ b/fms2_io/include/compressed_write.inc
@@ -18,10 +18,10 @@ subroutine compressed_write_0d(fileobj, variable_name, cdata, unlim_dim_level, &
                                           !! where the data
                                           !! will be written to.
 
-  integer :: compressed_dim_index
+  integer, dimension(2) :: compressed_dim_index
 
   compressed_dim_index = get_variable_compressed_dimension_index(fileobj, variable_name)
-  if (compressed_dim_index .eq. dimension_not_found) then
+  if (compressed_dim_index(1) .eq. dimension_not_found) then
     call netcdf_write_data(fileobj, variable_name, cdata, &
                            unlim_dim_level=unlim_dim_level, corner=corner)
     return
@@ -76,7 +76,7 @@ subroutine compressed_write_1d(fileobj, variable_name, cdata, unlim_dim_level, &
                                                               !! will be written
                                                               !! in each dimension.
 
-  integer :: compressed_dim_index
+  integer, dimension(2) :: compressed_dim_index
   integer, dimension(1) :: c
   integer, dimension(1) :: e
   integer :: i
@@ -86,7 +86,8 @@ subroutine compressed_write_1d(fileobj, variable_name, cdata, unlim_dim_level, &
   real(kind=real64), dimension(:), allocatable :: buf_real64
 
   compressed_dim_index = get_variable_compressed_dimension_index(fileobj, variable_name)
-  if (compressed_dim_index .eq. dimension_not_found) then
+
+  if (compressed_dim_index(1) .eq. dimension_not_found) then
     call netcdf_write_data(fileobj, variable_name, cdata, &
                            unlim_dim_level=unlim_dim_level, corner=corner, &
                            edge_lengths=edge_lengths)
@@ -98,8 +99,8 @@ subroutine compressed_write_1d(fileobj, variable_name, cdata, unlim_dim_level, &
     c(:) = 1
     e(:) = shape(cdata)
     do i = 1, size(fileobj%pelist)
-      c(compressed_dim_index) = fileobj%compressed_dims(compressed_dim_index)%npes_corner(i)
-      e(compressed_dim_index) = fileobj%compressed_dims(compressed_dim_index)%npes_nelems(i)
+      c(compressed_dim_index(1)) = fileobj%compressed_dims(compressed_dim_index(2))%npes_corner(i)
+      e(compressed_dim_index(1)) = fileobj%compressed_dims(compressed_dim_index(2))%npes_nelems(i)
       if (i .eq. 1) then
         call netcdf_write_data(fileobj, variable_name, cdata, &
                                unlim_dim_level=unlim_dim_level, corner=c, &
@@ -181,7 +182,7 @@ subroutine compressed_write_2d(fileobj, variable_name, cdata, unlim_dim_level, &
                                                               !! will be written
                                                               !! in each dimension.
 
-  integer :: compressed_dim_index
+  integer, dimension(2) :: compressed_dim_index
   integer, dimension(2) :: c
   integer, dimension(2) :: e
   integer :: i
@@ -191,7 +192,7 @@ subroutine compressed_write_2d(fileobj, variable_name, cdata, unlim_dim_level, &
   real(kind=real64), dimension(:,:), allocatable :: buf_real64
 
   compressed_dim_index = get_variable_compressed_dimension_index(fileobj, variable_name)
-  if (compressed_dim_index .eq. dimension_not_found) then
+  if (compressed_dim_index(1) .eq. dimension_not_found) then
     call netcdf_write_data(fileobj, variable_name, cdata, &
                            unlim_dim_level=unlim_dim_level, corner=corner, &
                            edge_lengths=edge_lengths)
@@ -203,8 +204,8 @@ subroutine compressed_write_2d(fileobj, variable_name, cdata, unlim_dim_level, &
     c(:) = 1
     e(:) = shape(cdata)
     do i = 1, size(fileobj%pelist)
-      c(compressed_dim_index) = fileobj%compressed_dims(compressed_dim_index)%npes_corner(i)
-      e(compressed_dim_index) = fileobj%compressed_dims(compressed_dim_index)%npes_nelems(i)
+      c(compressed_dim_index(1)) = fileobj%compressed_dims(compressed_dim_index(2))%npes_corner(i)
+      e(compressed_dim_index(1)) = fileobj%compressed_dims(compressed_dim_index(2))%npes_nelems(i)
       if (i .eq. 1) then
         call netcdf_write_data(fileobj, variable_name, cdata, &
                                unlim_dim_level=unlim_dim_level, corner=c, &
@@ -286,7 +287,7 @@ subroutine compressed_write_3d(fileobj, variable_name, cdata, unlim_dim_level, &
                                                               !! will be written
                                                               !! in each dimension.
 
-  integer :: compressed_dim_index
+  integer, dimension(2) :: compressed_dim_index
   integer, dimension(3) :: c
   integer, dimension(3) :: e
   integer :: i
@@ -296,7 +297,7 @@ subroutine compressed_write_3d(fileobj, variable_name, cdata, unlim_dim_level, &
   real(kind=real64), dimension(:,:,:), allocatable :: buf_real64
 
   compressed_dim_index = get_variable_compressed_dimension_index(fileobj, variable_name)
-  if (compressed_dim_index .eq. dimension_not_found) then
+  if (compressed_dim_index(1) .eq. dimension_not_found) then
     call netcdf_write_data(fileobj, variable_name, cdata, &
                            unlim_dim_level=unlim_dim_level, corner=corner, &
                            edge_lengths=edge_lengths)
@@ -308,8 +309,8 @@ subroutine compressed_write_3d(fileobj, variable_name, cdata, unlim_dim_level, &
     c(:) = 1
     e(:) = shape(cdata)
     do i = 1, size(fileobj%pelist)
-      c(compressed_dim_index) = fileobj%compressed_dims(compressed_dim_index)%npes_corner(i)
-      e(compressed_dim_index) = fileobj%compressed_dims(compressed_dim_index)%npes_nelems(i)
+      c(compressed_dim_index(1)) = fileobj%compressed_dims(compressed_dim_index(2))%npes_corner(i)
+      e(compressed_dim_index(1)) = fileobj%compressed_dims(compressed_dim_index(2))%npes_nelems(i)
       if (i .eq. 1) then
         call netcdf_write_data(fileobj, variable_name, cdata, &
                                unlim_dim_level=unlim_dim_level, corner=c, &
@@ -391,7 +392,7 @@ subroutine compressed_write_4d(fileobj, variable_name, cdata, unlim_dim_level, &
                                                               !! will be written
                                                               !! in each dimension.
 
-  integer :: compressed_dim_index
+  integer, dimension(2) :: compressed_dim_index
   integer, dimension(4) :: c
   integer, dimension(4) :: e
   integer :: i
@@ -401,7 +402,7 @@ subroutine compressed_write_4d(fileobj, variable_name, cdata, unlim_dim_level, &
   real(kind=real64), dimension(:,:,:,:), allocatable :: buf_real64
 
   compressed_dim_index = get_variable_compressed_dimension_index(fileobj, variable_name)
-  if (compressed_dim_index .eq. dimension_not_found) then
+  if (compressed_dim_index(1) .eq. dimension_not_found) then
     call netcdf_write_data(fileobj, variable_name, cdata, &
                            unlim_dim_level=unlim_dim_level, corner=corner, &
                            edge_lengths=edge_lengths)
@@ -413,8 +414,8 @@ subroutine compressed_write_4d(fileobj, variable_name, cdata, unlim_dim_level, &
     c(:) = 1
     e(:) = shape(cdata)
     do i = 1, size(fileobj%pelist)
-      c(compressed_dim_index) = fileobj%compressed_dims(compressed_dim_index)%npes_corner(i)
-      e(compressed_dim_index) = fileobj%compressed_dims(compressed_dim_index)%npes_nelems(i)
+      c(compressed_dim_index(1)) = fileobj%compressed_dims(compressed_dim_index(2))%npes_corner(i)
+      e(compressed_dim_index(1)) = fileobj%compressed_dims(compressed_dim_index(2))%npes_nelems(i)
       if (i .eq. 1) then
         call netcdf_write_data(fileobj, variable_name, cdata, &
                                unlim_dim_level=unlim_dim_level, corner=c, &
@@ -496,7 +497,7 @@ subroutine compressed_write_5d(fileobj, variable_name, cdata, unlim_dim_level, &
                                                               !! will be written
                                                               !! in each dimension.
 
-  integer :: compressed_dim_index
+  integer, dimension(2) :: compressed_dim_index
   integer, dimension(5) :: c
   integer, dimension(5) :: e
   integer :: i
@@ -506,7 +507,7 @@ subroutine compressed_write_5d(fileobj, variable_name, cdata, unlim_dim_level, &
   real(kind=real64), dimension(:,:,:,:,:), allocatable :: buf_real64
 
   compressed_dim_index = get_variable_compressed_dimension_index(fileobj, variable_name)
-  if (compressed_dim_index .eq. dimension_not_found) then
+  if (compressed_dim_index(1) .eq. dimension_not_found) then
     call netcdf_write_data(fileobj, variable_name, cdata, &
                            unlim_dim_level=unlim_dim_level, corner=corner, &
                            edge_lengths=edge_lengths)
@@ -518,8 +519,8 @@ subroutine compressed_write_5d(fileobj, variable_name, cdata, unlim_dim_level, &
     c(:) = 1
     e(:) = shape(cdata)
     do i = 1, size(fileobj%pelist)
-      c(compressed_dim_index) = fileobj%compressed_dims(compressed_dim_index)%npes_corner(i)
-      e(compressed_dim_index) = fileobj%compressed_dims(compressed_dim_index)%npes_nelems(i)
+      c(compressed_dim_index(1)) = fileobj%compressed_dims(compressed_dim_index(2))%npes_corner(i)
+      e(compressed_dim_index(1)) = fileobj%compressed_dims(compressed_dim_index(2))%npes_nelems(i)
       if (i .eq. 1) then
         call netcdf_write_data(fileobj, variable_name, cdata, &
                                unlim_dim_level=unlim_dim_level, corner=c, &

--- a/fms2_io/netcdf_io.F90
+++ b/fms2_io/netcdf_io.F90
@@ -731,11 +731,12 @@ function get_variable_compressed_dimension_index(fileobj, variable_name, broadca
                                              !! "I/O root" ranks.
                                              !! The broadcast will be done
                                              !! by default.
-  integer :: compressed_dimension_index
+  integer, dimension(2) :: compressed_dimension_index
 
   integer :: ndims
   character(len=nf90_max_name), dimension(:), allocatable :: dim_names
   integer :: i
+  integer :: j
 
   compressed_dimension_index = dimension_not_found
   if (fileobj%is_root) then
@@ -744,8 +745,10 @@ function get_variable_compressed_dimension_index(fileobj, variable_name, broadca
       allocate(dim_names(ndims))
       call get_variable_dimension_names(fileobj, variable_name, dim_names, broadcast=.false.)
       do i = 1, size(dim_names)
-        if (get_compressed_dimension_index(fileobj,dim_names(i)) .ne. dimension_not_found) then
-          compressed_dimension_index = i
+        j = get_compressed_dimension_index(fileobj,dim_names(i))
+        if (j .ne. dimension_not_found) then
+          compressed_dimension_index(1) = i
+          compressed_dimension_index(2) = j
           exit
         endif
       enddo
@@ -757,7 +760,7 @@ function get_variable_compressed_dimension_index(fileobj, variable_name, broadca
       return
     endif
   endif
-  call mpp_broadcast(compressed_dimension_index, fileobj%io_root, pelist=fileobj%pelist)
+  call mpp_broadcast(compressed_dimension_index(1), fileobj%io_root, pelist=fileobj%pelist)
 end function get_variable_compressed_dimension_index
 
 


### PR DESCRIPTION
Ran into a crash due to a buffer size error in save_vegn_restart with compressed_write. This error was because the wrong compressed dimension index was used. The code was using the fileobj compressed dimension when assigning c and e instead of the variable's

The function get_variable_compressed_dimension_index was used the get the index of the compressed dimension for the variable. This index was then used to assign c and e:
```fortran 
c(compressed_dim_index) = fileobj%compressed_dims(compressed_dim_index)%npes_corner(i)
e(compressed_dim_index) = fileobj%compressed_dims(compressed_dim_index)%npes_nelems(i)
```
 In this case they were not the same because the file_obj had more than 1 compressed dimension, so the code crash. 

I modified the function get_variable_compressed_dimension_index to output a 2 element array where the 1st element is the compressed dimension of the variable and the 2nd element is the compressed dimension of the file obj. Then, I used the correct index when assigning c and e in compressed_write.inc. 