### PR TITLE
fms2io: add netcdf file type to namelist

### DIFF
--- a/diag_manager/diag_output.F90
+++ b/diag_manager/diag_output.F90
@@ -202,7 +202,7 @@ CONTAINS
      iF ( associated(mpp_get_io_domain(domain)) ) then
        fileob => fileobj
        if (.not.check_if_open(fileob)) call open_check(open_file(fileobj, trim(fname_no_tile)//".nc", "overwrite", &
-                            domain, nc_format="64bit", is_restart=.false.))
+                            domain, is_restart=.false.))
        fnum_domain = "2d" ! 2d domain
        file_unit = 2
      elSE !< No io domain, so every core is going to write its own file.
@@ -211,7 +211,7 @@ CONTAINS
        write(mype_string,'(I0.4)') mype
         if (.not.check_if_open(fileob)) then
                call open_check(open_file(fileobjND, trim(fname_no_tile)//".nc."//trim(mype_string), "overwrite", &
-                            nc_format="64bit", is_restart=.false.))
+                            is_restart=.false.))
         endif
        fnum_domain = "nd" ! no domain
        if (file_unit < 0) file_unit = 10
@@ -219,7 +219,7 @@ CONTAINS
     ELSE IF (domainU .NE. NULL_DOMAINUG) THEN
        fileob => fileobjU
        if (.not.check_if_open(fileob)) call open_check(open_file(fileobjU, trim(fname_no_tile)//".nc", "overwrite", &
-                            domainU, nc_format="64bit", is_restart=.false.))
+                            domainU, is_restart=.false.))
        fnum_domain = "ug" ! unstructured grid
        file_unit=3
     ELSE

--- a/diag_manager/diag_output.F90
+++ b/diag_manager/diag_output.F90
@@ -212,7 +212,6 @@ CONTAINS
         if (.not.check_if_open(fileob)) then
                call open_check(open_file(fileobjND, trim(fname_no_tile)//".nc."//trim(mype_string), "overwrite", &
                             is_restart=.false.))
-        endif
                !< For regional subaxis add the NumFilesInSet attribute, which is added by fms2_io for (other)
                !< domains with sufficient decomposition info. Note mppnccombine will work with an entry of zero.
                call register_global_attribute(fileobjND, "NumFilesInSet", 0)

--- a/fms2_io/fms2_io.F90
+++ b/fms2_io/fms2_io.F90
@@ -244,6 +244,7 @@ subroutine fms2_io_init ()
   call netcdf_io_init (ncchksz,header_buffer_val,netcdf_default_format)
   if (header_buffer_val .le. 0) then
         call mpp_error(FATAL, "header_buffer_val in fms2_io_nml must be a positive number.")
+  endif
   call blackboxio_init (ncchksz)
 !> Mark the fms2_io as initialized
   fms2_io_is_initialized = .true.

--- a/fms2_io/fms2_io.F90
+++ b/fms2_io/fms2_io.F90
@@ -214,17 +214,20 @@ end interface read_new_restart
 
 logical, private :: fms2_io_is_initialized = .false. !< True after fms2_io_init is run
 !< Namelist variables
-integer :: ncchksz = 64*1024  !< User defined chunksize (in bytes) argument in netcdf file 
+integer :: ncchksz = 64*1024  !< User defined chunksize (in bytes) argument in netcdf file
                               !! creation calls. Replaces setting the NC_CHKSZ environment variable.
+character (len = 10) :: netcdf_default_format = "64bit" !< User defined netcdf file format, acceptable values
+                              !! are: "64bit", "classic", "netcdf4". This can be overwritten if you specify
+                              !! "nc_format" in the open_file call
 namelist / fms2_io_nml / &
-                      ncchksz
+                      ncchksz, netcdf_default_format
 
 contains
 
 !> @brief Reads the fms2_io_nml
 subroutine fms2_io_init ()
  integer :: mystat
- 
+
 !> Check if the module has already been initialized
   if (fms2_io_is_initialized) return
 !> Call initialization routines that this module depends on
@@ -236,9 +239,10 @@ subroutine fms2_io_init ()
   if (ncchksz .le. 0) then
         call mpp_error(FATAL, "ncchksz in fms2_io_nml must be a positive number.")
   endif
-  call netcdf_io_init (ncchksz)
+
+  call netcdf_io_init (ncchksz,netcdf_default_format)
   call blackboxio_init (ncchksz)
-!> Mark the fms2_io as initialized 
+!> Mark the fms2_io as initialized
   fms2_io_is_initialized = .true.
 end subroutine fms2_io_init
 

