### PR TITLE
Remove string overflow warning in field_manager

### DIFF
--- a/field_manager/field_manager.F90
+++ b/field_manager/field_manager.F90
@@ -1193,7 +1193,7 @@ do i = 1, num_elem
   if (val_name(1:1) .eq. squote) then  !{
 
     if (val_name(length:length) .eq. squote) then
-      val_name = val_name(2:length-1)
+      val_name = val_name(2:length-1)//repeat(" ",len(val_name)-length+2)
       val_type = string_type
     elseif (val_name(length:length) .eq. dquote) then
       call mpp_error(FATAL, trim(error_header) // ' Quotes do not match in ' // trim(val_name) //       &


### PR DESCRIPTION
**Description** 

Gfortran would issue a warning of reading 128 bytes from a region of 127 in field_manager.  This update removes that warning

Fixes #250 

**How Has This Been Tested?**
Tested on Mac OS X, `make distcheck`

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

