### PR TITLE
now check for sed and ncgen in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -61,7 +61,7 @@ if test -z "$FMS_SED"; then
    AC_MSG_ERROR([Cannot find sed. Install sed and try again.])
 fi
 
-# Is ncget installed? It is required for testing.
+# Is ncgen installed? It is required for testing.
 AC_CHECK_PROGS([FMS_NCGEN], [ncgen])
 if test -z "$FMS_NCGEN"; then
    AC_MSG_ERROR([Cannot find ncgen. Install ncgen and try again.])

--- a/configure.ac
+++ b/configure.ac
@@ -55,13 +55,13 @@ if test -z "$FMS_BATS"; then
    AC_MSG_ERROR([Cannot find bats utility. Install bats and try again.])
 fi
 
-# Is ncgen installed? It is required for testing.
+# Is sed installed? It is required for testing.
 AC_CHECK_PROGS([FMS_SED], [sed])
 if test -z "$FMS_SED"; then
    AC_MSG_ERROR([Cannot find sed. Install sed and try again.])
 fi
 
-# Is bats installed? It is required for testing.
+# Is ncget installed? It is required for testing.
 AC_CHECK_PROGS([FMS_NCGEN], [ncgen])
 if test -z "$FMS_NCGEN"; then
    AC_MSG_ERROR([Cannot find ncgen. Install ncgen and try again.])

--- a/configure.ac
+++ b/configure.ac
@@ -55,7 +55,7 @@ if test -z "$FMS_BATS"; then
    AC_MSG_ERROR([Cannot find bats utility. Install bats and try again.])
 fi
 
-# Is sed installed? It is required for testing.
+# Is ncgen installed? It is required for testing.
 AC_CHECK_PROGS([FMS_SED], [sed])
 if test -z "$FMS_SED"; then
    AC_MSG_ERROR([Cannot find sed. Install sed and try again.])

--- a/configure.ac
+++ b/configure.ac
@@ -55,6 +55,18 @@ if test -z "$FMS_BATS"; then
    AC_MSG_ERROR([Cannot find bats utility. Install bats and try again.])
 fi
 
+# Is sed installed? It is required for testing.
+AC_CHECK_PROGS([FMS_SED], [sed])
+if test -z "$FMS_SED"; then
+   AC_MSG_ERROR([Cannot find sed. Install sed and try again.])
+fi
+
+# Is bats installed? It is required for testing.
+AC_CHECK_PROGS([FMS_NCGEN], [ncgen])
+if test -z "$FMS_NCGEN"; then
+   AC_MSG_ERROR([Cannot find ncgen. Install ncgen and try again.])
+fi
+
 # Check to see if any macros must be set to enable large (>2GB) files.
 AC_SYS_LARGEFILE
 


### PR DESCRIPTION
Fixes #205 

Check for sed and ncgen in configure. If not found, give the user and error message and stop.