### PR TITLE
Interpolator fix

### DIFF
--- a/fms2_io/netcdf_io.F90
+++ b/fms2_io/netcdf_io.F90
@@ -531,7 +531,9 @@ subroutine netcdf_file_close(fileobj)
 
   if (fileobj%is_root) then
     err = nf90_close(fileobj%ncid)
-    call check_netcdf_code(err)
+    if (err .ne. nf90_ebadid) then
+       call check_netcdf_code(err)
+    endif
   endif
   if (allocated(fileobj%is_open)) fileobj%is_open = .false.
   fileobj%path = missing_path

--- a/interpolator/interpolator.F90
+++ b/interpolator/interpolator.F90
@@ -109,8 +109,7 @@ use fms2_io_mod,       only : FmsNetcdfFile_t, file_exists, dimension_exists, &
                               get_num_variables, get_dimension_size,   &
                               get_variable_units, get_variable_names,  &
                               get_time_calendar, close_file,           &
-                              get_variable_dimension_names, get_variable_sense, &
-                              check_if_open
+                              get_variable_dimension_names, get_variable_sense
 use horiz_interp_mod,  only : horiz_interp_type, &
                               horiz_interp_new,  &
                               horiz_interp_init, &
@@ -432,14 +431,16 @@ type(interpolate_type), intent(inout) :: Out
 
 end subroutine interpolate_type_eq
 
-!> \brief check_if_initiliazed checks if a filename and a set of variable names
+!> \brief check_if_initialized checks if a filename and a set of variable names
 !!  has already been used in another interpolator_init call
 !! \param [inout] <clim_type> Climatology type
 !! \param [in] <file_name> Climatology filename
-!! \param [in] <j> j=-1, file has not been opened j=0: file was opened and the variable(s)
+!! \param [in] <local_data_names> List of variable names to check if were
+!!  already initialized
+!! \param [out] <j> j=-1, file has not been opened j=0: file was opened and the variable(s)
 !!  have been read j>0: index where filename was found, but the variable have not been read
 
-function check_if_initiliazed (clim_type, file_name, local_data_names) result(j)
+function check_if_initialized (clim_type, file_name, local_data_names) result(j)
 type(interpolate_type), intent(inout)   :: clim_type
 character(len=*), intent(in)            :: file_name
 character(len=*), pointer, intent(in)   :: local_data_names(:)
@@ -473,7 +474,7 @@ do i = 1, num_files
     endif
 end do
 
-end function check_if_initiliazed
+end function check_if_initialized
 
 !#######################################################################
 !
@@ -574,7 +575,7 @@ num_fields = 0
 if (present(data_names)) local_data_names => data_names
 
 src_file = 'INPUT/'//trim(file_name)
-file_found_index = check_if_initiliazed (clim_type, file_name, local_data_names)
+file_found_index = check_if_initialized (clim_type, file_name, local_data_names)
 if (associated(local_data_names)) nullify(local_data_names)
 
 if (file_found_index == 0) then

--- a/interpolator/interpolator.F90
+++ b/interpolator/interpolator.F90
@@ -627,6 +627,29 @@ nlevh = 1
 !--lwh
         clim_type%vertical_indices = 0  ! initial value
 
+!! If the file has been used before, let's reuse some of the information
+if ( file_found_index /= -1) then
+   if (associated(init_interpolator_types(file_found_index)%lat)) &
+        clim_type%lat      =>  init_interpolator_types(file_found_index)%lat
+   if (associated(init_interpolator_types(file_found_index)%lon)) &
+        clim_type%lon      =>  init_interpolator_types(file_found_index)%lon
+   if (associated(init_interpolator_types(file_found_index)%latb)) &
+        clim_type%latb     =>  init_interpolator_types(file_found_index)%latb
+   if (associated(init_interpolator_types(file_found_index)%lonb)) &
+        clim_type%lonb     =>  init_interpolator_types(file_found_index)%lonb
+   if (associated(init_interpolator_types(file_found_index)%levs)) &
+        clim_type%levs     =>  init_interpolator_types(file_found_index)%levs
+   if (associated(init_interpolator_types(file_found_index)%halflevs)) &
+        clim_type%halflevs =>  init_interpolator_types(file_found_index)%halflevs
+   if (associated(init_interpolator_types(file_found_index)%time_slice)) &
+        clim_type%time_slice =>  init_interpolator_types(file_found_index)%time_slice
+   if (associated(init_interpolator_types(file_found_index)%clim_times)) &
+        clim_type%clim_times =>  init_interpolator_types(file_found_index)%clim_times
+   clim_type%level_type = init_interpolator_types(file_found_index)%level_type
+   clim_type%vertical_indices = init_interpolator_types(file_found_index)%vertical_indices
+   clim_type%climatological_year = init_interpolator_types(file_found_index)%climatological_year
+   clim_type%interph = init_interpolator_types(file_found_index)%interph
+else
 !--- get clim_type%lat
 if(dimension_exists(clim_type%fileobj, "lat")) then
    call get_dimension_size(clim_type%fileobj, "lat", nlat)
