### PR TITLE
Resolves #269.  Any variable that was named `pos` is now named `domain_position`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ sequential patch number (starting from `01`).
 
 ## [Unreleased]
 ### Added
+- Calls to register_diag_axis using an X or Y axis that is shifted from the `CENTER` position need to include the optional argument `domain_position` and should be equal to `EAST` or `NORTH` based on the position relative to the domain.  `EAST` and `NORTH` are exposed through `diag_manager_mod`.
 ### Changed
 ### Deprecated
 ### Removed

--- a/diag_manager/diag_axis.F90
+++ b/diag_manager/diag_axis.F90
@@ -154,7 +154,7 @@ CONTAINS
   !   </IN>
   !   <IN NAME="tile_count" TYPE="INTEGER, OPTIONAL" />
   INTEGER FUNCTION diag_axis_init(name, DATA, units, cart_name, long_name, direction,&
-       & set_name, edges, Domain, Domain2, DomainU, aux, req, tile_count, pos)
+       & set_name, edges, Domain, Domain2, DomainU, aux, req, tile_count, domain_position )
     CHARACTER(len=*), INTENT(in) :: name
     REAL, DIMENSION(:), INTENT(in) :: DATA
     CHARACTER(len=*), INTENT(in) :: units
@@ -166,7 +166,7 @@ CONTAINS
     TYPE(domainUG), INTENT(in), OPTIONAL :: DomainU
     CHARACTER(len=*), INTENT(in), OPTIONAL :: aux, req
     INTEGER, INTENT(in), OPTIONAL :: tile_count
-    INTEGER, INTENT(in), OPTIONAL :: pos
+    INTEGER, INTENT(in), OPTIONAL :: domain_position
 
 
     TYPE(domain1d) :: domain_x, domain_y
@@ -299,15 +299,15 @@ CONTAINS
     ELSE
        Axes(diag_axis_init)%req = 'none'
     END IF
-    IF ( PRESENT(pos) ) THEN
-       if (pos == NORTH .or. pos == EAST .or. pos == CENTER) then
-          Axes(diag_axis_init)%pos = pos
+    IF ( PRESENT(domain_position) ) THEN
+       if (domain_position == NORTH .or. domain_position == EAST .or. domain_position == CENTER) then
+          Axes(diag_axis_init)%domain_position = domain_position
        else
           CALL error_mesg('diag_axis_mod::diag_axis_init', "Position must be NORTH, EAST, or CENTER" ,&
                          FATAL)
        endif
     ELSE
-       Axes(diag_axis_init)%pos = CENTER
+       Axes(diag_axis_init)%domain_position = CENTER
     END IF
 
     !---- axis direction (-1, 0, or +1) ----
@@ -536,7 +536,7 @@ CONTAINS
   !     Array of coordinate values for this axis.
   !   </OUT>
   SUBROUTINE get_diag_axis(id, name, units, long_name, cart_name,&
-       & direction, edges, Domain, DomainU, DATA, num_attributes, attributes, pos)
+       & direction, edges, Domain, DomainU, DATA, num_attributes, attributes, domain_position)
     CHARACTER(len=*), INTENT(out) :: name, units, long_name, cart_name
     INTEGER, INTENT(in) :: id
     TYPE(domain1d), INTENT(out) :: Domain
@@ -545,7 +545,7 @@ CONTAINS
     REAL, DIMENSION(:), INTENT(out) :: DATA
     INTEGER, INTENT(out), OPTIONAL :: num_attributes
     TYPE(diag_atttype), ALLOCATABLE, DIMENSION(:), INTENT(out), OPTIONAL :: attributes
-    INTEGER, INTENT(out), OPTIONAL :: pos
+    INTEGER, INTENT(out), OPTIONAL :: domain_position
 
     INTEGER :: i, j, istat
 
@@ -558,7 +558,7 @@ CONTAINS
     edges     = Axes(id)%edges
     Domain    = Axes(id)%Domain
     DomainU   = Axes(id)%DomainUG
