### PR TITLE
Very basic I/O test for fms2_io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,8 +57,5 @@ before_script:
 script:
   - autoreconf -i
   - ./configure ${DISTCHECK_CONFIGURE_FLAGS}
-  - make -j 
-  - cd test_fms/fms2_io
-  - make test_io_simple
-  - bash -x ./test_io_simple.sh
+  - make -j distcheck
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,4 +57,8 @@ before_script:
 script:
   - autoreconf -i
   - ./configure ${DISTCHECK_CONFIGURE_FLAGS}
-  - make -j distcheck
+  - make -j 
+  - cd test_fms/fms2_io
+  - make test_io_simple
+  - bash -x ./test_io_simple.sh
+  

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,4 +58,3 @@ script:
   - autoreconf -i
   - ./configure ${DISTCHECK_CONFIGURE_FLAGS}
   - make -j distcheck
-  

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,3 +58,4 @@ script:
   - autoreconf -i
   - ./configure ${DISTCHECK_CONFIGURE_FLAGS}
   - make -j distcheck
+  

--- a/test_fms/fms2_io/Makefile.am
+++ b/test_fms/fms2_io/Makefile.am
@@ -38,8 +38,7 @@ test_fms2_io_SOURCES = argparse.F90 test_fms2_io.F90 create_atmosphere_domain.in
                        land_unstructured_restart_file_test.inc
 test_atmosphere_io_SOURCES = argparse.F90 setup.F90 test_atmosphere_io.F90 \
                              atmosphere_restart_file_test.inc
-test_io_simple_SOURCES = test_io_simple.F90 argparse.F90 setup.F90	\
-atmosphere_restart_file_test.inc
+test_io_simple_SOURCES = test_io_simple.F90 argparse.F90 setup.F90
 
 EXTRA_DIST = test_fms2_io.sh test_atmosphere_io.sh test_io_simple.sh
 

--- a/test_fms/fms2_io/Makefile.am
+++ b/test_fms/fms2_io/Makefile.am
@@ -29,7 +29,7 @@ AM_CPPFLAGS = -I${top_builddir}/mpp -I${top_builddir}/fms2_io
 LDADD = ${top_builddir}/libFMS/libFMS.la
 
 # Build this test program.
-check_PROGRAMS = test_fms2_io test_atmosphere_io
+check_PROGRAMS = test_fms2_io test_atmosphere_io test_io_simple
 
 # This is the source code for the test.
 test_fms2_io_SOURCES = argparse.F90 test_fms2_io.F90 create_atmosphere_domain.inc \
@@ -38,6 +38,7 @@ test_fms2_io_SOURCES = argparse.F90 test_fms2_io.F90 create_atmosphere_domain.in
                        land_unstructured_restart_file_test.inc
 test_atmosphere_io_SOURCES = argparse.F90 setup.F90 test_atmosphere_io.F90 \
                              atmosphere_restart_file_test.inc
+test_io_simple_SOURCES = test_io_simple.F90
 
 EXTRA_DIST = test_fms2_io.sh test_atmosphere_io.sh
 
@@ -48,7 +49,7 @@ test_atmosphere_io.$(OBJEXT): setup.mod
 test_fms2_io.$(OBJEXT): argparse.mod
 
 # Run the test program.
-TESTS = test_fms2_io.sh test_atmosphere_io.sh
+TESTS = test_fms2_io.sh test_atmosphere_io.sh test_io_simple.sh
 
 # Set srcdir as evironment variable to be reference in the job script
 TESTS_ENVIRONMENT = srcdir="$(top_srcdir)"

--- a/test_fms/fms2_io/Makefile.am
+++ b/test_fms/fms2_io/Makefile.am
@@ -38,14 +38,16 @@ test_fms2_io_SOURCES = argparse.F90 test_fms2_io.F90 create_atmosphere_domain.in
                        land_unstructured_restart_file_test.inc
 test_atmosphere_io_SOURCES = argparse.F90 setup.F90 test_atmosphere_io.F90 \
                              atmosphere_restart_file_test.inc
-test_io_simple_SOURCES = test_io_simple.F90
+test_io_simple_SOURCES = test_io_simple.F90 argparse.F90 setup.F90	\
+atmosphere_restart_file_test.inc
 
