### PR TITLE
Adds test_system_clock unit test

### DIFF
--- a/test_fms/mpp/Makefile.am
+++ b/test_fms/mpp/Makefile.am
@@ -71,4 +71,4 @@ EXTRA_DIST = input_base.nml \
   test_system_clock.sh
 
 # Clean up
-CLEANFILES = input.nml *.out*
+CLEANFILES = include_files_mod.mod input.nml *.out* 

--- a/test_fms/mpp/Makefile.am
+++ b/test_fms/mpp/Makefile.am
@@ -71,4 +71,4 @@ EXTRA_DIST = input_base.nml \
   test_system_clock.sh
 
 # Clean up
-CLEANFILES = include_files_mod.mod input.nml *.out* 
+CLEANFILES = include_files_mod.mod input.nml *.out*

--- a/test_fms/mpp/Makefile.am
+++ b/test_fms/mpp/Makefile.am
@@ -37,7 +37,8 @@ check_PROGRAMS = test_mpp \
   test_mpp_print_memuse_stats_stderr \
   test_mpp_print_memuse_stats_file \
   test_mpp_memutils_begin_2x \
-  test_mpp_memutils_end_before_begin
+  test_mpp_memutils_end_before_begin \
+  test_system_clock
 
 # These are the sources for the tests.
 test_mpp_SOURCES = test_mpp.F90
@@ -50,6 +51,7 @@ test_mpp_print_memuse_stats_stderr_SOURCES=test_mpp_print_memuse_stats_stderr.F9
 test_mpp_print_memuse_stats_file_SOURCES=test_mpp_print_memuse_stats_file.F90
 test_mpp_memutils_begin_2x_SOURCES=test_mpp_memutils_begin_2x.F90
 test_mpp_memutils_end_before_begin_SOURCES=test_mpp_memutils_end_before_begin.F90
+test_system_clock_SOURCES=test_system_clock.F90
 
 # Run the test programs.
 TESTS = test_mpp_domains2.sh \
@@ -57,14 +59,16 @@ TESTS = test_mpp_domains2.sh \
   test_mpp2.sh \
   test_mpp_memuse \
   test_mpp_mem_dump \
-  test_mpp_memutils_mod.sh
+  test_mpp_memutils_mod.sh \
+  test_system_clock.sh
 
 # These files will also be included in the distribution.
 EXTRA_DIST = input_base.nml \
   test_mpp_domains2.sh \
   test_mpp_pset2.sh	\
   test_mpp2.sh \
-  test_mpp_memutils_mod.sh
+  test_mpp_memutils_mod.sh \
+  test_system_clock.sh
 
 # Clean up
 CLEANFILES = input.nml *.out*

