### PR TITLE
Final Merge before Release -- Modify GNU autotools files for 2020.01 release

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@ AC_PREREQ([2.59])
 
 # Initialize with name, version, and support email address.
 AC_INIT([GFDL FMS Library],
-  [2020.01-dev],
+  [2020.01],
   [gfdl.climate.model.info@noaa.gov],
   [FMS],
   [https://www.gfdl.noaa.gov/fms])

--- a/libFMS/Makefile.am
+++ b/libFMS/Makefile.am
@@ -9,7 +9,7 @@ lib_LTLIBRARIES = libFMS.la
 # These linker flags specify libtool version info.
 # See http://www.gnu.org/software/libtool/manual/libtool.html#Libtool-versioning
 # for information regarding incrementing `-version-info`.
-libFMS_la_LDFLAGS = -version-info 2:0:0
+libFMS_la_LDFLAGS = -version-info 3:0:0
 
 # Add the convenience libraries to the FMS library.
 libFMS_la_LIBADD = ${top_builddir}/platform/libplatform.la


### PR DESCRIPTION
The PR sets the version information in `configure.ac` and `libFMS/Makefile.am` for the 2020.01 release.

This should only be done as the last PR before the final `2020.01` tag is placed.