### PR TITLE
Adds levels to mpp_init to return at a certain point

### DIFF
--- a/mpp/include/mpp_comm_mpi.inc
+++ b/mpp/include/mpp_comm_mpi.inc
@@ -27,12 +27,14 @@
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   !    subroutine mpp_init( flags, in, out, err, log )
   !      integer, optional, intent(in) :: flags, in, out, err, log
-  subroutine mpp_init( flags, localcomm )
+  subroutine mpp_init( flags, localcomm, test_level )
   integer, optional, intent(in) :: flags
   integer, optional, intent(in) :: localcomm
+  integer, optional, intent(in) :: test_level
   integer                       :: my_pe, num_pes, len, i, iunit
   logical                       :: opened, existed
   integer                       :: unit_begin, unit_end, unit_nml, io_status
+  integer                       :: t_level
   character(len=5) :: this_pe
   type(mpp_type), pointer :: dtype
 
@@ -55,7 +57,12 @@
 #endif
 
   module_is_initialized = .TRUE.
-
+  if (present(test_level)) then
+    t_level = test_level
+  else
+    t_level = -1
+  endif
+  if (t_level == 0) return 
 
   !PEsets: make defaults illegal
   allocate(peset(0:current_peset_max))
@@ -74,11 +81,13 @@
   call MPI_COMM_GROUP( mpp_comm_private, peset(0)%group, error )
   world_peset_num = get_peset( (/(i,i=0,npes-1)/) )
   current_peset_num = world_peset_num !initialize current PEset to world
+  if (t_level == 1) return
 
   !initialize clocks
   call SYSTEM_CLOCK( count=tick0, count_rate=ticks_per_sec, count_max=max_ticks )
   tick_rate = 1./ticks_per_sec
   clock0 = mpp_clock_id( 'Total runtime', flags=MPP_CLOCK_SYNC )
+  if (t_level == 2) return
 
   ! Create the bytestream (default) mpp_datatype
   mpp_byte%counter = 1
@@ -101,9 +110,11 @@
      debug   = flags.EQ.MPP_DEBUG
      verbose = flags.EQ.MPP_VERBOSE .OR. debug
   end if
+  if (t_level == 3) return
 
   call mpp_init_logfile()
   call read_input_nml
+  if (t_level == 4) return
 
   !--- read namelist
 #ifdef INTERNAL_FILE_NML
@@ -124,6 +135,7 @@
   if (io_status > 0) then
      call mpp_error(FATAL,'=>mpp_init: Error reading input.nml')
   endif
+  if (t_level == 5) return
 
   if(sync_all_clocks .AND. mpp_pe()==mpp_root_pe() ) call mpp_error(NOTE, &
      "mpp_mod: mpp_nml variable sync_all_clocks is set to .true., all clocks are synchronized in mpp_clock_begin.")

--- a/mpp/include/mpp_comm_mpi.inc
+++ b/mpp/include/mpp_comm_mpi.inc
@@ -160,6 +160,8 @@
      endif
   endif
 
+  if (t_level == 6) return
+
 ! max_request is set to maximum of npes * REQUEST_MULTIPLY ( default is 20) and MAX_REQUEST_MIN ( default 10000)
   max_request = max(MAX_REQUEST_MIN, mpp_npes()*REQUEST_MULTIPLY)
 
@@ -171,6 +173,8 @@
   request_recv(:) = MPI_REQUEST_NULL
   size_recv(:)    = 0
   type_recv(:)    = 0
+
+  if (t_level == 7) return
 
   !if optional argument logunit=stdout, write messages to stdout instead.
   !if specifying non-defaults, you must specify units not yet in use.

--- a/mpp/mpp.F90
+++ b/mpp/mpp.F90
@@ -214,9 +214,9 @@ private
   public :: COMM_TAG_13, COMM_TAG_14, COMM_TAG_15, COMM_TAG_16
   public :: COMM_TAG_17, COMM_TAG_18, COMM_TAG_19, COMM_TAG_20
   public :: MPP_FILL_INT,MPP_FILL_DOUBLE
