### PR TITLE
Remove the duplicate setting of use_libMPI and use_netCDF in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -161,10 +161,6 @@ if test $enable_setting_flags = yes; then
   fi
 fi
 
-es are required for the build.
-AC_DEFINE([use_netCDF], [1])
-AC_DEFINE([use_libMPI], [1])
-
 # Define an AM_CONDITIONAL to determine if you are on a CRAY
 AM_CONDITIONAL([CRAY], [test `env | grep CRAY | wc -l` -gt 0])
 


### PR DESCRIPTION
**Description**

Removed three lines in configure.ac that had the use_libMPI and use_netCDF to be set two time when configure is run.

Include a summary of the change and which issue is fixed. Please also include
relevant motivation and context. List any dependencies that are required for
this change.

Fixes #307 

**How Has This Been Tested?**
Through travis CI

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