-EXTRA_DIST = test_fms2_io.sh test_atmosphere_io.sh
+EXTRA_DIST = test_fms2_io.sh test_atmosphere_io.sh test_io_simple.sh
 
 argparse.mod: argparse.$(OBJEXT)
 setup.mod: setup.$(OBJEXT)
 setup.$(OBJEXT): argparse.mod
 test_atmosphere_io.$(OBJEXT): setup.mod
+test_io_simple.$(OBJEXT): setup.mod
 test_fms2_io.$(OBJEXT): argparse.mod
 
 # Run the test program.

--- a/test_fms/fms2_io/test_io_simple.F90
+++ b/test_fms/fms2_io/test_io_simple.F90
@@ -40,7 +40,6 @@ program test_io_simple
   integer :: ncchksz = 64*1024 
   character (len = 10) :: netcdf_default_format = "64bit"
   integer :: header_buffer_val = 16384
-  character (len = 100) :: testfile
   integer :: ncid
   integer :: numfilesatt
   character(len=120), dimension(3) :: format
@@ -84,16 +83,13 @@ program test_io_simple
 
   ! Check for expected netcdf file.
   if (mpp_pe() .eq. 0) then
-     do i = 1, 6
-        write(testfile,'(a,i1,a)') 'test_io_simple.tile', i, '.nc'
-        err = nf90_open(testfile, nf90_nowrite, ncid)
-        if (err .ne. 0) stop 7
-        err = nf90_get_att(ncid, NF_GLOBAL, 'NumFilesInSet', numfilesatt)
-        if (err .ne. 0) stop 10
-        if (numfilesatt .ne. 1) stop 11
-        err = nf90_close(ncid)
-        if (err .ne. 0) stop 90
-     end do
+     err = nf90_open('test_io_simple.tile1.nc', nf90_nowrite, ncid)
+     if (err .ne. 0) stop 7
+     err = nf90_get_att(ncid, NF_GLOBAL, 'NumFilesInSet', numfilesatt)
+     if (err .ne. 0) stop 10
+     if (numfilesatt .ne. 1) stop 11
+     err = nf90_close(ncid)
+     if (err .ne. 0) stop 90
   endif
 
   call mpi_barrier(mpi_comm_world, err)

--- a/test_fms/fms2_io/test_io_simple.F90
+++ b/test_fms/fms2_io/test_io_simple.F90
@@ -31,16 +31,16 @@ program test_io_simple
   use setup
   use netcdf
   
-  type(Params) :: test_params
-  type(domain2d) :: domain
-  integer :: err
-  type(domain2d), pointer :: io_domain
-  type(FmsNetcdfDomainFile_t) :: fileobj
-  integer, parameter :: ntiles = 6
-  integer :: ncchksz = 64*1024 
-  character (len = 10) :: netcdf_default_format = "64bit"
-  integer :: header_buffer_val = 16384
-  integer :: ncid
+  type(Params) :: test_params  !> Some test parameters.
+  type(domain2d) :: domain     !> Not sure what a domain is.
+  type(domain2d), pointer :: io_domain   !> Not sure what a domain is.
+  type(FmsNetcdfDomainFile_t) :: fileobj !> FMS file object.
+  integer, parameter :: ntiles = 6       !> Number of tiles.
+  integer :: ncchksz = 64*1024           !> Required for IO initialization.
+  character (len = 10) :: netcdf_default_format = "64bit" !> NetCDF format.
+  integer :: header_buffer_val = 16384   !> Required for IO initialization.
+  integer :: ncid !> File ID for checking file.
+  integer :: err  !> Return code.
 
   ! Initialize.
   call init(test_params, ntiles)

--- a/test_fms/fms2_io/test_io_simple.F90
+++ b/test_fms/fms2_io/test_io_simple.F90
@@ -17,9 +17,9 @@
 !* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
 !***********************************************************************
 
-! This is a very simple test of FMS IO.
+! \brief This is a very simple test of FMS IO.
 
