### PR TITLE
Fix CPP warning

### DIFF
--- a/mpp/include/mpp_comm_mpi.inc
+++ b/mpp/include/mpp_comm_mpi.inc
@@ -1382,31 +1382,49 @@ end subroutine mpp_gsm_free
 !                                                                             !
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
+#undef MPP_TYPE_CREATE_
+#undef MPP_TYPE_
+#undef MPI_TYPE_
 #define MPP_TYPE_CREATE_ mpp_type_create_int4
 #define MPP_TYPE_ integer(INT_KIND)
 #define MPI_TYPE_ MPI_INTEGER4
 #include <mpp_type_mpi.h>
 
+#undef MPP_TYPE_CREATE_
+#undef MPP_TYPE_
+#undef MPI_TYPE_
 #define MPP_TYPE_CREATE_ mpp_type_create_int8
 #define MPP_TYPE_ integer(LONG_KIND)
 #define MPI_TYPE_ MPI_INTEGER8
 #include <mpp_type_mpi.h>
 
+#undef MPP_TYPE_CREATE_
+#undef MPP_TYPE_
+#undef MPI_TYPE_
 #define MPP_TYPE_CREATE_ mpp_type_create_real4
 #define MPP_TYPE_ real(FLOAT_KIND)
 #define MPI_TYPE_ MPI_REAL4
 #include <mpp_type_mpi.h>
 
+#undef MPP_TYPE_CREATE_
+#undef MPP_TYPE_
+#undef MPI_TYPE_
 #define MPP_TYPE_CREATE_ mpp_type_create_real8
 #define MPP_TYPE_ real(DOUBLE_KIND)
 #define MPI_TYPE_ MPI_REAL8
 #include <mpp_type_mpi.h>
 
+#undef MPP_TYPE_CREATE_
+#undef MPP_TYPE_
+#undef MPI_TYPE_
 #define MPP_TYPE_CREATE_ mpp_type_create_logical4
 #define MPP_TYPE_ logical(INT_KIND)
 #define MPI_TYPE_ MPI_INTEGER4
 #include <mpp_type_mpi.h>
 
+#undef MPP_TYPE_CREATE_
+#undef MPP_TYPE_
+#undef MPI_TYPE_
 #define MPP_TYPE_CREATE_ mpp_type_create_logical8
 #define MPP_TYPE_ logical(LONG_KIND)
 #define MPI_TYPE_ MPI_INTEGER8


### PR DESCRIPTION
CPP macro should not be defined with different value if it's already defined. It should be undefined first.