### PR TITLE
Fms2io nml

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -24,8 +24,8 @@
 ACLOCAL_AMFLAGS = -I m4
 
 # Make targets will be run in each subdirectory. Order is significant.
-SUBDIRS = include platform constants tridiagonal mpp memutils fms \
-affinity fms2_io mosaic time_manager axis_utils diag_manager drifters \
+SUBDIRS = include platform constants tridiagonal mpp memutils fms2_io \
+fms affinity mosaic time_manager axis_utils diag_manager drifters \
 horiz_interp time_interp column_diagnostics block_control \
 data_override astronomy field_manager coupler diag_integral \
 monin_obukhov interpolator amip_interp exchange topography \

--- a/fms/Makefile.am
+++ b/fms/Makefile.am
@@ -28,6 +28,7 @@ AM_CPPFLAGS += -I${top_builddir}/constants
 AM_CPPFLAGS += -I${top_builddir}/mpp
 AM_CPPFLAGS += -I${top_builddir}/platform
 AM_CPPFLAGS += -I${top_builddir}/memutils
+AM_CPPFLAGS += -I${top_builddir}/fms2_io
 
 # Build these uninstalled convenience libraries.
 noinst_LTLIBRARIES = libfms_io.la libfms.la

--- a/fms/fms.F90
+++ b/fms/fms.F90
@@ -165,6 +165,8 @@ use fms_io_mod, only : fms_io_init, fms_io_exit, field_size, &
                        get_mosaic_tile_file, get_global_att_value, file_exist, field_exist, &
                        write_version_number
 
+use fms2_io_mod, only: fms2_io_init
+
 use memutils_mod, only: print_memuse_stats, memutils_init
 
 
@@ -368,7 +370,7 @@ subroutine fms_init (localcomm )
     endif
     call mpp_domains_init
     call fms_io_init
-
+    call fms2_io_init ()
 !---- read namelist input ----
 
     call nml_error_init  ! first initialize namelist iostat error codes

--- a/fms2_io/blackboxio.F90
+++ b/fms2_io/blackboxio.F90
@@ -47,7 +47,7 @@ contains
 subroutine blackboxio_init (chksz)
 integer, intent(in) :: chksz
  fms2_ncchksz = chksz
-end subroutine netcdf_io_init
+end subroutine blackboxio_init
 
 
 !> @brief Create a new file path.

--- a/fms2_io/blackboxio.F90
+++ b/fms2_io/blackboxio.F90
@@ -29,7 +29,9 @@ use, intrinsic :: iso_fortran_env, only: error_unit, int32, int64, real32, real6
 implicit none
 private
 
+integer, private :: fms2_ncchksz = 1*1024*1024 !< Chunksize used in nc_open and nc_create
 
+public :: blackboxio_init
 public :: create_diskless_netcdf_file_wrap
 public :: netcdf_save_restart_wrap2
 public :: netcdf_restore_state_wrap
@@ -41,6 +43,11 @@ public :: unstructured_write_restart_wrap
 
 
 contains
+!> @brief Accepts the namelist fms2_io_nml variables relevant to blackboxio 
+subroutine blackboxio_init (chksz)
+integer, intent(in) :: chksz
+ fms2_ncchksz = chksz
+end subroutine netcdf_io_init
 
 
 !> @brief Create a new file path.
@@ -133,7 +140,7 @@ function create_diskless_netcdf_file(fileobj, pelist, path) &
   fileobj%is_diskless = .true.
   cmode = ior(nf90_noclobber, nf90_classic_model)
   cmode = ior(cmode, nf90_diskless)
-  err = nf90_create(trim(fileobj%path), cmode, fileobj%ncid)
+  err = nf90_create(trim(fileobj%path), cmode, fileobj%ncid, chunksize=fms2_ncchksz)
   success = err .eq. nf90_noerr
   if (.not. success) then
     deallocate(fileobj%pelist)

--- a/fms2_io/blackboxio.F90
+++ b/fms2_io/blackboxio.F90
@@ -29,7 +29,7 @@ use, intrinsic :: iso_fortran_env, only: error_unit, int32, int64, real32, real6
 implicit none
 private
 
-integer, private :: fms2_ncchksz = 1*1024*1024 !< Chunksize used in nc_open and nc_create
+integer, private :: fms2_ncchksz = -1 !< Chunksize (bytes) used in nc_open and nc_create
 
 public :: blackboxio_init
 public :: create_diskless_netcdf_file_wrap
