### PR TITLE
Change version in configure.ac for 2020.02-dev work

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@ AC_PREREQ([2.59])
 
 # Initialize with name, version, and support email address.
 AC_INIT([GFDL FMS Library],
-  [2020.01],
+  [2020.02-dev],
   [gfdl.climate.model.info@noaa.gov],
   [FMS],
   [https://www.gfdl.noaa.gov/fms])


### PR DESCRIPTION
**Description**
This is needed after each release to indicate work in development and not a release.  Version in configure.ac is 2020.02-dev.

No other changes.