-! Ed Hartnett, 6/10/20
+! \author Ed Hartnett, 6/10/20
 
 program test_io_simple
   use, intrinsic :: iso_fortran_env, only : real32, real64, int32, int64, error_unit, output_unit

--- a/test_fms/fms2_io/test_io_simple.F90
+++ b/test_fms/fms2_io/test_io_simple.F90
@@ -43,6 +43,10 @@ program test_io_simple
   character (len = 100) :: testfile
   integer :: ncid
   integer :: numfilesatt
+  character(len=120), dimension(3) :: format
+  format(1) = '64bit'
+  format(2) = 'classic'
+  format(3) = 'netcdf4'
 
   ! Initialize.
   call init(test_params, ntiles)
@@ -83,7 +87,7 @@ program test_io_simple
      do i = 1, 6
         write(testfile,'(a,i1,a)') 'test_io_simple.tile', i, '.nc'
         err = nf90_open(testfile, nf90_nowrite, ncid)
-        if (err .ne. 0) stop 1
+        if (err .ne. 0) stop 7
         err = nf90_get_att(ncid, NF_GLOBAL, 'NumFilesInSet', numfilesatt)
         if (err .ne. 0) stop 10
         if (numfilesatt .ne. 1) stop 11

--- a/test_fms/fms2_io/test_io_simple.F90
+++ b/test_fms/fms2_io/test_io_simple.F90
@@ -1,0 +1,4 @@
+program test_io_simple
+  print *,'Testing simple IO...'
+  print *,'SUCCESS!'
+end program test_io_simple

--- a/test_fms/fms2_io/test_io_simple.F90
+++ b/test_fms/fms2_io/test_io_simple.F90
@@ -49,7 +49,7 @@ program test_io_simple
   call mpi_check(err)
 
   if (test_params%debug) then
-     if (mpp_pe() .eq. 0) then
+     if (mpp_pe() .eq. mpp_root_pe()) then
         write(error_unit,'(/a)') &
              "Running atmosphere (6-tile domain decomposed) restart file test ... "
      endif
@@ -77,7 +77,7 @@ program test_io_simple
   call close_file(fileobj)
 
   ! Check for expected netcdf file.
-  if (mpp_pe() .eq. 0) then
+  if (mpp_pe() .eq. mpp_root_pe()) then
      err = nf90_open('test_io_simple.tile1.nc', nf90_nowrite, ncid)
      if (err .ne. 0) stop 1
      err = nf90_close(ncid)

--- a/test_fms/fms2_io/test_io_simple.F90
+++ b/test_fms/fms2_io/test_io_simple.F90
@@ -69,7 +69,7 @@ program test_io_simple
 
   call netcdf_io_init(ncchksz, header_buffer_val, netcdf_default_format)
 
-  ! Open a restart file and initialize the file object.
+  ! Open a netCDF file and initialize the file object.
   call open_check(open_file(fileobj, "test_io_simple.nc", "overwrite", &
        domain, nc_format="64bit", is_restart=.false.))
 

--- a/test_fms/fms2_io/test_io_simple.F90
+++ b/test_fms/fms2_io/test_io_simple.F90
@@ -17,9 +17,9 @@
 !* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
 !***********************************************************************
 
-! \brief This is a very simple test of FMS IO.
+!> \brief This is a very simple test of FMS IO.
 
-! \author Ed Hartnett, 6/10/20
+!> \author Ed Hartnett, 6/10/20
 
 program test_io_simple
   use, intrinsic :: iso_fortran_env, only : real32, real64, int32, int64, error_unit, output_unit

--- a/test_fms/fms2_io/test_io_simple.F90
+++ b/test_fms/fms2_io/test_io_simple.F90
@@ -40,7 +40,9 @@ program test_io_simple
   integer :: ncchksz = 64*1024 
   character (len = 10) :: netcdf_default_format = "64bit"
   integer :: header_buffer_val = 16384
-  integer ncid
+  character (len = 100) :: testfile
+  integer :: ncid
+  integer :: numfilesatt
 
   ! Initialize.
   call init(test_params, ntiles)
@@ -78,10 +80,16 @@ program test_io_simple
 
   ! Check for expected netcdf file.
   if (mpp_pe() .eq. 0) then
