### PR TITLE
Remove Cray Enhanced IO functionality

### DIFF
--- a/fms/fms_io.F90
+++ b/fms/fms_io.F90
@@ -534,7 +534,6 @@ logical           :: fms_netcdf_restart  = .true.
 character(len=32) :: threading_read      = 'multi'
 character(len=32) :: format              = 'netcdf'
 logical           :: read_all_pe         = .TRUE.
-character(len=64) :: iospec_ieee32       = '-N ieee_32'
 integer           :: max_files_w         = 40
 integer           :: max_files_r         = 40
 integer           :: dr_set_size         = 10
@@ -545,7 +544,7 @@ logical           :: show_open_namelist_file_warning = .false.
 logical           :: debug_mask_list     = .false.
 logical           :: checksum_required   = .true.
   namelist /fms_io_nml/ fms_netcdf_override, fms_netcdf_restart, &
-       threading_read, format, read_all_pe, iospec_ieee32,max_files_w,max_files_r, &
+       threading_read, format, read_all_pe, max_files_w,max_files_r, &
        read_data_bug, time_stamp_restart, print_chksum, show_open_namelist_file_warning, &
        debug_mask_list, checksum_required, dr_set_size
 
@@ -7351,15 +7350,9 @@ function open_ieee32_file (file, action) result (unit)
      call mpp_error (FATAL,'fms_io(open_ieee32_file): action should be either read or write in file'//trim(file))
   end select
 
-  if (iospec_ieee32(1:1) == ' ') then
-     call mpp_open ( unit, file, form=MPP_IEEE32, action=mpp_action, &
+  call mpp_open ( unit, file, form=MPP_IEEE32, action=mpp_action, &
           access=MPP_SEQUENTIAL, threading=MPP_SINGLE,    &
           nohdrs=.true. )
-  else
-     call mpp_open ( unit, file, form=MPP_IEEE32, action=mpp_action, &
-          access=MPP_SEQUENTIAL, threading=MPP_SINGLE,    &
-          nohdrs=.true., iospec=iospec_ieee32 )
-  endif
 end function open_ieee32_file
 ! </FUNCTION>
 
@@ -7689,7 +7682,7 @@ function open_file(file, form, action, access, threading, recl, dist) result(uni
     if ( .not.do_ieee32 ) then
        call mpp_open ( unit, file, form=mpp_format, action=mpp_action, &
                        access=mpp_access, threading=mpp_thread,        &
-                       fileset=MPP_SINGLE,nohdrs=no_headers, recl=recl )
+                       fileset=MPP_SINGLE, nohdrs=no_headers, recl=recl )
     else
      ! special open for ieee32 file
      ! fms_mod has iospec value

--- a/mpp/include/mpp_io_connect.inc
+++ b/mpp/include/mpp_io_connect.inc
@@ -29,7 +29,7 @@
 !   </DESCRIPTION>
 !   <TEMPLATE>
 !     call mpp_open( unit, file, action, form, access, threading, fileset,
-!             iospec, nohdrs, recl, pelist )
+!             nohdrs, recl, pelist )
 !   </TEMPLATE>
 
 !   <OUT NAME="unit" TYPE="integer">
@@ -68,9 +68,6 @@
 !   </IN>
 !   <IN NAME="recl" TYPE="integer">
 !     recl is the record length in bytes.
-!   </IN>
-!   <IN NAME="iospec" TYPE="character(len=*)">
-!     iospec is a system hint for I/O organization, e.g assign(1) on SGI/Cray systems.
 !   </IN>
 !   <IN NAME="nohdrs" TYPE="logical">
 !     nohdrs has no effect when action=MPP_RDONLY|MPP_APPEND or when form=MPP_NETCDF
@@ -111,41 +108,18 @@
 !
 !   For netCDF files, headers are always written even if
 !   <TT>nohdrs=.TRUE.</TT>
-!
-!   The string <TT>iospec</TT> is passed to the OS to
-!   characterize the I/O to be performed on the file opened on
-!   <TT>unit</TT>. This is typically used for I/O optimization. For
-!   example, the FFIO layer on SGI/Cray systems can be used for
-!   controlling synchronicity of reads and writes, buffering of data
-!   between user space and disk for I/O optimization, striping across
-!   multiple disk partitions, automatic data conversion and the like
-!   (<TT>man intro_ffio</TT>). All these actions are controlled through
-!   the <TT>assign</TT> command. For example, to specify asynchronous
-!   caching of data going to a file open on <TT>unit</TT>, one would do:
-!
-!   <PRE>
-!   call mpp_open( unit, ... iospec='-F cachea' )
-!   </PRE>
-!
-!   on an SGI/Cray system, which would pass the supplied
-!   <TT>iospec</TT> to the <TT>assign(3F)</TT> system call.
-!
-!   Currently <TT>iospec </TT>performs no action on non-SGI/Cray
-!   systems. The interface is still provided, however: users are cordially
-!   invited to add the requisite system calls for other systems.
-!   </NOTE>
+!!   </NOTE>
 ! </SUBROUTINE>
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !                                                                            !
 !           OPENING AND CLOSING FILES: mpp_open() and mpp_close()            !
 !                                                                            !
 ! mpp_open( unit, file, action, form, access, threading, &                   !
-!           fileset, iospec, nohdrs, recl, pelist )                          !
+!           fileset, nohdrs, recl, pelist )                          !
 !      integer, intent(out) :: unit                                          !
 !      character(len=*), intent(in) :: file                                  !
 !      integer, intent(in), optional :: action, form, access, threading,     !
 !                                       fileset, recl                        !