@@ -140,6 +140,7 @@ function create_diskless_netcdf_file(fileobj, pelist, path) &
   fileobj%is_diskless = .true.
   cmode = ior(nf90_noclobber, nf90_classic_model)
   cmode = ior(cmode, nf90_diskless)
+  if (fms2_ncchksz == -1) error("create_diskless_netcdf_file :: fms2_ncchksz not set.")
   err = nf90_create(trim(fileobj%path), cmode, fileobj%ncid, chunksize=fms2_ncchksz)
   success = err .eq. nf90_noerr
   if (.not. success) then

--- a/fms2_io/blackboxio.F90
+++ b/fms2_io/blackboxio.F90
@@ -140,7 +140,7 @@ function create_diskless_netcdf_file(fileobj, pelist, path) &
   fileobj%is_diskless = .true.
   cmode = ior(nf90_noclobber, nf90_classic_model)
   cmode = ior(cmode, nf90_diskless)
-  if (fms2_ncchksz == -1) error("create_diskless_netcdf_file :: fms2_ncchksz not set.")
+  if (fms2_ncchksz == -1) call error("create_diskless_netcdf_file :: fms2_ncchksz not set.")
   err = nf90_create(trim(fileobj%path), cmode, fileobj%ncid, chunksize=fms2_ncchksz)
   success = err .eq. nf90_noerr
   if (.not. success) then

--- a/fms2_io/fms2_io.F90
+++ b/fms2_io/fms2_io.F90
@@ -223,20 +223,22 @@ contains
 
 !> @brief Reads the fms2_io_nml
 subroutine fms2_io_init ()
-
-integer :: mystat
- call mpp_init()
- call mpp_domains_init()
+ integer :: mystat
+ 
+!> Check if the module has already been initialized
+  if (fms2_io_is_initialized) return
+!> Call initialization routines that this module depends on
+  call mpp_init()
+  call mpp_domains_init()
 !> Read the namelist
-READ (input_nml_file, NML=fms2_io_nml, IOSTAT=mystat)
-
+  READ (input_nml_file, NML=fms2_io_nml, IOSTAT=mystat)
 !>Send the namelist variables to their respective modules
   if (ncchksz .le. 0) then
         call mpp_error(FATAL, "ncchksz in fms2_io_nml must be a positive number.")
   endif
   call netcdf_io_init (ncchksz)
   call blackboxio_init (ncchksz)
-
+!> Mark the fms2_io as initialized 
   fms2_io_is_initialized = .true.
 end subroutine fms2_io_init
 

--- a/fms2_io/fms2_io.F90
+++ b/fms2_io/fms2_io.F90
@@ -212,8 +212,7 @@ interface read_new_restart
   module procedure restore_domain_state_wrap
 end interface read_new_restart
 
-logical, private :: fms2_io_is_initialized = .false. !< True after fms2_io_init
-is run
+logical, private :: fms2_io_is_initialized = .false. !< True after fms2_io_init is run
 !< Namelist variables
 integer :: ncchksz = 64*1024  !< User defined chunksize (in bytes) argument in netcdf file 
                               !! creation calls. Replaces setting the NC_CHKSZ environment variable.

--- a/fms2_io/fms2_io.F90
+++ b/fms2_io/fms2_io.F90
@@ -26,7 +26,8 @@ use netcdf_io_mod
 use fms_netcdf_domain_io_mod
 use fms_netcdf_unstructured_domain_io_mod
 use blackboxio
-use mpp_mod, only: input_nml_file, mpp_error, FATAL
+use mpp_mod, only: mpp_init, input_nml_file, mpp_error, FATAL
+use mpp_domains_mod, only: mpp_domains_init
 implicit none
 private
 
@@ -211,6 +212,8 @@ interface read_new_restart
   module procedure restore_domain_state_wrap
 end interface read_new_restart
 
+logical, private :: fms2_io_is_initialized = .false. !< True after fms2_io_init
+is run
 !< Namelist variables
 integer :: ncchksz = 64*1024  !< User defined chunksize (in bytes) argument in netcdf file 
                               !! creation calls. Replaces setting the NC_CHKSZ environment variable.
@@ -223,6 +226,8 @@ contains
 subroutine fms2_io_init ()
 
 integer :: mystat
+ call mpp_init()
+ call mpp_domains_init()
 !> Read the namelist
 READ (input_nml_file, NML=fms2_io_nml, IOSTAT=mystat)
 
@@ -232,6 +237,8 @@ READ (input_nml_file, NML=fms2_io_nml, IOSTAT=mystat)
   endif
   call netcdf_io_init (ncchksz)
   call blackboxio_init (ncchksz)
