### PR TITLE
no range check flag not needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_script:
   - export CC=mpicc
   - export FC=mpif90
   - export CPPFLAGS="-I/usr/include -Duse_LARGEFILE -DMAXFIELDMETHODS_=500 ${CPPFLAGS_ADD}"
-  - export FCFLAGS="-fcray-pointer -Waliasing -ffree-line-length-none -fno-range-check ${FCFLAGS_REAL_KIND} ${OPENMP}"
+  - export FCFLAGS="-fcray-pointer -Waliasing -ffree-line-length-none ${FCFLAGS_REAL_KIND} ${OPENMP}"
   - export LDFLAGS='-L/usr/lib'
 
 script:


### PR DESCRIPTION
We have been using the -fno-range-check flag (in gfortran).

However, there seem to be no range check violations in the code. When I remove this flag, the code builds just fine.

That being the case, I suggest you remove it from the travis file as well. That way, if a program introduces some range violation into the code, it will be automatically caught.