### PR TITLE
initializes valid%has_missing to .false. to avoid reproducing issues

### DIFF
--- a/fms2_io/netcdf_io.F90
+++ b/fms2_io/netcdf_io.F90
@@ -1487,6 +1487,8 @@ function get_valid(fileobj, variable_name) &
     has_max = .false.
     has_min = .false.
     valid%has_fill = .false.
+    valid%has_missing = .false.
+    valid%has_range = .false.
 
     !This routine makes use of netcdf's automatic type conversion to
     !store all range information in double precision.


### PR DESCRIPTION
**Description**
This initializes  valid%has_missing in get_valid function of fms2_io/netcdf_io.F90
Fixes # https://github.com/NOAA-GFDL/FMS/issues/287

**How Has This Been Tested?**
debug-openmp, repro-openmp, prod-openmp on c4 with intel17 c96L33_am4p0 awg experiment

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