+
+  fms2_io_is_initialized = .true.
 end subroutine fms2_io_init
 
 

--- a/fms2_io/fms2_io.F90
+++ b/fms2_io/fms2_io.F90
@@ -81,7 +81,7 @@ public :: is_registered_to_restart
 public :: check_if_open
 public :: set_fileobj_time_name
 public :: is_dimension_registered
-
+public :: fms2_io_init
 
 interface open_file
   module procedure netcdf_file_open_wrap
@@ -209,6 +209,26 @@ interface read_new_restart
   module procedure netcdf_restore_state_wrap
   module procedure restore_domain_state_wrap
 end interface read_new_restart
+
+!< Namelist variables
+integer :: ncchksz = 1*1024*1024 !< User defined chunksize argument in netcdf file creation calls.
+                                 !! Replaces setting the NC_CHKSZ environment variable.
+namelist / fms2_io_nml / &
+                      ncchksz
+
+contains
+
+!> @brief Reads the fms2_io_nml
+subroutine fms2_io_init ()
+
+integer :: mystat
+!> Read the namelist
+READ (input_nml_file, NML=fms2_io_nml, IOSTAT=mystat)
+
+!>Send the namelist variables to their respective modules
+  call netcdf_io_init (ncchksz)
+  call blackboxio_init (ncchksz)
+end subroutine fms2_io_init
 
 
 end module fms2_io_mod

--- a/fms2_io/fms2_io.F90
+++ b/fms2_io/fms2_io.F90
@@ -228,7 +228,7 @@ READ (input_nml_file, NML=fms2_io_nml, IOSTAT=mystat)
 
 !>Send the namelist variables to their respective modules
   if (ncchksz .le. 0) then
-        call mpp_error("ncchksz in fms2_io_nml must be a positive number.",FATAL) 
+        call mpp_error(FATAL, "ncchksz in fms2_io_nml must be a positive number.")
   endif
   call netcdf_io_init (ncchksz)
   call blackboxio_init (ncchksz)

--- a/fms2_io/fms2_io.F90
+++ b/fms2_io/fms2_io.F90
@@ -26,7 +26,7 @@ use netcdf_io_mod
 use fms_netcdf_domain_io_mod
 use fms_netcdf_unstructured_domain_io_mod
 use blackboxio
-use mpp_mod, only: input_nml_file
+use mpp_mod, only: input_nml_file, mpp_error, FATAL
 implicit none
 private
 
@@ -212,8 +212,8 @@ interface read_new_restart
 end interface read_new_restart
 
 !< Namelist variables
-integer :: ncchksz = 1*1024*1024 !< User defined chunksize argument in netcdf file creation calls.
-                                 !! Replaces setting the NC_CHKSZ environment variable.
+integer :: ncchksz = 64*1024  !< User defined chunksize (in bytes) argument in netcdf file 
+                              !! creation calls. Replaces setting the NC_CHKSZ environment variable.
 namelist / fms2_io_nml / &
                       ncchksz
 
@@ -227,6 +227,9 @@ integer :: mystat
 READ (input_nml_file, NML=fms2_io_nml, IOSTAT=mystat)
 
 !>Send the namelist variables to their respective modules
+  if (ncchksz .le. 0) then
+        call mpp_error("ncchksz in fms2_io_nml must be a positive number.",FATAL) 
+  endif
   call netcdf_io_init (ncchksz)
   call blackboxio_init (ncchksz)
 end subroutine fms2_io_init

--- a/fms2_io/fms2_io.F90
+++ b/fms2_io/fms2_io.F90
@@ -26,6 +26,7 @@ use netcdf_io_mod
 use fms_netcdf_domain_io_mod
 use fms_netcdf_unstructured_domain_io_mod
 use blackboxio
+use mpp_mod, only: input_nml_file
 implicit none
 private
 

--- a/fms2_io/netcdf_io.F90
+++ b/fms2_io/netcdf_io.F90
@@ -44,7 +44,7 @@ integer, parameter, public :: unlimited = nf90_unlimited !> Wrapper to specify u
 integer, parameter :: dimension_not_found = 0
 integer, parameter, public :: max_num_compressed_dims = 10 !> Maximum number of compressed
                                                            !! dimensions allowed.
-integer, private :: fms2_ncchksz = 1*1024*1024 !< Chunksize used in nc_open and nc_create
+integer, private :: fms2_ncchksz = -1 !< Chunksize (bytes) used in nc_open and nc_create
 
 !> @brief Restart variable.
 type :: RestartVariable_t
