### PR TITLE
Modify get_global_io_domain_indices to output buffer of axis data

### DIFF
--- a/fms2_io/fms_netcdf_domain_io.F90
+++ b/fms2_io/fms_netcdf_domain_io.F90
@@ -370,8 +370,8 @@ function open_domain_file(fileobj, path, mode, domain, nc_format, is_restart) &
     else
       success = netcdf_file_open(fileobj, combined_filepath, mode, nc_format, pelist, &
                                  is_restart)
-		!If the file is combined and the layout is not (1,1) set the adjust_indices flag to false
-		if (success .and. (io_layout(1)*io_layout(2) .gt. 1)) fileobj%adjust_indices = .false.
+!If the file is combined and the layout is not (1,1) set the adjust_indices flag to false
+      if (success .and. (io_layout(1)*io_layout(2) .gt. 1)) fileobj%adjust_indices = .false.
     endif
   endif
   if (.not. success) then
@@ -714,22 +714,22 @@ subroutine domain_offsets(data_xsize, data_ysize, domain, xpos, ypos, &
                               position=xpos)
   ! If the xpos is east and the ending x index is NOT equal to max allowed, set extra_x_point to true
   if (present(extra_x_point)) then
-	 if ((xpos .eq. east) .and. (iec .ne. xmax)) then 
-		extra_x_point = .true.
-    	else
-		extra_x_point = .false.
-	endif
+     if ((xpos .eq. east) .and. (iec .ne. xmax)) then 
+        extra_x_point = .true.
+     else
+        extra_x_point = .false.
+     endif
   endif
 
   call mpp_get_compute_domain(io_domain, ybegin=jsc, yend=jec, ysize=yc_size, &
                               position=ypos)
   ! If the ypost is north and the ending y index is NOT equal to max allowed, set extra_y_point to true
   if (present(extra_y_point)) then
-	 if ((ypos .eq. north) .and. (jec .ne. ymax)) then 
-		extra_y_point = .true.
-	 else
-		extra_y_point = .false.
-   	 endif
+      if ((ypos .eq. north) .and. (jec .ne. ymax)) then 
+         extra_y_point = .true.
+      else
+         extra_y_point = .false.
+      endif
   endif
 
   buffer_includes_halos = (data_xsize .eq. xd_size) .and. (data_ysize .eq. yd_size)

--- a/fms2_io/fms_netcdf_domain_io.F90
+++ b/fms2_io/fms_netcdf_domain_io.F90
@@ -749,10 +749,11 @@ subroutine get_global_io_domain_indices(fileobj, dimname, is, ie, indices)
   character(len=*), intent(in) :: dimname !< Name of dimension variable.
   integer, intent(out) :: is !< Staring index of I/O global domain.
   integer, intent(out) :: ie !< Ending index of I/O global domain.
-  integer, dimension(:), allocatable, intent(inout), optional :: indices
+  integer, dimension(:), allocatable, intent(out), optional :: indices !< Global domain indices
 
   type(domain2d), pointer :: io_domain
-  integer :: dpos, i
+  integer :: dpos
+  integer :: i
 
   io_domain => mpp_get_io_domain(fileobj%domain)
   dpos = get_domain_decomposed_index(dimname, fileobj%xdims, fileobj%nx)
@@ -769,9 +770,11 @@ subroutine get_global_io_domain_indices(fileobj, dimname, is, ie, indices)
     endif
   endif
 
+! Allocate indices to the difference between the ending and starting indices and
+! fill indices with the data
   if (present(indices)) then 
     if(allocated(indices)) then
-      deallocate(indices)
+      call error("get_global_io_domain_indices: the variable indices should not be allocated.")
     endif
     allocate(indices(ie-is+1))
     do i = is, ie

--- a/fms2_io/fms_netcdf_domain_io.F90
+++ b/fms2_io/fms_netcdf_domain_io.F90
@@ -714,15 +714,16 @@ end subroutine domain_offsets
 
 !> @brief Get starting/ending global indices of the I/O domain for a domain decomposed
 !!        file.
-subroutine get_global_io_domain_indices(fileobj, dimname, is, ie)
+subroutine get_global_io_domain_indices(fileobj, dimname, is, ie, indices)
 
   type(FmsNetcdfDomainFile_t), intent(in) :: fileobj !< File object.
   character(len=*), intent(in) :: dimname !< Name of dimension variable.
   integer, intent(out) :: is !< Staring index of I/O global domain.
   integer, intent(out) :: ie !< Ending index of I/O global domain.
+  integer, dimension(:), allocatable, intent(inout), optional :: indices
 
   type(domain2d), pointer :: io_domain
-  integer :: dpos
+  integer :: dpos, i
 
   io_domain => mpp_get_io_domain(fileobj%domain)
   dpos = get_domain_decomposed_index(dimname, fileobj%xdims, fileobj%nx)
@@ -738,6 +739,18 @@ subroutine get_global_io_domain_indices(fileobj, dimname, is, ie)
       call error("input dimension is not associated with the domain.")
     endif
   endif
+
+  if (present(indices)) then 
+    if(allocated(indices)) then
+      deallocate(indices)
+    endif
+    allocate(indices(ie-is+1))
+    do i = is, ie
+      indices(i-is+1) = i
+    enddo
+  endif
+
+
 end subroutine get_global_io_domain_indices
 
 

--- a/fms2_io/netcdf_io.F90
+++ b/fms2_io/netcdf_io.F90
@@ -1503,7 +1503,7 @@ function get_valid(fileobj, variable_name) &
       add_offset = 0._real64
     endif
 
-	!valid%max_val and valid%min_val are defined by the "valid_range", "valid_min", and
+    !valid%max_val and valid%min_val are defined by the "valid_range", "valid_min", and
     !"valid_max" variable attributes if they are present in the file. If either the maximum value
     !or minimum value is defined, valid%has_range is set to .true. (i.e. open ended ranges
     !are valid and should be tested within the is_valid function).
@@ -1536,7 +1536,7 @@ function get_valid(fileobj, variable_name) &
     endif
 
     !Get the fill value from the file if it exists.
-	!If the _FillValue attribute is present and the maximum or minimum value is not defined,
+    !If the _FillValue attribute is present and the maximum or minimum value is not defined,
     !then the maximum or minimum value will be determined by the _FillValue according to the NUG convention. 
     !The NUG convention states that a positive fill value will be the exclusive upper
     !bound (i.e. valid values are less than the fill value), while a


### PR DESCRIPTION
**Description**
This adds `indices` as optional argument to `get_global_io_domain_indices`
If present, the subroutine allocates `indices` to the size of the difference between the ending and starting dimensions and it add the data. 

Fixes #341 

This also removes tabs in fms2_io/fms_netcdf_domain_io.F90 and fms2_io/netcdf_io.F90
**How Has This Been Tested?**
GAEA on intel with AM4.0 and AM4.1

**Checklist:**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] `make distcheck` passes

