### PR TITLE
Add initial Makdown guides for libFMS

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,69 @@
+# Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others’ private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, or to ban temporarily or permanently any
+contributor for other behaviors that they deem inappropriate, threatening,
+offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at climate.model.info@noaa.gov. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project’s leadership.
+
+## Attribution
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/),
+version 1.4, available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html

--- a/CODE_STYLE.md
+++ b/CODE_STYLE.md
@@ -1,0 +1,115 @@
+# Coding Style
+
+## General
+
+* Trim all trailing whitespace from every line (some editors can do this
+  automatically).
+* No <Tab> characters.
+* Supply a header for each file with a description of the file and the author(s)
+  name or GitHub ID.
+* A copy of the [Gnu Lesser General Public License](https://www.gnu.org/licenses/lgpl-3.0.en.html)
+  must be included at the top of each file.
+* Documentation should be written so that it can be parsed by [Doxygen](http://www.doxygen.nl/).
+* All variables should be defined, and include units. Unit-less variables should be marked `unitless`
+* Provide detailed descriptions of modules, interfaces, functions, and subroutines
+* Define all function/subroutine arguments, and function results (see below)
+* Follow coding style of the current file, as much as possible.
+
+## Fortran
+
+### General
+
+* Two space indentation.
+* Use `KIND` parameters from intrinsic fortran modules such as iso_fortran_env
+  or iso_c_binding to ensure portability.
+* Never use implicit variables (i.e., always specify `IMPLICIT NONE`).
+* Lines must be <= 120 characters long (including comments).
+# logical, compound logical, and relational if statements may be one line,
+  using “&” for line continuation if necessary:
+  ```Fortran
+  if(file_exists(fileName)) call open_file(fileObj,fileName, is_restart=.false)
+  ```
+
+### Derived types
+
+* Type names must be in CapitalWord format.
+* Variables names must be in underscore_word format.
+* All member variables must be private.
+* Doxygen description on the line before the type definition.
+* Inline doxygen descriptions for all member variables.
+
+## Functions
+* Functions should include a result variable on its own line, that does not have
+  a specific intent.
+* Inline doxygen descriptions for all arguments, except the result variable.
+* Doxygen description on the line(s) before the function definition.  This must
+  specify what the function is returning using the `@return` doxygen keyword.
+
+## Blocks
+* terminate `do` loops with `enddo`
+* terminate block `if`, `then` statements with `endif`
+
+## OpenMP
+
+* Directives should start at the beginning of the line, and be in lowercase.
+* All openMP directives should specify default(none), and then explicitly list
+  all shared and private variables.
+* All critical sections must have a unique name.
+
+## Fortran Example
+
+```Fortran
+!> @file
+!! @brief Example code
+!! @author <developer>
+
+module example_mod
+  use, intrinsic :: iso_fortran_env, only: INT32, REAL32
+  use util_mod, only: util_func1
+  implicit none
+  private
+
+  public :: sub1
+  public :: func1
+
+  !> @brief Doxygen description of type.
+  type,public :: CustomType
+    private
+    integer(kind=INT32) :: a_var !< Inline doxygen description.
+    real(kind=REAL32),dimension(:),allocatable :: b_arr !< long description
+                                                        !! continued on
+                                                        !! multiple lines.
+  endtype CustomType
+
+  contains
+
+  !> @brief Doxygen description.
+  subroutine sub1(arg1, &
+    & arg2, &
+    & arg3)
+    real(kind=REAL32),intent(in) :: arg1 !< Inline doxygen description.
+    integer(kind=INT32),intent(inout) :: arg2 !< Inline doxygen description.
+    character(len=*),intent(inout) :: arg3 !< Long inline doxygen
+                                           !! description.
+  end subroutine sub1
+
+  !> @brief Doxygen description
+  !! @return Function return value.
+  function func1(arg1, &
+    & arg2) &
+    & result(res)
+    integer(kind=INT32),intent(in) :: arg1 !< Inline doxygen description
+    integer(kind=INT32),intent(in) :: arg2 !< Inline doxygen description
+    integer(kind=INT32) :: res
+  end function func1
+
+end module example_mod
+```
+
+## C/C++
+
+### General
+* C code is written in GNU style.  Each new level in a program block is indented
+  by 2 spaces. Braces start on a new line, and are also indented by 2 spaces.
+* See the [Gnome C coding style guide](https://developer.gnome.org/programming-guidelines/stable/c-coding-style.html.en)
+  for more information

--- a/CODE_STYLE.md
+++ b/CODE_STYLE.md
@@ -19,16 +19,20 @@
 
 ### General
 
-* Two space indentation.
+* Use Fortran 95 standard or newer
+* Two space indentation
 * Use `KIND` parameters from intrinsic fortran modules such as iso_fortran_env
-  or iso_c_binding to ensure portability.
-* Never use implicit variables (i.e., always specify `IMPLICIT NONE`).
-* Lines must be <= 120 characters long (including comments).
-# logical, compound logical, and relational if statements may be one line,
+  or iso_c_binding to ensure portability
+* Never use implicit variables (i.e., always specify `IMPLICIT NONE`)
+* Lines must be <= 120 characters long (including comments)
+* logical, compound logical, and relational if statements may be one line,
   using “&” for line continuation if necessary:
   ```Fortran
   if(file_exists(fileName)) call open_file(fileObj,fileName, is_restart=.false)
   ```
+* Avoid the use of `GOTO` statements
+* Avoid the use of Fortran reserved words as variables (e.g. `DATA`, `NAME`)
+* Avoid the use of `COMMON` blocks
 
 ### Derived types
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,119 @@
+# Contributing To libFMS
+
+Thank you for taking time to contribute.
+
+libFMS is a software framework for supporting the efficient development,
+construction, execution, and scientific interpretation of atmospheric, oceanic,
+and climate system models.
+
+Contributions to this project are released to the public under the
+[projects open source license](LICENSE.md).
+
+What follows is a set of guidelines and how-tos for contributing to libFMS.
+These are guidelines, not rules.  Use your best judgement and feel free to
+propose changes to this document in a pull request.
+
+
+Table of Contents
+* [Code of Conduct](#code-of-conduct)
+* [Quick Start Workflow](#quick-start-workflow)
+* [Support](#support)
+* [Issues](#issues)
+* [Pull Requests](#pull-requests)
+* [Tests](#tests)
+* [Styleguides](#styleguides)
+* [Maintainer Help](#maintainer-help)
+
+## Code of Conduct
+
+This project and everyone participating in it is governed by the
+[Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to
+uphold this code. Please report unacceptable behavior to
+[gfdl.climate.model.info@noaa.gov](mailto:gfdl.climate.model.info@noaa.gov).
+
+## Quick Start Workflow
+
+1. Create an issue that describes the change, or feature request
+2. Fork the project
+3. Create a feature branch off an up-do-date `master` branch
+4. Update the tests and code
+5. Push the commits to your fork
+6. Submit a pull request to the `master` branch
+
+## Support
+
+To get support, open a GitHub issue using the support issue template.  Please be
+as descriptive as possible.  See the [Issues](#issues) section for more details.
+
+Support for this project is primarily accomplished via this project’s community.
+Additional support may be offered from related communities
+(e.g. [MOM6](https://github.com/NOAA-GFDL/MOM6) or by members of the GFDL
+[Modeling Systems](https://www.gfdl.noaa.gov/modeling-systems) Group.  The
+members of the Modeling Systems group are the main developers and maintainers of
+this project.  Modeling Systems is a small group, and our ability to offer
+support is limited.  Please be patient when requesting support.
+
+## Issues
+
+When contributing to this project, please first open an issue using the template
+that best matches the change type.
+
+| Template        | Description                                                        |
+| --------------- | ------------------------------------------------------------------ |
+| Bug             | Report a bug, or unexpected behavior                               |
+| Feature Request | A requested feature or change to the code                          |
+| Support         |  Request for support.  Please see the [Support](#support) section. |
+
+The issue title should be short and descriptive.  The issue description should
+be clear and concise.  Include enough information to help others reproduce the
+issue, or understand the change requested.  Use
+[GitHub flavored markdown](https://guides.github.com/features/mastering-markdown/)
+to format the message, and include links to references.
+
+## Pull Requests
+
+Submit pull requests for bug fixes, improvements, including tests, or alerts to
+particular problems in the code.  We perform merge requests based on an internal
+GFDL schedule that addresses the needs of the GFDL scientists.  This release
+schedule is better described in the Release Schedule sections.  We follow the
+[GitHub fork-pull request workflow](https://guides.github.com/activities/forking/)
+workflow, briefly described in the [Quick Start Workflow](#quick-start-workflow)
+section.  When creating the pull request, please select a template that best
+matches the type of changes.
+
+Please keep the changes in a single pull to be as small as possible to help
+reviewer(s) quickly evaluate changes.  If you do have a large update, try to
+split the update into small, logical pull requests.  If the update includes code
+refactoring, please submit a pull request that includes just the code refactoring.
+
+Once a pull request is created, a member of the Modeling Systems group will
+review the changes, and, if necessary, will work with the author of the pull
+request to modify their code changes. Note that merging pull requests is
+contingent on several factors, including the ability to support the code changes
+long-term, portability, and the scope of the impact on the code base. Therefore,
+Modeling Systems does not guarantee that all pull requests will be accepted,
+even if the changes pass the initial testing phases, and are otherwise correct.
+
+## Tests
+
+FMS uses TravisCI and gitlab-CI to run build tests for libFMS.  Users may create
+unit tests, code coverage tests, and regression tests for new and existing code
+in yaml (.yml) files.  Github provides a guide
+(https://help.github.com/en/articles/about-continuous-integration) for
+implementing CI tests.
+
+## Code Style
+Code updates should follow the coding style for the project, contained in
+[CODE_STYLE.md](CODE_STYLE.md).
+
+## Release Schedule
+
+Releases will be tagged using the format `yyyy.rr[.pp]`, where `yyyy` is the
+4-digit year, `rr` is the 2-digit release number, and `pp` is the 2-digit patch
+number.  Preliminary releases mean for testing (i.e., code that is still under
+development) will be marked `yyyy.rr.alpha.pp` or `yyyy.rr.beta.pp`. Alpha tags
+mark code updates that are intended for developers to include in their baseline
+regression tests to determine whether the code contains bugs not encountered
+during baseline testing. Beta tags are intended for a wider audience of
+developers and end users to ensure that their simulations run as expected and
+reproduce prior results.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,91 @@
+# libFMS Installation
+
+## External Requirements
+
+The following external libraries are required when building libFMS
+
+* NetCDF C and Fortran (77/90) headers and libraries
+* Fortran 2003 standard compiler
+* Fortran compiler that supports Cray Pointer
+* MPI C and Fortran headers and libraries (optional)
+* Linux or Unix style system
+
+## Supported Compilers
+
+We strive to have libFMS built with as many C and Fortran compilers on as many
+Unix/Linux type systems as possible.  However, internally, we only use libFMS
+compiled with the Intel compilers.  Some group have had success using libFMS
+when compiled with the GNU C and Fortran compilers.
+
+## MPI Support
+
+The default way to build libMPI is with MPI support.  We have found that using
+the MPI aware compiler, or the MPI compiler wrappers (mpif90, mpicc, etc.), in
+general, offer the best results when building with MPI support.  If you decide
+to not use an MPI aware you should pass the include and library locations to
+the `configure` script through the `CPPFLAGS`, `FCFLAGS` and `LDFLAGS` variables.
+
+libFMS can be built without MPI support (sometimes called "no-comm mode").  To
+build libFMS without MPI support, pass to `configure` the `--disable-mpi` flag.
+
+## Supported Build Systems
+
+### GNU Autoconf/Automake
+
+In many cases, running the shell command `./configure && make && make install`
+will build and install this package.  Since libFMS requires the netCDF libraries,
+you will likely need to tell configure where to find the C and Fortran netCDF
+headers and libraries via the `CPPFLAGS`, `FCFLAGS` and `LDFLAGS` variables
+
+```bash
+> ./configure CPPFLAGS="-I/path/to/netcdf/include" \
+              FCFLAGS="-I/path/to/netcdff/include" \
+              LDFLAGS="-L/path/to/netcdf/lib -L/path/to/netcdff/lib"
+```
+
+When building from a GitHub clone, the user must run `autoreconf -i` before
+running the `./configure` script.
+
+The `./configure` script will guess as many compiler options as required to
+build libFMS.  In some cases you may require additional compiler flags for
+your system.  Additional compiler options can be passed to the build with the
+`CPPFLAGS`, `CFLAGS` and `FCFLAGS` variable.  The `./configure` option
+`--disable-setting-flags` will not guess required compiler flags.  Using this
+configure option will require the user to give all required flags.
+
+Run `./configure --help` to see other available configure options.
+
+### GFDL MKMF
+
+Make Makefile ([MKMF](https://github.com/NOAA-GFDL/mkmf)) is the GFDL developed
+makefile generator application.  MKMF uses a list of file, or a list of
+directories that contain Fortran or C file, a Make template file, and writes
+a Makefile with the correct dependencies to build a library or executable.  To
+use MKMF to build libFMS, do the following.
+
+1. Clone the MKMF repository from GitHub
+   `git clone https://github.com/NOAA-GFDL/mkmf.git`
+2. Add the `mkmf/bin` directory to your PATH
+   `export PATH=/path/to/mkmf/bin:${PATH}`
+   or
+   `setenv PATH /path/to/mkmf/bin:${PATH}`
+3. Run the `list_paths` command, on the FMS directory
+   `list_paths path/to/FMS`
+   This will create a path_names file in the current directory
+4. Pick a MKMF template from the `mkmf/templates` directory that mostl closely
+   matches you system and compiler.  Make any modifications as need
+5. Run `mkmf`
+   ```shell
+   mkmf -c "-Duse_netCDF -Duse_libMPI" \
+         -I /path/to/netcdff/include \
+         -I /path/to/netcdf/include \
+         -t /path/to/mkmf/template. \
+         -p libfms.a \
+         path_names
+   ```
+6. Once built, place the `libfms.a`, `*.mod`, `include/\*` files in your install
+   location.
+
+While MKMF has been the build system used by GFDL to build all the GFDL models
+for some time, this build method requires the most user intervention when
+building libFMS on a new system.


### PR DESCRIPTION
**Description**

The included documents are 

* CODE_OF_CONDUCT.md - Describes expected conduct of contributers
* CODE_STYLE.mk - basic style guide
* CONTRIBUTING.md - How to contribute to the project
* INSTALL.md - basic build instrauctions

**How Has This Been Tested?**
Only documentation.  No testing needed.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