-     err = nf90_open('test_io_simple.tile1.nc', nf90_nowrite, ncid)
-     if (err .ne. 0) stop 1
-     err = nf90_close(ncid)
-     if (err .ne. 0) stop 90
+     do i = 1, 6
+        write(testfile,'(a,i1,a)') 'test_io_simple.tile', i, '.nc'
+        err = nf90_open(testfile, nf90_nowrite, ncid)
+        if (err .ne. 0) stop 1
+        err = nf90_get_att(ncid, NF_GLOBAL, 'NumFilesInSet', numfilesatt)
+        if (err .ne. 0) stop 10
+        if (numfilesatt .ne. 1) stop 11
+        err = nf90_close(ncid)
+        if (err .ne. 0) stop 90
+     end do
   endif
 
   call mpi_barrier(mpi_comm_world, err)

--- a/test_fms/fms2_io/test_io_simple.F90
+++ b/test_fms/fms2_io/test_io_simple.F90
@@ -84,4 +84,7 @@ program test_io_simple
      if (err .ne. 0) stop 90
   endif
 
+  call mpi_barrier(mpi_comm_world, err)
+  call mpi_check(err)
+  call cleanup(test_params)
 end program test_io_simple

--- a/test_fms/fms2_io/test_io_simple.F90
+++ b/test_fms/fms2_io/test_io_simple.F90
@@ -79,9 +79,9 @@ program test_io_simple
   ! Check for expected netcdf file.
   if (mpp_pe() .eq. mpp_root_pe()) then
      err = nf90_open('test_io_simple.tile1.nc', nf90_nowrite, ncid)
-     if (err .ne. 0) stop 1
+     if (err .ne. NF90_NOERR) stop 1
      err = nf90_close(ncid)
-     if (err .ne. 0) stop 90
+     if (err .ne. NF90_NOERR) stop 90
   endif
 
   call mpi_barrier(mpi_comm_world, err)

--- a/test_fms/fms2_io/test_io_simple.F90
+++ b/test_fms/fms2_io/test_io_simple.F90
@@ -1,4 +1,73 @@
+!***********************************************************************
+!*                   GNU Lesser General Public License
+!*
+!* This file is part of the GFDL Flexible Modeling System (FMS).
+!*
+!* FMS is free software: you can redistribute it and/or modify it under
+!* the terms of the GNU Lesser General Public License as published by
+!* the Free Software Foundation, either version 3 of the License, or (at
+!* your option) any later version.
+!*
+!* FMS is distributed in the hope that it will be useful, but WITHOUT
+!* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+!* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+!* for more details.
+!*
+!* You should have received a copy of the GNU Lesser General Public
+!* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
+!***********************************************************************
+
 program test_io_simple
-  print *,'Testing simple IO...'
-  print *,'SUCCESS!'
+  use, intrinsic :: iso_fortran_env, only : real32, real64, int32, int64, error_unit, output_unit
+  use mpi
+  use fms2_io_mod
+  use netcdf_io_mod
+  use mpp_domains_mod
+  use mpp_mod
+  use setup
+
+  type(Params) :: test_params
+  type(domain2d) :: domain
+  integer :: err
+  type(domain2d), pointer :: io_domain
+  type(FmsNetcdfDomainFile_t) :: fileobj
+  integer, parameter :: ntiles = 6
+  integer :: ncchksz = 64*1024 
+  character (len = 10) :: netcdf_default_format = "64bit"
+  integer :: header_buffer_val = 16384
+  
+  ! Initialize.
+  call init(test_params, ntiles)
+  call create_cubed_sphere_domain(test_params, domain, (/1, 1/))
+  call mpi_barrier(mpi_comm_world, err)
+  call mpi_check(err)
+
+  if (test_params%debug) then
+    if (mpp_pe() .eq. 0) then
+      write(error_unit,'(/a)') &
+        "Running atmosphere (6-tile domain decomposed) restart file test ... "
+    endif
+  endif
+  call mpi_barrier(mpi_comm_world, err)
+  call mpi_check(err)
+
+  !Get the sizes of the I/O compute and data domains.
+  io_domain => mpp_get_io_domain(domain)
+  if (.not. associated(io_domain)) then
+    call mpp_error(fatal, "I/O domain is not associated.")
+  endif
+  call mpp_get_compute_domain(io_domain, xbegin=isc, xend=iec, xsize=nx, ybegin=jsc, yend=jec, ysize=ny)
+  call mpp_get_data_domain(io_domain, xbegin=isd, xsize=nxd, ybegin=jsd, ysize=nyd)
+  call mpp_get_compute_domain(io_domain, xbegin=isc_east, xend=iec_east, xsize=nx_east, position=east)
+  call mpp_get_compute_domain(io_domain, ybegin=jsc_north, yend=jec_north, ysize=ny_north, position=north)
+
+  call netcdf_io_init(ncchksz, header_buffer_val, netcdf_default_format)
+  
+  ! Open a restart file and initialize the file object.
+  call open_check(open_file(fileobj, "test_io_simple.nc", "overwrite", &
+                             domain, nc_format="64bit", is_restart=.true.))
+
+  ! ! Close the file.
+  call close_file(fileobj)
+
 end program test_io_simple

