### PR TITLE
Fix: get_valid and is_valid

### DIFF
--- a/fms2_io/netcdf_io.F90
+++ b/fms2_io/netcdf_io.F90
@@ -81,6 +81,8 @@ endtype FmsNetcdfFile_t
 !> @brief Range type for a netcdf variable.
 type, public :: Valid_t
   logical :: has_range !< Flag that's true if both min/max exist for a variable.
+  logical :: has_min !< Flag that's true if both min exists for a variable.
+  logical :: has_max !< Flag that's true if both max exists for a variable.
   logical :: has_fill !< Flag that's true a user defined fill value.
   logical :: has_missing !< Flag that's true a user defined missing value.
   real(kind=real64) :: fill_val !< Unpacked fill value for a variable.
@@ -1478,14 +1480,12 @@ function get_valid(fileobj, variable_name) &
   real(kind=real64) :: scale_factor
   real(kind=real64) :: add_offset
   real(kind=real64), dimension(2) :: buffer
-  logical :: has_max
-  logical :: has_min
   integer :: xtype
 
   if (fileobj%is_root) then
     varid = get_variable_id(fileobj%ncid, variable_name)
-    has_max = .false.
-    has_min = .false.
+    valid%has_max = .false.
+    valid%has_min = .false.
     valid%has_fill = .false.
     valid%has_missing = .false.
     valid%has_range = .false.
@@ -1503,86 +1503,80 @@ function get_valid(fileobj, variable_name) &
       add_offset = 0._real64
     endif
 
-	 !Max and and min data values are defined by the valid_range, valid_min, and valid_max attributes if they are present. 
-	 !If the fill_value attribute is present and valid_range is not, then fill_value determines valid_data values. 
-	 !Otherwise, the missing_value attribute determines valid data_values if it is present, and valid_range fill_value attributes are not.
+	!Max and and min data values are defined by the valid_range, valid_min, and valid_max attributes if they are present. 
+    !Assign max/min values using "valid" attributes.
+    if (attribute_exists(fileobj%ncid, varid, "valid_range")) then
+      call get_variable_attribute(fileobj, variable_name, "valid_range", buffer)
+      valid%max_val = buffer(2)*scale_factor + add_offset
+      valid%has_max = .true.
+      valid%min_val = buffer(1)*scale_factor + add_offset
+      valid%has_min = .true.
+    else
+      if (attribute_exists(fileobj%ncid, varid, "valid_max")) then
+        call get_variable_attribute(fileobj, variable_name, "valid_max", buffer(1))
+        valid%max_val = buffer(1)*scale_factor + add_offset
+        valid%has_max = .true.
+      endif
+      if (attribute_exists(fileobj%ncid, varid, "valid_min")) then
+        call get_variable_attribute(fileobj, variable_name, "valid_min", buffer(1))
+        valid%min_val = buffer(1)*scale_factor + add_offset
+        valid%has_min = .true.
+      endif
+    endif
+    valid%has_range = valid%has_min .or. valid%has_max
 
-    !Get default max/min from missing_value.  These could be overwritten by
-    !vaild_range/valid_min/valid_max/_Fill_Value.
+
     if (attribute_exists(fileobj%ncid, varid, "missing_value")) then
       call get_variable_attribute(fileobj, variable_name, "missing_value", buffer(1))
       xtype = get_variable_type(fileobj%ncid, varid)
       valid%missing_val = buffer(1)*scale_factor + add_offset
       valid%has_missing = .true.
-      if (xtype .eq. nf90_short .or. xtype .eq. nf90_int) then
-          valid%min_val = (buffer(1) + 1._real64)*scale_factor + add_offset
-          has_min = .true.
-      elseif (xtype .eq. nf90_float .or. xtype .eq. nf90_double) then
-          valid%min_val = (nearest(nearest(buffer(1), 1._real64), 1._real64)) &
-                          *scale_factor + add_offset
-          has_min = .true.
-      else
-        call error("unsupported type.")
-      endif
     endif
 