@@ -995,6 +1018,7 @@ endif
                         agrid_mod(:,:,1), agrid_mod(:,:,2), interp_method="bilinear")
  endif
 
+endif !if ( file_found_index /= -1)
 !--------------------------------------------------------------------
 !  allocate the variable clim_type%data . This will be the climatology
 !  data horizontally interpolated, so it will be on the model horizontal

--- a/interpolator/interpolator.F90
+++ b/interpolator/interpolator.F90
@@ -359,7 +359,7 @@ integer :: verbose = 0                              !< No description
 logical :: conservative_interp = .true.          !< No description
 logical :: retain_cm3_bug = .true.               !< No description
 integer :: num_files = 0                          !< Current number of files initiliazed
-integer, parameter :: max_num_files = 50                  !< Max number of files than can be initiliazed
+integer, parameter :: max_num_files = 100                  !< Max number of files than can be initiliazed
 character(len=256) :: filenames(max_num_files)   !< Character array of files that were initiliazed
 type(FmsNetcdfFile_t)    :: fileobjs(max_num_files) !< Array of file objs
 
@@ -441,7 +441,7 @@ integer                                 :: i
 j = -1
 do i = 1, num_files
    if (trim(file_name) == trim(filenames(i))) then
-      j = 1
+      j = i
       return
    endif
 end do
@@ -545,11 +545,11 @@ num_fields = 0
 src_file = 'INPUT/'//trim(file_name)
 file_found_index = check_if_initiliazed (src_file)
 if (file_found_index == -1) then
-   if(.not. open_file(clim_type%fileobj, trim(src_file), 'read')) &
-        call mpp_error(FATAL, 'Interpolator_init: Error in opening file '//trim(src_file))
    num_files = num_files + 1
-   fileobjs(num_files) = clim_type%fileobj
    filenames(num_files) = trim(src_file)
+   if(.not. open_file(fileobjs(num_files), trim(src_file), 'read')) &
+        call mpp_error(FATAL, 'Interpolator_init: Error in opening file '//trim(src_file))
+   clim_type%fileobj = fileobjs(num_files)
 else
    clim_type%fileobj = fileobjs(file_found_index)
 endif
@@ -3478,7 +3478,6 @@ endif
 if(  .not. (clim_type%TIME_FLAG .eq. LINEAR  .and.    &
 !     read_all_on_init)) .or. clim_type%TIME_FLAG .eq. BILINEAR  ) then
       read_all_on_init)  ) then
- call close_file(clim_type%fileobj)
 endif
 
 

--- a/interpolator/interpolator.F90
+++ b/interpolator/interpolator.F90
@@ -3543,7 +3543,7 @@ endif
 if (module_is_initialized) then
    !! if this is the first time calling interpolator_end, close all files
    do i = 1, num_files
-      if (check_if_open(init_interpolator_types(i)%fileobj)) call close_file(init_interpolator_types(i)%fileobj)
+      call close_file(init_interpolator_types(i)%fileobj)
    enddo
    module_is_initialized = .false.
 endif

--- a/interpolator/interpolator.F90
+++ b/interpolator/interpolator.F90
@@ -648,7 +648,6 @@ if ( file_found_index /= -1) then
    clim_type%level_type = init_interpolator_types(file_found_index)%level_type
    clim_type%vertical_indices = init_interpolator_types(file_found_index)%vertical_indices
    clim_type%climatological_year = init_interpolator_types(file_found_index)%climatological_year
