### PR TITLE
Correct Cray pointer check for autotools

### DIFF
--- a/m4/gx_fortran_options.m4
+++ b/m4/gx_fortran_options.m4
@@ -198,7 +198,6 @@ for ac_flag in none \
                '-Mcray=pointer'; do
   test "x$ac_flag" != xnone && FCFLAGS="$gx_cray_ptr_flag_FCFLAGS_save ${ac_flag}"
   AC_COMPILE_IFELSE([[      program test
-      integer(kind=8) :: ipt
       integer iarri(10)
       pointer (ipt, iarr)
       end program test]],


### PR DESCRIPTION
**Description**
Correct the Cray pointer check by removing a single integer variable in the test program.

Fixes #353 

**How Has This Been Tested?**
Run through configure using Gnu, Intel and Cray Fortran compilers.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

