### PR TITLE
Change write_restart to write out all meta_data before data

### DIFF
--- a/fms2_io/fms_netcdf_domain_io.F90
+++ b/fms2_io/fms_netcdf_domain_io.F90
@@ -546,16 +546,14 @@ subroutine save_domain_restart(fileobj, unlim_dim_level)
   if (.not. fileobj%is_restart) then
     call error("file "//trim(fileobj%path)//" is not a restart file.")
   endif
+
+! Calculate the checksum and write it out
   do i = 1, fileobj%num_restart_vars
     if (associated(fileobj%restart_vars(i)%data0d)) then
-      call domain_write_0d(fileobj, fileobj%restart_vars(i)%varname, &
-                           fileobj%restart_vars(i)%data0d, unlim_dim_level=unlim_dim_level)
+       cycle
     elseif (associated(fileobj%restart_vars(i)%data1d)) then
-      call domain_write_1d(fileobj, fileobj%restart_vars(i)%varname, &
-                           fileobj%restart_vars(i)%data1d, unlim_dim_level=unlim_dim_level)
+       cycle
     elseif (associated(fileobj%restart_vars(i)%data2d)) then
-      call domain_write_2d(fileobj, fileobj%restart_vars(i)%varname, &
-                           fileobj%restart_vars(i)%data2d, unlim_dim_level=unlim_dim_level)
       chksum = compute_global_checksum(fileobj, fileobj%restart_vars(i)%varname, &
                                        fileobj%restart_vars(i)%data2d, is_decomposed)
       if (is_decomposed) then
@@ -563,8 +561,6 @@ subroutine save_domain_restart(fileobj, unlim_dim_level)
                                          "checksum", chksum)
       endif
     elseif (associated(fileobj%restart_vars(i)%data3d)) then
-      call domain_write_3d(fileobj, fileobj%restart_vars(i)%varname, &
-                           fileobj%restart_vars(i)%data3d, unlim_dim_level=unlim_dim_level)
       chksum = compute_global_checksum(fileobj, fileobj%restart_vars(i)%varname, &
                                        fileobj%restart_vars(i)%data3d, is_decomposed)
       if (is_decomposed) then
@@ -572,8 +568,6 @@ subroutine save_domain_restart(fileobj, unlim_dim_level)
                                          "checksum", chksum)
       endif
     elseif (associated(fileobj%restart_vars(i)%data4d)) then
-      call domain_write_4d(fileobj, fileobj%restart_vars(i)%varname, &
-                           fileobj%restart_vars(i)%data4d, unlim_dim_level=unlim_dim_level)
       chksum = compute_global_checksum(fileobj, fileobj%restart_vars(i)%varname, &
                                        fileobj%restart_vars(i)%data4d, is_decomposed)
       if (is_decomposed) then
@@ -584,6 +578,29 @@ subroutine save_domain_restart(fileobj, unlim_dim_level)
       call error("this branch should not be reached.")
     endif
   enddo
+
+! Write out all of the data
+  do i = 1, fileobj%num_restart_vars
+    if (associated(fileobj%restart_vars(i)%data0d)) then
+      call domain_write_0d(fileobj, fileobj%restart_vars(i)%varname, &
+                           fileobj%restart_vars(i)%data0d, unlim_dim_level=unlim_dim_level)
+    elseif (associated(fileobj%restart_vars(i)%data1d)) then
+      call domain_write_1d(fileobj, fileobj%restart_vars(i)%varname, &
+                           fileobj%restart_vars(i)%data1d, unlim_dim_level=unlim_dim_level)
+    elseif (associated(fileobj%restart_vars(i)%data2d)) then
+      call domain_write_2d(fileobj, fileobj%restart_vars(i)%varname, &
+                           fileobj%restart_vars(i)%data2d, unlim_dim_level=unlim_dim_level)
+    elseif (associated(fileobj%restart_vars(i)%data3d)) then
+      call domain_write_3d(fileobj, fileobj%restart_vars(i)%varname, &
+                           fileobj%restart_vars(i)%data3d, unlim_dim_level=unlim_dim_level)
+    elseif (associated(fileobj%restart_vars(i)%data4d)) then
+      call domain_write_4d(fileobj, fileobj%restart_vars(i)%varname, &
+                           fileobj%restart_vars(i)%data4d, unlim_dim_level=unlim_dim_level)
+    else
+      call error("this branch should not be reached.")
+    endif
+  enddo
+
 end subroutine save_domain_restart
 
 

--- a/fms2_io/fms_netcdf_domain_io.F90
+++ b/fms2_io/fms_netcdf_domain_io.F90
@@ -563,7 +563,7 @@ subroutine save_domain_restart(fileobj, unlim_dim_level)
         call register_variable_attribute(fileobj, fileobj%restart_vars(i)%varname, &
                                          "checksum", chksum)
       endif
-    else (associated(fileobj%restart_vars(i)%data4d)) then
+    elseif (associated(fileobj%restart_vars(i)%data4d)) then
       chksum = compute_global_checksum(fileobj, fileobj%restart_vars(i)%varname, &
                                        fileobj%restart_vars(i)%data4d, is_decomposed)
       if (is_decomposed) then

