### PR TITLE
Remove allocatable macros

### DIFF
--- a/block_control/block_control.F90
+++ b/block_control/block_control.F90
@@ -31,12 +31,12 @@ implicit none
 public block_control_type
 
 type ix_type
-  integer, dimension(:,:), _ALLOCATABLE :: ix _NULL
+  integer, dimension(:,:), allocatable :: ix
 end type ix_type
 
 type pk_type
-  integer, dimension(:), _ALLOCATABLE :: ii _NULL
-  integer, dimension(:), _ALLOCATABLE :: jj _NULL
+  integer, dimension(:), allocatable :: ii
+  integer, dimension(:), allocatable :: jj
 end type pk_type
 
 type block_control_type
@@ -44,18 +44,18 @@ type block_control_type
   integer :: nblks               !< number of blocks cover MPI domain
   integer :: isc, iec, jsc, jec  !< MPI domain global extents
   integer :: npz                 !< vertical extent
-  integer, dimension(:),        _ALLOCATABLE :: ibs   _NULL, &  !< block extents for mpp-style
-                                                ibe   _NULL, &  !! decompositions
-                                                jbs   _NULL, &
-                                                jbe   _NULL
-  type(ix_type), dimension(:),  _ALLOCATABLE :: ix    _NULL !< dereference packed index from global index
+  integer, dimension(:),        allocatable :: ibs  , &  !< block extents for mpp-style
+                                                ibe  , &  !! decompositions
+                                                jbs  , &
+                                                jbe  
+  type(ix_type), dimension(:),  allocatable :: ix    !< dereference packed index from global index
   !--- packed blocking fields
-  integer, dimension(:),        _ALLOCATABLE :: blksz _NULL !< number of points in each individual block
+  integer, dimension(:),        allocatable :: blksz !< number of points in each individual block
                                                             !! blocks are not required to be uniforom in size
-  integer, dimension(:,:),      _ALLOCATABLE :: blkno _NULL !< dereference block number using global indices
-  integer, dimension(:,:),      _ALLOCATABLE :: ixp   _NULL !< dereference packed index from global indices
+  integer, dimension(:,:),      allocatable :: blkno !< dereference block number using global indices
+  integer, dimension(:,:),      allocatable :: ixp   !< dereference packed index from global indices
                                                             !! must be used in conjuction with blkno
-  type(pk_type), dimension(:),  _ALLOCATABLE :: index _NULL !< dereference global indices from
+  type(pk_type), dimension(:),  allocatable :: index !< dereference global indices from
                                                             !! block/ixp combo
 end type block_control_type
 
@@ -150,7 +150,7 @@ contains
     Block%ny_block = ny_block
     Block%nblks = nblks
 
