### PR TITLE
Fix parameter out of range setting for mixed-mode compiles

### DIFF
--- a/time_interp/time_interp_external.F90
+++ b/time_interp/time_interp_external.F90
@@ -137,7 +137,8 @@ module time_interp_external_mod
   type(ext_fieldtype), save, private, pointer :: field(:) => NULL()
   type(filetype),      save, private, pointer :: opened_files(:) => NULL()
 !Balaji: really should use field%missing
-  real(DOUBLE_KIND), private, parameter :: time_interp_missing=-1e99
+  integer, private, parameter :: dk = DOUBLE_KIND
+  real(DOUBLE_KIND), private, parameter :: time_interp_missing=-1e99_dk
   contains
 
 ! <SUBROUTINE NAME="time_interp_external_init">


### PR DESCRIPTION
Fixed time_interp_missing parameter in time_interp_external.F90 to be within range when compiled in mixed-mode.

Fixes #188 