-  public :: mpp_init_full_init, mpp_init_init_true_only, mpp_init_peset_allocated
-  public :: mpp_init_clocks_init, mpp_init_datatype_list_init, mpp_init_logfile_init
-  public :: mpp_init_read_namelist, mpp_init_etc_unit, mpp_init_requests_allocated
+  public :: mpp_init_test_full_init, mpp_init_test_init_true_only, mpp_init_test_peset_allocated
+  public :: mpp_init_test_clocks_init, mpp_init_test_datatype_list_init, mpp_init_test_logfile_init
+  public :: mpp_init_test_read_namelist, mpp_init_test_etc_unit, mpp_init_test_requests_allocated
 
   !--- public data from mpp_data_mod ------------------------------
 !  public :: request
@@ -1365,15 +1365,15 @@ private
   integer :: get_len_nocomm = 0 ! needed for mpp_transmit_nocomm.h
   
   !--- variables used in mpp_comm_mpi.inc
-  integer, parameter :: mpp_init_full_init = -1
-  integer, parameter :: mpp_init_init_true_only = 0
-  integer, parameter :: mpp_init_peset_allocated = 1
-  integer, parameter :: mpp_init_clocks_init = 2
-  integer, parameter :: mpp_init_datatype_list_init = 3
-  integer, parameter :: mpp_init_logfile_init = 4
-  integer, parameter :: mpp_init_read_namelist = 5
-  integer, parameter :: mpp_init_etc_unit = 6
-  integer, parameter :: mpp_init_requests_allocated = 7
+  integer, parameter :: mpp_init_test_full_init = -1
+  integer, parameter :: mpp_init_test_init_true_only = 0
+  integer, parameter :: mpp_init_test_peset_allocated = 1
+  integer, parameter :: mpp_init_test_clocks_init = 2
+  integer, parameter :: mpp_init_test_datatype_list_init = 3
+  integer, parameter :: mpp_init_test_logfile_init = 4
+  integer, parameter :: mpp_init_test_read_namelist = 5
+  integer, parameter :: mpp_init_test_etc_unit = 6
+  integer, parameter :: mpp_init_test_requests_allocated = 7
 
 
 !***********************************************************************

--- a/mpp/mpp.F90
+++ b/mpp/mpp.F90
@@ -214,6 +214,9 @@ private
   public :: COMM_TAG_13, COMM_TAG_14, COMM_TAG_15, COMM_TAG_16
   public :: COMM_TAG_17, COMM_TAG_18, COMM_TAG_19, COMM_TAG_20
   public :: MPP_FILL_INT,MPP_FILL_DOUBLE
+  public :: mpp_init_full_init, mpp_init_init_true_only, mpp_init_peset_allocated
+  public :: mpp_init_clocks_init, mpp_init_datatype_list_init, mpp_init_logfile_init
+  public :: mpp_init_read_namelist, mpp_init_etc_unit, mpp_init_requests_allocated
 
   !--- public data from mpp_data_mod ------------------------------
 !  public :: request
@@ -335,7 +338,7 @@ private
   !    exit, i.e:
   !    <PRE>
   !    call mpp_error
-  !    call mpp_error(FATAL)
+  !    call mpp_error()
   !    </PRE>
   !    are equivalent.
   !
@@ -1360,6 +1363,18 @@ private
 #endif
 
   integer :: get_len_nocomm = 0 ! needed for mpp_transmit_nocomm.h
+  
+  !--- variables used in mpp_comm_mpi.inc
+  integer, parameter :: mpp_init_full_init = -1
+  integer, parameter :: mpp_init_init_true_only = 0
+  integer, parameter :: mpp_init_peset_allocated = 1
+  integer, parameter :: mpp_init_clocks_init = 2
+  integer, parameter :: mpp_init_datatype_list_init = 3
+  integer, parameter :: mpp_init_logfile_init = 4
+  integer, parameter :: mpp_init_read_namelist = 5
+  integer, parameter :: mpp_init_etc_unit = 6
+  integer, parameter :: mpp_init_requests_allocated = 7
+
 
 !***********************************************************************
 !  variables needed for subroutine read_input_nml (include/mpp_util.inc)


### PR DESCRIPTION
**Description**
Adds a return to mpp_init so that different tests can use different amounts of mpp_init.

Fixes #454

**How Has This Been Tested?**
Tested with `make check` using intel20 and the travis_ci

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

