### PR TITLE
Ouputs the chksum as a 16 length character

### DIFF
--- a/fms2_io/include/compute_global_checksum.inc
+++ b/fms2_io/include/compute_global_checksum.inc
@@ -110,7 +110,6 @@ function compute_global_checksum_2d(fileobj, variable_name, variable_data, is_de
   end select
   chksum = ""
   write(chksum, "(Z16)") chksum_val
-  chksum = trim(adjustl(chksum))
 end function compute_global_checksum_2d
 
 
@@ -225,7 +224,6 @@ function compute_global_checksum_3d(fileobj, variable_name, variable_data, is_de
   end select
   chksum = ""
   write(chksum, "(Z16)") chksum_val
-  chksum = trim(adjustl(chksum))
 end function compute_global_checksum_3d
 
 
@@ -341,5 +339,4 @@ function compute_global_checksum_4d(fileobj, variable_name, variable_data, is_de
   end select
   chksum = ""
   write(chksum, "(Z16)") chksum_val
-  chksum = trim(adjustl(chksum))
 end function compute_global_checksum_4d


### PR DESCRIPTION
Changes the compute_global_checksum routine to output the checksum as a 16 length character instead of trimming the empty spaces. 