### PR TITLE
More get valid fix

### DIFF
--- a/fms2_io/netcdf_io.F90
+++ b/fms2_io/netcdf_io.F90
@@ -1578,7 +1578,7 @@ function get_valid(fileobj, variable_name) &
       endif
     endif
     valid%has_range = has_min .and. has_max
-  endif
+  endif !if (fileobj%is_root)
 
   if (valid%has_range) then !If it found has_range broadcast to the rest of the pes
     call mpp_broadcast(valid%has_range, fileobj%io_root, pelist=fileobj%pelist)
@@ -1592,7 +1592,6 @@ function get_valid(fileobj, variable_name) &
     call mpp_broadcast(valid%missing_val, fileobj%io_root, pelist=fileobj%pelist)     
   endif
 
-  endif
 end function get_valid
 
 

--- a/fms2_io/netcdf_io.F90
+++ b/fms2_io/netcdf_io.F90
@@ -1482,13 +1482,15 @@ function get_valid(fileobj, variable_name) &
   logical :: has_min
   integer :: xtype
 
+  ! Initiliaze valid_t to false for all ranks
+  has_max = .false.
+  has_min = .false.
+  valid%has_fill = .false.
+  valid%has_missing = .false.
+  valid%has_range = .false.
+
   if (fileobj%is_root) then
     varid = get_variable_id(fileobj%ncid, variable_name)
-    has_max = .false.
-    has_min = .false.
-    valid%has_fill = .false.
-    valid%has_missing = .false.
-    valid%has_range = .false.
 
     !This routine makes use of netcdf's automatic type conversion to
     !store all range information in double precision.
@@ -1578,15 +1580,18 @@ function get_valid(fileobj, variable_name) &
     valid%has_range = has_min .and. has_max
   endif
 
-  call mpp_broadcast(valid%has_range, fileobj%io_root, pelist=fileobj%pelist)
-  if (valid%has_range) then
+  if (valid%has_range) then !If it found has_range broadcast to the rest of the pes
+    call mpp_broadcast(valid%has_range, fileobj%io_root, pelist=fileobj%pelist)
     call mpp_broadcast(valid%max_val, fileobj%io_root, pelist=fileobj%pelist)
     call mpp_broadcast(valid%min_val, fileobj%io_root, pelist=fileobj%pelist)
-  else
+  else if (valid%has_fill) then !If it found has_fill broadcast to the rest of the pes
     call mpp_broadcast(valid%has_fill, fileobj%io_root, pelist=fileobj%pelist)
-    if (valid%has_fill) then
-      call mpp_broadcast(valid%fill_val, fileobj%io_root, pelist=fileobj%pelist)
-    endif
+    call mpp_broadcast(valid%fill_val, fileobj%io_root, pelist=fileobj%pelist)
+  else if (valid%has_missing) then !If it found has_missing broadcast to the rest of the pes
+    call mpp_broadcast(valid%has_missing, fileobj%io_root, pelist=fileobj%pelist)
+    call mpp_broadcast(valid%missing_val, fileobj%io_root, pelist=fileobj%pelist)     
+  endif
+
   endif
 end function get_valid
 


### PR DESCRIPTION
**Description**
This modifies logic in function get_valid of fms2_io/netcdf_io.F90 that broadcast valid to the other ranks

1. initializes valid%has_fill, valid%has_missing, valid%has_range as false for all ranks
2. root ranks goes in the file and fills  valid%has_fill, valid%has_missing, valid%has_range if it is in the file 
3. if each valid%has_fill, valid%has_missing, valid%has_range is true, it broadcast it to the other pes

**How Has This Been Tested?**
GAEA on c4 with intel17 compiler on prod,repro,debug with and without openmp and all experiments from awg_xml. 

It **FINALLY** reproduces xanadu!

**Checklist:**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] `make distcheck` passes

