### PR TITLE
new io: amip_interp with no scale factor

### DIFF
--- a/amip_interp/amip_interp.F90
+++ b/amip_interp/amip_interp.F90
@@ -1468,7 +1468,7 @@ endif
      else
           call read_data(fileobj, ncfieldname, dat, unlim_dim_level=k)
      endif
-     idat =  nint(dat*100.) ! reconstruct packed data for reproducibity
+     idat =  nint(dat) ! reconstruct packed data for reproducibity
 
    !---- unpacking of data ----
 


### PR DESCRIPTION
Removes the *100 in amip_interp routine because new io doesn't read/use the scale factor and add_offset attributes. 

Fix for https://github.com/NOAA-GFDL/FMS/issues/212


