### PR TITLE
Correct syntax error in test_common.sh.in

### DIFF
--- a/test_fms/test_common.sh.in
+++ b/test_fms/test_common.sh.in
@@ -49,26 +49,15 @@ oversubscribe='@OVERSUBSCRIBE@'
 run_test()
 {
     # If the tests is known to fail exit 
-    if test "x${3}" != "xskip" ; then     
-
-    # If there is no mpi launcher just ./{job_script}
-    if test "x$mpi_launcher" != "x" ; then  
-        npes="-n ${2}"
-    fi
-
-    # Check if the oversubscribe flag is turned on 
-    if test "x${4}" == "xtrue" ; then 
-    # Check if the your mpi launcher allows the oversubscribed option 
-        if "x$oversubscribe" != "x" ; then  
-            $mpi_launcher $oversubscribe $npes ./${1}
-            return 0
-        else #If you the mpi launcher doesn't allow the oversubscribed option, don't run the test
-            return 0
+    if test "x${3}" == "xskip" ; then     
+        return $TEST_SKIP
+    else
+        # If there is no mpi launcher just ./{job_script}
+        if test "x$mpi_launcher" != "x" ; then  
+            npes="-n ${2}"
         fi
     fi 
 
     # Run test
-    $mpi_launcher $npes ./${1}
-
-    fi
+    $mpi_launcher $oversubscribe $npes ./${1}
 }

--- a/test_fms/test_common.sh.in
+++ b/test_fms/test_common.sh.in
@@ -49,7 +49,7 @@ oversubscribe='@OVERSUBSCRIBE@'
 run_test()
 {
     # If the tests is known to fail exit 
-    if test "x${3}" == "xskip" ; then     
+    if test "x${3}" = "xskip" ; then     
         return $TEST_SKIP
     else
         # If there is no mpi launcher just ./{job_script}


### PR DESCRIPTION
**Description**
This commit removes the line in test_common.sh.in that had a syntax error.  This removal was done to allow test_common.sh.in to support more MPI run wrappers than the openMPI wrapper.

Fixes #309 

**How Has This Been Tested?**
Mac OS X using openMPI and Skylake box using Intel MPI.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

