### PR TITLE
Remove use_netCDF macro

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -87,7 +87,6 @@ if test $enable_fortran_flag_setting = "yes"; then
 fi
 
 # These defines are required for the build.
-AC_DEFINE([use_netCDF], [1])
 AC_DEFINE([use_libMPI], [1])
 
 # Define __APPLE__ macro if on a Apple/Mac OS X

--- a/diag_manager/diag_axis.F90
+++ b/diag_manager/diag_axis.F90
@@ -41,9 +41,7 @@ MODULE diag_axis_mod
   USE diag_data_mod, ONLY: diag_axis_type, max_subaxes, max_axes,&
        & max_num_axis_sets, max_axis_attributes, debug_diag_manager,&
        & first_send_data_call, diag_atttype
-#ifdef use_netCDF
   USE netcdf, ONLY: NF90_INT, NF90_FLOAT, NF90_CHAR
-#endif
 
   IMPLICIT NONE
 

--- a/diag_manager/diag_data.F90
+++ b/diag_manager/diag_data.F90
@@ -55,10 +55,8 @@ MODULE diag_data_mod
   USE mpp_domains_mod, ONLY: domain1d, domain2d, domainUG
   USE mpp_io_mod, ONLY: fieldtype
   USE fms_mod, ONLY: WARNING, write_version_number
-#ifdef use_netCDF
   ! NF90_FILL_REAL has value of 9.9692099683868690e+36.
   USE netcdf, ONLY: NF_FILL_REAL => NF90_FILL_REAL
-#endif
 
   IMPLICIT NONE
 
@@ -740,11 +738,7 @@ MODULE diag_data_mod
   !   Fill value used.  Value will be <TT>NF90_FILL_REAL</TT> if using the
   !   netCDF module, otherwise will be 9.9692099683868690e+36.
   ! </DATA>
-#ifdef use_netCDF
-  REAL :: FILL_VALUE = NF_FILL_REAL  ! from file /usr/local/include/netcdf.inc
-#else
-  REAL :: FILL_VALUE = 9.9692099683868690e+36
-#endif
+  REAL :: FILL_VALUE = NF_FILL_REAL
 
   INTEGER :: pack_size = 1 ! 1 for double and 2 for float
 

--- a/diag_manager/diag_manager.F90
+++ b/diag_manager/diag_manager.F90
@@ -237,9 +237,7 @@ MODULE diag_manager_mod
   USE diag_manifest_mod, ONLY: write_diag_manifest
   USE constants_mod, ONLY: SECONDS_PER_DAY
 
-#ifdef use_netCDF
   USE netcdf, ONLY: NF90_INT, NF90_FLOAT, NF90_CHAR
-#endif
 
 !----------
 !ug support

--- a/diag_manager/diag_output.F90
+++ b/diag_manager/diag_output.F90
@@ -42,16 +42,14 @@ MODULE diag_output_mod
   USE diag_data_mod, ONLY: diag_fieldtype, diag_global_att_type, CMOR_MISSING_VALUE, diag_atttype
   USE time_manager_mod, ONLY: get_calendar_type, valid_calendar_types
   USE fms_mod, ONLY: error_mesg, mpp_pe, write_version_number, fms_error_handler, FATAL
-
-#ifdef use_netCDF
-  USE netcdf, ONLY: NF90_INT, NF90_FLOAT, NF90_CHAR
-#endif
-
   use mpp_domains_mod, only: mpp_get_UG_io_domain
   use mpp_domains_mod, only: mpp_get_UG_domain_npes
   use mpp_domains_mod, only: mpp_get_UG_domain_pelist
   use mpp_mod,         only: mpp_gather
   use mpp_mod,         only: uppercase
+
+  USE netcdf, ONLY: NF90_INT, NF90_FLOAT, NF90_CHAR
+
 
   IMPLICIT NONE
 

--- a/diag_manager/diag_util.F90
+++ b/diag_manager/diag_util.F90
@@ -76,9 +76,7 @@ MODULE diag_util_mod
   USE fms_io_mod, ONLY: get_instance_filename, get_mosaic_tile_file_ug
   USE constants_mod, ONLY: SECONDS_PER_DAY, SECONDS_PER_HOUR, SECONDS_PER_MINUTE
 
-#ifdef use_netCDF
   USE netcdf, ONLY: NF90_CHAR
-#endif
 
   IMPLICIT NONE
   PRIVATE

--- a/mosaic/read_mosaic.c
+++ b/mosaic/read_mosaic.c
@@ -23,9 +23,8 @@
 #include "read_mosaic.h"
 #include "constant.h"
 #include "mosaic_util.h"
