### PR TITLE
Fixes for style in fms2_io

### DIFF
--- a/fms2_io/blackboxio.F90
+++ b/fms2_io/blackboxio.F90
@@ -5,6 +5,8 @@ use fms_io_utils_mod
 use netcdf_io_mod
 use fms_netcdf_domain_io_mod
 use fms_netcdf_unstructured_domain_io_mod
+use mpp_mod, only: mpp_pe
+use, intrinsic :: iso_fortran_env, only: error_unit, int32, int64, real32, real64
 implicit none
 private
 

--- a/fms2_io/fms_io_utils.F90
+++ b/fms2_io/fms_io_utils.F90
@@ -9,6 +9,8 @@ use omp_lib
 use mpp_mod
 
 
+implicit none
+
 public :: char_linked_list
 public :: error
 public :: file_exists

--- a/fms2_io/fms_io_utils.F90
+++ b/fms2_io/fms_io_utils.F90
@@ -7,9 +7,8 @@ use, intrinsic :: iso_fortran_env, only: error_unit, int32, int64, real32, real6
 use omp_lib
 #endif
 use mpp_mod
-
-
 implicit none
+private
 
 public :: char_linked_list
 public :: error
@@ -27,7 +26,8 @@ public :: get_array_section
 public :: get_data_type_string
 public :: get_checksum
 public :: open_check
-
+public :: string_compare
+public :: restart_filepath_mangle
 
 !> @brief A linked list of strings.
 type :: char_linked_list
@@ -132,7 +132,6 @@ interface get_checksum
   module procedure get_checksum_4d
   module procedure get_checksum_5d
 end interface get_checksum
-
 
 contains
 
@@ -360,7 +359,7 @@ end function has_io_domain_tile_string
 
 
 !> @brief Add the I/O domain tile id to an input filepath.
-!! @internal
+!! 
 subroutine io_domain_tile_filepath_mangle(dest, source, io_domain_tile_id)
 
   character(len=*), intent(inout) :: dest !< Output filepath.

--- a/fms2_io/fms_io_utils.F90
+++ b/fms2_io/fms_io_utils.F90
@@ -386,7 +386,7 @@ end function has_restart_string
 
 
 !> @brief Add ".res" to an input file path.
-!! @internal
+!! 
 subroutine restart_filepath_mangle(dest, source)
 
   character(len=*), intent(inout) :: dest


### PR DESCRIPTION
---
name: Fixes for style in fms2_io
about: Adds `implicit none` and private to fms_io_utils.F90
title: ''
labels: ''
---

**Description**
The file fms_io_utils.F90 did not have `implicit none` or `private`, so I added them.  I had to make some routines `public` and fix blackboxio.F90 to because fms_io_utils.F90 was exposing things it shouldn't have been.
Fixes #264 

**How Has This Been Tested?**
I ran c96L33_am4p0_cmip6Diag in the AWG XML with xanadu code, master FMS, and my updates. It also passed the travis-ci check.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [x] `make distcheck` passes

