### PR TITLE
Allow tests that fail on Travis CI to write the test output logs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ before_script:
   - export CPPFLAGS="-I/usr/include -Duse_LARGEFILE -DMAXFIELDMETHODS_=500"
   - export FCFLAGS="-Waliasing -fno-range-check ${FCFLAGS_ADD}"
   - export LDFLAGS='-L/usr/lib'
+  - export VERBOSE=1
 
 script:
   - autoreconf -i


### PR DESCRIPTION
**Description**
Add a new enviornment variable `VERBOSE` to have the travis tests output the test failures.  This is to allow developers to more easily discover what happened when the tests fail.

Fixes #379 

**How Has This Been Tested?**
Running this on other platforms setting the environment variable `VERBOSE`, and forcing a `make check` test to fail produced the log files as desired.  Unfortunately, this will not be shown in Travis CI until a developer pushes an update that causes the tests to fail.
 
**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

