### PR TITLE
Allow calendar "365_DAYS" in addition to "365_DAY"

### DIFF
--- a/time_manager/get_cal_time.F90
+++ b/time_manager/get_cal_time.F90
@@ -211,6 +211,7 @@ endif
 calendar_in_c = lowercase(trim(cut0(calendar)))
 
 correct_form = (trim(calendar_in_c)) == 'noleap'     .or. (trim(calendar_in_c)) == '365_day' .or. &
+               (trim(calendar_in_c)) == '365_days' .or. &
                (trim(calendar_in_c)) == '360_day'    .or. (trim(calendar_in_c)) == 'julian'  .or. &
                (trim(calendar_in_c)) == 'no_calendar'.or. (trim(calendar_in_c)) == 'thirty_day_months' .or. &
                (trim(calendar_in_c)) == 'gregorian'
@@ -218,7 +219,7 @@ correct_form = (trim(calendar_in_c)) == 'noleap'     .or. (trim(calendar_in_c)) 
 if(.not.correct_form) then
   call error_mesg('get_cal_time','"'//trim(calendar_in_c)//'"'// &
    ' is not an acceptable calendar attribute. acceptable calendars are: '// &
-   ' noleap, 365_day, 360_day, julian, no_calendar, thirty_day_months, gregorian',FATAL)
+   ' noleap, 365_day, 365_days, 360_day, julian, no_calendar, thirty_day_months, gregorian',FATAL)
 endif
 
 calendar_tm_i = get_calendar_type()
@@ -226,6 +227,7 @@ calendar_tm_i = get_calendar_type()
 if(.not.permit_conversion_local) then
   correct_form = (trim(calendar_in_c) == 'noleap'            .and. calendar_tm_i == NOLEAP)            .or. &
                  (trim(calendar_in_c) == '365_day'           .and. calendar_tm_i == NOLEAP)            .or. &
+                 (trim(calendar_in_c) == '365_days'          .and. calendar_tm_i == NOLEAP)            .or. &
                  (trim(calendar_in_c) == '360_day'           .and. calendar_tm_i == THIRTY_DAY_MONTHS) .or. &
                  (trim(calendar_in_c) == 'thirty_day_months' .and. calendar_tm_i == THIRTY_DAY_MONTHS) .or. &
                  (trim(calendar_in_c) == 'julian'            .and. calendar_tm_i == JULIAN)            .or. &
@@ -242,6 +244,8 @@ if (permit_conversion_local) then
     case ('noleap')
         calendar_in_i = NOLEAP
     case ('365_day')
+        calendar_in_i = NOLEAP
+    case ('365_days')
         calendar_in_i = NOLEAP
     case ('360_day')
         calendar_in_i = THIRTY_DAY_MONTHS


### PR DESCRIPTION
- The calendar in NCAR files are called "365_DAYS". E.g.,
             double TIME(TIME) ;
                    TIME:axis = "T" ;
                    TIME:calendar_type = "NO_LEAP" ;
                    TIME:modulo = " " ;
                    TIME:time_origin = "31-DEC-1899 00:00:00" ;
                    TIME:units = "days since 1900-12-31 18:00:00" ;
                    TIME:calendar = "365_DAYS" ;

      I think supporting these files was the reason  to put "365_DAY" (note the missing "S") in
      time_manager/get_cal_time.F90
      However, I don't know how it works in  fms1.
      There must be a magic or a bug in original time_interp_external.F90 call to
         call mpp_get_atts(time_axis,units=units,calendar=calendar_type)
      that drops the trailing "S" in the calendar_type
      and matches it with the option "365_DAY" rather than "365_DAYS"!

- Without this fix the CORE forcing models crash like:

    FATAL from PE    36: get_cal_time: "365_days" is not an acceptable calendar attribute. acceptable calendars are:  noleap, 365_day, 360_day, julian, no_calendar, thirty_da
y_months, gregorian

    fms_MOM6_SIS2_com  0000000001922F90  mpp_mod_mp_mpp_er          69  mpp_util_mpi.inc
    fms_MOM6_SIS2_com  0000000001C298EA  get_cal_time_mod_         219  get_cal_time.F90
    fms_MOM6_SIS2_com  0000000001C48BC5  time_interp_exter         603  time_interp_external2.F90
    fms_MOM6_SIS2_com  0000000001B8252A  data_override_mod         826  data_override.F90
    fms_MOM6_SIS2_com  0000000001B88ABE  data_override_mod         673  data_override.F90
    fms_MOM6_SIS2_com  00000000006783BB  ice_spec_mod_mp_g         105  ice_spec.F90
    fms_MOM6_SIS2_com  00000000004CADBF  ice_model_mod_mp_        2510  ice_model.F90
    fms_MOM6_SIS2_com  000000000041447E  coupler_main_IP_c        1762  coupler_main.F90
    fms_MOM6_SIS2_com  000000000040A717  MAIN__                    612  coupler_main.F90