-!      character(len=*), intent(in), optional :: iospec                      !
 !      logical, intent(in), optional :: nohdrs                               !
 !      integer, optional, intent(in) :: pelist(:) !default ALL               !
 !                                                                            !
@@ -153,8 +127,6 @@
 !  file is the filename: REQUIRED                                            !
 !    we append .nc to filename if it is a netCDF file                        !
 !    we append .<pppp> to filename if fileset is private (pppp is PE number) !
-!  iospec is a system hint for I/O organization                              !
-!         e.g assign(1) on SGI/Cray systems.                                 !
 !  if nohdrs is .TRUE. headers are not written on non-netCDF writes.         !
 !  nohdrs has no effect when action=MPP_RDONLY|MPP_APPEND                    !
 !                    or when form=MPP_NETCDF                                 !
@@ -179,7 +151,7 @@
 !                                                                            !
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     subroutine mpp_open( unit, file, action, form, access, threading, &
-                         fileset, iospec, nohdrs, recl,               &
+                         fileset, nohdrs, recl,               &
                          iostat, is_root_pe, domain, &
 !----------
 !ug support
@@ -189,7 +161,6 @@
       character(len=*), intent(in)           :: file
       integer,          intent(in), optional :: action, form, access
       integer,          intent(in), optional :: threading, fileset, recl
-      character(len=*), intent(in), optional :: iospec
       logical,          intent(in), optional :: nohdrs
       integer,         intent(out), optional :: iostat
       logical,          intent(in), optional :: is_root_pe
@@ -484,50 +455,11 @@
           if( fileset_flag.EQ.MPP_SINGLE )then
               if( form_flag.EQ.MPP_NETCDF .AND. act.EQ.'WRITE' ) &
                    call mpp_error( FATAL, 'MPP_OPEN: netCDF currently does not support single-file multi-threaded output.' )
-
-#ifdef _CRAYT3E
-              call ASSIGN( 'assign -I -F global.privpos f:'//trim(mpp_file(unit)%name), error )
-#endif
           else if( fileset_flag.NE.MPP_MULTI )then
               call mpp_error( FATAL, 'MPP_OPEN: fileset must be one of MPP_MULTI or MPP_SINGLE.' )
           end if
       else if( threading_flag.NE.MPP_SINGLE )then
           call mpp_error( FATAL, 'MPP_OPEN: threading must be one of MPP_SINGLE or MPP_MULTI.' )
-      end if
-
-!apply I/O specs before opening the file
-!note that -P refers to the scope of a fortran unit, which is always thread-private even if file is shared
-#ifdef CRAYPVP
-#ifndef _CRAYX1
-      call ASSIGN( 'assign -I -P thread  f:'//trim(mpp_file(unit)%name), error )
-#endif
-#endif
-#ifdef _CRAYT3E
-      call ASSIGN( 'assign -I -P private f:'//trim(mpp_file(unit)%name), error )
-#endif
-#ifdef _CRAYX1
-      if (file(length-3:length) == '.nml') then
-        call ASSIGN( 'assign -I -f77 f:'//trim(mpp_file(unit)%name), error )
-!       call ASSIGN( 'assign -I -F global f:'//trim(mpp_file(unit)%name), error )
-      endif
-#endif
-      if( PRESENT(iospec) )then
-!iospec provides hints to the system on how to organize I/O
-!on Cray systems this is done through 'assign', see assign(1) and assign(3F)
-!on other systems this will be expanded as needed
-!no error checks here on whether the supplied iospec is valid
-#if defined(SGICRAY) || defined(_CRAYX1)
-          call ASSIGN( 'assign -I '//trim(iospec)//' f:'//trim(mpp_file(unit)%name), error )
-          if( form_flag.EQ.MPP_NETCDF )then
-!for netCDF on SGI/Cray systems we pass it to the environment variable NETCDF_XFFIOSPEC
-!ideally we should parse iospec, pass the argument of -F to NETCDF_FFIOSPEC, and the rest to NETCDF_XFFIOSPEC
-!maybe I'll get around to it someday
-!PXFSETENV is a POSIX-standard routine for setting environment variables from fortran
-              !if we ever use this again....F2003 non-intel flavor of getenv
-              !call get_enviornment_variable( 'NETCDF_XFFIOSPEC', trim(iospec))
-              call PXFSETENV( 'NETCDF_XFFIOSPEC', 0, trim(iospec), 0, 1, error )
-          end if
-#endif
       end if
 
 !open the file as specified above for various formats
@@ -732,12 +664,6 @@
               for = 'FORMATTED'
           else if( form_flag.EQ.MPP_IEEE32 )then
               for = 'UNFORMATTED'
-!assign -N is currently unsupported on SGI
-#ifdef _CRAY
-#ifndef _CRAYX1
-              call ASSIGN( 'assign -I -N ieee_32 f:'//trim(mpp_file(unit)%name), error )
-#endif
-#endif
           else if( form_flag.EQ.MPP_NATIVE )then
               for = 'UNFORMATTED'
           else
@@ -876,11 +802,7 @@
             close(unit,status=status)
          end if
       endif
-#ifdef SGICRAY
-!this line deleted: since the FILENV is a shared file, this might cause a problem in
-! multi-threaded I/O if one PE does assign -R before another one has opened it.
-!      call ASSIGN( 'assign -R f:'//trim(mpp_file(unit)%name), error )
-#endif
+
       if ( associated(mpp_file(unit)%Axis) ) then
          do i=1, mpp_file(unit)%ndim
             if ( associated(mpp_file(unit)%Axis(i)%data) ) then

--- a/mpp/include/mpp_io_misc.inc
+++ b/mpp/include/mpp_io_misc.inc
@@ -183,11 +183,6 @@
 #endif
       endif
 
-#ifdef CRAYPVP
-!we require every file to be assigned threadwise: PVPs default to global, and are reset here
-      call ASSIGN( 'assign -P thread p:%', error )
-#endif
-
       call mpp_io_set_stack_size(131072) ! default initial value
       call mpp_sync()
       if( io_clocks_on )then
@@ -308,4 +303,3 @@
     logical function do_cf_compliance()
       do_cf_compliance = cf_compliance
     end function do_cf_compliance
-

--- a/mpp/include/mpp_io_util.inc
+++ b/mpp/include/mpp_io_util.inc
@@ -516,20 +516,6 @@
       return
    end function mpp_get_recdimid
 
-    subroutine mpp_get_iospec( unit, iospec )
-      integer, intent(in) :: unit
-      character(len=*), intent(inout) :: iospec
-
-      if( .NOT.module_is_initialized )call mpp_error( FATAL, 'MPP_GET_IOSPEC: must first call mpp_io_init.' )
-      if( .NOT.mpp_file(unit)%opened )call mpp_error( FATAL, 'MPP_GET_IOSPEC: invalid unit number.' )
-#ifdef SGICRAY
-!currently will write to stdout: don't know how to trap and return as string to iospec
-      call ASSIGN( 'assign -V f:'//trim(mpp_file(unit)%name), error )
-#endif
-      return
-    end subroutine mpp_get_iospec
-
-
   !#####################################################################
 ! <FUNCTION NAME="mpp_get_ncid">
 !   <OVERVIEW>

--- a/mpp/mpp_io.F90
+++ b/mpp/mpp_io.F90
@@ -384,7 +384,7 @@ private
   public :: default_field, default_axis, default_att
 
   !--- public interface from mpp_io_util.h ----------------------
-  public :: mpp_get_iospec, mpp_get_id, mpp_get_ncid, mpp_get_unit_range, mpp_is_valid
+  public :: mpp_get_id, mpp_get_ncid, mpp_get_unit_range, mpp_is_valid
   public :: mpp_set_unit_range, mpp_get_info, mpp_get_atts, mpp_get_fields
   public :: mpp_get_times, mpp_get_axes, mpp_get_recdimid, mpp_get_axis_data, mpp_get_axis_by_name
   public :: mpp_io_set_stack_size, mpp_get_field_index, mpp_get_axis_index

--- a/test_fms/diag_manager/test_diag_manager.F90
+++ b/test_fms/diag_manager/test_diag_manager.F90
@@ -303,7 +303,6 @@ PROGRAM test
     integer(INT_KIND)              :: stackmaxd = 500000                   !<Default size to which the mpp_domains stack will be set.
     logical(INT_KIND)              :: debug = .false.                      !<Flag to print debugging information.
     character(len=64)              :: test_file = "test_unstructured_grid" !<Base filename for the unit tests.
-    character(len=64)              :: iospec = '-F cachea'                 !<Something cray related ???
     integer(INT_KIND)              :: pack_size = 1                        !<(Number of bits in real(DOUBLE_KIND))/(Number of bits in real)
     integer(INT_KIND)              :: npes                                 !<Total number of ranks in the current pelist.
     integer(INT_KIND)              :: io_status                            !<Namelist read error code.

--- a/test_fms/fms/test_unstructured_fms_io.F90
+++ b/test_fms/fms/test_unstructured_fms_io.F90
@@ -71,7 +71,6 @@ program test_unstructured_fms_io
     integer(INT_KIND)              :: stackmaxd = 500000                   !<Default size to which the mpp_domains stack will be set.
     logical(INT_KIND)              :: debug = .false.                      !<Flag to print debugging information.
     character(len=64)              :: test_file = "test_unstructured_grid" !<Base filename for the unit tests.
-    character(len=64)              :: iospec = '-F cachea'                 !<Something cray related ???
     integer(INT_KIND)              :: pack_size = 1                        !<(Number of bits in real(DOUBLE_KIND))/(Number of bits in real)
     integer(INT_KIND)              :: npes                                 !<Total number of ranks in the current pelist.
     integer(INT_KIND)              :: io_status                            !<Namelist read error code.
@@ -97,7 +96,6 @@ program test_unstructured_fms_io
                                         stackmaxd, &
                                         debug, &
                                         test_file, &
-                                        iospec, &
                                         ntiles_x, &
                                         ntiles_y, &
                                         layout, &

--- a/test_fms/mpp_io/test_mpp_io.F90
+++ b/test_fms/mpp_io/test_mpp_io.F90
@@ -47,7 +47,7 @@ program test
   integer           :: nx=360, ny=200, nz=50, nt=2
   integer           :: halo=2, stackmax=1500000, stackmaxd=2000000
   logical           :: debug=.FALSE.
-  character(len=64) :: file='test', iospec='-F cachea'
+  character(len=64) :: file='test'
   integer           :: layout(2) = (/1,1/)
   integer           :: ntiles_x=1, ntiles_y=1  ! total number of tiles will be ntiles_x*ntiles_y,
                                                ! the grid size for each tile will be (nx/ntiles_x, ny/ntiles_y)
@@ -56,7 +56,7 @@ program test
                                                ! group and write out data from the root pe of each group.
   integer           :: pack_size = 1
 
-  namelist / test_mpp_io_nml / nx, ny, nz, nt, halo, stackmax, stackmaxd, debug, file, iospec, &
+  namelist / test_mpp_io_nml / nx, ny, nz, nt, halo, stackmax, stackmaxd, debug, file, &
                                ntiles_x, ntiles_y, layout, io_layout
 
   integer        :: pe, npes, io_status


### PR DESCRIPTION
**Description**
The Cray Enhanced IO functionality is not supported on our Cray system, and as such has not been tested.  This commit removes (as much as possible) the bits that would `call ASSIGN` to configure the enhanced IO functionality.

This leaves the call to open_ieee32_file, as it is used in other model components, but is now no more than a _special_ mpp_open.

Fixes #248 

**How Has This Been Tested?**
make && make check on Mac OS X.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

