### PR TITLE
check for bats in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -49,6 +49,12 @@ AC_PROG_F77
 # Find the install program.
 AC_PROG_INSTALL
 
+# Is bats installed? It is required for testing.
+AC_CHECK_PROGS([FMS_BATS], [bats])
+if test -z "$FMS_BATS"; then
+   AC_MSG_ERROR([Cannot find bats utility. Install bats and try again.])
+fi
+
 # Check to see if any macros must be set to enable large (>2GB) files.
 AC_SYS_LARGEFILE
 


### PR DESCRIPTION
In this PR I add a check for the bats utility in configure.ac. If not found, configure fails with an error message.

Fixes #159 

I strongly suggest you remove the dependency on bats. It is a utility suited for complex shell script testing. It's not needed for simple Fortran library checking, which is what you are doing. 

Each new utility you require is:
* something else that can go wrong
* another barrier for entry to your software for new users
* something that will generate support questions and issues you won't want to cope with
* something we HOPE has been correctly ported to every HPC platform we care about

My advice is to use the minimum tools that get the job done. The netcdf-fortran project does many advanced fortran tests, including with parallel I/O, without relying on bats. I would suggest that you get your testing to at least to that level, using simple tools, before considering the need to bring in a tool to handle more complex tests.