-    !Get default max/min from _Fillvalue.  These could be overwritten by
-    !vaild_range/valid_min/valid_max.
+    !Get default max/min from _Fillvalue.
+	!If the fill_value attribute is present and valid_range is not, then fill_value determines valid_data values. 
     if (attribute_exists(fileobj%ncid, varid, "_FillValue")) then
       call get_variable_attribute(fileobj, variable_name, "_FillValue", buffer(1))
       valid%fill_val = buffer(1)*scale_factor + add_offset
       valid%has_fill = .true.
       xtype = get_variable_type(fileobj%ncid, varid)
-      if (xtype .eq. nf90_short .or. xtype .eq. nf90_int) then
-        if (buffer(1) .gt. 0) then
-          valid%max_val = (buffer(1) - 1._real64)*scale_factor + add_offset
-          has_max = .true.
+      if (.not. valid%has_range) then
+        if (xtype .eq. nf90_short .or. xtype .eq. nf90_int) then
+          if (buffer(1) .gt. 0) then
+            valid%max_val = (buffer(1) - 1._real64)*scale_factor + add_offset
+            valid%has_max = .true.
+          else
+            valid%min_val = (buffer(1) + 1._real64)*scale_factor + add_offset
+            valid%has_min = .true.
+          endif
+        elseif (xtype .eq. nf90_float .or. xtype .eq. nf90_double) then
+          if (buffer(1) .gt. 0) then
+            valid%max_val = (nearest(nearest(buffer(1), -1._real64), -1._real64)) &
+                            *scale_factor + add_offset
+            valid%has_max = .true.
+          else
+            valid%min_val = (nearest(nearest(buffer(1), 1._real64), 1._real64)) &
+                            *scale_factor + add_offset
+            valid%has_min = .true.
+          endif
         else
-          valid%min_val = (buffer(1) + 1._real64)*scale_factor + add_offset
-          has_min = .true.
+          call error("unsupported type.")
         endif
-      elseif (xtype .eq. nf90_float .or. xtype .eq. nf90_double) then
-        if (buffer(1) .gt. 0) then
-          valid%max_val = (nearest(nearest(buffer(1), -1._real64), -1._real64)) &
-                          *scale_factor + add_offset
-          has_max = .true.
-        else
-          valid%min_val = (nearest(nearest(buffer(1), 1._real64), 1._real64)) &
-                          *scale_factor + add_offset
-          has_min = .true.
-        endif
-      else
-        call error("unsupported type.")
+        valid%has_range = .true.
       endif
     endif
 
-    !Override fill value max/min with using "valid" attributes.
-    if (attribute_exists(fileobj%ncid, varid, "valid_range")) then
-      call get_variable_attribute(fileobj, variable_name, "valid_range", buffer)
-      valid%max_val = buffer(2)*scale_factor + add_offset
-      has_max = .true.
-      valid%min_val = buffer(1)*scale_factor + add_offset
-      has_min = .true.
-    else
-      if (attribute_exists(fileobj%ncid, varid, "valid_max")) then
-        call get_variable_attribute(fileobj, variable_name, "valid_max", buffer(1))
-        valid%max_val = buffer(1)*scale_factor + add_offset
-        has_max = .true.
-      endif
-      if (attribute_exists(fileobj%ncid, varid, "valid_min")) then
-        call get_variable_attribute(fileobj, variable_name, "valid_min", buffer(1))
-        valid%min_val = buffer(1)*scale_factor + add_offset
-        has_min = .true.
-      endif
-    endif
-    valid%has_range = has_min .and. has_max
   endif
 
-  call mpp_broadcast(valid%has_range, fileobj%io_root, pelist=fileobj%pelist)
-  if (valid%has_range) then
-    call mpp_broadcast(valid%max_val, fileobj%io_root, pelist=fileobj%pelist)
+  call mpp_broadcast(valid%has_min, fileobj%io_root, pelist=fileobj%pelist)
+  if (valid%has_min) then
     call mpp_broadcast(valid%min_val, fileobj%io_root, pelist=fileobj%pelist)
   endif