--- a/fms2_io/netcdf_io.F90
+++ b/fms2_io/netcdf_io.F90
@@ -514,9 +514,9 @@ function netcdf_file_open(fileobj, path, mode, nc_format, pelist, is_restart) &
     elseif (string_compare(mode, "append", .true.)) then
       err = nf90_open(trim(fileobj%path), nf90_write, fileobj%ncid, chunksize=fms2_ncchksz)
     elseif (string_compare(mode, "write", .true.)) then
-      err = nf90_create(trim(fileobj%path), ior(nf90_noclobber, fms2_nc_format_param), fileobj%ncid, chunksize=fms2_ncchksz)
+      err = nf90_create(trim(fileobj%path), ior(nf90_noclobber, nc_format_param), fileobj%ncid, chunksize=fms2_ncchksz)
     elseif (string_compare(mode,"overwrite",.true.)) then
-      err = nf90_create(trim(fileobj%path), ior(nf90_clobber, fms2_nc_format_param), fileobj%ncid, chunksize=fms2_ncchksz)
+      err = nf90_create(trim(fileobj%path), ior(nf90_clobber, nc_format_param), fileobj%ncid, chunksize=fms2_ncchksz)
     else
       call error("unrecognized file mode "//trim(mode)//".")
     endif

--- a/fms2_io/netcdf_io.F90
+++ b/fms2_io/netcdf_io.F90
@@ -258,7 +258,7 @@ character (len = 10), intent(in) :: netcdf_default_format
      fms2_nc_format_param = nf90_classic_model
      call string_copy(fms2_nc_format, "classic")
  elseif (string_compare(netcdf_default_format, "netcdf4", .true.)) then
-     fms2_nc_format_param = nf90_hdf5
+     fms2_nc_format_param = nf90_netcdf4
      call string_copy(fms2_nc_format, "netcdf4")
  else
      call error("unrecognized netcdf file format "//trim(netcdf_default_format)//". Check fms2io namelist")
@@ -499,7 +499,7 @@ function netcdf_file_open(fileobj, path, mode, nc_format, pelist, is_restart) &
       elseif (string_compare(nc_format, "classic", .true.)) then
         nc_format_param = nf90_classic_model
       elseif (string_compare(nc_format, "netcdf4", .true.)) then
-        nc_format_param = nf90_hdf5
+        nc_format_param = nf90_netcdf4
       else
         call error("unrecognized netcdf file format "//trim(nc_format)//".")
       endif

--- a/fms2_io/netcdf_io.F90
+++ b/fms2_io/netcdf_io.F90
@@ -45,7 +45,8 @@ integer, parameter :: dimension_not_found = 0
 integer, parameter, public :: max_num_compressed_dims = 10 !> Maximum number of compressed
                                                            !! dimensions allowed.
 integer, private :: fms2_ncchksz = -1 !< Chunksize (bytes) used in nc_open and nc_create
-
+integer, private :: fms2_nc_format_param = -1 !< Netcdf format type param used in nc_create
+character (len = 10), private :: fms2_nc_format !< Netcdf format type used in netcdf_file_open
 !> @brief Restart variable.
 type :: RestartVariable_t
   character(len=256) :: varname !< Variable name.
@@ -245,9 +246,24 @@ end interface get_variable_attribute
 contains
 
 !> @brief Accepts the namelist fms2_io_nml variables relevant to netcdf_io_mod
-subroutine netcdf_io_init (chksz)
+subroutine netcdf_io_init (chksz, netcdf_default_format)
 integer, intent(in) :: chksz
+character (len = 10), intent(in) :: netcdf_default_format
+
  fms2_ncchksz = chksz
+ if (string_compare(netcdf_default_format, "64bit", .true.)) then
+     fms2_nc_format_param = nf90_64bit_offset
+     call string_copy(fms2_nc_format, "64bit")
+ elseif (string_compare(netcdf_default_format, "classic", .true.)) then
+     fms2_nc_format_param = nf90_classic_model
+     call string_copy(fms2_nc_format, "classic")
+ elseif (string_compare(netcdf_default_format, "netcdf4", .true.)) then
+     fms2_nc_format_param = nf90_hdf5
+     call string_copy(fms2_nc_format, "netcdf4")
+ else
+     call error("unrecognized netcdf file format "//trim(netcdf_default_format)//". Check fms2io namelist")
+ endif
+
 end subroutine netcdf_io_init
 
 !> @brief Check for errors returned by netcdf.
@@ -416,7 +432,9 @@ function netcdf_file_open(fileobj, path, mode, nc_format, pelist, is_restart) &
                                                      !! as.  Allowed values
                                                      !! are: "64bit", "classic",
                                                      !! or "netcdf4". Defaults to
-                                                     !! "64bit".
+                                                     !! "64bit". This overwrites
+                                                     !! the value set in the fms2io
+                                                     !! namelist
   integer, dimension(:), intent(in), optional :: pelist !< List of ranks associated
                                                         !! with this file.  If not
                                                         !! provided, only the current
@@ -472,8 +490,9 @@ function netcdf_file_open(fileobj, path, mode, nc_format, pelist, is_restart) &
 
   !Open the file with netcdf if this rank is the I/O root.
   if (fileobj%is_root) then
-    nc_format_param = nf90_64bit_offset
-    call string_copy(fileobj%nc_format, "64bit")
+    if (fms2_ncchksz == -1) call error("netcdf_file_open:: fms2_ncchksz not set.")
+    if (fms2_nc_format_param == -1) call error("netcdf_file_open:: fms2_nc_format_param not set.")
+
     if (present(nc_format)) then
       if (string_compare(nc_format, "64bit", .true.)) then
         nc_format_param = nf90_64bit_offset
@@ -485,16 +504,19 @@ function netcdf_file_open(fileobj, path, mode, nc_format, pelist, is_restart) &
         call error("unrecognized netcdf file format "//trim(nc_format)//".")
       endif
       call string_copy(fileobj%nc_format, nc_format)
+    else
+      call string_copy(fileobj%nc_format, trim(fms2_nc_format))
+      nc_format_param = fms2_nc_format_param
     endif
-    if (fms2_ncchksz == -1) call error("netcdf_file_open:: fms2_ncchksz not set.")
+
     if (string_compare(mode, "read", .true.)) then
       err = nf90_open(trim(fileobj%path), nf90_nowrite, fileobj%ncid, chunksize=fms2_ncchksz)
     elseif (string_compare(mode, "append", .true.)) then
       err = nf90_open(trim(fileobj%path), nf90_write, fileobj%ncid, chunksize=fms2_ncchksz)
     elseif (string_compare(mode, "write", .true.)) then
-      err = nf90_create(trim(fileobj%path), ior(nf90_noclobber, nc_format_param), fileobj%ncid, chunksize=fms2_ncchksz)
+      err = nf90_create(trim(fileobj%path), ior(nf90_noclobber, fms2_nc_format_param), fileobj%ncid, chunksize=fms2_ncchksz)
     elseif (string_compare(mode,"overwrite",.true.)) then
-      err = nf90_create(trim(fileobj%path), ior(nf90_clobber, nc_format_param), fileobj%ncid, chunksize=fms2_ncchksz)
+      err = nf90_create(trim(fileobj%path), ior(nf90_clobber, fms2_nc_format_param), fileobj%ncid, chunksize=fms2_ncchksz)
     else
       call error("unrecognized file mode "//trim(mode)//".")
     endif

--- a/fms2_io/netcdf_io.F90
+++ b/fms2_io/netcdf_io.F90
@@ -262,7 +262,7 @@ character (len = 10), intent(in) :: netcdf_default_format
      call string_copy(fms2_nc_format, "netcdf4")
  else
      call error("unrecognized netcdf file format "//trim(netcdf_default_format)// &
-       ". The acceptable values are 64bit, classic, netcdf4. Check fms2io namelist")
+     '. The acceptable values are "64bit", "classic", "netcdf4". Check fms2_io_nml: netcdf_default_format')
  endif
 
 end subroutine netcdf_io_init

--- a/fms2_io/netcdf_io.F90
+++ b/fms2_io/netcdf_io.F90
@@ -261,7 +261,8 @@ character (len = 10), intent(in) :: netcdf_default_format
      fms2_nc_format_param = nf90_netcdf4
      call string_copy(fms2_nc_format, "netcdf4")
  else
-     call error("unrecognized netcdf file format "//trim(netcdf_default_format)//". Check fms2io namelist")
+     call error("unrecognized netcdf file format "//trim(netcdf_default_format)// &
+       ". The acceptable values are 64bit, classic, netcdf4. Check fms2io namelist")
  endif
 
 end subroutine netcdf_io_init


### PR DESCRIPTION
**Description**
This PR:

1. Adds `netcdf_default_format` as a namelist parameter in `fms2_io_nml`. It accepts "64bit", "classic", or "netcdf4".
2. If no value is given in the namelist it defaults to "64bit"

**NOTE** The value given in the namelist can be "overwritten" if you use the optional argument `nc_format` when calling `open_file` 
For example, if you do
```F90
open_file(fileobj, "ncformat_classic.nc", "overwrite", nc_format="classic", is_restart=.true.)
``` 
and have `netcdf_default_format` set as `64bit` in the namelist, the file written will be `classic`. 

Fixes #425 

**How Has This Been Tested?**
It passes my ["unit" test](https://github.com/uramirez8707/FMS/blob/open_file_unit_test/test_fms/fms2_io/test_open_file.sh)

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

