### PR TITLE
Adds unit test for get_ascii_file_num_lines

### DIFF
--- a/test_fms/mpp/Makefile.am
+++ b/test_fms/mpp/Makefile.am
@@ -37,7 +37,8 @@ check_PROGRAMS = test_mpp \
   test_mpp_print_memuse_stats_stderr \
   test_mpp_print_memuse_stats_file \
   test_mpp_memutils_begin_2x \
-  test_mpp_memutils_end_before_begin
+  test_mpp_memutils_end_before_begin \
+  test_mpp_get_ascii_lines
 
 # These are the sources for the tests.
 test_mpp_SOURCES = test_mpp.F90
@@ -50,6 +51,7 @@ test_mpp_print_memuse_stats_stderr_SOURCES=test_mpp_print_memuse_stats_stderr.F9
 test_mpp_print_memuse_stats_file_SOURCES=test_mpp_print_memuse_stats_file.F90
 test_mpp_memutils_begin_2x_SOURCES=test_mpp_memutils_begin_2x.F90
 test_mpp_memutils_end_before_begin_SOURCES=test_mpp_memutils_end_before_begin.F90
+test_mpp_get_ascii_lines_SOURCES=test_mpp_get_ascii_lines.F90
 
 # Run the test programs.
 TESTS = test_mpp_domains2.sh \
@@ -57,14 +59,21 @@ TESTS = test_mpp_domains2.sh \
   test_mpp2.sh \
   test_mpp_memuse \
   test_mpp_mem_dump \
-  test_mpp_memutils_mod.sh
+  test_mpp_memutils_mod.sh \
+  test_mpp_get_ascii_lines2.sh
 
 # These files will also be included in the distribution.
 EXTRA_DIST = input_base.nml \
   test_mpp_domains2.sh \
   test_mpp_pset2.sh	\
   test_mpp2.sh \
-  test_mpp_memutils_mod.sh
+  test_mpp_memutils_mod.sh \
+  test_mpp_get_ascii_lines2.sh \
+  base_ascii_5 \
+  base_ascii_25 \
+  base_ascii_0 \
+  base_ascii_skip \
+  base_ascii_long
 
 # Clean up
-CLEANFILES = input.nml *.out*
+CLEANFILES = input.nml *.out* ascii*

--- a/test_fms/mpp/base_ascii_25
+++ b/test_fms/mpp/base_ascii_25
@@ -1,0 +1,25 @@
+"this is an ascii file with 5 lines"
+"it will contain commas inside quotes", "as well as outside quotes"
+"it will not have the same number of fields on every line"
+some lines will not have quotes
+"there might be a line with the character string \n"
+"this is an ascii file with 5 lines"
+"it will contain commas inside quotes", "as well as outside quotes"
+"it will not have the same number of fields on every line"
+some lines will not have quotes
+"there might be a line with the character string \n"
+"this is an ascii file with 5 lines"
+"it will contain commas inside quotes", "as well as outside quotes"
+"it will not have the same number of fields on every line"
+some lines will not have quotes
+"there might be a line with the character string \n"
+"this is an ascii file with 5 lines"
+"it will contain commas inside quotes", "as well as outside quotes"
+"it will not have the same number of fields on every line"
+some lines will not have quotes
+"there might be a line with the character string \n"
+"this is an ascii file with 5 lines"
+"it will contain commas inside quotes", "as well as outside quotes"
+"it will not have the same number of fields on every line"
+some lines will not have quotes
+"there might be a line with the character string \n"

--- a/test_fms/mpp/base_ascii_5
+++ b/test_fms/mpp/base_ascii_5
@@ -1,0 +1,5 @@
+"this is an ascii file with 5 lines"
+"it will contain commas inside quotes", "as well as outside quotes"
+"it will not have the same number of fields on every line"
+some lines will not have quotes
+"there might be a line with the character string \n"