-    if (.not._ALLOCATED(Block%ibs)) &
+    if (.not.allocated(Block%ibs)) &
          allocate (Block%ibs(nblks), &
                    Block%ibe(nblks), &
                    Block%jbs(nblks), &
@@ -258,7 +258,7 @@ contains
     Block%jec   = jec
     Block%npz   = kpts
     Block%nblks = nblks
-    if (.not. _ALLOCATED(Block%blksz)) &
+    if (.not. allocated(Block%blksz)) &
       allocate (Block%blksz(nblks), &
                 Block%index(nblks), &
                 Block%blkno(isc:iec,jsc:jec), &

--- a/data_override/data_override.F90
+++ b/data_override/data_override.F90
@@ -100,9 +100,9 @@ type override_type
    integer                          :: dims(4)                 ! dimensions(x,y,z,t) of the field in filename
    integer                          :: comp_domain(4)          ! istart,iend,jstart,jend for compute domain
    integer                          :: numthreads
-   real, _ALLOCATABLE               :: lon_in(:) _NULL
-   real, _ALLOCATABLE               :: lat_in(:) _NULL
-   logical, _ALLOCATABLE            :: need_compute(:) _NULL
+   real, allocatable               :: lon_in(:)
+   real, allocatable               :: lat_in(:)
+   logical, allocatable            :: need_compute(:)
    integer                          :: numwindows
    integer                          :: window_size(2)
    integer                          :: is_src, ie_src, js_src, je_src

--- a/diag_manager/diag_axis.F90
+++ b/diag_manager/diag_axis.F90
@@ -570,7 +570,7 @@ CONTAINS
        num_attributes = Axes(id)%num_attributes
     END IF
     IF ( PRESENT(attributes) ) THEN
-       IF ( _ALLOCATED(Axes(id)%attributes) ) THEN
+       IF ( allocated(Axes(id)%attributes) ) THEN
           IF ( ALLOCATED(attributes) ) THEN
              ! If allocate, make sure attributes is large enough to hold Axis(id)%attributes
              IF ( Axes(id)%num_attributes .GT. SIZE(attributes(:)) ) THEN
@@ -585,10 +585,10 @@ CONTAINS
           END IF
           DO i=1, Axes(id)%num_attributes
              ! Unallocate all att arrays in preparation for new data
-             IF ( _ALLOCATED(attributes(i)%fatt) ) THEN
+             IF ( allocated(attributes(i)%fatt) ) THEN
                 DEALLOCATE(attributes(i)%fatt)
              END IF
-             IF ( _ALLOCATED(attributes(i)%iatt) ) THEN
+             IF ( allocated(attributes(i)%iatt) ) THEN
                 DEALLOCATE(attributes(i)%iatt)
              END IF
 
@@ -598,7 +598,7 @@ CONTAINS
              attributes(i)%name = Axes(id)%attributes(i)%name
              attributes(i)%catt = Axes(id)%attributes(i)%catt
              ! Allocate fatt arrays (if needed), and copy in data
-             IF ( _ALLOCATED(Axes(id)%attributes(i)%fatt) ) THEN
+             IF ( allocated(Axes(id)%attributes(i)%fatt) ) THEN
                 ALLOCATE(attributes(i)%fatt(SIZE(Axes(id)%attributes(i)%fatt(:))), STAT=istat)
                 IF ( istat .NE. 0 ) THEN
                    CALL error_mesg('diag_axis_mod::get_diag_axis', 'Unable to allocate memory for attribute%fatt', FATAL)
@@ -608,7 +608,7 @@ CONTAINS
                 END DO
              END IF
              ! Allocate iatt arrays (if needed), and copy in data
-             IF ( _ALLOCATED(Axes(id)%attributes(i)%iatt) ) THEN
+             IF ( allocated(Axes(id)%attributes(i)%iatt) ) THEN
                 ALLOCATE(attributes(i)%iatt(SIZE(Axes(id)%attributes(i)%iatt(:))), STAT=istat)
                 IF ( istat .NE. 0 ) THEN
                    CALL error_mesg('diag_axis_mod::get_diag_axis', 'Unable to allocate memory for attribute%iatt', FATAL)
@@ -1393,7 +1393,7 @@ CONTAINS
     IF ( PRESENT(err_msg) ) err_msg = ''
 
     ! Allocate memory for the attributes
-    IF ( .NOT._ALLOCATED(out_axis%attributes) ) THEN
+    IF ( .NOT.allocated(out_axis%attributes) ) THEN
        ALLOCATE(out_axis%attributes(max_axis_attributes), STAT=istat)
        IF ( istat.NE.0 ) THEN
           ! <ERROR STATUS="FATAL">
@@ -1524,7 +1524,7 @@ CONTAINS
     CALL valid_id_check(id, 'axis_is_compressed')
 
     axis_is_compressed = .FALSE.
-    if (.not._ALLOCATED(Axes(id)%attributes)) return
+    if (.not.allocated(Axes(id)%attributes)) return
     do i = 1, Axes(id)%num_attributes
        if (trim(Axes(id)%attributes(i)%name)=='compress') then
           axis_is_compressed = .TRUE.
@@ -1548,7 +1548,7 @@ CONTAINS
     CALL valid_id_check(id, tag)
 
     associate (axis=>Axes(id))
-    if (.not._ALLOCATED(axis%attributes)) call error_mesg(tag, &
+    if (.not.allocated(axis%attributes)) call error_mesg(tag, &
        'attempt to get compression dimensions from axis "'//trim(axis%name)//'" which is not compressed (does not have any attributes)', FATAL)
 
     iatt = 0

--- a/diag_manager/diag_data.F90
+++ b/diag_manager/diag_data.F90
@@ -192,8 +192,8 @@ use fms2_io_mod
      INTEGER             :: len
      CHARACTER(len=128)  :: name
      CHARACTER(len=1280) :: catt
-     REAL, _ALLOCATABLE, DIMENSION(:)    :: fatt _NULL
-     INTEGER, _ALLOCATABLE, DIMENSION(:) :: iatt _NULL
+     REAL, allocatable, DIMENSION(:)    :: fatt
+     INTEGER, allocatable, DIMENSION(:) :: iatt
   end type diag_atttype
   ! </TYPE>
   ! <TYPE NAME="coord_type">
@@ -313,7 +313,7 @@ use fms2_io_mod
      TYPE(time_type) :: start_time !< Time file opened.
      TYPE(time_type) :: close_time !< Time file closed.  File does not allow data after close time
      TYPE(diag_fieldtype):: f_avg_start, f_avg_end, f_avg_nitems, f_bounds
-     TYPE(diag_atttype), _ALLOCATABLE, dimension(:) :: attributes _NULL
+     TYPE(diag_atttype), allocatable, dimension(:) :: attributes
      INTEGER :: num_attributes
 !----------
 !ug support
@@ -395,7 +395,7 @@ use fms2_io_mod
      LOGICAL :: missing_value_present, range_present
      REAL :: missing_value
      REAL, DIMENSION(2) :: range
-     INTEGER, _ALLOCATABLE, dimension(:) :: output_fields _NULL
+     INTEGER, allocatable, dimension(:) :: output_fields
      INTEGER :: num_output_fields
      INTEGER, DIMENSION(3) :: size
      LOGICAL :: static, register, mask_variant, local
@@ -445,15 +445,15 @@ use fms2_io_mod
   !   <DATA NAME="time_method" TYPE="CHARACTER(len=50)">
   !     Time method field from the input file
   !   </DATA>
-  !   <DATA NAME="buffer" TYPE="REAL, _ALLOCATABLE, DIMENSION(:,:,:,:)" DEFAULT="_NULL">
+  !   <DATA NAME="buffer" TYPE="REAL, allocatable, DIMENSION(:,:,:,:)" DEFAULT="_NULL">
   !     Coordinates of buffer are (x, y, z, time-of-day)
   !   </DATA>
-  !   <DATA NAME="counter" TYPE="REAL, _ALLOCATABLE, DIMENSION(:,:,:,:)" DEFAULT="_NULL">
+  !   <DATA NAME="counter" TYPE="REAL, allocatable, DIMENSION(:,:,:,:)" DEFAULT="_NULL">
   !     Coordinates of buffer are (x, y, z, time-of-day)
   !   </DATA>
-  !   <DATA NAME="count_0d" TYPE="REAL, _ALLOCATABLE, DIMENSION(:)">
+  !   <DATA NAME="count_0d" TYPE="REAL, allocatable, DIMENSION(:)">
   !   </DATA>
-  !   <DATA NAME="num_elements" TYPE="REAL, _ALLOCATABLE, DIMENSION(:)">
+  !   <DATA NAME="num_elements" TYPE="REAL, allocatable, DIMENSION(:)">
   !   </DATA>
   !   <DATA NAME="last_output" TYPE="TYPE(time_type)">
   !   </DATA>
@@ -524,16 +524,16 @@ use fms2_io_mod
      INTEGER :: pow_value !< Power value to use for mean_pow(n) calculations
      CHARACTER(len=50) :: time_method ! time method field from the input file
      ! coordinates of the buffer and counter are (x, y, z, time-of-day)
-     REAL, _ALLOCATABLE, DIMENSION(:,:,:,:) :: buffer _NULL
-     REAL, _ALLOCATABLE, DIMENSION(:,:,:,:) :: counter _NULL
+     REAL, allocatable, DIMENSION(:,:,:,:) :: buffer
+     REAL, allocatable, DIMENSION(:,:,:,:) :: counter
      ! the following two counters are used in time-averaging for some
      ! combination of the field options. Their size is the length of the
      ! diurnal axis; the counters must be tracked separately for each of
      ! the diurnal interval, because the number of time slices accumulated
      ! in each can be different, depending on time step and the number of
      ! diurnal samples.
-     REAL, _ALLOCATABLE, DIMENSION(:)  :: count_0d
-     INTEGER, _ALLOCATABLE, dimension(:) :: num_elements
+     REAL, allocatable, DIMENSION(:)  :: count_0d
+     INTEGER, allocatable, dimension(:) :: num_elements
 
      TYPE(time_type) :: last_output, next_output, next_next_output
      TYPE(diag_fieldtype) :: f_type
@@ -545,7 +545,7 @@ use fms2_io_mod
      LOGICAL :: reduced_k_range
      INTEGER :: imin, imax, jmin, jmax, kmin, kmax
      TYPE(time_type) :: Time_of_prev_field_data
-     TYPE(diag_atttype), _ALLOCATABLE, dimension(:) :: attributes _NULL
+     TYPE(diag_atttype), allocatable, dimension(:) :: attributes
      INTEGER :: num_attributes
 !----------
 !ug support
@@ -620,7 +620,7 @@ use fms2_io_mod
      type(domainUG) :: DomainUG
      CHARACTER(len=128) :: aux, req
      INTEGER :: tile_count
-     TYPE(diag_atttype), _ALLOCATABLE, dimension(:) :: attributes _NULL
+     TYPE(diag_atttype), allocatable, dimension(:) :: attributes
      INTEGER :: num_attributes
      INTEGER :: domain_position !< The position in the doman (NORTH or EAST or CENTER)
   END TYPE diag_axis_type

--- a/diag_manager/diag_grid.F90
+++ b/diag_manager/diag_grid.F90
@@ -87,17 +87,17 @@ MODULE diag_grid_mod
   !   <DESCRIPTION>
   !     Contains the model's global grid data, and other grid information.
   !   </DESCRIPTION>
-  !   <DATA NAME="glo_lat" TYPE="REAL, _ALLOCATABLE, DIMENSION(:,:)">
+  !   <DATA NAME="glo_lat" TYPE="REAL, allocatable, DIMENSION(:,:)">
   !     The latitude values on the global grid.
   !   </DATA>
-  !   <DATA NAME="glo_lon" TYPE="REAL, _ALLOCATABLE, DIMENSION(:,:)">
+  !   <DATA NAME="glo_lon" TYPE="REAL, allocatable, DIMENSION(:,:)">
   !     The longitude values on the global grid.
   !   </DATA>
-  !   <DATA NAME="aglo_lat" TYPE="REAL, _ALLOCATABLE, DIMENSION(:,:)">
+  !   <DATA NAME="aglo_lat" TYPE="REAL, allocatable, DIMENSION(:,:)">
   !     The latitude values on the global a-grid.  Here we expect isc-1:iec+1 and
   !     jsc=1:jec+1 to be passed in.
   !   </DATA>
-  !   <DATA NAME="aglo_lon" TYPE="REAL, _ALLOCATABLE, DIMENSION(:,:)">
+  !   <DATA NAME="aglo_lon" TYPE="REAL, allocatable, DIMENSION(:,:)">
   !     The longitude values on the global a-grid.  Here we expec isc-1:iec+j and
   !     jsc-1:jec+1 to be passed in.
   !   </DATA>
@@ -137,8 +137,8 @@ MODULE diag_grid_mod
   !     The global grid type.
   !   </DATA>
   TYPE :: diag_global_grid_type
-     REAL, _ALLOCATABLE, DIMENSION(:,:) :: glo_lat, glo_lon
-     REAL, _ALLOCATABLE, DIMENSION(:,:) :: aglo_lat, aglo_lon
+     REAL, allocatable, DIMENSION(:,:) :: glo_lat, glo_lon
+     REAL, allocatable, DIMENSION(:,:) :: aglo_lat, aglo_lon
      INTEGER :: myXbegin, myYbegin
      INTEGER :: dimI, dimJ
      INTEGER :: adimI, adimJ
@@ -313,8 +313,8 @@ CONTAINS
     END IF
 
     ! Allocate the grid arrays
-    IF (   _ALLOCATED(diag_global_grid%glo_lat) .OR.&
-         & _ALLOCATED(diag_global_grid%glo_lon) ) THEN
+    IF (   allocated(diag_global_grid%glo_lat) .OR.&
+         & allocated(diag_global_grid%glo_lon) ) THEN
        IF ( mpp_pe() == mpp_root_pe() ) &
             & CALL error_mesg('diag_grid_mod::diag_grid_init',&
             &'The global grid has already been initialized', WARNING)
@@ -328,8 +328,8 @@ CONTAINS
     END IF
 
     ! Same thing for the a-grid
-    IF (   _ALLOCATED(diag_global_grid%aglo_lat) .OR.&
-         & _ALLOCATED(diag_global_grid%aglo_lon) ) THEN
+    IF (   allocated(diag_global_grid%aglo_lat) .OR.&
+         & allocated(diag_global_grid%aglo_lon) ) THEN
        IF ( mpp_pe() == mpp_root_pe() ) &
             & CALL error_mesg('diag_grid_mod::diag_grid_init',&
             &'The global a-grid has already been initialized', WARNING)
@@ -400,28 +400,28 @@ CONTAINS
 
     IF ( diag_grid_initialized ) THEN
        ! De-allocate grid
-       IF ( _ALLOCATED(diag_global_grid%glo_lat) ) THEN
+       IF ( allocated(diag_global_grid%glo_lat) ) THEN
           DEALLOCATE(diag_global_grid%glo_lat)
        ELSE IF ( mpp_pe() == mpp_root_pe() ) THEN
           CALL error_mesg('diag_grid_mod::diag_grid_end',&
                &'diag_global_grid%glo_lat was not allocated.', WARNING)
        END IF
 
-       IF ( _ALLOCATED(diag_global_grid%glo_lon) ) THEN
+       IF ( allocated(diag_global_grid%glo_lon) ) THEN
           DEALLOCATE(diag_global_grid%glo_lon)
        ELSE IF ( mpp_pe() == mpp_root_pe() ) THEN
           CALL error_mesg('diag_grid_mod::diag_grid_end',&
                &'diag_global_grid%glo_lon was not allocated.', WARNING)
        END IF
        ! De-allocate a-grid
-       IF ( _ALLOCATED(diag_global_grid%aglo_lat) ) THEN
+       IF ( allocated(diag_global_grid%aglo_lat) ) THEN
           DEALLOCATE(diag_global_grid%aglo_lat)
        ELSE IF ( mpp_pe() == mpp_root_pe() ) THEN
           CALL error_mesg('diag_grid_mod::diag_grid_end',&
                &'diag_global_grid%aglo_lat was not allocated.', WARNING)
        END IF
 
-       IF ( _ALLOCATED(diag_global_grid%aglo_lon) ) THEN
+       IF ( allocated(diag_global_grid%aglo_lon) ) THEN
           DEALLOCATE(diag_global_grid%aglo_lon)
        ELSE IF ( mpp_pe() == mpp_root_pe() ) THEN
           CALL error_mesg('diag_grid_mod::diag_grid_end',&

--- a/diag_manager/diag_output.F90
+++ b/diag_manager/diag_output.F90
@@ -613,10 +613,10 @@ integer :: domain_size, axis_length, axis_pos
        ! Deallocate attributes
        IF ( ALLOCATED(attributes) ) THEN
           DO j=1, num_attributes
-             IF ( _ALLOCATED(attributes(j)%fatt ) ) THEN
+             IF ( allocated(attributes(j)%fatt ) ) THEN
                 DEALLOCATE(attributes(j)%fatt)
              END IF
-             IF ( _ALLOCATED(attributes(j)%iatt ) ) THEN
+             IF ( allocated(attributes(j)%iatt ) ) THEN
                 DEALLOCATE(attributes(j)%iatt)
              END IF
           END DO
@@ -730,10 +730,10 @@ integer :: domain_size, axis_length, axis_pos
        ! Deallocate attributes
        IF ( ALLOCATED(attributes) ) THEN
           DO j=1, num_attributes
-             IF ( _ALLOCATED(attributes(j)%fatt ) ) THEN
+             IF ( allocated(attributes(j)%fatt ) ) THEN
                 DEALLOCATE(attributes(j)%fatt)
              END IF
-             IF ( _ALLOCATED(attributes(j)%iatt ) ) THEN
+             IF ( allocated(attributes(j)%iatt ) ) THEN
                 DEALLOCATE(attributes(j)%iatt)
              END IF
           END DO
@@ -789,7 +789,7 @@ integer :: domain_size, axis_length, axis_pos
     INTEGER, OPTIONAL, INTENT(in) :: pack
     CHARACTER(len=*), OPTIONAL, INTENT(in) :: avg_name, time_method, standard_name
     CHARACTER(len=*), OPTIONAL, INTENT(in) :: interp_method
-    TYPE(diag_atttype), DIMENSION(:), _ALLOCATABLE, OPTIONAL, INTENT(in) :: attributes
+    TYPE(diag_atttype), DIMENSION(:), allocatable, OPTIONAL, INTENT(in) :: attributes
     INTEGER, OPTIONAL, INTENT(in) :: num_attributes
     LOGICAL, OPTIONAL, INTENT(in) :: use_UGdomain
 class(FmsNetcdfFile_t), intent(inout)     :: fileob
@@ -995,7 +995,7 @@ character(len=128),dimension(size(axes)) :: axis_names
     !---- write user defined attributes -----
     IF ( PRESENT(num_attributes) ) THEN
        IF ( PRESENT(attributes) ) THEN
-          IF ( num_attributes .GT. 0 .AND. _ALLOCATED(attributes) ) THEN
+          IF ( num_attributes .GT. 0 .AND. allocated(attributes) ) THEN
              CALL write_attribute_meta(file_unit, mpp_get_id(Field%Field), num_attributes, attributes, time_method, err_msg, fileob=fileob, varname=name)
              IF ( LEN_TRIM(err_msg) .GT. 0 ) THEN
                 CALL error_mesg('diag_output_mod::write_field_meta_data',&
@@ -1003,11 +1003,11 @@ character(len=128),dimension(size(axes)) :: axis_names
              END IF
           ELSE
              ! Catch some bad cases
-             IF ( num_attributes .GT. 0 .AND. .NOT._ALLOCATED(attributes) ) THEN
+             IF ( num_attributes .GT. 0 .AND. .NOT.allocated(attributes) ) THEN
                 CALL error_mesg('diag_output_mod::write_field_meta_data',&
                      & 'num_attributes > 0 but attributes is not allocated for attribute '&
                      &//TRIM(attributes(i)%name)//' for field '//TRIM(name)//'. Contact the developers.', FATAL)
-             ELSE IF ( num_attributes .EQ. 0 .AND. _ALLOCATED(attributes) ) THEN
+             ELSE IF ( num_attributes .EQ. 0 .AND. allocated(attributes) ) THEN
                 CALL error_mesg('diag_output_mod::write_field_meta_data',&
                      & 'num_attributes == 0 but attributes is allocated for attribute '&
                      &//TRIM(attributes(i)%name)//' for field '//TRIM(name)//'. Contact the developers.', FATAL)
@@ -1075,7 +1075,7 @@ class(FmsNetcdfFile_t), intent(inout)     :: fileob
     DO i = 1, num_attributes
        SELECT CASE (attributes(i)%type)
        CASE (NF90_INT)
-          IF ( .NOT._ALLOCATED(attributes(i)%iatt) ) THEN
+          IF ( .NOT.allocated(attributes(i)%iatt) ) THEN
              IF ( fms_error_handler('diag_output_mod::write_attribute_meta',&
                   & 'Integer attribute type indicated, but array not allocated for attribute '&
                   &//TRIM(attributes(i)%name)//'.', err_msg) ) THEN
@@ -1084,7 +1084,7 @@ class(FmsNetcdfFile_t), intent(inout)     :: fileob
           END IF
           if (present(varname))call register_variable_attribute(fileob, varname,TRIM(attributes(i)%name)  , attributes(i)%iatt)
        CASE (NF90_FLOAT)
-          IF ( .NOT._ALLOCATED(attributes(i)%fatt) ) THEN
+          IF ( .NOT.allocated(attributes(i)%fatt) ) THEN
              IF ( fms_error_handler('diag_output_mod::write_attribute_meta',&
                   & 'Real attribute type indicated, but array not allocated for attribute '&
                   &//TRIM(attributes(i)%name)//'.', err_msg) ) THEN

--- a/diag_manager/diag_util.F90
+++ b/diag_manager/diag_util.F90
@@ -1934,7 +1934,7 @@ CONTAINS
           fname = TRIM(filename)
           CALL get_mosaic_tile_file_ug(fname,filename,domainU)
     ENDIF
-    IF ( _ALLOCATED(files(file)%attributes) ) THEN
+    IF ( allocated(files(file)%attributes) ) THEN
        CALL diag_output_init(filename, files(file)%format, global_descriptor,&
             & files(file)%file_unit, all_scalar_or_1d, domain2, domainU,&
             & fileobj(file),fileobjU(file), fileobjND(file), fnum_for_domain(file),&
@@ -2756,7 +2756,7 @@ CONTAINS
     IF ( PRESENT(err_msg) ) err_msg = ''
 
     ! Allocate memory for the attributes
-    IF ( .NOT._ALLOCATED(out_field%attributes) ) THEN
+    IF ( .NOT.allocated(out_field%attributes) ) THEN
        ALLOCATE(out_field%attributes(max_field_attributes), STAT=istat)
        IF ( istat.NE.0 ) THEN
           ! <ERROR STATUS="FATAL">
@@ -2901,7 +2901,7 @@ CONTAINS
     IF ( PRESENT(err_msg) ) err_msg = ''
 
     ! Allocate memory for the attributes
-    IF ( .NOT._ALLOCATED(out_file%attributes) ) THEN
+    IF ( .NOT.allocated(out_file%attributes) ) THEN
        ALLOCATE(out_file%attributes(max_field_attributes), STAT=istat)
        IF ( istat.NE.0 ) THEN
           ! <ERROR STATUS="FATAL">

--- a/drifters/drifters.F90
+++ b/drifters/drifters.F90
@@ -141,30 +141,30 @@ module drifters_mod
      real    :: dt             ! total dt, over a complete step
      real    :: time
      ! fields
-     real, _ALLOCATABLE :: fields(:,:) _NULL
+     real, allocatable :: fields(:,:)
      ! velocity field axes
-     real, _ALLOCATABLE :: xu(:) _NULL
-     real, _ALLOCATABLE :: yu(:) _NULL
-     real, _ALLOCATABLE :: zu(:) _NULL
-     real, _ALLOCATABLE :: xv(:) _NULL
-     real, _ALLOCATABLE :: yv(:) _NULL
-     real, _ALLOCATABLE :: zv(:) _NULL
-     real, _ALLOCATABLE :: xw(:) _NULL
-     real, _ALLOCATABLE :: yw(:) _NULL
-     real, _ALLOCATABLE :: zw(:) _NULL
+     real, allocatable :: xu(:)
+     real, allocatable :: yu(:)
+     real, allocatable :: zu(:)
+     real, allocatable :: xv(:)
+     real, allocatable :: yv(:)
+     real, allocatable :: zv(:)
+     real, allocatable :: xw(:)
+     real, allocatable :: yw(:)
+     real, allocatable :: zw(:)
      ! Runge Kutta coefficients holding intermediate results (positions)
-     real, _ALLOCATABLE :: temp_pos(:,:) _NULL
-     real, _ALLOCATABLE :: rk4_k1(:,:) _NULL
-     real, _ALLOCATABLE :: rk4_k2(:,:) _NULL
-     real, _ALLOCATABLE :: rk4_k3(:,:) _NULL
-     real, _ALLOCATABLE :: rk4_k4(:,:) _NULL
+     real, allocatable :: temp_pos(:,:)
+     real, allocatable :: rk4_k1(:,:)
+     real, allocatable :: rk4_k2(:,:)
+     real, allocatable :: rk4_k3(:,:)
+     real, allocatable :: rk4_k4(:,:)
      ! store filenames for convenience
      character(len=MAX_STR_LEN) :: input_file, output_file
      ! Runge Kutta stuff
      integer :: rk4_step
      logical :: rk4_completed
      integer :: nx, ny
-     logical, _ALLOCATABLE   :: remove(:) _NULL
+     logical, allocatable   :: remove(:)
   end type drifters_type
 
   interface assignment(=)
@@ -1001,16 +1001,16 @@ contains
 
     ermesg = ''
 
-    if(.not._ALLOCATED(self%xu) .or. .not._ALLOCATED(self%yu)) then
+    if(.not.allocated(self%xu) .or. .not.allocated(self%yu)) then
        ermesg = 'drifters_set_domain_bounds: ERROR "u"-component axes not set'
        return
     endif
     call drifters_comm_set_domain(self%comm, domain, self%xu, self%yu, backoff_x, backoff_y)
-    if(.not._ALLOCATED(self%xv) .or. .not._ALLOCATED(self%yv)) then
+    if(.not.allocated(self%xv) .or. .not.allocated(self%yv)) then
        ermesg = 'drifters_set_domain_bounds: ERROR "v"-component axes not set'
        return
     endif
-    if(_ALLOCATED(self%xw) .and. _ALLOCATED(self%yw)) then
+    if(allocated(self%xw) .and. allocated(self%yw)) then
        call drifters_comm_set_domain(self%comm, domain, self%xv, self%yv, backoff_x, backoff_y)
     endif
 

--- a/drifters/drifters_core.F90
+++ b/drifters/drifters_core.F90
@@ -43,8 +43,8 @@ module drifters_core_mod
      integer :: nd     ! number of dimensions
      integer :: np     ! number of particles (drifters)
      integer :: npdim  ! max number of particles (drifters)
-     integer, _ALLOCATABLE :: ids(:)_NULL  ! particle id number
-     real   , _ALLOCATABLE :: positions(:,:)   _NULL
+     integer, allocatable :: ids(:)_NULL  ! particle id number
+     real   , allocatable :: positions(:,:)  
   end type drifters_core_type
 
   interface assignment(=)
@@ -90,9 +90,9 @@ contains
     self%nd  = 0
     self%np  = 0
     iflag = 0
-    if(_ALLOCATED(self%positions)) deallocate(self%positions, stat=iflag)
+    if(allocated(self%positions)) deallocate(self%positions, stat=iflag)
     if(iflag/=0) ier = ier + 1
-    if(_ALLOCATED(self%ids)) deallocate(self%ids, stat=iflag)
+    if(allocated(self%ids)) deallocate(self%ids, stat=iflag)
     if(iflag/=0) ier = ier + 1
 
     if(ier/=0) ermesg = 'drifters::ERROR in drifters_core_del'

--- a/drifters/drifters_input.F90
+++ b/drifters/drifters_input.F90
@@ -34,13 +34,13 @@ module drifters_input_mod
   type drifters_input_type
      ! Be sure to update drifters_input_new, drifters_input_del and drifters_input_copy_new
      ! when adding members
-     character(len=MAX_STR_LEN), _ALLOCATABLE :: position_names(:) _NULL
-     character(len=MAX_STR_LEN), _ALLOCATABLE :: position_units(:) _NULL
-     character(len=MAX_STR_LEN), _ALLOCATABLE :: field_names(:)    _NULL
-     character(len=MAX_STR_LEN), _ALLOCATABLE :: field_units(:)    _NULL
-     character(len=MAX_STR_LEN), _ALLOCATABLE :: velocity_names(:) _NULL
-     real                      , _ALLOCATABLE :: positions(:,:) _NULL
-     integer                   , _ALLOCATABLE :: ids(:)         _NULL
+     character(len=MAX_STR_LEN), allocatable :: position_names(:)
+     character(len=MAX_STR_LEN), allocatable :: position_units(:)
+     character(len=MAX_STR_LEN), allocatable :: field_names(:)   
+     character(len=MAX_STR_LEN), allocatable :: field_units(:)   
+     character(len=MAX_STR_LEN), allocatable :: velocity_names(:)
+     real                      , allocatable :: positions(:,:)
+     integer                   , allocatable :: ids(:)        
      character(len=MAX_STR_LEN)               :: time_units
      character(len=MAX_STR_LEN)               :: title
      character(len=MAX_STR_LEN)               :: version

--- a/exchange/xgrid.F90
+++ b/exchange/xgrid.F90
@@ -403,13 +403,13 @@ type overlap_type
    integer          :: count
    integer          :: pe
    integer          :: buffer_pos
-   integer, _ALLOCATABLE :: i(:) _NULL
-   integer, _ALLOCATABLE :: j(:) _NULL
-   integer, _ALLOCATABLE :: g(:) _NULL
-   integer, _ALLOCATABLE :: xLoc(:) _NULL
-   integer, _ALLOCATABLE :: tile(:) _NULL
-   real,    _ALLOCATABLE :: di(:) _NULL
-   real,    _ALLOCATABLE :: dj(:) _NULL
+   integer, allocatable :: i(:)
+   integer, allocatable :: j(:)
+   integer, allocatable :: g(:)
+   integer, allocatable :: xLoc(:)
+   integer, allocatable :: tile(:)
+   real,    allocatable :: di(:)
+   real,    allocatable :: dj(:)
 end type overlap_type
 
 type comm_type

--- a/fms/fms_io.F90
+++ b/fms/fms_io.F90
@@ -216,7 +216,7 @@ type var_type
    character(len=128)                     :: name = ''
    character(len=128)                     :: longname = ''
    character(len=128)                     :: units = ''
-   real, dimension(:,:,:,:), _ALLOCATABLE :: buffer _NULL
+   real, dimension(:,:,:,:), allocatable :: buffer
    logical                                :: domain_present = .FALSE.
    integer                                :: domain_idx = -1
    logical                                :: is_dimvar = .FALSE.

--- a/include/fms_platform.h
+++ b/include/fms_platform.h
@@ -59,14 +59,14 @@ use,intrinsic :: iso_c_binding, only: c_double,c_float,c_int64_t, &
 
 !Control array members of derived types.
 #ifdef NO_F2000
-#define allocatable pointer
-#define =>null()
-#define allocated associated
+#define _ALLOCATABLE pointer
+#define _NULL =>null()
+#define _ALLOCATED associated
 !DEC$ MESSAGE:'Using pointer derived type array members.'
 #else
-#define allocatable allocatable
-#define
-#define allocated allocated
+#define _ALLOCATABLE allocatable
+#define _NULL
+#define _ALLOCATED allocated
 !DEC$ MESSAGE:'Using allocatable derived type array members.'
 #endif
 

--- a/include/fms_platform.h
+++ b/include/fms_platform.h
@@ -59,14 +59,14 @@ use,intrinsic :: iso_c_binding, only: c_double,c_float,c_int64_t, &
 
 !Control array members of derived types.
 #ifdef NO_F2000
-#define _ALLOCATABLE pointer
-#define _NULL =>null()
-#define _ALLOCATED associated
+#define allocatable pointer
+#define =>null()
+#define allocated associated
 !DEC$ MESSAGE:'Using pointer derived type array members.'
 #else
-#define _ALLOCATABLE allocatable
-#define _NULL
-#define _ALLOCATED allocated
+#define allocatable allocatable
+#define
+#define allocated allocated
 !DEC$ MESSAGE:'Using allocatable derived type array members.'
 #endif
 

--- a/mpp/include/mpp_domains_comm.inc
+++ b/mpp/include/mpp_domains_comm.inc
@@ -663,20 +663,20 @@
       d_comm%l_addrx =-9999
       d_comm%l_addry =-9999
 
-      if( _ALLOCATED(d_comm%sendis) )   DEALLOCATE(d_comm%sendis);    !!d_comm%sendis =>NULL()
-      if( _ALLOCATED(d_comm%sendie) )   DEALLOCATE(d_comm%sendie);    !!d_comm%sendie =>NULL()
-      if( _ALLOCATED(d_comm%sendjs) )   DEALLOCATE(d_comm%sendjs);    !!d_comm%sendjs =>NULL()
-      if( _ALLOCATED(d_comm%sendje) )   DEALLOCATE(d_comm%sendje);    !!d_comm%sendje =>NULL()
-      if( _ALLOCATED(d_comm%S_msize) )  DEALLOCATE(d_comm%S_msize);   !!d_comm%S_msize =>NULL()
-      if( _ALLOCATED(d_comm%S_do_buf) ) DEALLOCATE(d_comm%S_do_buf);  !!d_comm%S_do_buf =>NULL()
-      if( _ALLOCATED(d_comm%cto_pe) )   DEALLOCATE(d_comm%cto_pe);    !!d_comm%cto_pe  =>NULL()
-      if( _ALLOCATED(d_comm%recvis) )   DEALLOCATE(d_comm%recvis);    !!d_comm%recvis =>NULL()
-      if( _ALLOCATED(d_comm%recvie) )   DEALLOCATE(d_comm%recvie);    !!d_comm%recvie =>NULL()
-      if( _ALLOCATED(d_comm%recvjs) )   DEALLOCATE(d_comm%recvjs);    !!d_comm%recvjs =>NULL()
-      if( _ALLOCATED(d_comm%recvje) )   DEALLOCATE(d_comm%recvje);    !!d_comm%recvje =>NULL()
-      if( _ALLOCATED(d_comm%R_msize) )  DEALLOCATE(d_comm%R_msize);   !!d_comm%R_msize =>NULL()
-      if( _ALLOCATED(d_comm%R_do_buf) ) DEALLOCATE(d_comm%R_do_buf);  !!d_comm%R_do_buf =>NULL()
-      if( _ALLOCATED(d_comm%cfrom_pe) ) DEALLOCATE(d_comm%cfrom_pe);  !!d_comm%cfrom_pe  =>NULL()
+      if( allocated(d_comm%sendis) )   DEALLOCATE(d_comm%sendis);    !!d_comm%sendis =>NULL()
+      if( allocated(d_comm%sendie) )   DEALLOCATE(d_comm%sendie);    !!d_comm%sendie =>NULL()
+      if( allocated(d_comm%sendjs) )   DEALLOCATE(d_comm%sendjs);    !!d_comm%sendjs =>NULL()
+      if( allocated(d_comm%sendje) )   DEALLOCATE(d_comm%sendje);    !!d_comm%sendje =>NULL()
+      if( allocated(d_comm%S_msize) )  DEALLOCATE(d_comm%S_msize);   !!d_comm%S_msize =>NULL()
+      if( allocated(d_comm%S_do_buf) ) DEALLOCATE(d_comm%S_do_buf);  !!d_comm%S_do_buf =>NULL()
+      if( allocated(d_comm%cto_pe) )   DEALLOCATE(d_comm%cto_pe);    !!d_comm%cto_pe  =>NULL()
+      if( allocated(d_comm%recvis) )   DEALLOCATE(d_comm%recvis);    !!d_comm%recvis =>NULL()
+      if( allocated(d_comm%recvie) )   DEALLOCATE(d_comm%recvie);    !!d_comm%recvie =>NULL()
+      if( allocated(d_comm%recvjs) )   DEALLOCATE(d_comm%recvjs);    !!d_comm%recvjs =>NULL()
+      if( allocated(d_comm%recvje) )   DEALLOCATE(d_comm%recvje);    !!d_comm%recvje =>NULL()
+      if( allocated(d_comm%R_msize) )  DEALLOCATE(d_comm%R_msize);   !!d_comm%R_msize =>NULL()
+      if( allocated(d_comm%R_do_buf) ) DEALLOCATE(d_comm%R_do_buf);  !!d_comm%R_do_buf =>NULL()
+      if( allocated(d_comm%cfrom_pe) ) DEALLOCATE(d_comm%cfrom_pe);  !!d_comm%cfrom_pe  =>NULL()
       d_comm%Slist_size=0; d_comm%Rlist_size=0
       d_comm%isize=0; d_comm%jsize=0; d_comm%ke=0
       d_comm%isize_in=0; d_comm%jsize_in=0
@@ -684,14 +684,14 @@
       d_comm%isize_max=0; d_comm%jsize_max=0
       d_comm%gf_ioff=0; d_comm%gf_joff=0
     ! Remote data
-      if( _ALLOCATED(d_comm%isizeR) )   DEALLOCATE(d_comm%isizeR);    !!dd_comm%isizeR =>NULL()
-      if( _ALLOCATED(d_comm%jsizeR) )   DEALLOCATE(d_comm%jsizeR);    !!dd_comm%jsizeR =>NULL()
-      if( _ALLOCATED(d_comm%sendisR) )  DEALLOCATE(d_comm%sendisR);   !!dd_comm%sendisR =>NULL()
-      if( _ALLOCATED(d_comm%sendjsR) )  DEALLOCATE(d_comm%sendjsR);   !!dd_comm%sendjsR =>NULL()
-      if( _ALLOCATED(d_comm%rem_addr) ) DEALLOCATE(d_comm%rem_addr);  !!dd_comm%rem_addr  =>NULL()
-      if( _ALLOCATED(d_comm%rem_addrx) )DEALLOCATE(d_comm%rem_addrx); !!dd_comm%rem_addrx =>NULL()
-      if( _ALLOCATED(d_comm%rem_addry) )DEALLOCATE(d_comm%rem_addry); !!dd_comm%rem_addry =>NULL()
-      if( _ALLOCATED(d_comm%rem_addrl) )DEALLOCATE(d_comm%rem_addrl); !!dd_comm%rem_addrl =>NULL()
+      if( allocated(d_comm%isizeR) )   DEALLOCATE(d_comm%isizeR);    !!dd_comm%isizeR =>NULL()
+      if( allocated(d_comm%jsizeR) )   DEALLOCATE(d_comm%jsizeR);    !!dd_comm%jsizeR =>NULL()
+      if( allocated(d_comm%sendisR) )  DEALLOCATE(d_comm%sendisR);   !!dd_comm%sendisR =>NULL()
+      if( allocated(d_comm%sendjsR) )  DEALLOCATE(d_comm%sendjsR);   !!dd_comm%sendjsR =>NULL()
+      if( allocated(d_comm%rem_addr) ) DEALLOCATE(d_comm%rem_addr);  !!dd_comm%rem_addr  =>NULL()
+      if( allocated(d_comm%rem_addrx) )DEALLOCATE(d_comm%rem_addrx); !!dd_comm%rem_addrx =>NULL()
+      if( allocated(d_comm%rem_addry) )DEALLOCATE(d_comm%rem_addry); !!dd_comm%rem_addry =>NULL()
+      if( allocated(d_comm%rem_addrl) )DEALLOCATE(d_comm%rem_addrl); !!dd_comm%rem_addrl =>NULL()
     end subroutine deallocate_comm
 
 

--- a/mpp/mpp_domains.F90
+++ b/mpp/mpp_domains.F90
@@ -493,20 +493,20 @@ module mpp_domains_mod
      type(domain2D), pointer :: domain_out =>NULL()
      type(overlapSpec), pointer :: send(:,:,:,:) => NULL()
      type(overlapSpec), pointer :: recv(:,:,:,:) => NULL()
-     integer, dimension(:,:),       _ALLOCATABLE :: sendis _NULL
-     integer, dimension(:,:),       _ALLOCATABLE :: sendie _NULL
-     integer, dimension(:,:),       _ALLOCATABLE :: sendjs _NULL
-     integer, dimension(:,:),       _ALLOCATABLE :: sendje _NULL
-     integer, dimension(:,:),       _ALLOCATABLE :: recvis _NULL
-     integer, dimension(:,:),       _ALLOCATABLE :: recvie _NULL
-     integer, dimension(:,:),       _ALLOCATABLE :: recvjs _NULL
-     integer, dimension(:,:),       _ALLOCATABLE :: recvje _NULL
-     logical, dimension(:),         _ALLOCATABLE :: S_do_buf _NULL
-     logical, dimension(:),         _ALLOCATABLE :: R_do_buf _NULL
-     integer, dimension(:),         _ALLOCATABLE :: cto_pe  _NULL
-     integer, dimension(:),         _ALLOCATABLE :: cfrom_pe  _NULL
-     integer, dimension(:),         _ALLOCATABLE :: S_msize _NULL
-     integer, dimension(:),         _ALLOCATABLE :: R_msize _NULL
+     integer, dimension(:,:),       allocatable :: sendis
+     integer, dimension(:,:),       allocatable :: sendie
+     integer, dimension(:,:),       allocatable :: sendjs
+     integer, dimension(:,:),       allocatable :: sendje
+     integer, dimension(:,:),       allocatable :: recvis
+     integer, dimension(:,:),       allocatable :: recvie
+     integer, dimension(:,:),       allocatable :: recvjs
+     integer, dimension(:,:),       allocatable :: recvje
+     logical, dimension(:),         allocatable :: S_do_buf
+     logical, dimension(:),         allocatable :: R_do_buf
+     integer, dimension(:),         allocatable :: cto_pe 
+     integer, dimension(:),         allocatable :: cfrom_pe 
+     integer, dimension(:),         allocatable :: S_msize
+     integer, dimension(:),         allocatable :: R_msize
      integer :: Slist_size=0, Rlist_size=0
      integer :: isize=0, jsize=0, ke=0
      integer :: isize_in=0, jsize_in=0
@@ -514,16 +514,16 @@ module mpp_domains_mod
      integer :: isize_max=0, jsize_max=0
      integer :: gf_ioff=0, gf_joff=0
   ! Remote data
-     integer, dimension(:)  , _ALLOCATABLE :: isizeR _NULL
-     integer, dimension(:)  , _ALLOCATABLE :: jsizeR _NULL
-     integer, dimension(:,:), _ALLOCATABLE :: sendisR _NULL
-     integer, dimension(:,:), _ALLOCATABLE :: sendjsR _NULL
-     integer(LONG_KIND), dimension(:), _ALLOCATABLE :: rem_addr  _NULL
-     integer(LONG_KIND), dimension(:), _ALLOCATABLE :: rem_addrx _NULL
-     integer(LONG_KIND), dimension(:), _ALLOCATABLE :: rem_addry _NULL
-     integer(LONG_KIND), dimension(:,:), _ALLOCATABLE :: rem_addrl  _NULL
-     integer(LONG_KIND), dimension(:,:), _ALLOCATABLE :: rem_addrlx  _NULL
-     integer(LONG_KIND), dimension(:,:), _ALLOCATABLE :: rem_addrly  _NULL
+     integer, dimension(:)  , allocatable :: isizeR
+     integer, dimension(:)  , allocatable :: jsizeR
+     integer, dimension(:,:), allocatable :: sendisR
+     integer, dimension(:,:), allocatable :: sendjsR
+     integer(LONG_KIND), dimension(:), allocatable :: rem_addr 
+     integer(LONG_KIND), dimension(:), allocatable :: rem_addrx
+     integer(LONG_KIND), dimension(:), allocatable :: rem_addry
+     integer(LONG_KIND), dimension(:,:), allocatable :: rem_addrl 
+     integer(LONG_KIND), dimension(:,:), allocatable :: rem_addrlx 
+     integer(LONG_KIND), dimension(:,:), allocatable :: rem_addrly 
      integer                             :: position        ! data location. T, E, C, or N.
   end type DomainCommunicator2D
 

--- a/mpp/mpp_pset.F90
+++ b/mpp/mpp_pset.F90
@@ -78,10 +78,10 @@ module mpp_pset_mod
      integer :: pos !position of current PE within pset
 !stack is allocated by root
 !it is then mapped to mpp_pset_stack by mpp_pset_broadcast_ptr
-     real, _ALLOCATABLE :: stack(:) _NULL
-     integer, _ALLOCATABLE :: pelist(:) _NULL !base PElist
-     integer, _ALLOCATABLE :: root_pelist(:) _NULL !a PElist of all the roots
-     integer, _ALLOCATABLE :: pset(:) _NULL !PSET IDs
+     real, allocatable :: stack(:)
+     integer, allocatable :: pelist(:) !base PElist
+     integer, allocatable :: root_pelist(:) !a PElist of all the roots
+     integer, allocatable :: pset(:) !PSET IDs
      integer(POINTER_KIND) :: p_stack
      integer :: lstack, maxstack, hiWM !current stack length, max, hiWM
      integer :: commID


### PR DESCRIPTION
**Description**
Replaces marcos `_ALLOCATABLE` with `allocatable`, `_ALLOCATED` with `allocated`, and _NULL with nothing.

Fixes #373 

**How Has This Been Tested?**
travis_ci and `make check` on GFDL skylake dev machine

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

