### PR TITLE
Adds the netcdf buffer as a namelist and uses it in nf90_enddef

### DIFF
--- a/fms2_io/fms2_io.F90
+++ b/fms2_io/fms2_io.F90
@@ -216,8 +216,11 @@ logical, private :: fms2_io_is_initialized = .false. !< True after fms2_io_init 
 !< Namelist variables
 integer :: ncchksz = 64*1024  !< User defined chunksize (in bytes) argument in netcdf file 
                               !! creation calls. Replaces setting the NC_CHKSZ environment variable.
+
+integer :: header_buffer_val = 16384 !< Use defined netCDF header buffer size (in bytes) used in
+                                     !! NF__ENDDEF
 namelist / fms2_io_nml / &
-                      ncchksz
+                      ncchksz, header_buffer_val
 
 contains
 
@@ -236,7 +239,10 @@ subroutine fms2_io_init ()
   if (ncchksz .le. 0) then
         call mpp_error(FATAL, "ncchksz in fms2_io_nml must be a positive number.")
   endif
-  call netcdf_io_init (ncchksz)
+  if (header_buffer_val .le. 0) then
+        call mpp_error(FATAL, "header_buffer_val in fms2_io_nml must be a positive number.")
+  endif
+  call netcdf_io_init (ncchksz, header_buffer_val)
   call blackboxio_init (ncchksz)
 !> Mark the fms2_io as initialized 
   fms2_io_is_initialized = .true.

--- a/fms2_io/netcdf_io.F90
+++ b/fms2_io/netcdf_io.F90
@@ -45,6 +45,7 @@ integer, parameter :: dimension_not_found = 0
 integer, parameter, public :: max_num_compressed_dims = 10 !> Maximum number of compressed
                                                            !! dimensions allowed.
 integer, private :: fms2_ncchksz = -1 !< Chunksize (bytes) used in nc_open and nc_create
+integer, private :: fms2_header_buffer_val = 16384  !< value used in NF__ENDDEF
 
 !> @brief Restart variable.
 type :: RestartVariable_t
@@ -245,9 +246,12 @@ end interface get_variable_attribute
 contains
 
 !> @brief Accepts the namelist fms2_io_nml variables relevant to netcdf_io_mod
-subroutine netcdf_io_init (chksz)
+subroutine netcdf_io_init (chksz, header_buffer_val)
 integer, intent(in) :: chksz
+integer, intent(in) :: header_buffer_val
+
  fms2_ncchksz = chksz
+ fms2_header_buffer_val = header_buffer_val
 end subroutine netcdf_io_init
 
 !> @brief Check for errors returned by netcdf.
@@ -280,7 +284,7 @@ subroutine set_netcdf_mode(ncid, mode)
       return
     endif
   elseif (mode .eq. data_mode) then
-    err = nf90_enddef(ncid)
+    err = nf90_enddef(ncid, h_minfree=fms2_header_buffer_val)
     if (err .eq. nf90_enotindefine .or. err .eq. nf90_eperm) then
       return
     endif


### PR DESCRIPTION
**Description**
This allows the user to specify the netcdf metadata header size through the fms2io namelist, if a namelist is not specified it uses the default value of 16kb. 

Fixes #394 

**How Has This Been Tested?**
My unit test and Travis CI. Needs more testing ... 

**Checklist:**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
- [X] New check tests, if applicable, are included
- [X] `make distcheck` passes