--- a/fms2_io/fms_netcdf_domain_io.F90
+++ b/fms2_io/fms_netcdf_domain_io.F90
@@ -547,7 +547,7 @@ subroutine save_domain_restart(fileobj, unlim_dim_level)
     call error("file "//trim(fileobj%path)//" is not a restart file.")
   endif
 
-! Calculate the checksum and write it out
+! Calculate the variable's checksum and write it to the netcdf file
   do i = 1, fileobj%num_restart_vars
     if (associated(fileobj%restart_vars(i)%data2d)) then
       chksum = compute_global_checksum(fileobj, fileobj%restart_vars(i)%varname, &
@@ -573,7 +573,7 @@ subroutine save_domain_restart(fileobj, unlim_dim_level)
     endif
   enddo
 
-! Write out all of the data
+! Write the variable's data to the netcdf file
   do i = 1, fileobj%num_restart_vars
     if (associated(fileobj%restart_vars(i)%data0d)) then
       call domain_write_0d(fileobj, fileobj%restart_vars(i)%varname, &
@@ -591,7 +591,7 @@ subroutine save_domain_restart(fileobj, unlim_dim_level)
       call domain_write_4d(fileobj, fileobj%restart_vars(i)%varname, &
                            fileobj%restart_vars(i)%data4d, unlim_dim_level=unlim_dim_level)
     else
-      call error("save_domain_restart: this branch should not be reached.")
+      call error("This routine only accepts data that is scalar, 1d 2d 3d or 4d.  The data sent in has an unsupported dimensionality")
     endif
   enddo
 

--- a/fms2_io/fms_netcdf_domain_io.F90
+++ b/fms2_io/fms_netcdf_domain_io.F90
@@ -549,9 +549,7 @@ subroutine save_domain_restart(fileobj, unlim_dim_level)
 
 ! Calculate the checksum and write it out
   do i = 1, fileobj%num_restart_vars
-    if (associated(fileobj%restart_vars(i)%data0d)) then
-       cycle
-    elseif (associated(fileobj%restart_vars(i)%data1d)) then
+    if (associated(fileobj%restart_vars(i)%data0d) .and. associated(fileobj%restart_vars(i)%data1d)) then
        cycle
     elseif (associated(fileobj%restart_vars(i)%data2d)) then
       chksum = compute_global_checksum(fileobj, fileobj%restart_vars(i)%varname, &
@@ -575,7 +573,7 @@ subroutine save_domain_restart(fileobj, unlim_dim_level)
                                          "checksum", chksum)
       endif
     else
-      call error("this branch should not be reached.")
+      call error("save_domain_restart: this branch should not be reached.")
     endif
   enddo
 
@@ -597,7 +595,7 @@ subroutine save_domain_restart(fileobj, unlim_dim_level)
       call domain_write_4d(fileobj, fileobj%restart_vars(i)%varname, &
                            fileobj%restart_vars(i)%data4d, unlim_dim_level=unlim_dim_level)
     else
-      call error("this branch should not be reached.")
+      call error("save_domain_restart: this branch should not be reached.")
     endif
   enddo
 

--- a/fms2_io/fms_netcdf_domain_io.F90
+++ b/fms2_io/fms_netcdf_domain_io.F90
@@ -549,9 +549,7 @@ subroutine save_domain_restart(fileobj, unlim_dim_level)
 
 ! Calculate the checksum and write it out
   do i = 1, fileobj%num_restart_vars
-    if (associated(fileobj%restart_vars(i)%data0d) .and. associated(fileobj%restart_vars(i)%data1d)) then
-       cycle
-    elseif (associated(fileobj%restart_vars(i)%data2d)) then
+    if (associated(fileobj%restart_vars(i)%data2d)) then
       chksum = compute_global_checksum(fileobj, fileobj%restart_vars(i)%varname, &
                                        fileobj%restart_vars(i)%data2d, is_decomposed)
       if (is_decomposed) then
@@ -565,15 +563,13 @@ subroutine save_domain_restart(fileobj, unlim_dim_level)
         call register_variable_attribute(fileobj, fileobj%restart_vars(i)%varname, &
                                          "checksum", chksum)
       endif
-    elseif (associated(fileobj%restart_vars(i)%data4d)) then
+    else (associated(fileobj%restart_vars(i)%data4d)) then
       chksum = compute_global_checksum(fileobj, fileobj%restart_vars(i)%varname, &
                                        fileobj%restart_vars(i)%data4d, is_decomposed)
       if (is_decomposed) then
         call register_variable_attribute(fileobj, fileobj%restart_vars(i)%varname, &
                                          "checksum", chksum)
       endif
-    else
-      call error("save_domain_restart: this branch should not be reached.")
     endif
   enddo
 


### PR DESCRIPTION
**Description**
write_restart now loops through the restart_variables, calculates the checksum and writes out the metadata. Then it loops through the restart_variables (again!) and writes out the data. 

Fixes #396 

**How Has This Been Tested?**
I have a "unit" tests that writes a restart, using `write_restart` that has two restart variables (on a cube sphere grid), and I used Darshan to analyze performance. 

If I run it with current master, for each *tileX.nc file, Darshan outputs: 
`POSIX_BYTES_WRITTEN     8852488`

even though the size of the file is `4425424`

Data is in: /lustre/f2/darshan/2020/4/27/Uriel.Ra_current_master_id62720_4-27-56196-18121498855530832921_1.darshan

If you run it with this fix, for each *tileX.nc file, Darshan outputs: 
`POSIX_BYTES_WRITTEN     4427172`

The file created from current master and from this fix is exactly the same. 

**Checklist:**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
- [X] New check tests, if applicable, are included
- [X] `make distcheck` passes