-#ifdef use_netCDF
 #include <netcdf.h>
-#endif
+
 /*********************************************************************
     void netcdf_error( int status )
     status is the returning value of netcdf call. this routine will
@@ -72,8 +71,6 @@ int field_exist(const char* file, const char *name)
   char msg[512];
   int existed=0;
 
-#ifdef use_netCDF
-
   status = nc_open(file, NC_NOWRITE, &ncid);
   if(status != NC_NOERR) {
     sprintf(msg, "field_exist: in opening file %s", file);
@@ -91,10 +88,6 @@ int field_exist(const char* file, const char *name)
     handle_netcdf_error(msg, status);
   }
 
-#else  /* ndef use_netCDF */
-  error_handler("read_mosaic: Add flag -Duse_netCDF when compiling");
-#endif  /* use_netcdf */
-
   return existed;
 
 } /* field_exist */
@@ -106,7 +99,6 @@ int get_dimlen(const char* file, const char *name)
   char msg[512];
 
   len = 0;
-#ifdef use_netCDF
   status = nc_open(file, NC_NOWRITE, &ncid);
   if(status != NC_NOERR) {
     sprintf(msg, "in opening file %s", file);
@@ -135,9 +127,6 @@ int get_dimlen(const char* file, const char *name)
     sprintf(msg, "in closing file %s", file);
     handle_netcdf_error(msg, status);
   }
-#else
-  error_handler("read_mosaic: Add flag -Duse_netCDF when compiling");
-#endif
 
   return len;
 
@@ -152,7 +141,6 @@ void get_string_data(const char *file, const char *name, char *data)
   int ncid, varid, status;
   char msg[512];
 
-#ifdef use_netCDF
   status = nc_open(file, NC_NOWRITE, &ncid);
   if(status != NC_NOERR) {
     sprintf(msg, "in opening file %s", file);
@@ -173,10 +161,6 @@ void get_string_data(const char *file, const char *name, char *data)
     sprintf(msg, "in closing file %s.", file);
     handle_netcdf_error(msg, status);
   }
-#else
-  error_handler("read_mosaic: Add flag -Duse_netCDF when compiling");
-#endif
-
 } /* get_string_data */
 
 /*******************************************************************************
@@ -189,7 +173,6 @@ void get_string_data_level(const char *file, const char *name, char *data, const
   size_t start[4], nread[4];
   char msg[512];
 
-#ifdef use_netCDF
   status = nc_open(file, NC_NOWRITE, &ncid);
   if(status != NC_NOERR) {
     sprintf(msg, "in opening file %s", file);
@@ -214,10 +197,6 @@ void get_string_data_level(const char *file, const char *name, char *data, const
     sprintf(msg, "in closing file %s.", file);
     handle_netcdf_error(msg, status);
   }
-#else
-  error_handler("read_mosaic: Add flag -Duse_netCDF when compiling");
-#endif
-
 } /* get_string_data_level */
 
 
@@ -232,7 +211,6 @@ void get_var_data(const char *file, const char *name, void *data)
   nc_type vartype;
   char msg[512];
 
-#ifdef use_netCDF
   status = nc_open(file, NC_NOWRITE, &ncid);
   if(status != NC_NOERR) {
     sprintf(msg, "in opening file %s", file);
@@ -275,10 +253,6 @@ void get_var_data(const char *file, const char *name, void *data)
     sprintf(msg, "in closing file %s.", file);
     handle_netcdf_error(msg, status);
   }