--- a/test_fms/mpp/base_ascii_long
+++ b/test_fms/mpp/base_ascii_long
@@ -1,0 +1,5 @@
+"this is an ascii file with 5 lines"
+""it will contain commas inside quotes", "as well as outside quotes""it will contain commas inside quotes", "as well as outside quotes""it will contain commas inside quotes", "as well as outside quotes""it will contain commas inside quotes", "as well as outside quotes""it will contain commas inside quotes", "as well as outside quotes""it will contain commas inside quotes", "as well as outside quotes""it will contain commas inside quotes", "as well as outside quotes""it will contain commas inside quotes", "as well as outside quotes""it will contain commas inside quotes", "as well as outside quotes""it will contain commas inside quotes", "as well as outside quotes""it will contain commas inside quotes", "as well as outside quotes"it will contain commas inside quotes", "as well as outside quotes"
+"it will not have the same number of fields on every line"
+some lines will not have quotes
+"there might be a line with the character string \n"

--- a/test_fms/mpp/base_ascii_skip
+++ b/test_fms/mpp/base_ascii_skip
@@ -1,0 +1,5 @@
+"this is an ascii file with 5 lines"
+"it will contain commas inside quotes", "as well as outside quotes"
+"it will not have the same number of fields on every line"
+
+"there might be a blank line beforehand"

--- a/test_fms/mpp/input_base.nml
+++ b/test_fms/mpp/input_base.nml
@@ -2,6 +2,10 @@
 test_number = <test_num>
 /
 
+&test_mpp_get_ascii_lines_nml
+test_number = <test_num>
+/
+
 
 &test_mpp_domains_nml
 nx=64

--- a/test_fms/mpp/test_mpp_get_ascii_lines.F90
+++ b/test_fms/mpp/test_mpp_get_ascii_lines.F90
@@ -1,0 +1,83 @@
+!***********************************************************************
+!*                   GNU Lesser General Public License
+!*
+!* This file is part of the GFDL Flexible Modeling System (FMS).
+!*
+!* FMS is free software: you can redistribute it and/or modify it under
+!* the terms of the GNU Lesser General Public License as published by
+!* the Free Software Foundation, either version 3 of the License, or (at
+!* your option) any later version.
+!*
+!* FMS is distributed in the hope that it will be useful, but WITHOUT
+!* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+!* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+!* for more details.
+!*
+!* You should have received a copy of the GNU Lesser General Public
+!* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
+!***********************************************************************
+
+program test_get_ascii_lines
+  use mpp_mod, only: mpp_init, mpp_exit, get_ascii_file_num_lines, read_ascii_file, INPUT_STR_LENGTH
+  use mpp_mod, only: input_nml_file
+  use, intrinsic ::  iso_fortran_env, only: INT8
+
+  implicit none
+
+  interface assertEquals
+     procedure assertEquals_int_int
+  end interface assertEquals
+
+  integer, parameter :: num_tests = 5
+  integer(KIND=INT8) :: test_number
+  integer, dimension(num_tests) :: my_num_lines=(/5,25,0,5,5/)
+  integer :: f_num_lines, io_status
+  character(len=10), dimension(num_tests) :: file_name=(/"ascii_5   ",&
+                                                         "ascii_25  ",&
+                                                         "ascii_0   ",&
+                                                         "ascii_skip",&
+                                                         "ascii_long"/)
+  character(len=15), dimension(num_tests) :: test_name=(/"5 line test    ",&
+                                                         "25 line test   ",&
+                                                         "0 line test    ",&
+                                                         "blank line test",&
+                                                         "long line test "/)
+  character(len=INPUT_STR_LENGTH), allocatable :: file_contents(:)
+  namelist /test_mpp_get_ascii_lines_nml/ test_number
+
+  call mpp_init()
+  read (input_nml_file, test_mpp_get_ascii_lines_nml, iostat=io_status)
+  my_num_lines(test_number) = my_num_lines(test_number)+1 !!!!! Please See Note At End of File
+  f_num_lines = get_ascii_file_num_lines(trim(file_name(test_number)), INPUT_STR_LENGTH)
+  call assertEquals(f_num_lines, my_num_lines(test_number), trim(test_name(test_number)))
+  call mpp_exit()
+
+contains
+
+  subroutine assertEquals_int_int(tstval, expval, test_name)
+    use, intrinsic ::  iso_fortran_env, only: ERROR_UNIT
+    integer, intent(in) :: tstval
+    integer, intent(in) :: expval
+    character(len=*), intent(in) :: test_name
+
+
+
+    if (tstval .eq. expval) then
+       write (ERROR_UNIT, '(A," ",I0,": ",A," - ",A)') "Test number", test_number, test_name, "success"
+    else
+       write (ERROR_UNIT, '(A," ",I0,": ",A," - ",A)') "Test number", test_number, test_name, "failure"
+       write (ERROR_UNIT, '("Expected """,I0,""" got """,I0,""".""")') expval, tstval
+    end if
+  end subroutine assertEquals_int_int
+end program test_get_ascii_lines
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! IMPORTANT NOTE REGARDING LINE COUNT !
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+! The current implmenetation of mpp (as of release 2020.02) requires that the
+! number of lines returned from a file be one more than the actual number of
+! lines contained within the file. This is set up so that there are no attempts
+! to read nml information from an array of dimension zero, as that results in a
+! segmentation fault. This workaround may be addressed in future versions of
+! mpp, in which case this test must be adapted.

