### PR TITLE
Change in time_interp_external2 to read the end times correctly

### DIFF
--- a/time_interp/time_interp_external2.F90
+++ b/time_interp/time_interp_external2.F90
@@ -359,8 +359,8 @@ module time_interp_external2_mod
       tend = tstamp
       if(variable_att_exists(fileobj, fieldname, 'time_avg_info')) then
         if(variable_exists(fileobj, 'average_T1')) call read_data(fileobj, 'average_T1', tstart)
-        if(variable_exists(fileobj, 'average_T2')) call read_data(fileobj, 'average_T1', tend)
-        if(variable_exists(fileobj, 'average_DT')) call read_data(fileobj, 'average_T1', tavg)
+        if(variable_exists(fileobj, 'average_T2')) call read_data(fileobj, 'average_T2', tend)
+        if(variable_exists(fileobj, 'average_DT')) call read_data(fileobj, 'average_DT', tavg)
       endif
 
       if (.not. variable_exists(fileobj, fieldname) ) then


### PR DESCRIPTION
**Description**

Fixes https://github.com/NOAA-GFDL/FMS/issues/278

**How Has This Been Tested?**
awg_xml in GAEA with intel 17 in c4 

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