-   clim_type%interph = init_interpolator_types(file_found_index)%interph
 else
 !--- get clim_type%lat
 if(dimension_exists(clim_type%fileobj, "lat")) then
@@ -986,6 +985,8 @@ else
    call mpp_error(FATAL, 'Interpolator_init: time axis does not exist in file '//trim(src_file))
 endif
 
+endif !if ( file_found_index /= -1)
+
 !Assume that the horizontal interpolation within a file is the same for each variable.
 
  if (conservative_interp) then
@@ -1018,7 +1019,6 @@ endif
                         agrid_mod(:,:,1), agrid_mod(:,:,2), interp_method="bilinear")
  endif
 
-endif !if ( file_found_index /= -1)
 !--------------------------------------------------------------------
 !  allocate the variable clim_type%data . This will be the climatology
 !  data horizontally interpolated, so it will be on the model horizontal
@@ -3517,26 +3517,26 @@ if ( mpp_pe() == mpp_root_pe() ) then
    write (logunit,'(/,(a))') 'Exiting interpolator, have a nice day ...'
 end if
 
-if (associated (clim_type%lat     )) deallocate(clim_type%lat)
-if (associated (clim_type%lon     )) deallocate(clim_type%lon)
-if (associated (clim_type%latb    )) deallocate(clim_type%latb)
-if (associated (clim_type%lonb    )) deallocate(clim_type%lonb)
-if (associated (clim_type%levs    )) deallocate(clim_type%levs)
-if (associated (clim_type%halflevs)) deallocate(clim_type%halflevs)
+if (associated (clim_type%lat     )) nullify(clim_type%lat)
+if (associated (clim_type%lon     )) nullify(clim_type%lon)
+if (associated (clim_type%latb    )) nullify(clim_type%latb)
+if (associated (clim_type%lonb    )) nullify(clim_type%lonb)
+if (associated (clim_type%levs    )) nullify(clim_type%levs)
+if (associated (clim_type%halflevs)) nullify(clim_type%halflevs)
 call horiz_interp_del(clim_type%interph)
-if (associated (clim_type%time_slice)) deallocate(clim_type%time_slice)
-if (associated (clim_type%has_level))  deallocate(clim_type%has_level)
-if (associated (clim_type%field_name)) deallocate(clim_type%field_name)
-if (associated (clim_type%time_init )) deallocate(clim_type%time_init)
-if (associated (clim_type%mr        )) deallocate(clim_type%mr)
+if (associated (clim_type%time_slice)) nullify(clim_type%time_slice)
+if (associated (clim_type%has_level))  nullify(clim_type%has_level)
+if (associated (clim_type%field_name)) nullify(clim_type%field_name)
+if (associated (clim_type%time_init )) nullify(clim_type%time_init)
+if (associated (clim_type%mr        )) nullify(clim_type%mr)
 if (associated (clim_type%data)) then
-  deallocate(clim_type%data)
+  nullify(clim_type%data)
 endif
 if (associated (clim_type%pmon_pyear)) then
-  deallocate(clim_type%pmon_pyear)
-  deallocate(clim_type%pmon_nyear)
-  deallocate(clim_type%nmon_nyear)
-  deallocate(clim_type%nmon_pyear)
+  nullify(clim_type%pmon_pyear)
+  nullify(clim_type%pmon_nyear)
+  nullify(clim_type%nmon_nyear)
+  nullify(clim_type%nmon_pyear)
 endif
 
 if (module_is_initialized) then


### PR DESCRIPTION
**Description**
This PR: 

- Stores the interpolator types that have a already being processed as `init_interpolator_types`
- Adds a function called `check_if_initialized`, which checks if the file has already been opened, and if the variables that you are calling `interpolator_init` on has already been processed 
- It reuses interpolator types whenever possible
- All files are closed the first time `interpolator_end` is called.  

Fixes #404 

**How Has This Been Tested?**
AM4.1 with intel16, prod-openmp 

After this PR, based on Darshan the file `depvel_gc_am3_tran.nc`:
```
POSIX_OPENS	432
POSIX_BYTES_READ	2740915584
```

Before this change: 
```
POSIX_OPENS	15552
POSIX_BYTES_READ	98672961024
```

Xandu: 
```
POSIX_OPENS     432
POSIX_BYTES_READ        23072059264
```

So we are now doing **A LOT** less io :) 

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

