### PR TITLE
Change configure to ensure cray pointers are handled by fortran compiler

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -8,17 +8,23 @@ AC_DEFUN([GFDL_CHECK_FORTRAN_LONG_LINES],
 # Tell autoconf that language tests are in fortran.
 AC_LANG_PUSH(Fortran)
 
+# Check a fortran compile with a test program with this file
+# extension.
 AC_FC_SRCEXT(F90)
+
+# Attempt to compile test program with 160 char line of code.
 AC_MSG_CHECKING([whether Fortran compiler can handle long lines of code])
 AC_COMPILE_IFELSE([AC_LANG_SOURCE([
         subroutine foo(bar)
         integer, intent(in) :: bar
-        print *,'7890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890'
+        print *,'789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890'
         end subroutine foo
         ])],
         [test_result=yes],
         [test_result=no])
 AC_MSG_RESULT($test_result)
+
+# If it failed, error out of configure with a helpful message.
 if test $test_result = no; then
    AC_MSG_ERROR([Fortran compiler must be able to handle long lines of code. \
    Set FCFLAGS to allow this (-ffree-line-length-none for gfortran)])

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -106,3 +106,37 @@ fi
 # Done testing Fortran compiler.
 AC_LANG_POP(Fortran)
 ])
+
+
+dnl Check that Fortran compiler can handle cray pointeres.
+dnl Ed Hartnett, 9/11/19
+AC_DEFUN([GFDL_CHECK_FORTRAN_CRAY_POINTERS],
+[
+# Tell autoconf that language tests are in fortran.
+AC_LANG_PUSH(Fortran)
+
+# Check a fortran compile with a test program with this file
+# extension.
+AC_FC_SRCEXT(F90)
+
+# Check that code that uses a cray pointer can be compiled.
+AC_MSG_CHECKING([whether Fortran compiler can handle cray pointers])
+AC_COMPILE_IFELSE([AC_LANG_SOURCE([
+        subroutine foo(bar)
+        real :: dummy
+        pointer( ptr, dummy )
+        end subroutine foo
+        ])],
+        [test_result=yes],
+        [test_result=no])
+AC_MSG_RESULT($test_result)
+
+# If it failed, error out of configure with a helpful message.
+if test $test_result = no; then
+   AC_MSG_ERROR([Fortran compiler must handle cray pointers. \
+   Set FCFLAGS to allow this (-fcray-pointer for gfortran)])
+fi
+
+# Done testing Fortran compiler.
+AC_LANG_POP(Fortran)
+])

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1,0 +1,29 @@
+dnl Some autoconf macros to help build GFDL Fortran projects.
+
+dnl Ed Hartnett, 9/11/19
+
+dnl Check that Fortran compiler can hanlde long lines of code.
+AC_DEFUN([GFDL_CHECK_FORTRAN_LONG_LINES],
+[
+# Tell autoconf that language tests are in fortran.
+AC_LANG_PUSH(Fortran)
+
+AC_FC_SRCEXT(F90)
+AC_MSG_CHECKING([whether Fortran compiler can handle long lines of code])
+AC_COMPILE_IFELSE([AC_LANG_SOURCE([
+        subroutine foo(bar)
+        integer, intent(in) :: bar
+        print *,'7890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890'
+        end subroutine foo
+        ])],
+        [test_result=yes],
+        [test_result=no])
+AC_MSG_RESULT($test_result)
+if test $test_result = no; then
+   AC_MSG_ERROR([Fortran compiler must be able to handle long lines of code. \
+   Set FCFLAGS to allow this (-ffree-line-length-none for gfortran)])
+fi
+
+# Done testing Fortran compiler.
+AC_LANG_POP(Fortran)
+])

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1,8 +1,8 @@
 dnl Some autoconf macros to help build GFDL Fortran projects.
 
-dnl Ed Hartnett, 9/11/19
 
 dnl Check that Fortran compiler can hanlde long lines of code.
