### PR TITLE
OMP line continuation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,9 @@ addons:
     - pkg-config gfortran netcdf-bin libnetcdf-dev libnetcdff-dev openmpi-bin libopenmpi-dev 
 
 env:
-  - CPPFLAGS_ADD='' FCFLAGS_REAL_KIND='-fdefault-real-8 -fdefault-double-8'
-  - CPPFLAGS_ADD='-DOVERLOAD_R4 -DOVERLOAD_R8' FCFLAGS_REAL_KIND=''
-  - CPPFLAGS_ADD='' FCFLAGS_REAL_KIND='-fdefault-real-8 -fdefault-double-8 -fopenmp'
+  - CPPFLAGS_ADD='' FCFLAGS_REAL_KIND='-fdefault-real-8 -fdefault-double-8' OPENMP=''
+  - CPPFLAGS_ADD='-DOVERLOAD_R4 -DOVERLOAD_R8' FCFLAGS_REAL_KIND='' OPENMP=''
+  - CPPFLAGS_ADD='' FCFLAGS_REAL_KIND='-fdefault-real-8 -fdefault-double-8' OPENMP='-fopenmp'
 
 # Travis sets CC to gcc, but we need to ensure it is not set, so we can use mpicc
 before_install:
@@ -30,7 +30,7 @@ before_script:
   - export CC=mpicc
   - export FC=mpif90
   - export CPPFLAGS="-I/usr/include -Duse_LARGEFILE -DMAXFIELDMETHODS_=500 ${CPPFLAGS_ADD}"
-  - export FCFLAGS="-fcray-pointer -Waliasing -ffree-line-length-none -fno-range-check ${FCFLAGS_REAL_KIND}"
+  - export FCFLAGS="-fcray-pointer -Waliasing -ffree-line-length-none -fno-range-check ${FCFLAGS_REAL_KIND} ${OPENMP}"
   - export LDFLAGS='-L/usr/lib'
 
 script:

--- a/affinity/fms_affinity.F90
+++ b/affinity/fms_affinity.F90
@@ -147,9 +147,9 @@ contains
 
      !--- set affinity for threads associated with this MPI-rank 
 !$OMP PARALLEL NUM_THREADS (nthreads) &
-!$             DEFAULT (none) & 
-!$             SHARED (use_hyper_thread, cpuset_sz, component, cpu_set, debug_affinity) &
-!$             PRIVATE (th_num, indx, retcode, h_name)
+!$OMP&         DEFAULT (none) & 
+!$OMP&         SHARED (use_hyper_thread, cpuset_sz, component, cpu_set, debug_affinity) &
+!$OMP&         PRIVATE (th_num, indx, retcode, h_name)
 !$   th_num = omp_get_thread_num()
      !--- handle hyper threading case by alternating threads between logical and virtual cores
 !$   if (use_hyper_thread) then


### PR DESCRIPTION
This resolves a problem when compiling with gfortran using the -fopenmp flag in #135 .  It also adds a travis-CI build with the -fopenmp flag to spot issues with openMP in the future.