### PR TITLE
__APPLE__ replaced with autoconf test for gettid

### DIFF
--- a/affinity/affinity.c
+++ b/affinity/affinity.c
@@ -27,7 +27,7 @@
 #include <sys/resource.h>
 #include <sys/syscall.h>
 
-#ifndef __APPLE__
+#ifndef HAVE_GETTID
 static pid_t gettid(void)
 {
   return syscall(__NR_gettid);

--- a/configure.ac
+++ b/configure.ac
@@ -58,6 +58,9 @@ fi
 # Check to see if any macros must be set to enable large (>2GB) files.
 AC_SYS_LARGEFILE
 
+# Check if Linux gettid is avaiable
+AC_CHECK_FUNCS([gettid], [], [])
+
 # Require MPI.
 AC_CHECK_FUNC([MPI_Init], [], [AC_MSG_ERROR([MPI C library required to build FMS])])
 


### PR DESCRIPTION
On my Arch Linux distribution, the FMS build failed due to a pre-defined
gettid function, which refused to allow the build of a local gettid inside of
affinity.c.  (GCC 9.2, libc 2.30, Linux 5.3.5)

This patch adds a AC_CHECK_FUNCS test for gettid and redefines the local
version if it's unavailable.

HAVE_GETTID is defined for an automake build, but this patch may
potentially break any legacy MKMF builds for Darwin (OSX) users, unless
they manually define it in their templates.  (But perhaps that is the
preferred solution anyway?)

----

Some additional info below not part of the commit log.

This is the error:
```
../src/affinity/affinity.c:31:14: error: static declaration of ‘gettid’ follows non-static declaration
   31 | static pid_t gettid(void)
      |              ^~~~~~
In file included from /usr/include/unistd.h:1170,
                 from ../src/affinity/affinity.c:24:
/usr/include/bits/unistd_ext.h:34:16: note: previous declaration of ‘gettid’ was here
   34 | extern __pid_t gettid (void) __THROW;
      |                ^~~~~~
make[1]: *** [Makefile:15: affinity.o] Error 1
```

The problem seems to be a namespace conflict with the libc `gettid` function.  I don't know why it is specifically occurring in my case.  Maybe this is just a difference in order of name resolution or if the rules around static functions are more strict (or more correct?).

Removing `static` also resolves the problem, but it seems more correct to use `static` in this case and isolate this function to the file.

My environment:
```
$ uname -a
Linux argus 5.3.5-arch1-1-ARCH #1 SMP PREEMPT Mon Oct 7 19:03:08 UTC 2019 x86_64 GNU/Linux

$ /lib/libc.so.6 
GNU C Library (GNU libc) stable release version 2.30.
Copyright (C) 2019 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.
There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A
PARTICULAR PURPOSE.
Compiled by GNU CC version 9.2.0.
libc ABIs: UNIQUE IFUNC ABSOLUTE
For bug reporting instructions, please see:
<https://bugs.archlinux.org/>.

$ gcc --version
gcc (GCC) 9.2.0
Copyright (C) 2019 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```
