### PR TITLE
Domain read/write bug fixes 

### DIFF
--- a/fms2_io/fms_netcdf_domain_io.F90
+++ b/fms2_io/fms_netcdf_domain_io.F90
@@ -683,24 +683,24 @@ subroutine domain_offsets(data_xsize, data_ysize, domain, xpos, ypos, &
 
   call mpp_get_compute_domain(io_domain, xbegin=isc, xend=iec, xsize=xc_size, &
                               position=xpos)
-  ! If the xpos is east and the ending x index is equal to max allowed, set extra_x_point to true
+  ! If the xpos is east and the ending x index is NOT equal to max allowed, set extra_x_point to true
   if (present(extra_x_point)) then
-	 if ((xpos .eq. east) .and. (iec .eq. xmax)) then 
+	 if ((xpos .eq. east) .and. (iec .ne. xmax)) then 
 		extra_x_point = .true.
-    else
+    	else
 		extra_x_point = .false.
-	 endif
+	endif
   endif
 
   call mpp_get_compute_domain(io_domain, ybegin=jsc, yend=jec, ysize=yc_size, &
                               position=ypos)
-  ! If the ypost is north and the ending y index is equal to max allowed, set extra_y_point to true
+  ! If the ypost is north and the ending y index is NOT equal to max allowed, set extra_y_point to true
   if (present(extra_y_point)) then
-	 if ((ypos .eq. north) .and. (jec .eq. ymax)) then 
+	 if ((ypos .eq. north) .and. (jec .ne. ymax)) then 
 		extra_y_point = .true.
 	 else
 		extra_y_point = .false.
-    endif
+   	 endif
   endif
 
   buffer_includes_halos = (data_xsize .eq. xd_size) .and. (data_ysize .eq. yd_size)

--- a/fms2_io/include/compute_global_checksum.inc
+++ b/fms2_io/include/compute_global_checksum.inc
@@ -44,7 +44,7 @@ function compute_global_checksum_2d(fileobj, variable_name, variable_data, is_de
   endif
   io_domain => mpp_get_io_domain(fileobj%domain)
   call domain_offsets(size(variable_data, xdim), size(variable_data, ydim), fileobj%domain, &
-                      io_domain, xpos, ypos, isd, isc, xc_size, jsd, jsc, &
+                      xpos, ypos, isd, isc, xc_size, jsd, jsc, &
                       yc_size, buffer_includes_halos, extra_x, extra_y)
   c(:) = 1
   if (buffer_includes_halos) then
@@ -55,14 +55,19 @@ function compute_global_checksum_2d(fileobj, variable_name, variable_data, is_de
   e(:) = shape(variable_data)
   e(xdim) = xc_size
   e(ydim) = yc_size
-  if (.not. extra_x) then
+
+  if (extra_x) then
     !Adjust sizes since compute domains overlap whe there are non-centered
     !domain position.
     e(xdim) = e(xdim) - 1
   endif
-  if (.not. extra_y) then
+
+  if (extra_y) then
+    !Adjust sizes since compute domains overlap whe there are non-centered
+    !domain position.
     e(ydim) = e(ydim) - 1
   endif
+
   select type (variable_data)
     type is (integer(kind=int32))
       call allocate_array(buf_int32, e)
@@ -155,7 +160,7 @@ function compute_global_checksum_3d(fileobj, variable_name, variable_data, is_de
   endif
   io_domain => mpp_get_io_domain(fileobj%domain)
   call domain_offsets(size(variable_data, xdim), size(variable_data, ydim), fileobj%domain, &
-                      io_domain, xpos, ypos, isd, isc, xc_size, jsd, jsc, &
+                      xpos, ypos, isd, isc, xc_size, jsd, jsc, &
                       yc_size, buffer_includes_halos, extra_x, extra_y)
   c(:) = 1
   if (buffer_includes_halos) then
@@ -166,12 +171,16 @@ function compute_global_checksum_3d(fileobj, variable_name, variable_data, is_de
   e(:) = shape(variable_data)
   e(xdim) = xc_size
   e(ydim) = yc_size
-  if (.not. extra_x) then
+
+  if (extra_x) then
     !Adjust sizes since compute domains overlap whe there are non-centered
     !domain position.
     e(xdim) = e(xdim) - 1
   endif
+
   if (.not. extra_y) then
+    !Adjust sizes since compute domains overlap whe there are non-centered
+    !domain position.
     e(ydim) = e(ydim) - 1
   endif
   select type (variable_data)
@@ -266,7 +275,7 @@ function compute_global_checksum_4d(fileobj, variable_name, variable_data, is_de
   endif
   io_domain => mpp_get_io_domain(fileobj%domain)
   call domain_offsets(size(variable_data, xdim), size(variable_data, ydim), fileobj%domain, &
-                      io_domain, xpos, ypos, isd, isc, xc_size, jsd, jsc, &
+                      xpos, ypos, isd, isc, xc_size, jsd, jsc, &
                       yc_size, buffer_includes_halos, extra_x, extra_y)
   c(:) = 1
   if (buffer_includes_halos) then
@@ -277,14 +286,19 @@ function compute_global_checksum_4d(fileobj, variable_name, variable_data, is_de
   e(:) = shape(variable_data)
   e(xdim) = xc_size
   e(ydim) = yc_size
-  if (.not. extra_x) then
+
+  if (extra_x) then
     !Adjust sizes since compute domains overlap whe there are non-centered
     !domain position.
     e(xdim) = e(xdim) - 1
   endif
-  if (.not. extra_y) then
+
+  if (extra_y) then
+    !Adjust sizes since compute domains overlap whe there are non-centered
+    !domain position.
     e(ydim) = e(ydim) - 1
   endif
+
   select type (variable_data)
     type is (integer(kind=int32))
       call allocate_array(buf_int32, e)

--- a/fms2_io/include/compute_global_checksum.inc
+++ b/fms2_io/include/compute_global_checksum.inc
@@ -21,6 +21,8 @@ function compute_global_checksum_2d(fileobj, variable_name, variable_data, is_de
   integer :: jsc
   integer :: yc_size
   logical :: buffer_includes_halos
+  logical :: extra_x
+  logical :: extra_y
   integer, dimension(2) :: c
   integer, dimension(2) :: e
   integer(kind=int32), dimension(:,:), allocatable :: buf_int32
@@ -41,9 +43,9 @@ function compute_global_checksum_2d(fileobj, variable_name, variable_data, is_de
     return
   endif
   io_domain => mpp_get_io_domain(fileobj%domain)
-  call domain_offsets(size(variable_data, xdim), size(variable_data, ydim), &
+  call domain_offsets(size(variable_data, xdim), size(variable_data, ydim), fileobj%domain, &
                       io_domain, xpos, ypos, isd, isc, xc_size, jsd, jsc, &
-                      yc_size, buffer_includes_halos)
+                      yc_size, buffer_includes_halos, extra_x, extra_y)
   c(:) = 1
   if (buffer_includes_halos) then
     !Adjust if the input buffer has room for halos.
@@ -53,15 +55,13 @@ function compute_global_checksum_2d(fileobj, variable_name, variable_data, is_de
   e(:) = shape(variable_data)
   e(xdim) = xc_size
   e(ydim) = yc_size
-  if (mpp_pe() .ne. fileobj%pelist(size(fileobj%pelist))) then
+  if (.not. extra_x) then
     !Adjust sizes since compute domains overlap whe there are non-centered
     !domain position.
-    if (xpos .eq. east) then
-      e(xdim) = xc_size - 1
-    endif
-    if (ypos .eq. north) then
-      e(ydim) = yc_size - 1
-    endif
+    e(xdim) = e(xdim) - 1
+  endif
+  if (.not. extra_y) then
+    e(ydim) = e(ydim) - 1
   endif
   select type (variable_data)
     type is (integer(kind=int32))
@@ -132,6 +132,8 @@ function compute_global_checksum_3d(fileobj, variable_name, variable_data, is_de
   integer :: jsc
   integer :: yc_size
   logical :: buffer_includes_halos
+  logical :: extra_x
+  logical :: extra_y
   integer, dimension(3) :: c
   integer, dimension(3) :: e
   integer(kind=int32), dimension(:,:,:), allocatable :: buf_int32
@@ -152,9 +154,9 @@ function compute_global_checksum_3d(fileobj, variable_name, variable_data, is_de
     return
   endif
   io_domain => mpp_get_io_domain(fileobj%domain)
-  call domain_offsets(size(variable_data, xdim), size(variable_data, ydim), &
+  call domain_offsets(size(variable_data, xdim), size(variable_data, ydim), fileobj%domain, &
                       io_domain, xpos, ypos, isd, isc, xc_size, jsd, jsc, &
-                      yc_size, buffer_includes_halos)
+                      yc_size, buffer_includes_halos, extra_x, extra_y)
   c(:) = 1
   if (buffer_includes_halos) then
     !Adjust if the input buffer has room for halos.
@@ -164,15 +166,13 @@ function compute_global_checksum_3d(fileobj, variable_name, variable_data, is_de
   e(:) = shape(variable_data)
   e(xdim) = xc_size
   e(ydim) = yc_size
-  if (mpp_pe() .ne. fileobj%pelist(size(fileobj%pelist))) then
+  if (.not. extra_x) then
     !Adjust sizes since compute domains overlap whe there are non-centered
     !domain position.
-    if (xpos .eq. east) then
-      e(xdim) = xc_size - 1
-    endif
-    if (ypos .eq. north) then
-      e(ydim) = yc_size - 1
-    endif
+    e(xdim) = e(xdim) - 1
+  endif
+  if (.not. extra_y) then
+    e(ydim) = e(ydim) - 1
   endif
   select type (variable_data)
     type is (integer(kind=int32))
@@ -243,6 +243,8 @@ function compute_global_checksum_4d(fileobj, variable_name, variable_data, is_de
   integer :: jsc
   integer :: yc_size
   logical :: buffer_includes_halos
+  logical :: extra_x
+  logical :: extra_y
   integer, dimension(4) :: c
   integer, dimension(4) :: e
   integer(kind=int32), dimension(:,:,:,:), allocatable :: buf_int32
@@ -263,9 +265,9 @@ function compute_global_checksum_4d(fileobj, variable_name, variable_data, is_de
     return
   endif
   io_domain => mpp_get_io_domain(fileobj%domain)
-  call domain_offsets(size(variable_data, xdim), size(variable_data, ydim), &
+  call domain_offsets(size(variable_data, xdim), size(variable_data, ydim), fileobj%domain, &
                       io_domain, xpos, ypos, isd, isc, xc_size, jsd, jsc, &
-                      yc_size, buffer_includes_halos)
+                      yc_size, buffer_includes_halos, extra_x, extra_y)
   c(:) = 1
   if (buffer_includes_halos) then
     !Adjust if the input buffer has room for halos.
@@ -275,15 +277,13 @@ function compute_global_checksum_4d(fileobj, variable_name, variable_data, is_de
   e(:) = shape(variable_data)
   e(xdim) = xc_size
   e(ydim) = yc_size
-  if (mpp_pe() .ne. fileobj%pelist(size(fileobj%pelist))) then
+  if (.not. extra_x) then
     !Adjust sizes since compute domains overlap whe there are non-centered
     !domain position.
-    if (xpos .eq. east) then
-      e(xdim) = xc_size - 1
-    endif
-    if (ypos .eq. north) then
-      e(ydim) = yc_size - 1
-    endif
+    e(xdim) = e(xdim) - 1
+  endif
+  if (.not. extra_y) then
+    e(ydim) = e(ydim) - 1
   endif
   select type (variable_data)
     type is (integer(kind=int32))

--- a/fms2_io/include/domain_read.inc
+++ b/fms2_io/include/domain_read.inc
@@ -119,7 +119,7 @@ subroutine domain_read_2d(fileobj, variable_name, vdata, unlim_dim_level, &
     return
   endif
   io_domain => mpp_get_io_domain(fileobj%domain)
-  call domain_offsets(size(vdata, xdim_index), size(vdata, ydim_index), fileobj%domain, io_domain, &
+  call domain_offsets(size(vdata, xdim_index), size(vdata, ydim_index), fileobj%domain, &
                       xpos, ypos, isd, isc, xc_size, jsd, jsc, yc_size, buffer_includes_halos)
   c(:) = 1
   e(:) = shape(vdata)
@@ -333,7 +333,7 @@ subroutine domain_read_3d(fileobj, variable_name, vdata, unlim_dim_level, &
     return
   endif
   io_domain => mpp_get_io_domain(fileobj%domain)
-  call domain_offsets(size(vdata, xdim_index), size(vdata, ydim_index), fileobj%domain, io_domain, &
+  call domain_offsets(size(vdata, xdim_index), size(vdata, ydim_index), fileobj%domain, &
                       xpos, ypos, isd, isc, xc_size, jsd, jsc, yc_size, buffer_includes_halos)
   c(:) = 1
   e(:) = shape(vdata)
@@ -547,7 +547,7 @@ subroutine domain_read_4d(fileobj, variable_name, vdata, unlim_dim_level, &
     return
   endif
   io_domain => mpp_get_io_domain(fileobj%domain)
-  call domain_offsets(size(vdata, xdim_index), size(vdata, ydim_index), fileobj%domain, io_domain, &
+  call domain_offsets(size(vdata, xdim_index), size(vdata, ydim_index), fileobj%domain, &
                       xpos, ypos, isd, isc, xc_size, jsd, jsc, yc_size, buffer_includes_halos)
   c(:) = 1
   e(:) = shape(vdata)
@@ -761,7 +761,7 @@ subroutine domain_read_5d(fileobj, variable_name, vdata, unlim_dim_level, &
     return
   endif
   io_domain => mpp_get_io_domain(fileobj%domain)
-  call domain_offsets(size(vdata, xdim_index), size(vdata, ydim_index), fileobj%domain, io_domain, &
+  call domain_offsets(size(vdata, xdim_index), size(vdata, ydim_index), fileobj%domain, &
                       xpos, ypos, isd, isc, xc_size, jsd, jsc, yc_size, buffer_includes_halos)
   c(:) = 1
   e(:) = shape(vdata)

--- a/fms2_io/include/domain_read.inc
+++ b/fms2_io/include/domain_read.inc
@@ -119,7 +119,7 @@ subroutine domain_read_2d(fileobj, variable_name, vdata, unlim_dim_level, &
     return
   endif
   io_domain => mpp_get_io_domain(fileobj%domain)
-  call domain_offsets(size(vdata, xdim_index), size(vdata, ydim_index), io_domain, &
+  call domain_offsets(size(vdata, xdim_index), size(vdata, ydim_index), fileobj%domain, io_domain, &
                       xpos, ypos, isd, isc, xc_size, jsd, jsc, yc_size, buffer_includes_halos)
   c(:) = 1
   e(:) = shape(vdata)
@@ -133,8 +133,12 @@ subroutine domain_read_2d(fileobj, variable_name, vdata, unlim_dim_level, &
     call mpp_get_compute_domains(io_domain, xbegin=pe_isc, xsize=pe_icsize, position=xpos)
     call mpp_get_compute_domains(io_domain, ybegin=pe_jsc, ysize=pe_jcsize, position=ypos)
     do i = 1, size(fileobj%pelist)
-      c(xdim_index) = pe_isc(i) - pe_isc(1) + 1
-      c(ydim_index) = pe_jsc(i) - pe_jsc(1) + 1
+      c(xdim_index) = pe_isc(i)
+      c(ydim_index) = pe_jsc(i)
+      if (fileobj%adjust_indices) then
+        c(xdim_index) = c(xdim_index) - pe_isc(1) + 1
+        c(ydim_index) = c(ydim_index) - pe_jsc(1) + 1
+      endif
       e(xdim_index) = pe_icsize(i)
       e(ydim_index) = pe_jcsize(i)
       select type(vdata)
@@ -150,6 +154,9 @@ subroutine domain_read_2d(fileobj, variable_name, vdata, unlim_dim_level, &
               !Adjust if the input buffer has room for halos.
               c(xdim_index) = isc - isd + 1
               c(ydim_index) = jsc - jsd + 1
+            else
+              c(xdim_index) = 1
+              c(ydim_index) = 1
             endif
             call put_array_section(buf_int32, vdata, c, e)
           else
@@ -170,6 +177,9 @@ subroutine domain_read_2d(fileobj, variable_name, vdata, unlim_dim_level, &
               !Adjust if the input buffer has room for halos.
               c(xdim_index) = isc - isd + 1
               c(ydim_index) = jsc - jsd + 1
+            else
+              c(xdim_index) = 1
+              c(ydim_index) = 1
             endif
             call put_array_section(buf_int64, vdata, c, e)
           else
@@ -190,6 +200,9 @@ subroutine domain_read_2d(fileobj, variable_name, vdata, unlim_dim_level, &
               !Adjust if the input buffer has room for halos.
               c(xdim_index) = isc - isd + 1
               c(ydim_index) = jsc - jsd + 1
+            else
+              c(xdim_index) = 1
+              c(ydim_index) = 1
             endif
             call put_array_section(buf_real32, vdata, c, e)
           else
@@ -210,6 +223,9 @@ subroutine domain_read_2d(fileobj, variable_name, vdata, unlim_dim_level, &
               !Adjust if the input buffer has room for halos.
               c(xdim_index) = isc - isd + 1
               c(ydim_index) = jsc - jsd + 1
+            else
+              c(xdim_index) = 1
+              c(ydim_index) = 1
             endif
             call put_array_section(buf_real64, vdata, c, e)
           else
@@ -317,7 +333,7 @@ subroutine domain_read_3d(fileobj, variable_name, vdata, unlim_dim_level, &
     return
   endif
   io_domain => mpp_get_io_domain(fileobj%domain)
-  call domain_offsets(size(vdata, xdim_index), size(vdata, ydim_index), io_domain, &
+  call domain_offsets(size(vdata, xdim_index), size(vdata, ydim_index), fileobj%domain, io_domain, &
                       xpos, ypos, isd, isc, xc_size, jsd, jsc, yc_size, buffer_includes_halos)
   c(:) = 1
   e(:) = shape(vdata)
@@ -331,8 +347,12 @@ subroutine domain_read_3d(fileobj, variable_name, vdata, unlim_dim_level, &
     call mpp_get_compute_domains(io_domain, xbegin=pe_isc, xsize=pe_icsize, position=xpos)
     call mpp_get_compute_domains(io_domain, ybegin=pe_jsc, ysize=pe_jcsize, position=ypos)
     do i = 1, size(fileobj%pelist)
-      c(xdim_index) = pe_isc(i) - pe_isc(1) + 1
-      c(ydim_index) = pe_jsc(i) - pe_jsc(1) + 1
+      c(xdim_index) = pe_isc(i)
+      c(ydim_index) = pe_jsc(i)
+      if (fileobj%adjust_indices) then
+        c(xdim_index) = c(xdim_index) - pe_isc(1) + 1
+        c(ydim_index) = c(ydim_index) - pe_jsc(1) + 1
+      endif
       e(xdim_index) = pe_icsize(i)
       e(ydim_index) = pe_jcsize(i)
       select type(vdata)
@@ -348,6 +368,9 @@ subroutine domain_read_3d(fileobj, variable_name, vdata, unlim_dim_level, &
               !Adjust if the input buffer has room for halos.
               c(xdim_index) = isc - isd + 1
               c(ydim_index) = jsc - jsd + 1
+            else
+              c(xdim_index) = 1
+              c(ydim_index) = 1
             endif
             call put_array_section(buf_int32, vdata, c, e)
           else
@@ -368,6 +391,9 @@ subroutine domain_read_3d(fileobj, variable_name, vdata, unlim_dim_level, &
               !Adjust if the input buffer has room for halos.
               c(xdim_index) = isc - isd + 1
               c(ydim_index) = jsc - jsd + 1
+            else
+              c(xdim_index) = 1
+              c(ydim_index) = 1
             endif
             call put_array_section(buf_int64, vdata, c, e)
           else
@@ -388,6 +414,9 @@ subroutine domain_read_3d(fileobj, variable_name, vdata, unlim_dim_level, &
               !Adjust if the input buffer has room for halos.
               c(xdim_index) = isc - isd + 1
               c(ydim_index) = jsc - jsd + 1
+            else
+              c(xdim_index) = 1
+              c(ydim_index) = 1
             endif
             call put_array_section(buf_real32, vdata, c, e)
           else
@@ -408,6 +437,9 @@ subroutine domain_read_3d(fileobj, variable_name, vdata, unlim_dim_level, &
               !Adjust if the input buffer has room for halos.
               c(xdim_index) = isc - isd + 1
               c(ydim_index) = jsc - jsd + 1
+            else
+              c(xdim_index) = 1
+              c(ydim_index) = 1
             endif
             call put_array_section(buf_real64, vdata, c, e)
           else
@@ -515,7 +547,7 @@ subroutine domain_read_4d(fileobj, variable_name, vdata, unlim_dim_level, &
     return
   endif
   io_domain => mpp_get_io_domain(fileobj%domain)
-  call domain_offsets(size(vdata, xdim_index), size(vdata, ydim_index), io_domain, &
+  call domain_offsets(size(vdata, xdim_index), size(vdata, ydim_index), fileobj%domain, io_domain, &
                       xpos, ypos, isd, isc, xc_size, jsd, jsc, yc_size, buffer_includes_halos)
   c(:) = 1
   e(:) = shape(vdata)
@@ -529,8 +561,12 @@ subroutine domain_read_4d(fileobj, variable_name, vdata, unlim_dim_level, &
     call mpp_get_compute_domains(io_domain, xbegin=pe_isc, xsize=pe_icsize, position=xpos)
     call mpp_get_compute_domains(io_domain, ybegin=pe_jsc, ysize=pe_jcsize, position=ypos)
     do i = 1, size(fileobj%pelist)
-      c(xdim_index) = pe_isc(i) - pe_isc(1) + 1
-      c(ydim_index) = pe_jsc(i) - pe_jsc(1) + 1
+      c(xdim_index) = pe_isc(i)
+      c(ydim_index) = pe_jsc(i)
+      if (fileobj%adjust_indices) then
+        c(xdim_index) = c(xdim_index) - pe_isc(1) + 1
+        c(ydim_index) = c(ydim_index) - pe_jsc(1) + 1
+      endif
       e(xdim_index) = pe_icsize(i)
       e(ydim_index) = pe_jcsize(i)
       select type(vdata)
@@ -546,6 +582,9 @@ subroutine domain_read_4d(fileobj, variable_name, vdata, unlim_dim_level, &
               !Adjust if the input buffer has room for halos.
               c(xdim_index) = isc - isd + 1
               c(ydim_index) = jsc - jsd + 1
+            else
+              c(xdim_index) = 1
+              c(ydim_index) = 1
             endif
             call put_array_section(buf_int32, vdata, c, e)
           else
@@ -566,6 +605,9 @@ subroutine domain_read_4d(fileobj, variable_name, vdata, unlim_dim_level, &
               !Adjust if the input buffer has room for halos.
               c(xdim_index) = isc - isd + 1
               c(ydim_index) = jsc - jsd + 1
+            else
+              c(xdim_index) = 1
+              c(ydim_index) = 1
             endif
             call put_array_section(buf_int64, vdata, c, e)
           else
@@ -586,6 +628,9 @@ subroutine domain_read_4d(fileobj, variable_name, vdata, unlim_dim_level, &
               !Adjust if the input buffer has room for halos.
               c(xdim_index) = isc - isd + 1
               c(ydim_index) = jsc - jsd + 1
+            else
+              c(xdim_index) = 1
+              c(ydim_index) = 1
             endif
             call put_array_section(buf_real32, vdata, c, e)
           else
@@ -606,6 +651,9 @@ subroutine domain_read_4d(fileobj, variable_name, vdata, unlim_dim_level, &
               !Adjust if the input buffer has room for halos.
               c(xdim_index) = isc - isd + 1
               c(ydim_index) = jsc - jsd + 1
+            else
+              c(xdim_index) = 1
+              c(ydim_index) = 1
             endif
             call put_array_section(buf_real64, vdata, c, e)
           else
@@ -713,7 +761,7 @@ subroutine domain_read_5d(fileobj, variable_name, vdata, unlim_dim_level, &
     return
   endif
   io_domain => mpp_get_io_domain(fileobj%domain)
-  call domain_offsets(size(vdata, xdim_index), size(vdata, ydim_index), io_domain, &
+  call domain_offsets(size(vdata, xdim_index), size(vdata, ydim_index), fileobj%domain, io_domain, &
                       xpos, ypos, isd, isc, xc_size, jsd, jsc, yc_size, buffer_includes_halos)
   c(:) = 1
   e(:) = shape(vdata)
@@ -727,8 +775,13 @@ subroutine domain_read_5d(fileobj, variable_name, vdata, unlim_dim_level, &
     call mpp_get_compute_domains(io_domain, xbegin=pe_isc, xsize=pe_icsize, position=xpos)
     call mpp_get_compute_domains(io_domain, ybegin=pe_jsc, ysize=pe_jcsize, position=ypos)
     do i = 1, size(fileobj%pelist)
-      c(xdim_index) = pe_isc(i) - pe_isc(1) + 1
-      c(ydim_index) = pe_jsc(i) - pe_jsc(1) + 1
+      !Calculate the indices of the domain-decomposed chunk relative to its position in the file.
+      c(xdim_index) = pe_isc(i)
+      c(ydim_index) = pe_jsc(i)
+      if (fileobj%adjust_indices) then
+        c(xdim_index) = c(xdim_index) - pe_isc(1) + 1
+        c(ydim_index) = c(ydim_index) - pe_jsc(1) + 1
+      endif
       e(xdim_index) = pe_icsize(i)
       e(ydim_index) = pe_jcsize(i)
       select type(vdata)
@@ -739,11 +792,15 @@ subroutine domain_read_5d(fileobj, variable_name, vdata, unlim_dim_level, &
                                 unlim_dim_level=unlim_dim_level, &
                                 corner=c, edge_lengths=e, broadcast=.false.)
           if (i .eq. 1) then
-            !Root rank stores data directly.
+            !Root rank stores data directly.  Re-adjust the indicies relative
+            !to the input buffer vdata.
             if (buffer_includes_halos) then
               !Adjust if the input buffer has room for halos.
               c(xdim_index) = isc - isd + 1
               c(ydim_index) = jsc - jsd + 1
+            else
+              c(xdim_index) = 1
+              c(ydim_index) = 1
             endif
             call put_array_section(buf_int32, vdata, c, e)
           else
@@ -764,6 +821,9 @@ subroutine domain_read_5d(fileobj, variable_name, vdata, unlim_dim_level, &
               !Adjust if the input buffer has room for halos.
               c(xdim_index) = isc - isd + 1
               c(ydim_index) = jsc - jsd + 1
+            else
+              c(xdim_index) = 1
+              c(ydim_index) = 1
             endif
             call put_array_section(buf_int64, vdata, c, e)
           else
@@ -784,6 +844,9 @@ subroutine domain_read_5d(fileobj, variable_name, vdata, unlim_dim_level, &
               !Adjust if the input buffer has room for halos.
               c(xdim_index) = isc - isd + 1
               c(ydim_index) = jsc - jsd + 1
+            else
+              c(xdim_index) = 1
+              c(ydim_index) = 1
             endif
             call put_array_section(buf_real32, vdata, c, e)
           else
@@ -804,6 +867,9 @@ subroutine domain_read_5d(fileobj, variable_name, vdata, unlim_dim_level, &
               !Adjust if the input buffer has room for halos.
               c(xdim_index) = isc - isd + 1
               c(ydim_index) = jsc - jsd + 1
+            else
+              c(xdim_index) = 1
+              c(ydim_index) = 1
             endif
             call put_array_section(buf_real64, vdata, c, e)
           else

--- a/fms2_io/include/domain_write.inc
+++ b/fms2_io/include/domain_write.inc
@@ -119,7 +119,7 @@ subroutine domain_write_2d(fileobj, variable_name, vdata, unlim_dim_level, &
     return
   endif
   io_domain => mpp_get_io_domain(fileobj%domain)
-  call domain_offsets(size(vdata, xdim_index), size(vdata, ydim_index), fileobj%domain, io_domain, &
+  call domain_offsets(size(vdata, xdim_index), size(vdata, ydim_index), fileobj%domain, &
                       xpos, ypos, isd, isc, xc_size, jsd, jsc, yc_size, &
                       buffer_includes_halos, extra_x, extra_y)
   c(:) = 1
@@ -258,12 +258,19 @@ subroutine domain_write_2d(fileobj, variable_name, vdata, unlim_dim_level, &
     endif
     e(xdim_index) = xc_size
     e(ydim_index) = yc_size
-    if (.not. extra_x) then
+
+    if (extra_x) then
+    !Adjust sizes since compute domains overlap whe there are non-centered
+    !domain position.
       e(xdim_index) = e(xdim_index) - 1
     endif
-    if (.not. extra_y) then
+
+    if (extra_y) then
+    !Adjust sizes since compute domains overlap whe there are non-centered
+    !domain position.
       e(ydim_index) = e(ydim_index) - 1
     endif
+
     select type(vdata)
       type is (integer(kind=int32))
         call allocate_array(buf_int32, e)
@@ -348,7 +355,7 @@ subroutine domain_write_3d(fileobj, variable_name, vdata, unlim_dim_level, &
     return
   endif
   io_domain => mpp_get_io_domain(fileobj%domain)
-  call domain_offsets(size(vdata, xdim_index), size(vdata, ydim_index), fileobj%domain, io_domain, &
+  call domain_offsets(size(vdata, xdim_index), size(vdata, ydim_index), fileobj%domain, &
                       xpos, ypos, isd, isc, xc_size, jsd, jsc, yc_size, &
                       buffer_includes_halos, extra_x, extra_y)
   c(:) = 1
@@ -487,12 +494,19 @@ subroutine domain_write_3d(fileobj, variable_name, vdata, unlim_dim_level, &
     endif
     e(xdim_index) = xc_size
     e(ydim_index) = yc_size
-    if (.not. extra_x) then
+
+    if (extra_x) then
+    !Adjust sizes since compute domains overlap whe there are non-centered
+    !domain position.
       e(xdim_index) = e(xdim_index) - 1
     endif
-    if (.not. extra_y) then
+
+    if (extra_y) then
+    !Adjust sizes since compute domains overlap whe there are non-centered
+    !domain position.
       e(ydim_index) = e(ydim_index) - 1
     endif
+
     select type(vdata)
       type is (integer(kind=int32))
         call allocate_array(buf_int32, e)
@@ -577,7 +591,7 @@ subroutine domain_write_4d(fileobj, variable_name, vdata, unlim_dim_level, &
     return
   endif
   io_domain => mpp_get_io_domain(fileobj%domain)
-  call domain_offsets(size(vdata, xdim_index), size(vdata, ydim_index), fileobj%domain, io_domain, &
+  call domain_offsets(size(vdata, xdim_index), size(vdata, ydim_index), fileobj%domain, &
                       xpos, ypos, isd, isc, xc_size, jsd, jsc, yc_size, &
                       buffer_includes_halos, extra_x, extra_y)
   c(:) = 1
@@ -716,12 +730,19 @@ subroutine domain_write_4d(fileobj, variable_name, vdata, unlim_dim_level, &
     endif
     e(xdim_index) = xc_size
     e(ydim_index) = yc_size
-    if (.not. extra_x) then
+
+    if (extra_x) then
+    !Adjust sizes since compute domains overlap whe there are non-centered
+    !domain position.
       e(xdim_index) = e(xdim_index) - 1
     endif
-    if (.not. extra_y) then
+
+    if (extra_y) then
+    !Adjust sizes since compute domains overlap whe there are non-centered
+    !domain position.
       e(ydim_index) = e(ydim_index) - 1
     endif
+
     select type(vdata)
       type is (integer(kind=int32))
         call allocate_array(buf_int32, e)
@@ -806,7 +827,7 @@ subroutine domain_write_5d(fileobj, variable_name, vdata, unlim_dim_level, &
     return
   endif
   io_domain => mpp_get_io_domain(fileobj%domain)
-  call domain_offsets(size(vdata, xdim_index), size(vdata, ydim_index), fileobj%domain, io_domain, &
+  call domain_offsets(size(vdata, xdim_index), size(vdata, ydim_index), fileobj%domain, &
                       xpos, ypos, isd, isc, xc_size, jsd, jsc, yc_size, &
                       buffer_includes_halos, extra_x, extra_y)
   c(:) = 1
@@ -945,12 +966,19 @@ subroutine domain_write_5d(fileobj, variable_name, vdata, unlim_dim_level, &
     endif
     e(xdim_index) = xc_size
     e(ydim_index) = yc_size
-    if (.not. extra_x) then
+
+    if (extra_x) then
+    !Adjust sizes since compute domains overlap whe there are non-centered
+    !domain position.
       e(xdim_index) = e(xdim_index) - 1
     endif
-    if (.not. extra_y) then
+
+    if (extra_y) then
+    !Adjust sizes since compute domains overlap whe there are non-centered
+    !domain position.
       e(ydim_index) = e(ydim_index) - 1
     endif
+
     select type(vdata)
       type is (integer(kind=int32))
         call allocate_array(buf_int32, e)

--- a/fms2_io/include/domain_write.inc
+++ b/fms2_io/include/domain_write.inc
@@ -88,6 +88,8 @@ subroutine domain_write_2d(fileobj, variable_name, vdata, unlim_dim_level, &
   type(domain2d), pointer :: io_domain
   integer :: xpos
   integer :: ypos
+  integer :: xmax
+  integer :: ymax
   integer :: isd
   integer :: isc
   integer :: xc_size
@@ -95,6 +97,8 @@ subroutine domain_write_2d(fileobj, variable_name, vdata, unlim_dim_level, &
   integer :: jsc
   integer :: yc_size
   logical :: buffer_includes_halos
+  logical :: extra_x
+  logical :: extra_y
   integer, dimension(2) :: c
   integer, dimension(2) :: e
   integer, dimension(:), allocatable :: pe_isc
@@ -115,8 +119,9 @@ subroutine domain_write_2d(fileobj, variable_name, vdata, unlim_dim_level, &
     return
   endif
   io_domain => mpp_get_io_domain(fileobj%domain)
-  call domain_offsets(size(vdata, xdim_index), size(vdata, ydim_index), io_domain, &
-                      xpos, ypos, isd, isc, xc_size, jsd, jsc, yc_size, buffer_includes_halos)
+  call domain_offsets(size(vdata, xdim_index), size(vdata, ydim_index), fileobj%domain, io_domain, &
+                      xpos, ypos, isd, isc, xc_size, jsd, jsc, yc_size, &
+                      buffer_includes_halos, extra_x, extra_y)
   c(:) = 1
   e(:) = shape(vdata)
 
@@ -126,6 +131,8 @@ subroutine domain_write_2d(fileobj, variable_name, vdata, unlim_dim_level, &
     allocate(pe_icsize(size(fileobj%pelist)))
     allocate(pe_jsc(size(fileobj%pelist)))
     allocate(pe_jcsize(size(fileobj%pelist)))
+    call mpp_get_global_domain(io_domain, xend=xmax, position=xpos)
+    call mpp_get_global_domain(io_domain, yend=ymax, position=ypos)
     call mpp_get_compute_domains(io_domain, xbegin=pe_isc, xsize=pe_icsize, position=xpos)
     call mpp_get_compute_domains(io_domain, ybegin=pe_jsc, ysize=pe_jcsize, position=ypos)
     do i = 1, size(fileobj%pelist)
@@ -133,6 +140,12 @@ subroutine domain_write_2d(fileobj, variable_name, vdata, unlim_dim_level, &
       c(ydim_index) = pe_jsc(i) - pe_jsc(1) + 1
       e(xdim_index) = pe_icsize(i)
       e(ydim_index) = pe_jcsize(i)
+      if (xpos .ne. center .and. pe_isc(i)+pe_icsize(i)-1 .ne. xmax) then
+        e(xdim_index) = e(xdim_index) - 1
+      endif
+      if (ypos .ne. center .and. pe_jsc(i)+pe_jcsize(i)-1 .ne. ymax) then
+        e(ydim_index) = e(ydim_index) - 1
+      endif
       select type(vdata)
         type is (integer(kind=int32))
           call allocate_array(buf_int32, e)
@@ -245,6 +258,12 @@ subroutine domain_write_2d(fileobj, variable_name, vdata, unlim_dim_level, &
     endif
     e(xdim_index) = xc_size
     e(ydim_index) = yc_size
+    if (.not. extra_x) then
+      e(xdim_index) = e(xdim_index) - 1
+    endif
+    if (.not. extra_y) then
+      e(ydim_index) = e(ydim_index) - 1
+    endif
     select type(vdata)
       type is (integer(kind=int32))
         call allocate_array(buf_int32, e)
@@ -298,6 +317,8 @@ subroutine domain_write_3d(fileobj, variable_name, vdata, unlim_dim_level, &
   type(domain2d), pointer :: io_domain
   integer :: xpos
   integer :: ypos
+  integer :: xmax
+  integer :: ymax
   integer :: isd
   integer :: isc
   integer :: xc_size
@@ -305,6 +326,8 @@ subroutine domain_write_3d(fileobj, variable_name, vdata, unlim_dim_level, &
   integer :: jsc
   integer :: yc_size
   logical :: buffer_includes_halos
+  logical :: extra_x
+  logical :: extra_y
   integer, dimension(3) :: c
   integer, dimension(3) :: e
   integer, dimension(:), allocatable :: pe_isc
@@ -325,8 +348,9 @@ subroutine domain_write_3d(fileobj, variable_name, vdata, unlim_dim_level, &
     return
   endif
   io_domain => mpp_get_io_domain(fileobj%domain)
-  call domain_offsets(size(vdata, xdim_index), size(vdata, ydim_index), io_domain, &
-                      xpos, ypos, isd, isc, xc_size, jsd, jsc, yc_size, buffer_includes_halos)
+  call domain_offsets(size(vdata, xdim_index), size(vdata, ydim_index), fileobj%domain, io_domain, &
+                      xpos, ypos, isd, isc, xc_size, jsd, jsc, yc_size, &
+                      buffer_includes_halos, extra_x, extra_y)
   c(:) = 1
   e(:) = shape(vdata)
 
@@ -336,6 +360,8 @@ subroutine domain_write_3d(fileobj, variable_name, vdata, unlim_dim_level, &
     allocate(pe_icsize(size(fileobj%pelist)))
     allocate(pe_jsc(size(fileobj%pelist)))
     allocate(pe_jcsize(size(fileobj%pelist)))
+    call mpp_get_global_domain(io_domain, xend=xmax, position=xpos)
+    call mpp_get_global_domain(io_domain, yend=ymax, position=ypos)
     call mpp_get_compute_domains(io_domain, xbegin=pe_isc, xsize=pe_icsize, position=xpos)
     call mpp_get_compute_domains(io_domain, ybegin=pe_jsc, ysize=pe_jcsize, position=ypos)
     do i = 1, size(fileobj%pelist)
@@ -343,6 +369,12 @@ subroutine domain_write_3d(fileobj, variable_name, vdata, unlim_dim_level, &
       c(ydim_index) = pe_jsc(i) - pe_jsc(1) + 1
       e(xdim_index) = pe_icsize(i)
       e(ydim_index) = pe_jcsize(i)
+      if (xpos .ne. center .and. pe_isc(i)+pe_icsize(i)-1 .ne. xmax) then
+        e(xdim_index) = e(xdim_index) - 1
+      endif
+      if (ypos .ne. center .and. pe_jsc(i)+pe_jcsize(i)-1 .ne. ymax) then
+        e(ydim_index) = e(ydim_index) - 1
+      endif
       select type(vdata)
         type is (integer(kind=int32))
           call allocate_array(buf_int32, e)
@@ -455,6 +487,12 @@ subroutine domain_write_3d(fileobj, variable_name, vdata, unlim_dim_level, &
     endif
     e(xdim_index) = xc_size
     e(ydim_index) = yc_size
+    if (.not. extra_x) then
+      e(xdim_index) = e(xdim_index) - 1
+    endif
+    if (.not. extra_y) then
+      e(ydim_index) = e(ydim_index) - 1
+    endif
     select type(vdata)
       type is (integer(kind=int32))
         call allocate_array(buf_int32, e)
@@ -508,6 +546,8 @@ subroutine domain_write_4d(fileobj, variable_name, vdata, unlim_dim_level, &
   type(domain2d), pointer :: io_domain
   integer :: xpos
   integer :: ypos
+  integer :: xmax
+  integer :: ymax
   integer :: isd
   integer :: isc
   integer :: xc_size
@@ -515,6 +555,8 @@ subroutine domain_write_4d(fileobj, variable_name, vdata, unlim_dim_level, &
   integer :: jsc
   integer :: yc_size
   logical :: buffer_includes_halos
+  logical :: extra_x
+  logical :: extra_y
   integer, dimension(4) :: c
   integer, dimension(4) :: e
   integer, dimension(:), allocatable :: pe_isc
@@ -535,8 +577,9 @@ subroutine domain_write_4d(fileobj, variable_name, vdata, unlim_dim_level, &
     return
   endif
   io_domain => mpp_get_io_domain(fileobj%domain)
-  call domain_offsets(size(vdata, xdim_index), size(vdata, ydim_index), io_domain, &
-                      xpos, ypos, isd, isc, xc_size, jsd, jsc, yc_size, buffer_includes_halos)
+  call domain_offsets(size(vdata, xdim_index), size(vdata, ydim_index), fileobj%domain, io_domain, &
+                      xpos, ypos, isd, isc, xc_size, jsd, jsc, yc_size, &
+                      buffer_includes_halos, extra_x, extra_y)
   c(:) = 1
   e(:) = shape(vdata)
 
@@ -546,6 +589,8 @@ subroutine domain_write_4d(fileobj, variable_name, vdata, unlim_dim_level, &
     allocate(pe_icsize(size(fileobj%pelist)))
     allocate(pe_jsc(size(fileobj%pelist)))
     allocate(pe_jcsize(size(fileobj%pelist)))
+    call mpp_get_global_domain(io_domain, xend=xmax, position=xpos)
+    call mpp_get_global_domain(io_domain, yend=ymax, position=ypos)
     call mpp_get_compute_domains(io_domain, xbegin=pe_isc, xsize=pe_icsize, position=xpos)
     call mpp_get_compute_domains(io_domain, ybegin=pe_jsc, ysize=pe_jcsize, position=ypos)
     do i = 1, size(fileobj%pelist)
@@ -553,6 +598,12 @@ subroutine domain_write_4d(fileobj, variable_name, vdata, unlim_dim_level, &
       c(ydim_index) = pe_jsc(i) - pe_jsc(1) + 1
       e(xdim_index) = pe_icsize(i)
       e(ydim_index) = pe_jcsize(i)
+      if (xpos .ne. center .and. pe_isc(i)+pe_icsize(i)-1 .ne. xmax) then
+        e(xdim_index) = e(xdim_index) - 1
+      endif
+      if (ypos .ne. center .and. pe_jsc(i)+pe_jcsize(i)-1 .ne. ymax) then
+        e(ydim_index) = e(ydim_index) - 1
+      endif
       select type(vdata)
         type is (integer(kind=int32))
           call allocate_array(buf_int32, e)
@@ -665,6 +716,12 @@ subroutine domain_write_4d(fileobj, variable_name, vdata, unlim_dim_level, &
     endif
     e(xdim_index) = xc_size
     e(ydim_index) = yc_size
+    if (.not. extra_x) then
+      e(xdim_index) = e(xdim_index) - 1
+    endif
+    if (.not. extra_y) then
+      e(ydim_index) = e(ydim_index) - 1
+    endif
     select type(vdata)
       type is (integer(kind=int32))
         call allocate_array(buf_int32, e)
@@ -718,6 +775,8 @@ subroutine domain_write_5d(fileobj, variable_name, vdata, unlim_dim_level, &
   type(domain2d), pointer :: io_domain
   integer :: xpos
   integer :: ypos
+  integer :: xmax
+  integer :: ymax
   integer :: isd
   integer :: isc
   integer :: xc_size
@@ -725,6 +784,8 @@ subroutine domain_write_5d(fileobj, variable_name, vdata, unlim_dim_level, &
   integer :: jsc
   integer :: yc_size
   logical :: buffer_includes_halos
+  logical :: extra_x
+  logical :: extra_y
   integer, dimension(5) :: c
   integer, dimension(5) :: e
   integer, dimension(:), allocatable :: pe_isc
@@ -745,8 +806,9 @@ subroutine domain_write_5d(fileobj, variable_name, vdata, unlim_dim_level, &
     return
   endif
   io_domain => mpp_get_io_domain(fileobj%domain)
-  call domain_offsets(size(vdata, xdim_index), size(vdata, ydim_index), io_domain, &
-                      xpos, ypos, isd, isc, xc_size, jsd, jsc, yc_size, buffer_includes_halos)
+  call domain_offsets(size(vdata, xdim_index), size(vdata, ydim_index), fileobj%domain, io_domain, &
+                      xpos, ypos, isd, isc, xc_size, jsd, jsc, yc_size, &
+                      buffer_includes_halos, extra_x, extra_y)
   c(:) = 1
   e(:) = shape(vdata)
 
@@ -756,6 +818,8 @@ subroutine domain_write_5d(fileobj, variable_name, vdata, unlim_dim_level, &
     allocate(pe_icsize(size(fileobj%pelist)))
     allocate(pe_jsc(size(fileobj%pelist)))
     allocate(pe_jcsize(size(fileobj%pelist)))
+    call mpp_get_global_domain(io_domain, xend=xmax, position=xpos)
+    call mpp_get_global_domain(io_domain, yend=ymax, position=ypos)
     call mpp_get_compute_domains(io_domain, xbegin=pe_isc, xsize=pe_icsize, position=xpos)
     call mpp_get_compute_domains(io_domain, ybegin=pe_jsc, ysize=pe_jcsize, position=ypos)
     do i = 1, size(fileobj%pelist)
@@ -763,6 +827,12 @@ subroutine domain_write_5d(fileobj, variable_name, vdata, unlim_dim_level, &
       c(ydim_index) = pe_jsc(i) - pe_jsc(1) + 1
       e(xdim_index) = pe_icsize(i)
       e(ydim_index) = pe_jcsize(i)
+      if (xpos .ne. center .and. pe_isc(i)+pe_icsize(i)-1 .ne. xmax) then
+        e(xdim_index) = e(xdim_index) - 1
+      endif
+      if (ypos .ne. center .and. pe_jsc(i)+pe_jcsize(i)-1 .ne. ymax) then
+        e(ydim_index) = e(ydim_index) - 1
+      endif
       select type(vdata)
         type is (integer(kind=int32))
           call allocate_array(buf_int32, e)
@@ -875,6 +945,12 @@ subroutine domain_write_5d(fileobj, variable_name, vdata, unlim_dim_level, &
     endif
     e(xdim_index) = xc_size
     e(ydim_index) = yc_size
+    if (.not. extra_x) then
+      e(xdim_index) = e(xdim_index) - 1
+    endif
+    if (.not. extra_y) then
+      e(ydim_index) = e(ydim_index) - 1
+    endif
     select type(vdata)
       type is (integer(kind=int32))
         call allocate_array(buf_int32, e)

--- a/test_fms/fms2_io/setup.F90
+++ b/test_fms/fms2_io/setup.F90
@@ -163,10 +163,11 @@ end subroutine cleanup
 
 
 !> @brief Initialize a cubed-sphere domain.
-subroutine create_cubed_sphere_domain(test_params, domain)
+subroutine create_cubed_sphere_domain(test_params, domain, io_layout)
 
   type(Params), intent(in) :: test_params !< Test parameters.
   type(domain2d), intent(inout) :: domain !< A cubed-sphere domain.
+  integer, dimension(2), intent(in) :: io_layout
 
   integer, dimension(12) :: tile1
   integer, dimension(12) :: tile2
@@ -357,7 +358,7 @@ subroutine create_cubed_sphere_domain(test_params, domain)
                          test_params%pe_end, symmetry=.true., whalo=whalo, ehalo=ehalo, &
                          shalo=shalo, nhalo=nhalo, name=trim("Cubed-sphere"), &
                          memory_size=msize)
-  call mpp_define_io_domain(domain, test_params%io_layout)
+  call mpp_define_io_domain(domain, io_layout)
 end subroutine create_cubed_sphere_domain
 
 


### PR DESCRIPTION
This fixes https://github.com/NOAA-GFDL/FMS/issues/119

There were two main problems:

1.  Domain_read was not reading a combined file correctly because the starting and ending index of the read were adjusted for all of the ranks 

This is fixed by adding a flag called "adjust_indices" in the fileobj. The flag is set to true by default unless you have combined file and the io_layout is not (1,1). 

2. Global checksums were not calculated correctly in cases were the position was set to North or East because the ending index of the buffer of each rank was counted twice. 

This is fixed by adding flags "extra_x_point" and "extra_x_point". These flags are true if the ending x/y index is not equal to the max index allowed and the position is set to east/north.  If true the x/y dimension of the buffer is decreased by one.

This also changes the unit_tests to test this case. 