### PR TITLE
Correctly broadcast valid%has_missing to other pe ranks

### DIFF
--- a/fms2_io/netcdf_io.F90
+++ b/fms2_io/netcdf_io.F90
@@ -1582,12 +1582,18 @@ function get_valid(fileobj, variable_name) &
   if (valid%has_range) then
     call mpp_broadcast(valid%max_val, fileobj%io_root, pelist=fileobj%pelist)
     call mpp_broadcast(valid%min_val, fileobj%io_root, pelist=fileobj%pelist)
-  else
-    call mpp_broadcast(valid%has_fill, fileobj%io_root, pelist=fileobj%pelist)
-    if (valid%has_fill) then
-      call mpp_broadcast(valid%fill_val, fileobj%io_root, pelist=fileobj%pelist)
-    endif
   endif
+
+  call mpp_broadcast(valid%has_fill, fileobj%io_root, pelist=fileobj%pelist)
+  if (valid%has_fill) then
+     call mpp_broadcast(valid%fill_val, fileobj%io_root, pelist=fileobj%pelist)
+  endif
+
+  call mpp_broadcast(valid%has_missing, fileobj%io_root, pelist=fileobj%pelist)
+  if (valid%has_missing) then
+     call mpp_broadcast(valid%missing_val, fileobj%io_root, pelist=fileobj%pelist)
+  endif  
+
 end function get_valid
 
 


### PR DESCRIPTION
**Description**
This broadcasts valid%has_missing to the other ranks in the PE list. 

Fixes # https://github.com/NOAA-GFDL/FMS/issues/297

**How Has This Been Tested?**
travis CI

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