-#else
-  error_handler("read_mosaic: Add flag -Duse_netCDF when compiling");
-#endif
-
 } /* get_var_data */
 
 /*******************************************************************************
@@ -292,7 +266,6 @@ void get_var_data_region(const char *file, const char *name, const size_t *start
   nc_type vartype;
   char msg[512];
 
-#ifdef use_netCDF
   status = nc_open(file, NC_NOWRITE, &ncid);
   if(status != NC_NOERR) {
     sprintf(msg, "get_var_data_region: in opening file %s", file);
@@ -336,10 +309,6 @@ void get_var_data_region(const char *file, const char *name, const size_t *start
     sprintf(msg, "get_var_data_region: in closing file %s.", file);
     handle_netcdf_error(msg, status);
   }
-#else
-  error_handler("read_mosaic: Add flag -Duse_netCDF when compiling");
-#endif
-
 } /* get_var_data_region */
 
 /******************************************************************************
@@ -351,7 +320,6 @@ void get_var_text_att(const char *file, const char *name, const char *attname, c
   int ncid, varid, status;
   char msg[512];
 
-#ifdef use_netCDF
   status = nc_open(file, NC_NOWRITE, &ncid);
   if(status != NC_NOERR) {
     sprintf(msg, "in opening file %s", file);
@@ -372,10 +340,6 @@ void get_var_text_att(const char *file, const char *name, const char *attname, c
     sprintf(msg, "in closing file %s.", file);
     handle_netcdf_error(msg, status);
   }
-#else
-  error_handler("read_mosaic: Add flag -Duse_netCDF when compiling");
-#endif
-
 } /* get_var_text_att */
 
 /***********************************************************************

--- a/mpp/include/mpp_io_connect.inc
+++ b/mpp/include/mpp_io_connect.inc
@@ -251,10 +251,6 @@
       if( PRESENT(action) )action_flag = action
       form_flag = MPP_ASCII
       if( PRESENT(form) )form_flag = form
-#ifndef use_netCDF
-      if( form_flag.EQ.MPP_NETCDF ) &
-           call mpp_error( FATAL, 'MPP_OPEN: To open a file with form=MPP_NETCDF, you must compile mpp_io with -Duse_netCDF.' )
-#endif
       access_flag = MPP_SEQUENTIAL
       if( PRESENT(access) )access_flag = access
       threading_flag = MPP_SINGLE
@@ -602,7 +598,6 @@
                  !ends addition from fmi - oct.22.2008
 #endif
 
-#ifdef use_netCDF
 #ifdef use_netCDF3
           if( action_flag.EQ.MPP_WRONLY )then
               if(debug) write(*,*) 'Blocksize for create of ', trim(mpp_file(unit)%name),' is ', fsize
@@ -724,7 +719,6 @@
           end if
           mpp_file(unit)%opened = .TRUE.
 
-#endif
 #endif
       else
 !format: ascii, native, or IEEE 32 bit
@@ -869,9 +863,7 @@
       if( mpp_file(unit)%fileset.NE.MPP_MULTI )collect = .FALSE.
       if( mpp_file(unit)%opened) then
          if( mpp_file(unit)%format.EQ.MPP_NETCDF )then
-#ifdef use_netCDF
             error = NF_CLOSE(mpp_file(unit)%ncid); call netcdf_err( error, mpp_file(unit) )
-#endif
          else
             close(unit,status=status)
          end if

--- a/mpp/include/mpp_io_misc.inc
+++ b/mpp/include/mpp_io_misc.inc
@@ -177,10 +177,8 @@
       if( pe.EQ.mpp_root_pe() )then
           iunit = stdlog()  ! PGI compiler does not like stdlog() doing I/O within write call
           write( iunit,'(/a)' )'MPP_IO module '//trim(version)
-#ifdef use_netCDF
           text = NF_INQ_LIBVERS()
           write( iunit,'(/a)' )'Using netCDF library version '//trim(text)
-#endif
       endif
 
 #ifdef CRAYPVP
@@ -234,12 +232,10 @@
       do unit = unit_begin,unit_end
          if( mpp_file(unit)%opened )close(unit)
       end do
-#ifdef use_netCDF
 !close all open netCDF units
       do unit = maxunits+1,2*maxunits
          if( mpp_file(unit)%opened )error = NF_CLOSE(mpp_file(unit)%ncid)
       end do
-#endif
 
 !      call mpp_max(mpp_io_stack_hwm)
 
@@ -262,7 +258,6 @@
       character(len=*), optional :: string
       character(len=256) :: errmsg
 
-#ifdef use_netCDF
       if( err.EQ.NF_NOERR )return
       errmsg = NF_STRERROR(err)
       if( PRESENT(file) )errmsg = trim(errmsg)//' File='//file%name
@@ -272,7 +267,6 @@
       if( PRESENT(string) )errmsg = trim(errmsg)//string
       call mpp_io_exit('NOSYNC')        !make sure you close all open files
       call mpp_error( FATAL, 'NETCDF ERROR: '//trim(errmsg) )
-#endif
       return
     end subroutine netcdf_err
 
@@ -287,9 +281,7 @@
       if( .NOT.mpp_file(unit)%initialized )call mpp_error( FATAL, 'MPP_FLUSH: cannot flush a file during writing of metadata.' )
 
       if( mpp_file(unit)%format.EQ.MPP_NETCDF )then
-#ifdef use_netCDF
           error = NF_SYNC(mpp_file(unit)%ncid); call netcdf_err( error, mpp_file(unit) )
-#endif
       else
           call FLUSH(unit)
       end if

--- a/mpp/include/mpp_io_read.inc
+++ b/mpp/include/mpp_io_read.inc
@@ -221,7 +221,6 @@
       integer, dimension(size(field%axes(:))) :: start, axsiz
       character(len=len(data))        :: text
 
-#ifdef use_netCDF
       if( .NOT.module_is_initialized )call mpp_error( FATAL, 'READ_RECORD: must first call mpp_io_init.' )
       if( .NOT.mpp_file(unit)%opened )call mpp_error( FATAL, 'READ_RECORD: invalid unit number.' )
       if( mpp_file(unit)%threading.EQ.MPP_SINGLE .AND. pe.NE.mpp_root_pe() )return
@@ -273,9 +272,7 @@
           call mpp_error( FATAL, 'Currently dont support non-NetCDF mpp read' )
 
       end if
-#else
-      call mpp_error( FATAL, 'mpp_read_text currently requires use_netCDF option' )
-#endif
+
       return
     end subroutine mpp_read_text
 
@@ -333,8 +330,6 @@
 
       get_time_info = .TRUE.
       if(present(read_time)) get_time_info = read_time
-
-#ifdef use_netCDF
 
       if( mpp_file(unit)%format.EQ.MPP_NETCDF )then
         ncid = mpp_file(unit)%ncid
@@ -1077,9 +1072,7 @@
       endif
 
       mpp_file(unit)%initialized = .TRUE.
-#else
-      call mpp_error( FATAL, 'MPP_READ currently requires use_netCDF option' )
-#endif
+
       return
     end subroutine mpp_read_meta
 
@@ -1126,7 +1119,6 @@
 
       tavg_info_exists = .false.
 
-#ifdef use_netCDF
       do n= 1, field%natt
          if (field%Att(n)%type .EQ. NF_CHAR) then
              if (field%Att(n)%name(1:13) == 'time_avg_info') then
@@ -1135,7 +1127,7 @@
              endif
          endif
       enddo
-#endif
+
       if (tavg_info_exists) then
           do n = 1, size(fields(:))
              if (trim(fields(n)%name) == 'average_T1') then

--- a/mpp/include/mpp_io_unstructured_read.inc
+++ b/mpp/include/mpp_io_unstructured_read.inc
@@ -1,3 +1,5 @@
+! -*-f90-*-
+
 !***********************************************************************
 !*                   GNU Lesser General Public License
 !*
@@ -154,7 +156,6 @@ subroutine mpp_io_unstructured_read_r_1D(funit, &
 
    !If necessary, compute a check-sum of the read-in data.
     if (compute_chksum) then
-#ifdef use_netCDF
         if (field%type .eq. NF_INT) then
             if (field%fill .eq. MPP_FILL_DOUBLE .or. field%fill .eq. &
                 real(MPP_FILL_INT)) then
@@ -176,7 +177,7 @@ subroutine mpp_io_unstructured_read_r_1D(funit, &
             chk = mpp_chksum(fdata, &
                              mask_val=field%fill)
         endif
-#endif
+
        !Print out the computed check-sum for the field.  This feature is
        !currently turned off.  Uncomment the following lines to turn it
        !back on.
@@ -334,7 +335,6 @@ subroutine mpp_io_unstructured_read_r_2D(funit, &
 
    !If necessary, compute a check-sum of the read-in data.
     if (compute_chksum) then
-#ifdef use_netCDF
         if (field%type .eq. NF_INT) then
             if (field%fill .eq. MPP_FILL_DOUBLE .or. field%fill .eq. &
                 real(MPP_FILL_INT)) then
@@ -356,7 +356,7 @@ subroutine mpp_io_unstructured_read_r_2D(funit, &
             chk = mpp_chksum(fdata, &
                              mask_val=field%fill)
         endif
-#endif
+
        !Print out the computed check-sum for the field.  This feature is
        !currently turned off.  Uncomment the following lines to turn it
        !back on.
@@ -514,7 +514,6 @@ subroutine mpp_io_unstructured_read_r_3D(funit, &
 
    !If necessary, compute a check-sum of the read-in data.
     if (compute_chksum) then
-#ifdef use_netCDF
         if (field%type .eq. NF_INT) then
             if (field%fill .eq. MPP_FILL_DOUBLE .or. field%fill .eq. &
                 real(MPP_FILL_INT)) then
@@ -536,7 +535,7 @@ subroutine mpp_io_unstructured_read_r_3D(funit, &
             chk = mpp_chksum(fdata, &
                              mask_val=field%fill)
         endif
-#endif
+
        !Print out the computed check-sum for the field.  This feature is
        !currently turned off.  Uncomment the following lines to turn it
        !back on.

--- a/mpp/include/mpp_io_util.inc
+++ b/mpp/include/mpp_io_util.inc
@@ -658,8 +658,6 @@
         ! external representation
         v%min = f%att(imissing)%fatt(1)*f%scale + f%add
      else if (ifill>0) then
-     !z1l ifdef is added in to be able to compile without using use_netCDF.
-#ifdef use_netCDF
         ! define min and max according to _FillValue
         if(f%att(ifill)%fatt(1)>0) then
             ! if _FillValue is positive, then it defines valid maximum
@@ -690,7 +688,6 @@
             ! representation
             v%min = v%min*f%scale + f%add
         endif
-#endif
     endif
    ! If valid_range is the same type as scale_factor (actually the wider of
    ! scale_factor and add_offset) and this is wider than the external data, then it

--- a/mpp/include/mpp_io_write.inc
+++ b/mpp/include/mpp_io_write.inc
@@ -157,9 +157,7 @@
            call mpp_error( FATAL, 'MPP_WRITE_META: cannot write metadata to file after an mpp_write.' )
 
       if( mpp_file(unit)%format.EQ.MPP_NETCDF )then
-#ifdef use_netCDF
           call write_attribute_netcdf( unit, NF_GLOBAL, name, rval, ival, cval, pack )
-#endif
       else
           call write_attribute( unit, 'GLOBAL '//trim(name), rval, ival, cval, pack )
       end if
@@ -251,7 +249,6 @@
       naxis = size (axes)
       allocate (mpp_file(unit)%axis(naxis))
       mpp_file(unit)%axis(1:naxis) = axes(1:naxis)
-#ifdef use_netCDF
       if( mpp_file(unit)%action.EQ.MPP_WRONLY )then
          if(header_buffer_val>0) then
             error = NF__ENDDEF(mpp_file(unit)%ncid,header_buffer_val,4,0,4)
@@ -259,7 +256,6 @@
             error = NF_ENDDEF(mpp_file(unit)%ncid)
          endif
       endif
-#endif
     end subroutine mpp_write_axis_data
 
     subroutine mpp_def_dim_nodata(unit,name,size)
@@ -270,10 +266,8 @@
 
     ! This routine assumes the file is in define mode
       if(.NOT. mpp_file(unit)%write_on_this_pe) return
-#ifdef use_netCDF
       error = NF_DEF_DIM(mpp_file(unit)%ncid,name,size,did)
       call netcdf_err(error, mpp_file(unit),string='Axis='//trim(name))
-#endif
     end subroutine mpp_def_dim_nodata
 
     subroutine mpp_def_dim_int(unit,name,dsize,longname,data)
@@ -285,7 +279,6 @@
       integer :: error,did,id
 
     ! This routine assumes the file is in define mode
-#ifdef use_netCDF
       if(.NOT. mpp_file(unit)%write_on_this_pe) return
       error = NF_DEF_DIM(mpp_file(unit)%ncid,name,dsize,did)
       call netcdf_err(error, mpp_file(unit),string='Axis='//trim(name))
@@ -309,7 +302,7 @@
       call netcdf_err( error, mpp_file(unit), string=' axis varable '//trim(name))
       error = NF_REDEF(mpp_file(unit)%ncid)
       call netcdf_err( error, mpp_file(unit), string=' subroutine mpp_def_dim')
-#endif
+
     return
   end subroutine mpp_def_dim_int
 
@@ -322,7 +315,6 @@
       integer :: error,did,id
 
     ! This routine assumes the file is in define mode
-#ifdef use_netCDF
       if(.NOT. mpp_file(unit)%write_on_this_pe) return
       error = NF_DEF_DIM(mpp_file(unit)%ncid,name,dsize,did)
       call netcdf_err(error, mpp_file(unit),string='Axis='//trim(name))
@@ -346,7 +338,7 @@
       call netcdf_err( error, mpp_file(unit), string=' axis varable '//trim(name))
       error = NF_REDEF(mpp_file(unit)%ncid)
       call netcdf_err( error, mpp_file(unit), string=' subroutine mpp_def_dim')
-#endif
+
     return
   end subroutine mpp_def_dim_real
 
@@ -438,7 +430,6 @@
       endif
 !write metadata
       if( mpp_file(unit)%format.EQ.MPP_NETCDF )then
-#ifdef use_netCDF
 !write axis def
 !space axes are always floats, time axis is always double
           if( ASSOCIATED(axis%data) )then !space axis
@@ -463,7 +454,6 @@
               call netcdf_err( error, mpp_file(unit), axis )
               mpp_file(unit)%id = axis%id !file ID is the same as time axis varID
           end if
-#endif
       else
           varnum = varnum + 1
           axis%id = varnum
@@ -576,7 +566,6 @@
       allocate(axis%idata(axis%len))
        axis%idata = data
 !write metadata
-#ifdef use_netCDF
       if( mpp_file(unit)%format.EQ.MPP_NETCDF )then
           error = NF_DEF_DIM( mpp_file(unit)%ncid, axis%name, axis%len, axis%did )
           call netcdf_err( error, mpp_file(unit), axis )
@@ -585,7 +574,6 @@
       else
           call mpp_error( FATAL, 'MPP_WRITE_META_AXIS_I1D: Only netCDF format is currently supported.' )
       end if
-#endif
 !write axis attributes
       call mpp_write_meta( unit, axis%id, 'long_name', cval=axis%longname) ; axis%natt = axis%natt + 1
       if (lowercase(trim(axis%units)).ne.'none' .OR. .NOT.cf_compliance) then
@@ -643,7 +631,6 @@
       allocate(axis%idata(1))
       axis%idata = data
 !write metadata
-#ifdef use_netCDF
       if( mpp_file(unit)%format.EQ.MPP_NETCDF )then
           error = NF_DEF_DIM( mpp_file(unit)%ncid, axis%name, NF_UNLIMITED, axis%did )
           call netcdf_err( error, mpp_file(unit), axis )
@@ -652,7 +639,6 @@
       else
           call mpp_error( FATAL, 'MPP_WRITE_META_AXIS_UNLIMITED: Only netCDF format is currently supported.' )
       end if
-#endif
 !write axis attributes
       if(present(longname)) then
          call mpp_write_meta(unit,axis%id,'long_name',cval=axis%longname); axis%natt=axis%natt+1
@@ -725,9 +711,7 @@
       if( .NOT.mpp_file(unit)%opened ) call mpp_error( FATAL, 'MPP_WRITE_META: invalid unit number.' )
       if( mpp_file(unit)%initialized )  then
 !     File has already been written to and needs to be returned to define mode.
-#ifdef use_netCDF
         error = NF_REDEF(mpp_file(unit)%ncid)
-#endif
         mpp_file(unit)%initialized = .false.
       endif
 !           call mpp_error( FATAL, 'MPP_WRITE_META: cannot write metadata to file after an mpp_write.' )
@@ -776,7 +760,6 @@
       field%pack = 2        !default write 32-bit floats
       if( PRESENT(pack) )field%pack = pack
       if( mpp_file(unit)%format.EQ.MPP_NETCDF )then
-#ifdef use_netCDF
           allocate( axis_id(size(field%axes(:))) )
           do i = 1,size(field%axes(:))
              axis_id(i) = field%axes(i)%did
@@ -807,7 +790,6 @@
              error = NF_DEF_VAR_DEFLATE(mpp_file(unit)%ncid, field%id, shuffle, deflate, deflate_level)
              call netcdf_err( error, mpp_file(unit), field=field )
           endif
-#endif
 #endif
       else
           varnum = varnum + 1
@@ -947,7 +929,7 @@
       character(len=*), intent(in), optional :: cval
       integer, intent(in), optional :: pack
       integer, allocatable :: rval_i(:)
-#ifdef use_netCDF
+
       if( PRESENT(rval) )then
 !pack was only meaningful for FP numbers, but is now extended by the ival branch of this routine
           if( PRESENT(pack) )then
@@ -1035,7 +1017,7 @@
       else
           call mpp_error( FATAL, 'WRITE_ATTRIBUTE_NETCDF: one of rval, ival, cval must be present.' )
       end if
-#endif /* use_netCDF */
+
       return
     end subroutine write_attribute_netcdf
 
