### PR TITLE
Quick fix for test_fms/data_override with new FMS IO

### DIFF
--- a/test_fms/data_override/input.nml_base
+++ b/test_fms/data_override/input.nml_base
@@ -1,7 +1,7 @@
 &test_data_override_nml
 nx_cubic = 90
 ny_cubic = 90
-nx_latlon = 90
+nx_latlon = 144
 ny_latlon = 90
 test_num = <test_num>
 /

--- a/test_fms/data_override/test_data_override.F90
+++ b/test_fms/data_override/test_data_override.F90
@@ -45,7 +45,7 @@
  ! /archive/pjp/unit_tests/test_data_override/lima/exp1
 
  use           mpp_mod, only: input_nml_file, stdout, mpp_chksum
- use   mpp_domains_mod, only: domain2d, mpp_define_domains, mpp_get_compute_domain, mpp_define_layout
+ use   mpp_domains_mod, only: domain2d, mpp_define_domains, mpp_define_io_domain, mpp_get_compute_domain, mpp_define_layout
  use           fms_mod, only: fms_init, fms_end, mpp_npes, file_exist, open_namelist_file, check_nml_error, close_file
  use           fms_mod, only: error_mesg, FATAL, file_exist, field_exist, field_size
  use        fms_io_mod, only: read_data, fms_io_exit
@@ -171,6 +171,7 @@
 
 
  call mpp_define_domains( (/1,nlon,1,nlat/), layout, Domain, name='test_data_override')
+ call mpp_define_io_domain(Domain, (/1,1/))
  call data_override_init(Ice_domain_in=Domain, Ocean_domain_in=Domain)
  call data_override_init(Ice_domain_in=Domain, Ocean_domain_in=Domain)
  call mpp_get_compute_domain(Domain, is, ie, js, je)

--- a/test_fms/data_override/test_data_override.bats
+++ b/test_fms/data_override/test_data_override.bats
@@ -13,16 +13,20 @@ teardown () {
 }
 
 @test "Test 1: Cubic-Grid" {
-    skip "The input file is missing"
-   cp -r $srcdir/test_fms/data_override/INPUT $builddir/test_fms/data_override/INPUT
+#    skip "The input file is missing"
+#   cp -r $srcdir/test_fms/data_override/INPUT $builddir/test_fms/data_override/INPUT
    run mpirun -n 2 ./test_data_override
    [ "$status" -eq 0 ]
 }
 
 @test "Test 2: Latlon-Grid" {
-   skip "The input file is missing"
+#   skip "The input file is missing"
    run mpirun -n 2 ./test_data_override
    [ "$status" -eq 0 ]
-   chmod 755 $builddir/test_fms/data_override/INPUT
-   rm -rf $builddir/test_fms/data_override/INPUT
+#   chmod 755 $builddir/test_fms/data_override/INPUT
+#   rm -rf $builddir/test_fms/data_override/INPUT
+}
+@test "Test 3: Check_blend" {
+   run mpirun -n 6 ./test_data_override
+   [ "$status" -eq 0 ]
 }

--- a/test_fms/data_override/test_data_override.bats
+++ b/test_fms/data_override/test_data_override.bats
@@ -13,20 +13,16 @@ teardown () {
 }
 
 @test "Test 1: Cubic-Grid" {
-#    skip "The input file is missing"
-#   cp -r $srcdir/test_fms/data_override/INPUT $builddir/test_fms/data_override/INPUT
+    skip "The input file is missing"
+   cp -r $srcdir/test_fms/data_override/INPUT $builddir/test_fms/data_override/INPUT
    run mpirun -n 2 ./test_data_override
    [ "$status" -eq 0 ]
 }
 
 @test "Test 2: Latlon-Grid" {
-#   skip "The input file is missing"
+   skip "The input file is missing"
    run mpirun -n 2 ./test_data_override
    [ "$status" -eq 0 ]
-#   chmod 755 $builddir/test_fms/data_override/INPUT
-#   rm -rf $builddir/test_fms/data_override/INPUT
-}
-@test "Test 3: Check_blend" {
-   run mpirun -n 6 ./test_data_override
-   [ "$status" -eq 0 ]
+   chmod 755 $builddir/test_fms/data_override/INPUT
+   rm -rf $builddir/test_fms/data_override/INPUT
 }


### PR DESCRIPTION
Modified input.nml_base to work with lat / lon grid, as well as test_data_override.F90 to work with new IO (was missing a mpp_define_io_domain call). The test_data_override.bats script has been modified not to skip the first two tests and has added a 3rd test that will be used during the testing of the data blend feature. **Please note** that the changes to the .bats file will likely result in overall test failures if the appropriate netcdf files are not contained in the INPUT sub-directory of test_fms/data_override. I have those files there on my system (they're relatively easy to acquire), but if that's going to create headaches I can go ahead and revert those changes.