--- a/test_fms/mpp/test_system_clock.F90
+++ b/test_fms/mpp/test_system_clock.F90
@@ -1,0 +1,42 @@
+!***********************************************************************
+!*                   GNU Lesser General Public License
+!*
+!* This file is part of the GFDL Flexible Modeling System (FMS).
+!*
+!* FMS is free software: you can redistribute it and/or modify it under
+!* the terms of the GNU Lesser General Public License as published by
+!* the Free Software Foundation, either version 3 of the License, or (at
+!* your option) any later version.
+!*
+!* FMS is distributed in the hope that it will be useful, but WITHOUT
+!* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+!* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+!* for more details.
+!*
+!* You should have received a copy of the GNU Lesser General Public
+!* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
+!***********************************************************************
+!> @author Lauren Chilutti
+!> @description This test program is for testing the system_clock
+!! routine.  The test initializes mpp, then calls the function 
+!! SYSTEM_CLOCK.  SYSTEM_CLOCK returns COUNT, COUNT_RATE, and/or 
+!! COUNT_MAX (all optional). 
+program test_system_clock
+#include <system_clock.h>
+  use mpp_mod, only : mpp_init, mpp_exit, stderr, stdout, mpp_error, FATAL
+  use mpp_mod, only : input_nml_file
+  implicit none
+
+  integer :: count, count_rate, count_max, mpicount, mpicount_rate, mpicount_max
+
+  call SYSTEM_CLOCK(count, count_rate, count_max)
+  if (count < count_max) then
+    call mpp_error(FATAL, "SYSTEM_CLOCK returns a count that is greater than count_max"
+  endif
+  write(*,*) count, count_rate, count_max
+
+  call mpp_init()  
+  call SYSTEM_CLOCK(mpicount, mpicount_rate,mpicount_max)
+  write(*,*) mpicount, mpicount_rate, mpicount_max
+  call mpp_exit()
+end program test_system_clock

--- a/test_fms/mpp/test_system_clock.F90
+++ b/test_fms/mpp/test_system_clock.F90
@@ -16,8 +16,11 @@
 !* You should have received a copy of the GNU Lesser General Public
 !* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
 !***********************************************************************
-!> @author Lauren Chilutti
-!> @description This test program is for testing the system_clock
+!> @file
+!! @author Lauren Chilutti
+!! @brief Test program for the system_clock routine.
+!! @email gfdl.climate.model.info@noaa.gov
+!! @description This test program is for testing the system_clock
 !! routine.  The test initializes mpp, then calls the function
 !! SYSTEM_CLOCK twice.  SYSTEM_CLOCK returns COUNT, COUNT_RATE, and/or
 !! COUNT_MAX (all optional).  This test returns errors if COUNT,

--- a/test_fms/mpp/test_system_clock.F90
+++ b/test_fms/mpp/test_system_clock.F90
@@ -38,12 +38,13 @@ end module include_files_mod
 
 program test_system_clock
   use include_files_mod
-  use mpp_mod, only : mpp_init, mpp_exit, stderr, stdout, mpp_error, FATAL
+  use mpp_mod, only : mpp_init, mpp_init_test_init_true_only, stderr, stdout, mpp_error, FATAL
   implicit none
 
   integer(LONG_KIND) :: count1, count_rate1, count_max1, count2, count_rate2, count_max2
+  integer :: ierr
 !> Initialize mpp
-  call mpp_init() 
+  call mpp_init(test_level=mpp_init_test_init_true_only) 
 !> Call system_clock and ensure output is not undefined
   call system_clock(count1, count_rate1, count_max1)
   write(*,*) count1, count_rate1, count_max1
@@ -66,5 +67,5 @@ program test_system_clock
   if (count_max1 .ne. count_max2) then
     call mpp_error(FATAL, "count maxes are not equal")
   endif
-  call mpp_exit()
+  call MPI_FINALIZE(ierr)
 end program test_system_clock

--- a/test_fms/mpp/test_system_clock.F90
+++ b/test_fms/mpp/test_system_clock.F90
@@ -18,25 +18,50 @@
 !***********************************************************************
 !> @author Lauren Chilutti
 !> @description This test program is for testing the system_clock
-!! routine.  The test initializes mpp, then calls the function 
-!! SYSTEM_CLOCK.  SYSTEM_CLOCK returns COUNT, COUNT_RATE, and/or 
-!! COUNT_MAX (all optional). 
+!! routine.  The test initializes mpp, then calls the function
+!! SYSTEM_CLOCK twice.  SYSTEM_CLOCK returns COUNT, COUNT_RATE, and/or
+!! COUNT_MAX (all optional).  This test returns errors if COUNT,
+!! COUNT_RATE, and/or COUNT_MAX are undefined, if the COUNT is
+!! greater than COUNT_MAX, that the second call returns the
+!! same value for COUNT_MAX and COUNT_RATE as the first call, and that
+!! the second call returns a COUNT value greater than that of the
+!! first call.
+module include_files_mod
+#include "../../include/fms_platform.h"
+  logical :: first_call_system_clock_mpi=.TRUE.
+contains
+#include "../../mpp/include/system_clock.h"
+end module include_files_mod
+
 program test_system_clock
-#include <system_clock.h>
+  use include_files_mod
   use mpp_mod, only : mpp_init, mpp_exit, stderr, stdout, mpp_error, FATAL
-  use mpp_mod, only : input_nml_file
   implicit none
 
-  integer :: count, count_rate, count_max, mpicount, mpicount_rate, mpicount_max
-
-  call SYSTEM_CLOCK(count, count_rate, count_max)
-  if (count < count_max) then
-    call mpp_error(FATAL, "SYSTEM_CLOCK returns a count that is greater than count_max"
+  integer(LONG_KIND) :: count1, count_rate1, count_max1, count2, count_rate2, count_max2
+!> Initialize mpp
+  call mpp_init() 
+!> Call system_clock and ensure output is not undefined
+  call system_clock(count1, count_rate1, count_max1)
+  write(*,*) count1, count_rate1, count_max1
+  call system_clock(count2, count_rate2, count_max2)
+  write(*,*) count2, count_rate2, count_max2
+!> Check that the count is less than the count_max
+  if (count1 .gt. count_max1) then
+    call mpp_error(FATAL, "SYSTEM_CLOCK returns a count that is greater than count_max")
   endif
-  write(*,*) count, count_rate, count_max
-
-  call mpp_init()  
-  call SYSTEM_CLOCK(mpicount, mpicount_rate,mpicount_max)
-  write(*,*) mpicount, mpicount_rate, mpicount_max
+  if (count2 > count_max2) then
+    call mpp_error(FATAL, "SYSTEM_CLOCK returns a count that is greater than count_max")
+  endif
+!> Check that the second call to system_clock function returns the same COUNT_MAX and COUNT_RATE, but a larger COUNT
+  if (count1 .gt. count2) then
+    call mpp_error(FATAL, "count2 is less than count1")
+  endif
+  if (count_rate1 .ne. count_rate2) then
+    call mpp_error(FATAL, "count rates are not equal")
+  endif
+  if (count_max1 .ne. count_max2) then
+    call mpp_error(FATAL, "count maxes are not equal")
+  endif
   call mpp_exit()
 end program test_system_clock

--- a/test_fms/mpp/test_system_clock.sh
+++ b/test_fms/mpp/test_system_clock.sh
@@ -22,7 +22,7 @@
 # This is part of the GFDL FMS package. This is a shell script to
 # execute tests in the test_fms/mpp directory.
 
-# Lauren Chilutti 04/30/2020
+# Lauren Chilutti 05/21/2020
 
 # Set common test settings.
 . ../test_common.sh

--- a/test_fms/mpp/test_system_clock.sh
+++ b/test_fms/mpp/test_system_clock.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+#***********************************************************************
+#                   GNU Lesser General Public License
+#
+# This file is part of the GFDL Flexible Modeling System (FMS).
+#
+# FMS is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or (at
+# your option) any later version.
+#
+# FMS is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
+#***********************************************************************
+
+# This is part of the GFDL FMS package. This is a shell script to
+# execute tests in the test_fms/mpp directory.
+
+# Lauren Chilutti 04/30/2020
+
+# Set common test settings.
+. ../test_common.sh
+
+# Run the test for one processor
+run_test test_system_clock 1


### PR DESCRIPTION
**Description**
Adds a unit test for [system_clock](https://github.com/NOAA-GFDL/FMS/blob/master/mpp/include/system_clock.h)

Fixes # (issue)

**How Has This Been Tested?**
Tested on Gaea using fre/bronx-16 and cray/hdf-5 modules with `make check`

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