-    if (present(pos)) pos = Axes(id)%pos
+    if (present(domain_position)) domain_position = Axes(id)%domain_position
     IF ( Axes(id)%length > SIZE(DATA(:)) ) THEN
        ! <ERROR STATUS="FATAL">array data is too small.</ERROR>
        CALL error_mesg('diag_axis_mod::get_diag_axis', 'array data is too small', FATAL)

--- a/diag_manager/diag_axis.F90
+++ b/diag_manager/diag_axis.F90
@@ -55,7 +55,8 @@ MODULE diag_axis_mod
        & get_tile_count, get_axes_shift, get_diag_axis_name,&
        & get_axis_num, get_diag_axis_domain_name, diag_axis_add_attribute,&
        & get_domainUG, axis_compatible_check, axis_is_compressed, &
-       & get_compressed_axes_ids, get_axis_reqfld
+       & get_compressed_axes_ids, get_axis_reqfld, &
+       & NORTH, EAST, CENTER
 
   ! Module variables
   ! Parameters

--- a/diag_manager/diag_data.F90
+++ b/diag_manager/diag_data.F90
@@ -622,7 +622,7 @@ use fms2_io_mod
      INTEGER :: tile_count
      TYPE(diag_atttype), _ALLOCATABLE, dimension(:) :: attributes _NULL
      INTEGER :: num_attributes
-     INTEGER :: pos !< The position in the doman (NORTH or EAST or CENTER)
+     INTEGER :: domain_position !< The position in the doman (NORTH or EAST or CENTER)
   END TYPE diag_axis_type
   ! </TYPE>
 

--- a/diag_manager/diag_manager.F90
+++ b/diag_manager/diag_manager.F90
@@ -213,7 +213,7 @@ MODULE diag_manager_mod
        & file_exist, fms_error_handler, check_nml_error, get_mosaic_tile_file, lowercase
   USE fms_io_mod, ONLY: get_instance_filename
   USE diag_axis_mod, ONLY: diag_axis_init, get_axis_length, get_axis_num, get_domain2d, get_tile_count,&
-       & diag_axis_add_attribute, axis_compatible_check
+       & diag_axis_add_attribute, axis_compatible_check, CENTER, NORTH, EAST
   USE diag_util_mod, ONLY: get_subfield_size, log_diag_field_info, update_bounds,&
        & check_out_of_bounds, check_bounds_are_exact_dynamic, check_bounds_are_exact_static,&
        & diag_time_inc, find_input_field, init_input_field, init_output_field,&
@@ -255,6 +255,7 @@ MODULE diag_manager_mod
        & DIAG_MINUTES, DIAG_HOURS, DIAG_DAYS, DIAG_MONTHS, DIAG_YEARS, get_diag_global_att,&
        & set_diag_global_att, diag_field_add_attribute, diag_field_add_cell_measures,&
        & get_diag_field_id, diag_axis_add_attribute
+  PUBLIC :: CENTER, NORTH, EAST !< Used for diag_axis_init
   ! Public interfaces from diag_grid_mod
   PUBLIC :: diag_grid_init, diag_grid_end
   PUBLIC :: diag_manager_set_time_end, diag_send_complete

--- a/diag_manager/diag_output.F90
+++ b/diag_manager/diag_output.F90
@@ -364,7 +364,7 @@ integer :: domain_size, axis_length, axis_pos
 
        CALL get_diag_axis(id_axis, axis_name, axis_units, axis_long_name,&
             & axis_cart_name, axis_direction, axis_edges, Domain, DomainU, axis_data,&
-            & num_attributes, attributes, pos=axis_pos)
+            & num_attributes, attributes, domain_position=axis_pos)
 
        IF ( Domain .NE. null_domain1d ) THEN
           IF ( length > 0 ) THEN


### PR DESCRIPTION
**Description**
All variables in the diag_manager named `pos` have been renamed `domain_position`
Requires updates to atmos_cubed_sphere

Fixes # (issue)
#269 

**How Has This Been Tested?**
passed travis CI checks

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

