### PR TITLE
Added missing libraries to libFMS

### DIFF
--- a/libFMS/Makefile.am
+++ b/libFMS/Makefile.am
@@ -87,6 +87,10 @@ libFMS_la_LIBADD += ${top_builddir}/exchange/libstock_constants.la
 libFMS_la_LIBADD += ${top_builddir}/exchange/libxgrid.la
 libFMS_la_LIBADD += ${top_builddir}/topography/libtopography.la
 libFMS_la_LIBADD += ${top_builddir}/tracer_manager/libtracer_manager.la
+libFMS_la_LIBADD += ${top_builddir}/sat_vapor_pres/libsat_vapor_pres_k.la
+libFMS_la_LIBADD += ${top_builddir}/sat_vapor_pres/libsat_vapor_pres.la
+libFMS_la_LIBADD += ${top_builddir}/random_numbers/libMersenneTwister.la
+libFMS_la_LIBADD += ${top_builddir}/random_numbers/librandom_numbers.la
 
 # At least one source file must be included to please Automake.
 libFMS_la_SOURCES = ${top_builddir}/include/file_version.h


### PR DESCRIPTION
**Description**
Added libsat_vapor_pres_k.la, libsat_vapor_pres.la, libMersenneTwister.la, librandom_numbers.la to libFMS, as they were reported to be missing

Fixes # (issue)
#316 #317 

**How Has This Been Tested?**
TravisCI

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

