### PR TITLE
ANOTHER checksum problem 

### DIFF
--- a/fms2_io/fms_netcdf_domain_io.F90
+++ b/fms2_io/fms_netcdf_domain_io.F90
@@ -570,7 +570,7 @@ subroutine restore_domain_state(fileobj, unlim_dim_level)
           is_decomposed) then
         call get_variable_attribute(fileobj, fileobj%restart_vars(i)%varname, &
                                     "checksum", chksum_in_file)
-        if (.not. string_compare(chksum_in_file, chksum)) then
+        if (.not. string_compare(trim(adjustl(chksum_in_file)), trim(adjustl(chksum)))) then
           call error("checksum attribute does not match data in file.")
         endif
       endif
@@ -583,7 +583,7 @@ subroutine restore_domain_state(fileobj, unlim_dim_level)
           is_decomposed) then
         call get_variable_attribute(fileobj, fileobj%restart_vars(i)%varname, &
                                     "checksum", chksum_in_file)
-        if (.not. string_compare(chksum_in_file, chksum)) then
+        if (.not. string_compare(trim(adjustl(chksum_in_file)), trim(adjustl(chksum)))) then
           call error("checksum attribute does not match data in file.")
         endif
       endif
@@ -596,7 +596,7 @@ subroutine restore_domain_state(fileobj, unlim_dim_level)
           is_decomposed) then
         call get_variable_attribute(fileobj, fileobj%restart_vars(i)%varname, &
                                     "checksum", chksum_in_file)
-        if (.not. string_compare(chksum_in_file, chksum)) then
+        if (.not. string_compare(trim(adjustl(chksum_in_file)), trim(adjustl(chksum)))) then
           call error("checksum attribute does not match data in file.")
         endif
       endif


### PR DESCRIPTION
When using the `read_restart` routines in `fms2_io`, after each registered variable is read it calculates the chksum using `compute_global_checksum` and reads the chksum from the file using `get_variable_attribute` and compares the two 

```F90
      call domain_read_3d(fileobj, fileobj%restart_vars(i)%varname, &
                          fileobj%restart_vars(i)%data3d, unlim_dim_level=unlim_dim_level)
      chksum = compute_global_checksum(fileobj, fileobj%restart_vars(i)%varname, &
                                       fileobj%restart_vars(i)%data3d, is_decomposed)
      if (variable_att_exists(fileobj, fileobj%restart_vars(i)%varname, "checksum") .and. &
          is_decomposed) then
        call get_variable_attribute(fileobj, fileobj%restart_vars(i)%varname, &
                                    "checksum", chksum_in_file)
        if (.not. string_compare(chksum_in_file, chksum)) then
          call error("checksum attribute does not match data in file.")
        endif
      endif
```
The output of `compute_global_checksum` is a string with a length of 16 characters **including empty trailing spaces** as expected as of https://github.com/NOAA-GFDL/FMS/pull/211 (e.g '_______________0')

The output of `get_variable_attribute` is a string but it **does not include any empty trailing spaces** (see [L27-L32](https://github.com/NOAA-GFDL/FMS/blob/78d197897c69c95b3582bba444d04f196ae28a8d/fms2_io/include/get_variable_attribute.inc#L27l) of get_variable_attribute.inc) (e.g. '0_______________') 
When it gets to `string_compare` the checksums won't match in [L198](https://github.com/NOAA-GFDL/FMS/blob/78d197897c69c95b3582bba444d04f196ae28a8d/fms2_io/fms_io_utils.F90#L198) (1 vs 16 because it uses len_trim)

This trims and adjusts the checksum before it goes into `string_compare` .