### PR TITLE
One line change to enable 3D Data Override

### DIFF
--- a/time_interp/time_interp_external2.F90
+++ b/time_interp/time_interp_external2.F90
@@ -479,7 +479,7 @@ module time_interp_external2_mod
             endif
          case ('Z')
             field(num_fields)%axisname(3) = axisname(j)
-            field(num_fields)%siz(3) = siz_in(3)
+            field(num_fields)%siz(3) = len
          case ('T')
             field(num_fields)%axisname(4) = axisname(j)
             field(num_fields)%siz(4) = ntime


### PR DESCRIPTION
**Description**
One line change to enable 3D Data Override. The number of vertical levels has been hardcoded to 1 in time_interp_external2. This allows for the override of an equal number of vertical levels as the variable contains (note that no vertical interpolation is done in Data Override).

Fixes #235 

**How Has This Been Tested?**
Tested with test_fms/data_override tests (not included in this PR) to ensure the values are being overwritten correctly.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