--- a/test_fms/fms2_io/test_io_simple.F90
+++ b/test_fms/fms2_io/test_io_simple.F90
@@ -41,11 +41,6 @@ program test_io_simple
   character (len = 10) :: netcdf_default_format = "64bit"
   integer :: header_buffer_val = 16384
   integer :: ncid
-  integer :: numfilesatt
-  character(len=120), dimension(3) :: format
-  format(1) = '64bit'
-  format(2) = 'classic'
-  format(3) = 'netcdf4'
 
   ! Initialize.
   call init(test_params, ntiles)
@@ -84,10 +79,7 @@ program test_io_simple
   ! Check for expected netcdf file.
   if (mpp_pe() .eq. 0) then
      err = nf90_open('test_io_simple.tile1.nc', nf90_nowrite, ncid)
-     if (err .ne. 0) stop 7
-     err = nf90_get_att(ncid, NF_GLOBAL, 'NumFilesInSet', numfilesatt)
-     if (err .ne. 0) stop 10
-     if (numfilesatt .ne. 1) stop 11
+     if (err .ne. 0) stop 1
      err = nf90_close(ncid)
      if (err .ne. 0) stop 90
   endif

--- a/test_fms/fms2_io/test_io_simple.sh
+++ b/test_fms/fms2_io/test_io_simple.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+#***********************************************************************
+#*                   GNU Lesser General Public License
+#*
+#* This file is part of the GFDL Flexible Modeling System (FMS).
+#*
+#* FMS is free software: you can redistribute it and/or modify it under
+#* the terms of the GNU Lesser General Public License as published by
+#* the Free Software Foundation, either version 3 of the License, or (at
+#* your option) any later version.
+#*
+#* FMS is distributed in the hope that it will be useful, but WITHOUT
+#* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+#* for more details.
+#*
+#* You should have received a copy of the GNU Lesser General Public
+#* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
+#***********************************************************************
+
+# This is part of the GFDL FMS package. This is a shell script to
+# execute tests in the test_fms/fms2_io directory.
+
+# Author: Ed Hartnett 6/10/20
+#
+# Set common test settings.
+. ../test_common.sh
+
+# run the tests
+run_test test_io_simple 6 

--- a/test_fms/fms2_io/test_io_simple.sh
+++ b/test_fms/fms2_io/test_io_simple.sh
@@ -27,5 +27,8 @@
 # Set common test settings.
 . ../test_common.sh
 
+# make an input.nml for mpp_init to read
+printf "EOF\n&dummy\nEOF" | cat > input.nml
+
 # run the tests
 run_test test_io_simple 6 


### PR DESCRIPTION
**Description**
Currently there are no I/O tests that are not skipped. (!)

My goal is to add PIO as an I/O option to FMS. But first, I need the FMS I/O to be tested, so I can ensure I don't break it, and that, with PIO, it works exactly the same.

Part of #244

**How Has This Been Tested?**
Let's see how travis does. I have tested this on my Linux system with GNU tools.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

(BTW you should be asking people to run make -j distcheck, which will also check that they got dependencies correct.)