@@ -1245,13 +1227,10 @@
       if( .NOT.mpp_file(unit)%opened )call mpp_error( FATAL, 'MPP_WRITE_META: invalid unit number.' )
       if( mpp_file(unit)%initialized ) then
 !     File has already been written to and needs to be returned to define mode.
-#ifdef use_netCDF
         error = NF_REDEF(mpp_file(unit)%ncid)
-#endif
         mpp_file(unit)%initialized = .false.
       endif
 !           call mpp_error( FATAL, 'MPP_WRITE_META: cannot write metadata to file after an mpp_write.' )
-#ifdef use_netCDF
       if( mpp_file(unit)%format.EQ.MPP_NETCDF )then
          if( gatt%type.EQ.NF_CHAR )then
             len = gatt%len
@@ -1267,10 +1246,8 @@
             call write_attribute( unit, 'GLOBAL '//trim(gatt%name), rval=gatt%fatt )
          endif
      end if
-#else
-     call mpp_error( FATAL, 'MPP_READ currently requires use_netCDF option' )
-#endif
-      return
+
+     return
     end subroutine mpp_copy_meta_global
 
     subroutine mpp_copy_meta_axis( unit, axis, domain )
@@ -1293,9 +1270,7 @@
       if( .NOT.mpp_file(unit)%opened )call mpp_error( FATAL, 'MPP_WRITE_META: invalid unit number.' )
       if( mpp_file(unit)%initialized )  then
 !     File has already been written to and needs to be returned to define mode.
-#ifdef use_netCDF
         error = NF_REDEF(mpp_file(unit)%ncid)
-#endif
         mpp_file(unit)%initialized = .false.
       endif
 !           call mpp_error( FATAL, 'MPP_WRITE_META: cannot write metadata to file after an mpp_write.' )
@@ -1307,7 +1282,6 @@
           axis%domain = NULL_DOMAIN1D
       end if
 
-#ifdef use_netCDF
 !write metadata
       if( mpp_file(unit)%format.EQ.MPP_NETCDF )then
 
@@ -1373,9 +1347,6 @@
       end if
       if( verbose )print '(a,2i6,x,a,2i3)', 'MPP_WRITE_META: Wrote axis metadata, pe, unit, axis%name, axis%id, axis%did=', &
            pe, unit, trim(axis%name), axis%id, axis%did
-#else
-      call mpp_error( FATAL, 'MPP_READ currently requires use_netCDF option' )
-#endif
 !      call mpp_clock_end(mpp_write_clock)
       return
     end subroutine mpp_copy_meta_axis
@@ -1400,9 +1371,7 @@
       if( .NOT.mpp_file(unit)%opened )call mpp_error( FATAL, 'MPP_WRITE_META: invalid unit number.' )
       if( mpp_file(unit)%initialized )  then
 !     File has already been written to and needs to be returned to define mode.
-#ifdef use_netCDF
         error = NF_REDEF(mpp_file(unit)%ncid)
-#endif
         mpp_file(unit)%initialized = .false.
       endif
 !           call mpp_error( FATAL, 'MPP_WRITE_META: cannot write metadata to file after an mpp_write.' )
@@ -1429,7 +1398,6 @@
       endif
 
       if( mpp_file(unit)%format.EQ.MPP_NETCDF )then
-#ifdef use_netCDF
           allocate( axis_id(size(field%axes(:))) )
           do i = 1,size(field%axes(:))
              axis_id(i) = field%axes(i)%did
@@ -1452,7 +1420,6 @@
                   call mpp_error( FATAL, 'MPP_WRITE_META_FIELD: only legal packing values are 1,2,4,8.' )
           end select
           deallocate( axis_id )
-#endif
       else
           varnum = varnum + 1
           field%id = varnum

--- a/mpp/include/mpp_read_2Ddecomp.h
+++ b/mpp/include/mpp_read_2Ddecomp.h
@@ -42,7 +42,6 @@
       pointer( ptr4, r8vals )
       if (mpp_io_stack_size < nwords) call mpp_io_set_stack_size(nwords)
 
-#ifdef use_netCDF
       word_sz = size(transfer(data(1),one_byte))
 
           select case (field%type)
@@ -106,10 +105,6 @@
              case default
                 call mpp_error( FATAL, 'MPP_READ: invalid pack value' )
           end select
-#else
-      call mpp_error( FATAL, 'MPP_READ currently requires use_netCDF option' )
-#endif
-
     end subroutine READ_RECORD_CORE_
 
 

--- a/mpp/include/mpp_read_compressed.h
+++ b/mpp/include/mpp_read_compressed.h
@@ -92,7 +92,6 @@
       if (ANY(field%checksum /= default_field%checksum) ) compute_chksum = .TRUE.
 
       if (compute_chksum) then
-#ifdef use_netCDF
       if (field%type==NF_INT) then
          if (field%fill == MPP_FILL_DOUBLE .or. field%fill == real(MPP_FILL_INT) ) then
             chk = mpp_chksum( ceiling(data), mask_val=MPP_FILL_INT )
@@ -105,7 +104,6 @@
       else !!real data
          chk = mpp_chksum(data,mask_val=field%fill)
       end if
-#endif
       !!compare
          if ( print_compressed_chksum) then
             if ( mpp_pe() == mpp_root_pe() ) then
@@ -184,7 +182,6 @@
       if (ANY(field%checksum /= default_field%checksum) ) compute_chksum = .TRUE.
 
       if (compute_chksum) then
-#ifdef use_netCDF
       if (field%type==NF_INT) then
          if (field%fill == MPP_FILL_DOUBLE .or. field%fill == real(MPP_FILL_INT) ) then
             chk = mpp_chksum( ceiling(data), mask_val=MPP_FILL_INT )
@@ -197,7 +194,6 @@
       else !!real
          chk = mpp_chksum(data,mask_val=field%fill)
       end if
-#endif
       !!compare
          if ( print_compressed_chksum) then
             if ( mpp_pe() == mpp_root_pe() ) then

--- a/mpp/include/mpp_write_2Ddecomp.h
+++ b/mpp/include/mpp_write_2Ddecomp.h
@@ -61,7 +61,6 @@
 !we now declare the file to be initialized
 !if this is netCDF we switch file from DEFINE mode to DATA mode
           if( mpp_file(unit)%format.EQ.MPP_NETCDF )then
-#ifdef use_netCDF
 !NOFILL is probably required for parallel: any circumstances in which not advisable?
               error = NF_SET_FILL( mpp_file(unit)%ncid, NF_NOFILL, i ); call netcdf_err( error, mpp_file(unit) )
               if( mpp_file(unit)%action.EQ.MPP_WRONLY )then
@@ -72,7 +71,6 @@
                  endif
               endif
               call netcdf_err( error, mpp_file(unit) )
-#endif
           else
               call mpp_write_meta( unit, 'END', cval='metadata' )
           end if
@@ -126,7 +124,6 @@
           end do
 
           if( debug )print '(a,2i6,12i6)', 'WRITE_RECORD: PE, unit, start, axsiz=', pe, unit, start, axsiz
-#ifdef use_netCDF
 !write time information if new time
           if( newtime )then
               if( KIND(time).EQ.DOUBLE_KIND )then
@@ -149,7 +146,6 @@
               error = NF_PUT_VARA_INT   ( mpp_file(unit)%ncid, field%id, start, axsiz, packed_data )
           end if
           call netcdf_err( error, mpp_file(unit), field=field )
-#endif
       else                      !non-netCDF
           ptr1 = LOC(mpp_io_stack(1))
 !subdomain contains (/is,ie,js,je/)

--- a/mpp/mpp_io.F90
+++ b/mpp/mpp_io.F90
@@ -367,9 +367,7 @@ use mpp_domains_mod, only: domainUG, &
 implicit none
 private
 
-#ifdef use_netCDF
 #include <netcdf.inc>
-#endif
 
   !--- public parameters  -----------------------------------------------
   public :: MPP_WRONLY, MPP_RDONLY, MPP_APPEND, MPP_OVERWR, MPP_ASCII, MPP_IEEE32

--- a/test_fms/fms/test_unstructured_fms_io.F90
+++ b/test_fms/fms/test_unstructured_fms_io.F90
@@ -48,9 +48,7 @@ program test_unstructured_fms_io
                                             fms_io_exit
     implicit none
 
-#ifdef use_netCDF
 #include <netcdf.inc>
-#endif
 
    !Local variables
     integer(INT_KIND)              :: nx = 8                               !<Total number of grid points in the x-dimension (longitude?)

--- a/test_fms/fms/test_unstructured_fms_io.F90
+++ b/test_fms/fms/test_unstructured_fms_io.F90
@@ -48,8 +48,6 @@ program test_unstructured_fms_io
                                             fms_io_exit
     implicit none
 
-#include <netcdf.inc>
-
    !Local variables
     integer(INT_KIND)              :: nx = 8                               !<Total number of grid points in the x-dimension (longitude?)
     integer(INT_KIND)              :: ny = 8                               !<Total number of grid points in the y-dimension (latitude?)

--- a/test_fms/mpp_io/test_mpp_io.F90
+++ b/test_fms/mpp_io/test_mpp_io.F90
@@ -39,9 +39,7 @@ program test
 
   implicit none
 
-#ifdef use_netCDF
 #include <netcdf.inc>
-#endif
 
   !--- namelist definition
   integer           :: nx=360, ny=200, nz=50, nt=2

--- a/test_fms/mpp_io/test_mpp_io.F90
+++ b/test_fms/mpp_io/test_mpp_io.F90
@@ -39,8 +39,6 @@ program test
 
   implicit none
 
-#include <netcdf.inc>
-
   !--- namelist definition
   integer           :: nx=360, ny=200, nz=50, nt=2
   integer           :: halo=2, stackmax=1500000, stackmaxd=2000000


### PR DESCRIPTION
**Description**

libFMS can now _only_ be built with netCDF, thus the use_netCDF preprocessor macro is not needed.  This commit removes the use_netCDF macro from all FMS sources.

Fixes #246 

**How Has This Been Tested?**
Standard build/make distcheck on Apple Mac OS X system.

**Checklist:**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
- [X] New check tests, if applicable, are included
- [X] `make distcheck` passes