--- a/test_fms/mpp/test_mpp_get_ascii_lines2.sh
+++ b/test_fms/mpp/test_mpp_get_ascii_lines2.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+
+#***********************************************************************
+#*                   GNU Lesser General Public License
+#*
+#* This file is part of the GFDL Flexible Modeling System (FMS).
+#*
+#* FMS is free software: you can redistribute it and/or modify it under
+#* the terms of the GNU Lesser General Public License as published by
+#* the Free Software Foundation, either version 3 of the License, or (at
+#* your option) any later version.
+#*
+#* FMS is distributed in the hope that it will be useful, but WITHOUT
+#* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+#* for more details.
+#*
+#* You should have received a copy of the GNU Lesser General Public
+#* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
+#***********************************************************************
+
+# This is part of the GFDL FMS package. This is a shell script to
+# execute tests in the test_fms/mpp directory.
+
+# Ed Hartnett 11/29/19
+
+# Set common test settings.
+. ../test_common.sh
+
+skip_test="no"
+
+# Copy file for test.
+cp $top_srcdir/test_fms/mpp/base_ascii_5 ascii_5
+cp $top_srcdir/test_fms/mpp/base_ascii_25 ascii_25
+cp $top_srcdir/test_fms/mpp/base_ascii_0 ascii_0
+cp $top_srcdir/test_fms/mpp/base_ascii_skip ascii_skip
+cp $top_srcdir/test_fms/mpp/base_ascii_long ascii_long
+
+for tst in 1 2 3 4
+do
+sed "s/test_number = <test_num>/test_number = ${tst}/" $top_srcdir/test_fms/mpp/input_base.nml > input.nml
+echo "Running test ${tst}..."
+run_test test_mpp_get_ascii_lines 2 $skip_test
+echo "Test ${tst} has passed"
+done
+
+sed "s/test_number = <test_num>/test_number = 5/" $top_srcdir/test_fms/mpp/input_base.nml > input.nml
+echo "Running test 5..."
+run_test test_mpp_get_ascii_lines 2 $skip_test || err=1
+if [ "$err" -ne 1 ]; then
+  echo "ERROR: Test 5 was unsuccessful."
+  exit 5
+else
+   echo "Test 5 has passed"
+fi


### PR DESCRIPTION
**Description**
This is a suite of unit tests (currently 5 tests but may be expanded) for the get_ascii_file_num_lines mpp function.

Fixes # (issue)

**How Has This Been Tested?**
Ran make distcheck as well as make check in the mpp folder. This was with Intel19 on the Skylake box.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