+dnl Ed Hartnett, 9/11/19
 AC_DEFUN([GFDL_CHECK_FORTRAN_LONG_LINES],
 [
 # Tell autoconf that language tests are in fortran.
@@ -28,6 +28,79 @@ AC_MSG_RESULT($test_result)
 if test $test_result = no; then
    AC_MSG_ERROR([Fortran compiler must be able to handle long lines of code. \
    Set FCFLAGS to allow this (-ffree-line-length-none for gfortran)])
+fi
+
+# Done testing Fortran compiler.
+AC_LANG_POP(Fortran)
+])
+
+
+dnl Check that Fortran compiler is using 8-byte reals.
+dnl Ed Hartnett, 9/11/19
+AC_DEFUN([GFDL_CHECK_FORTRAN_REAL_8],
+[
+# Tell autoconf that language tests are in fortran.
+AC_LANG_PUSH(Fortran)
+
+# Check a fortran compile with a test program with this file
+# extension.
+AC_FC_SRCEXT(F90)
+
+# Check the size of real.
+AC_MSG_CHECKING([whether Fortran compiler has 8-byte real])
+AC_RUN_IFELSE([AC_LANG_SOURCE([
+        program foo
+        real var
+        if (sizeof(var) .ne. 8) then
+        stop 2
+        end if
+        end program foo
+        ])],
+        [test_result=yes],
+        [test_result=no],
+        [AC_MSG_WARN([Test for 8-byte real cannot be run for cross-compile builds. Set FC flags to ensure 8-byte reals are being used.])])
+AC_MSG_RESULT($test_result)
+
+# If it failed, error out of configure with a helpful message.
+if test $test_result = no; then
+   AC_MSG_ERROR([Fortran compiler must be set to 8-byte reals. \
+   Set FCFLAGS to allow this (-fdefault-real-8 for gfortran)])
+fi
+
+# Done testing Fortran compiler.
+AC_LANG_POP(Fortran)
+])
+
+dnl Check that Fortran compiler is using 8-byte doubles.
+dnl Ed Hartnett, 9/11/19
+AC_DEFUN([GFDL_CHECK_FORTRAN_DOUBLE_8],
+[
+# Tell autoconf that language tests are in fortran.
+AC_LANG_PUSH(Fortran)
+
+# Check a fortran compile with a test program with this file
+# extension.
+AC_FC_SRCEXT(F90)
+
+# Check the size of double.
+AC_MSG_CHECKING([whether Fortran compiler has 8-byte double])
+AC_RUN_IFELSE([AC_LANG_SOURCE([
+        program foo
+        double precision var
+        if (sizeof(var) .ne. 8) then
+        stop 2
+        end if
+        end program foo
+        ])],
+        [test_result=yes],
+        [test_result=no],
+        [AC_MSG_WARN([Test for 8-byte double cannot be run for cross-compile builds. Set FC flags to ensure 8-byte doubles are being used.])])
+AC_MSG_RESULT($test_result)
+
+# If it failed, error out of configure with a helpful message.
+if test $test_result = no; then
+   AC_MSG_ERROR([Fortran compiler must be set to 8-byte doubles. \
+   Set FCFLAGS to allow this (-fdefault-double-8 for gfortran)])
 fi
 
 # Done testing Fortran compiler.

--- a/configure.ac
+++ b/configure.ac
@@ -53,11 +53,15 @@ AC_LANG_POP(Fortran)
 # Check that long lines of Fortran code can be handled.
 GFDL_CHECK_FORTRAN_LONG_LINES()
 
-# Check that reals in Fortran are 8 bytes.
-GFDL_CHECK_FORTRAN_REAL_8()
+# Check that reals in Fortran are 8 bytes, unless -DOVERLOAD_R4 is used.
+if [ -z ${OVERLOAD_R4+x} ]; then
+   GFDL_CHECK_FORTRAN_REAL_8()
+fi
 
-# Check that doubles in Fortran are 8 bytes.
-GFDL_CHECK_FORTRAN_DOUBLE_8()
+# Check that doubles in Fortran are 8 bytes, unless -DOVERLOAD_P8 is used.
+if [ -z ${OVERLOAD_R8+x} ]; then
+   GFDL_CHECK_FORTRAN_DOUBLE_8()
+fi
 
 # Check that cray pointers are supported by Fortran compiler.
 GFDL_CHECK_FORTRAN_CRAY_POINTERS()

--- a/configure.ac
+++ b/configure.ac
@@ -59,6 +59,9 @@ GFDL_CHECK_FORTRAN_REAL_8()
 # Check that doubles in Fortran are 8 bytes.
 GFDL_CHECK_FORTRAN_DOUBLE_8()
 
+# Check that cray pointers are supported by Fortran compiler.
+GFDL_CHECK_FORTRAN_CRAY_POINTERS()
+
 # These defines are required for the build.
 AC_DEFINE([use_netCDF], [1])
 AC_DEFINE([use_libMPI], [1])

--- a/configure.ac
+++ b/configure.ac
@@ -50,8 +50,8 @@ AC_SEARCH_LIBS([nf_create], [netcdff], [],
                             [AC_MSG_ERROR([Can't find or link to the netcdf Fortran library, set CPPFLAGS/LDFLAGS.])])
 AC_LANG_POP(Fortran)
 
-# Require netCDF.
-#AC_CHECK_FUNC([nf_open], [], [AC_MSG_ERROR([NetCDF Fortran library required to build FMS])])
+# Check that long lines of Fortran code can be handled.
+GFDL_CHECK_FORTRAN_LONG_LINES()
 
 # These defines are required for the build.
 AC_DEFINE([use_netCDF], [1])

--- a/configure.ac
+++ b/configure.ac
@@ -53,6 +53,12 @@ AC_LANG_POP(Fortran)
 # Check that long lines of Fortran code can be handled.
 GFDL_CHECK_FORTRAN_LONG_LINES()
 
+# Check that reals in Fortran are 8 bytes.
+GFDL_CHECK_FORTRAN_REAL_8()
+
+# Check that doubles in Fortran are 8 bytes.
+GFDL_CHECK_FORTRAN_DOUBLE_8()
+
 # These defines are required for the build.
 AC_DEFINE([use_netCDF], [1])
 AC_DEFINE([use_libMPI], [1])


### PR DESCRIPTION
Fixes #149 

This PR includes PR #148 .

In this PR I add a macro GFDL_CHECK_FORTRAN_CRAY_POINTERS to acinclude.m4, and run it in configure. If the user fails to set the cray pointer flag, then the configure will fail.