### PR TITLE
Fix for get_ascii_file_num_lines issue

### DIFF
--- a/mpp/include/mpp_util.inc
+++ b/mpp/include/mpp_util.inc
@@ -1410,7 +1410,7 @@ end function rarray_to_char
              call mpp_error(FATAL, 'get_ascii_file_num_lines: Error opening file:' //trim(FILENAME)// &
                             '.  (IOSTAT = '//trim(text)//')')
           else
-             num_lines = 1
+             num_lines = 0
              do
                 read (UNIT=f_unit, FMT='(A)', IOSTAT=status) str_tmp
                 if ( status .lt. 0 ) exit


### PR DESCRIPTION
Changed num_lines starting value to 0 from 1 to avoid miscount in the get_ascii_file_num_lines function in mpp.

**Description**
This PR addresses the miscount shown in #399 by setting the initial value of `num_lines` in the function `get_ascii_file_num_lines` to 0 (the previous value was 1).

Fixes #399 

**How Has This Been Tested?**
Makes the unit test that I've written for the get_ascii_file_num_lines function pass instead of fail, as it now outputs the correct number of lines for a file with a known line count. n.b. that unit test will be submitted in a future PR

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [ ] `make distcheck` passes

