### PR TITLE
updates fv3fgfs make.rules and makefile

### DIFF
--- a/fv3gfs/make.rules
+++ b/fv3gfs/make.rules
@@ -1,21 +1,21 @@
-/***********************************************************************
- *                   GNU Lesser General Public License
- *
- * This file is part of the GFDL Flexible Modeling System (FMS).
- *
- * FMS is free software: you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or (at
- * your option) any later version.
- *
- * FMS is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- * for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
- **********************************************************************/
+#***********************************************************************
+#*                   GNU Lesser General Public License
+#*
+#* This file is part of the GFDL Flexible Modeling System (FMS).
+#*
+#* FMS is free software: you can redistribute it and/or modify it under
+#* the terms of the GNU Lesser General Public License as published by
+#* the Free Software Foundation, either version 3 of the License, or (at
+#* your option) any later version.
+#*
+#* FMS is distributed in the hope that it will be useful, but WITHOUT
+#* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+#* for more details.
+#*
+#* You should have received a copy of the GNU Lesser General Public
+#* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
+#**********************************************************************
 
 .SUFFIXES:
 .SUFFIXES: .F90 .f90 .F .f .o .c

--- a/fv3gfs/makefile
+++ b/fv3gfs/makefile
@@ -25,7 +25,7 @@ include ../../NEMS/src/conf/configure.nems
 LIBRARY  = libfms.a
 FMS_INSTALL=$(realpath $(PWD)/..)/FMS_INSTALL
 
-FFLAGS   += -I../include -I../mpp/include -I../fms
+FFLAGS   += -I../include -I../mpp/include -I../fms -I../fms2_io/include
 
 SRCS_f   =
 


### PR DESCRIPTION
**Description**
Updated make.rules in fv3gfs directory for the license header to have the correct comment delimiter character.
Adds fms2_io/include to the include search path.

Fixes #416 

**How Has This Been Tested?**
Compile test was run using the ufs-weather-model regression test system.

**Checklist:**
- [X] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