+  call mpp_broadcast(valid%has_max, fileobj%io_root, pelist=fileobj%pelist)
+  if (valid%has_max) then
+    call mpp_broadcast(valid%max_val, fileobj%io_root, pelist=fileobj%pelist)
+  endif
+  call mpp_broadcast(valid%has_range, fileobj%io_root, pelist=fileobj%pelist)
 
   call mpp_broadcast(valid%has_fill, fileobj%io_root, pelist=fileobj%pelist)
   if (valid%has_fill) then
@@ -1621,11 +1615,22 @@ elemental function is_valid(datum, validobj) &
 
   valid_data = .true.
   if (validobj%has_range) then
-    valid_data = rdatum .ge. validobj%min_val .and. rdatum .le. validobj%max_val
-  elseif (validobj%has_fill) then
-    valid_data = rdatum .ne. validobj%fill_val
-  elseif (validobj%has_missing) then 
-    valid_data = rdatum .ne. validobj%missing_val
+    if (validobj%has_min .and. .not. validobj%has_max) then
+      valid_data = rdatum .ge. validobj%min_val
+    elseif (validobj%has_max .and. .not. validobj%has_min) then
+      valid_data = rdatum .le. validobj%max_val
+    else
+      valid_data = .not. (rdatum .lt. validobj%min_val .or. rdatum .gt. validobj%max_val)
+    endif
+  endif
+  if (validobj%has_fill .or. validobj%has_missing) then
+    if (validobj%has_fill .and. .not. validobj%has_missing) then
+      valid_data = rdatum .ne. validobj%fill_val
+    elseif (validobj%has_missing .and. .not. validobj%has_fill) then 
+      valid_data = rdatum .ne. validobj%missing_val
+    else
+      valid_data = .not. (rdatum .eq. validobj%missing_val .or. rdatum .eq. validobj%fill_val)
+    endif
   endif
 end function is_valid
 

--- a/fms2_io/netcdf_io.F90
+++ b/fms2_io/netcdf_io.F90
@@ -81,8 +81,8 @@ endtype FmsNetcdfFile_t
 !> @brief Range type for a netcdf variable.
 type, public :: Valid_t
   logical :: has_range !< Flag that's true if both min/max exist for a variable.
-  logical :: has_min !< Flag that's true if both min exists for a variable.
-  logical :: has_max !< Flag that's true if both max exists for a variable.
+  logical :: has_min !< Flag that's true if min exists for a variable.
+  logical :: has_max !< Flag that's true if max exists for a variable.
   logical :: has_fill !< Flag that's true a user defined fill value.
   logical :: has_missing !< Flag that's true a user defined missing value.
   real(kind=real64) :: fill_val !< Unpacked fill value for a variable.


### PR DESCRIPTION
Fixes to get_valid and is_valid to assign minimum and maximum valid values without creating impossible situations. @menzel-gfdl @uramirez8707 

**Description**
Prior to this fix, the get_valid function would auto-assign a minimum or maximum value according to the fill value or missing value in the file, which is consistent with the NUG convention. However, the implementation was incorrect, and resulted in situations in which it was impossible for any values to be valid. This situation occurred because the specific netcdf file referenced in data_override contained both a "missing value" and a "fill value" attribute for the variable, and those attributes contained the same value. The fix moves has_min and has_max attributes inside the valid type and now prohibits missing value from influencing the minimum or maximum value, in accordance with the NUG convention. Furthermore, either a minimum or maximum value will make the range valid (aka an open range is allowed and tested within `is_valid`, and there are also validity tests for fill value and missing values.



Fixes #321 

**How Has This Been Tested?**
Tests have used the data_override unit tests (in test_fms). The fix was tested with the unit test, and should accommodate scenarios for every combination of "min_val, max_val, valid_range, _FillValue, and missing_value" contained in a given netcdf file.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [ ] `make distcheck` passes

