### PR TITLE
now have configure check whether fortran compiler can handle extra long lines of code

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -8,17 +8,23 @@ AC_DEFUN([GFDL_CHECK_FORTRAN_LONG_LINES],
 # Tell autoconf that language tests are in fortran.
 AC_LANG_PUSH(Fortran)
 
+# Check a fortran compile with a test program with this file
+# extension.
 AC_FC_SRCEXT(F90)
+
+# Attempt to compile test program with 160 char line of code.
 AC_MSG_CHECKING([whether Fortran compiler can handle long lines of code])
 AC_COMPILE_IFELSE([AC_LANG_SOURCE([
         subroutine foo(bar)
         integer, intent(in) :: bar
-        print *,'7890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890'
+        print *,'789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890'
         end subroutine foo
         ])],
         [test_result=yes],
         [test_result=no])
 AC_MSG_RESULT($test_result)
+
+# If it failed, error out of configure with a helpful message.
 if test $test_result = no; then
    AC_MSG_ERROR([Fortran compiler must be able to handle long lines of code. \
    Set FCFLAGS to allow this (-ffree-line-length-none for gfortran)])

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1,0 +1,29 @@
+dnl Some autoconf macros to help build GFDL Fortran projects.
+
+dnl Ed Hartnett, 9/11/19
+
+dnl Check that Fortran compiler can hanlde long lines of code.
+AC_DEFUN([GFDL_CHECK_FORTRAN_LONG_LINES],
+[
+# Tell autoconf that language tests are in fortran.
+AC_LANG_PUSH(Fortran)
+
+AC_FC_SRCEXT(F90)
+AC_MSG_CHECKING([whether Fortran compiler can handle long lines of code])
+AC_COMPILE_IFELSE([AC_LANG_SOURCE([
+        subroutine foo(bar)
+        integer, intent(in) :: bar
+        print *,'7890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890'
+        end subroutine foo
+        ])],
+        [test_result=yes],
+        [test_result=no])
+AC_MSG_RESULT($test_result)
+if test $test_result = no; then
+   AC_MSG_ERROR([Fortran compiler must be able to handle long lines of code. \
+   Set FCFLAGS to allow this (-ffree-line-length-none for gfortran)])
+fi
+
+# Done testing Fortran compiler.
+AC_LANG_POP(Fortran)
+])

--- a/configure.ac
+++ b/configure.ac
@@ -50,8 +50,8 @@ AC_SEARCH_LIBS([nf_create], [netcdff], [],
                             [AC_MSG_ERROR([Can't find or link to the netcdf Fortran library, set CPPFLAGS/LDFLAGS.])])
 AC_LANG_POP(Fortran)
 
-# Require netCDF.
-#AC_CHECK_FUNC([nf_open], [], [AC_MSG_ERROR([NetCDF Fortran library required to build FMS])])
+# Check that long lines of Fortran code can be handled.
+GFDL_CHECK_FORTRAN_LONG_LINES()
 
 # These defines are required for the build.
 AC_DEFINE([use_netCDF], [1])


### PR DESCRIPTION
Fixes #144 

In this PR I have configure check that the Fortran compiler can handle extra long lines of Fortran code.

I introduce file acinclude.m4 to the build in the root directory. This is a special file in autotools which contains M4 macros that are (automatically) available in configure.ac. In this PR I define the macro GFDL_CHECK_FORTRAN_LONG_LINES.

I then call GFDL_CHECK_FORTRAN_LONG_LINES in configure.ac to run the check.

Note that this will check for lines of 160 chars. Hopefully that's long enough to exceed the max in any of the code, but I have not checked. ;-)

@underwoo you may be interested in this PR. I intend to develop macros to check for all necessary fortran flags.