### PR TITLE
Correct Fortran STOP statement in mpp test programs

### DIFF
--- a/test_fms/mpp/test_mpp_mem_dump.F90
+++ b/test_fms/mpp/test_mpp_mem_dump.F90
@@ -32,13 +32,10 @@ program test_mpp_mem_dump
   implicit none
 
   real :: memuse
-  integer(kind=INT_KIND) :: return_val = 0
 
   call mpp_mem_dump(memuse)
 
   if (memuse .LT. 0.0) then
-    return_val = 1
+    stop "mpp_mem_dump return negative value for memory"
   endif
-
-  stop return_val
 end program test_mpp_mem_dump

--- a/test_fms/mpp/test_mpp_memuse.F90
+++ b/test_fms/mpp/test_mpp_memuse.F90
@@ -39,14 +39,10 @@ program test_mpp_memuse
   ! Real to hold results from getpeakrss
   real :: memuse
 
-  integer(kind=INT_KIND) :: return_val = 0 !< Return value for the program
-
   ! Cast to real, this is how getpeakrss is called in mpp_memutils.F90
   memuse = real(getpeakrss())
 
   if ( memuse < 0 ) then
-    return_val = 1
+    stop "getpeakrss returned negative value for memory"
   endif
-
-  stop return_val
 end program test_mpp_memuse


### PR DESCRIPTION
**Description**
The Fortran STOP statement only accepts constant integers and characters, according to the standard.  gfortran ignores that part of the standard.  This commit corrects two Fortran STOP statements in mpp test programs.

Fixes #305 

**How Has This Been Tested?**
Tested fix on Mac OS with openMPI, and an Intel Skylake box using Intel's MPI

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