@@ -486,6 +486,7 @@ function netcdf_file_open(fileobj, path, mode, nc_format, pelist, is_restart) &
       endif
       call string_copy(fileobj%nc_format, nc_format)
     endif
+    if (fms2_ncchksz == -1) error("netcdf_file_open:: fms2_ncchksz not set.")
     if (string_compare(mode, "read", .true.)) then
       err = nf90_open(trim(fileobj%path), nf90_nowrite, fileobj%ncid, chunksize=fms2_ncchksz)
     elseif (string_compare(mode, "append", .true.)) then

--- a/fms2_io/netcdf_io.F90
+++ b/fms2_io/netcdf_io.F90
@@ -486,7 +486,7 @@ function netcdf_file_open(fileobj, path, mode, nc_format, pelist, is_restart) &
       endif
       call string_copy(fileobj%nc_format, nc_format)
     endif
-    if (fms2_ncchksz == -1) error("netcdf_file_open:: fms2_ncchksz not set.")
+    if (fms2_ncchksz == -1) call error("netcdf_file_open:: fms2_ncchksz not set.")
     if (string_compare(mode, "read", .true.)) then
       err = nf90_open(trim(fileobj%path), nf90_nowrite, fileobj%ncid, chunksize=fms2_ncchksz)
     elseif (string_compare(mode, "append", .true.)) then

--- a/fms2_io/netcdf_io.F90
+++ b/fms2_io/netcdf_io.F90
@@ -44,7 +44,7 @@ integer, parameter, public :: unlimited = nf90_unlimited !> Wrapper to specify u
 integer, parameter :: dimension_not_found = 0
 integer, parameter, public :: max_num_compressed_dims = 10 !> Maximum number of compressed
                                                            !! dimensions allowed.
-
+integer, private :: fms2_ncchksz = 1*1024*1024 !< Chunksize used in nc_open and nc_create
 
 !> @brief Restart variable.
 type :: RestartVariable_t
@@ -111,6 +111,7 @@ type, public :: Valid_t
 endtype Valid_t
 
 
+public :: netcdf_io_init
 public :: netcdf_file_open
 public :: netcdf_file_close
 public :: netcdf_add_dimension
@@ -243,6 +244,11 @@ end interface get_variable_attribute
 
 contains
 
+!> @brief Accepts the namelist fms2_io_nml variables relevant to netcdf_io_mod
+subroutine netcdf_io_init (chksz)
+integer, intent(in) :: chksz
+ fms2_ncchksz = chksz
+end subroutine netcdf_io_init
 
 !> @brief Check for errors returned by netcdf.
 !! @internal
@@ -481,13 +487,13 @@ function netcdf_file_open(fileobj, path, mode, nc_format, pelist, is_restart) &
       call string_copy(fileobj%nc_format, nc_format)
     endif
     if (string_compare(mode, "read", .true.)) then
-      err = nf90_open(trim(fileobj%path), nf90_nowrite, fileobj%ncid)
+      err = nf90_open(trim(fileobj%path), nf90_nowrite, fileobj%ncid, chunksize=fms2_ncchksz)
     elseif (string_compare(mode, "append", .true.)) then
-      err = nf90_open(trim(fileobj%path), nf90_write, fileobj%ncid)
+      err = nf90_open(trim(fileobj%path), nf90_write, fileobj%ncid, chunksize=fms2_ncchksz)
     elseif (string_compare(mode, "write", .true.)) then
-      err = nf90_create(trim(fileobj%path), ior(nf90_noclobber, nc_format_param), fileobj%ncid)
+      err = nf90_create(trim(fileobj%path), ior(nf90_noclobber, nc_format_param), fileobj%ncid, chunksize=fms2_ncchksz)
     elseif (string_compare(mode,"overwrite",.true.)) then
-      err = nf90_create(trim(fileobj%path), ior(nf90_clobber, nc_format_param), fileobj%ncid)
+      err = nf90_create(trim(fileobj%path), ior(nf90_clobber, nc_format_param), fileobj%ncid, chunksize=fms2_ncchksz)
     else
       call error("unrecognized file mode "//trim(mode)//".")
     endif


### PR DESCRIPTION
**Description**
mpp_io reads an environment variable that sets the `chunksize` in `nf_open` and `nf_create` calls. This PR changes setting this variable in the fms2_io namelist.

Fixes #371 
Replaces #372 

**How Has This Been Tested?**
Passes `make distcheck`

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes
