### PR TITLE
added platform to some include paths

### DIFF
--- a/coupler/Makefile.am
+++ b/coupler/Makefile.am
@@ -30,6 +30,7 @@ AM_CPPFLAGS += -I${top_builddir}/time_manager
 AM_CPPFLAGS += -I${top_builddir}/diag_manager
 AM_CPPFLAGS += -I${top_builddir}/data_override
 AM_CPPFLAGS += -I${top_builddir}/field_manager
+AM_CPPFLAGS += -I${top_builddir}/platform
 
 # Build these uninstalled convenience libraries.
 noinst_LTLIBRARIES = libcoupler_types.la libensemble_manager.la \

--- a/exchange/Makefile.am
+++ b/exchange/Makefile.am
@@ -31,6 +31,7 @@ AM_CPPFLAGS += -I${top_builddir}/diag_manager
 AM_CPPFLAGS += -I${top_builddir}/constants
 AM_CPPFLAGS += -I${top_builddir}/mosaic
 AM_CPPFLAGS += -I${top_builddir}/fms2_io
+AM_CPPFLAGS += -I${top_builddir}/platform
 
 # Build these uninstalled convenience libraries.
 noinst_LTLIBRARIES = libstock_constants.la libxgrid.la

--- a/interpolator/Makefile.am
+++ b/interpolator/Makefile.am
@@ -32,6 +32,7 @@ AM_CPPFLAGS += -I${top_builddir}/time_manager
 AM_CPPFLAGS += -I${top_builddir}/time_interp
 AM_CPPFLAGS += -I${top_builddir}/constants
 AM_CPPFLAGS += -I${top_builddir}/fms2_io
+AM_CPPFLAGS += -I${top_builddir}/platform
 
 # Build this uninstalled convenience library.
 noinst_LTLIBRARIES = libinterpolator.la

--- a/test_fms/data_override/Makefile.am
+++ b/test_fms/data_override/Makefile.am
@@ -30,7 +30,8 @@ AM_CPPFLAGS = -I${top_srcdir}/include \
   -I${top_builddir}/constants \
   -I${top_builddir}/time_manager \
   -I${top_builddir}/diag_manager \
-  -I${top_builddir}/data_override
+  -I${top_builddir}/data_override \
+  -I${top_builddir}/platform
 
 # Link to the FMS library.
 LDADD = ${top_builddir}/libFMS/libFMS.la

--- a/test_fms/diag_manager/Makefile.am
+++ b/test_fms/diag_manager/Makefile.am
@@ -28,7 +28,8 @@ AM_CPPFLAGS = -I${top_srcdir}/include \
   -I${top_builddir}/axis_utils \
   -I${top_builddir}/diag_manager \
   -I${top_builddir}/time_manager \
-  -I${top_builddir}/constants
+  -I${top_builddir}/constants \
+  -I${top_builddir}/platform
 
 # Link to the FMS library.
 LDADD = ${top_builddir}/libFMS/libFMS.la

--- a/test_fms/interpolator/Makefile.am
+++ b/test_fms/interpolator/Makefile.am
@@ -26,7 +26,7 @@
 AM_CPPFLAGS = -I${top_builddir}/mpp -I${top_builddir}/fms	\
 -I${top_builddir}/time_manager -I${top_builddir}/diag_manager	\
 -I${top_builddir}/interpolator -I${top_builddir}/constants	\
--I${top_builddir}/time_interp
+-I${top_builddir}/time_interp -I${top_builddir}/platform
 
 # Link to the FMS library.
 LDADD = ${top_builddir}/libFMS/libFMS.la


### PR DESCRIPTION
**Description**
Fixes #386 
This just adds platform to `AM_CPPFLAGS` for some of the Makefile.am 

**How Has This Been Tested?**
GAEA with intel: 
```
module load fre/test
module load cray-hdf5
 ./configure FC=ftn CC=cc FCFLAGS="-g -O0 -qopenmp " CFLAGS="-g -O0 -qopenmp "
make
```

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

