### PR TITLE
Allows region diagnostic history files to be written 

### DIFF
--- a/diag_manager/diag_output.F90
+++ b/diag_manager/diag_output.F90
@@ -57,7 +57,7 @@ use,intrinsic :: iso_c_binding, only: c_double,c_float,c_int64_t, &
   USE mpp_domains_mod, ONLY: domain1d, domain2d, mpp_define_domains, mpp_get_pelist,&
        &  mpp_get_global_domain, mpp_get_compute_domains, null_domain1d, null_domain2d,&
        & domainUG, null_domainUG, CENTER, EAST, NORTH, mpp_get_compute_domain,&
-       & OPERATOR(.NE.), mpp_get_layout, OPERATOR(.EQ.)
+       & OPERATOR(.NE.), mpp_get_layout, OPERATOR(.EQ.), mpp_get_io_domain
   USE mpp_mod, ONLY: mpp_npes, mpp_pe, mpp_root_pe, mpp_get_current_pelist
   USE diag_axis_mod, ONLY: diag_axis_init, get_diag_axis, get_axis_length,&
        & get_axis_global_length, get_domain1d, get_domain2d, get_axis_aux, get_tile_count,&
@@ -155,6 +155,8 @@ CONTAINS
     character(len=:),allocatable :: fname_no_tile
     integer :: len_file_name
     integer, allocatable, dimension(:) :: current_pelist
+    integer :: mype  !< The pe you are on
+    character(len=4) :: mype_string !< a string to store the pe
     !---- initialize mpp_io ----
     IF ( .NOT.module_is_initialized ) THEN
        CALL mpp_io_init ()
@@ -214,11 +216,37 @@ CONTAINS
 
     !---- open output file (return file_unit id) -----
     IF ( domain .NE. NULL_DOMAIN2D ) THEN
+     !> Check if there is an io_domain
+     iF ( associated(mpp_get_io_domain(domain)) ) then
        fileob => fileobj
        if (.not.check_if_open(fileob)) call open_check(open_file(fileobj, trim(fname_no_tile)//".nc", "overwrite", &
                             domain, nc_format="64bit", is_restart=.false.))
        fnum_domain = "2d" ! 2d domain
        file_unit = 2
+     elSE !< No io domain, so every core is going to write its own file.
+       fileob => fileobjND
+       mype = mpp_pe()
+       write(mype_string,'(I0)') mype
+       select case (mype)
+          case ( : 9)
+               mype_string = "000"//trim(mype_string)
+          case (10 : 99)
+               mype_string = "00"//trim(mype_string)
+          case (100 : 999)
+               mype_string = "0"//trim(mype_string)
+          case (1000 : 9999)
+               mype_string = trim(mype_string)
+          case default
+               CALL error_mesg('diag_output_init', "The PE number is above 9999, so you can not add 4 digits to the "//&
+                    "end of the file name "//trim(file_name) ,FATAL)
+        end select
+        if (.not.check_if_open(fileob)) then
+               call open_check(open_file(fileobjND, trim(fname_no_tile)//".nc."//trim(mype_string), "overwrite", &
+                            nc_format="64bit", is_restart=.false.))
+        endif
+       fnum_domain = "nd" ! no domain
+       if (file_unit < 0) file_unit = 10
+     endiF
     ELSE IF (domainU .NE. NULL_DOMAINUG) THEN
        fileob => fileobjU
        if (.not.check_if_open(fileob)) call open_check(open_file(fileobjU, trim(fname_no_tile)//".nc", "overwrite", &
@@ -386,10 +414,25 @@ integer :: domain_size, axis_length, axis_pos
                          end select 
                          call write_data(fptr, axis_name, axis_data(istart:iend) )
                       endif
+                    type is (FmsNetcdfFile_t) !< For regional X and Y axes, treat as any other axis
+                         call register_axis(fptr, axis_name, dimension_length=size(axis_data))
+                         istart = lbound(axis_data,1)
+                         iend = ubound(axis_data,1)
+                         call register_field(fptr, axis_name, "double", (/axis_name/) )
+                         call register_variable_attribute(fptr, axis_name, "long_name", axis_long_name)
+                         call register_variable_attribute(fptr, axis_name, "units", axis_units)
+                         call register_variable_attribute(fptr, axis_name, "axis",trim(axis_cart_name))
+                         select case (axis_direction)
+                              case (1)
+                                   call register_variable_attribute(fptr, axis_name, "positive", "up")
+                              case (-1)
+                                   call register_variable_attribute(fptr, axis_name, "positive", "down")
+                         end select
+                         call write_data(fptr, axis_name, axis_data(istart:iend) )
                     class default
                          call error_mesg("diag_output_mod::write_axis_meta_data", &
-                              "The file object is not the right type. It must be FmsNetcdfDomainFile_t for a "//&
-                              "X or Y axis", FATAL)
+                              "The file object is not the right type. It must be FmsNetcdfDomainFile_t or "//&
+                                "FmsNetcdfFile_t for a X or Y axis, ", FATAL)
                   end select
              endif
              

--- a/diag_manager/diag_output.F90
+++ b/diag_manager/diag_output.F90
@@ -156,7 +156,7 @@ CONTAINS
     integer :: len_file_name
     integer, allocatable, dimension(:) :: current_pelist
     integer :: mype  !< The pe you are on
-    character(len=4) :: mype_string !< a string to store the pe
+    character(len=9) :: mype_string !< a string to store the pe
     !---- initialize mpp_io ----
     IF ( .NOT.module_is_initialized ) THEN
        CALL mpp_io_init ()
@@ -226,20 +226,7 @@ CONTAINS
      elSE !< No io domain, so every core is going to write its own file.
        fileob => fileobjND
        mype = mpp_pe()
-       write(mype_string,'(I0)') mype
-       select case (mype)
-          case ( : 9)
-               mype_string = "000"//trim(mype_string)
-          case (10 : 99)
-               mype_string = "00"//trim(mype_string)
-          case (100 : 999)
-               mype_string = "0"//trim(mype_string)
-          case (1000 : 9999)
-               mype_string = trim(mype_string)
-          case default
-               CALL error_mesg('diag_output_init', "The PE number is above 9999, so you can not add 4 digits to the "//&
-                    "end of the file name "//trim(file_name) ,FATAL)
-        end select
+       write(mype_string,'(I0.4)') mype
         if (.not.check_if_open(fileob)) then
                call open_check(open_file(fileobjND, trim(fname_no_tile)//".nc."//trim(mype_string), "overwrite", &
                             nc_format="64bit", is_restart=.false.))


### PR DESCRIPTION
**Description**
The regional diagnostics have a 2d domain, but the IO is done on a per core basis and not on an IO domain.  This PR checks if the 2D domain has an IO domain.  If it does, then the file is opened as a domain decomposed file.  If there is no IO domain (`io_domain` is not associated), then the file is opened by the code without using the domain.  The X and Y axes are not handles in any special way.

Fixes #281 
Replaces #289 

**How Has This Been Tested?**
The details of the test are in #281.  I added the suggest diagnostics to the diag table as @nikizadehgfdl suggested.  

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes