### PR TITLE
Update .travis.yml file to clear Travis CI warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@
 # FMS is not a c-language project, although there are a few c-language
 # sources.  However, this is the best choice.
 language: c
+os: linux
 dist: bionic
-sudo: false
 
 addons:
   apt:


### PR DESCRIPTION
**Description**
Travis CI warns of missing os, and deprecated key sudo.  This commit corrects those to clear the warnings.

Fixes #312 

**How Has This Been Tested?**
Can only be tested on Travis CI

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

