### PR TITLE
Bug fix amip_interp with new io

### DIFF
--- a/amip_interp/amip_interp.F90
+++ b/amip_interp/amip_interp.F90
@@ -1466,7 +1466,7 @@ endif
      else
           call read_data(fileobj, ncfieldname, dat, unlim_dim_level=k)
      endif
-     idat =  nint(dat*100.) ! reconstruct packed data for reproducibity
+     idat =  nint(dat) ! reconstruct packed data for reproducibity
 
    !---- unpacking of data ----
 


### PR DESCRIPTION
I run into the following crash in my land only test case with the new io:

FATAL from PE    46: lookup_es: saturation vapor pressure table overflow, nbad=     63

fms_lad2_xanadu.x  0000000000DFD858  mpp_mod_mp_mpp_er          69  mpp_util_mpi.inc
fms_lad2_xanadu.x  0000000000E042C2  mpp_mod_mp_mpp_er         195  mpp_util.inc
fms_lad2_xanadu.x  00000000026F89E3  fms_mod_mp_fms_er         585  fms.F90
fms_lad2_xanadu.x  000000000131EDD4  sat_vapor_pres_mo         609  sat_vapor_pres.F90
fms_lad2_xanadu.x  00000000005D9A08  surface_flux_mod_         284  surface_flux.F90
fms_lad2_xanadu.x  00000000004A2DD4  atm_land_ice_flux        1148  atm_land_ice_flux_exchange.F90
fms_lad2_xanadu.x  000000000040CDB2  MAIN__                    816  coupler_main.F90

The problem is that the surface temperature goes outside the accepted range. The surface temperatures are also different between the new io and old io. I was able to trace the issue to amip_interp.F90. In amip_interp.F90, the data is read and then multiplied by 100 and converted to an integer. 
``` F90
     if ( interp_oi_sst ) then
          call read_data(fileobj, ncfieldname, tmp_dat, unlim_dim_level=k)
!     interpolate tmp_dat(360, 180) ---> dat(mobs,nobs) (to enable SST anom computation)
          if ( mobs/=360 .or. nobs/=180 ) then
               call a2a_bilinear(360, 180, tmp_dat, mobs, nobs, dat)
          else
               dat(:,:) = tmp_dat(:,:)
          endif
     else
          call read_data(fileobj, ncfieldname, dat, unlim_dim_level=k)
     endif
     idat =  nint(dat*100.)  ! reconstruct packed data for reproducibity
```
I compared 'dat' after it comes out of [L1467](https://github.com/uramirez8707/FMS/blob/b406734d91a44bc088d4acb999637278a8ba8ad8/amip_interp/amip_interp.F90#L1467) from the new io and old io and I saw that they were off by a factor of 100. 

This is because in the **old io** after read_data is called: 
It calls 
1. fms/fms_io.F90:5996  read_data_3d_new
2. fms/fms_io.F90:5434 mpp_read
3. mpp/include/mpp_io_read.inc:98 read_record
4. mpp/include/mpp_read_2Ddecomp.h:233 READ_RECORD_CORE_

In  READ_RECORD_CORE_, after it reads the data it multiplies it by field%scale (~0.01) and adds field%add:
```F90
             case(NF_SHORT)
                ptr1 = LOC(mpp_io_stack(1))
                error = NF_GET_VARA_INT2  ( mpp_file(unit)%ncid, field%id, start, axsiz, i2vals )
                call netcdf_err( error, mpp_file(unit), field=field )
                if(field%scale == 1.0 .and. field%add == 0.0) then
                   data(:)=i2vals(:)
                else
                   data(:)=i2vals(:)*field%scale + field%add
                end if
```
Then back in amip_interp: 
```F90
idat =  nint(dat*100.)
```
The new io doesn't do this multiplication by ~0.01 when it goes into read_data so the *100 in [L1467](https://github.com/uramirez8707/FMS/blob/b406734d91a44bc088d4acb999637278a8ba8ad8/amip_interp/amip_interp.F90#L1467) is not needed. 

This solves my issue and answers in restart still reproduce. 



