### PR TITLE
WIP - initialize buffers to zero

### DIFF
--- a/fms2_io/include/domain_write.inc
+++ b/fms2_io/include/domain_write.inc
@@ -169,12 +169,16 @@ subroutine domain_write_2d(fileobj, variable_name, vdata, unlim_dim_level, &
     select type(vdata)
       type is (integer(kind=int32))
         call allocate_array(global_buf_int32, e)
+        global_buf_int32 = 0
       type is (integer(kind=int64))
         call allocate_array(global_buf_int64, e)
+        global_buf_int64 = 0
       type is (real(kind=real32))
         call allocate_array(global_buf_real32, e)
+        global_buf_real32 = 0.
       type is (real(kind=real64))
         call allocate_array(global_buf_real64, e)
+        global_buf_real64 = 0.
       class default
         call error("unsupported type.")
     end select
@@ -434,12 +438,16 @@ subroutine domain_write_3d(fileobj, variable_name, vdata, unlim_dim_level, &
     select type(vdata)
       type is (integer(kind=int32))
         call allocate_array(global_buf_int32, e)
+        global_buf_int32 = 0
       type is (integer(kind=int64))
         call allocate_array(global_buf_int64, e)
+        global_buf_int64 = 0
       type is (real(kind=real32))
         call allocate_array(global_buf_real32, e)
+        global_buf_real32 = 0.
       type is (real(kind=real64))
         call allocate_array(global_buf_real64, e)
+        global_buf_real64 = 0.
       class default
         call error("unsupported type.")
     end select
@@ -699,12 +707,16 @@ subroutine domain_write_4d(fileobj, variable_name, vdata, unlim_dim_level, &
     select type(vdata)
       type is (integer(kind=int32))
         call allocate_array(global_buf_int32, e)
+        global_buf_int32 = 0
       type is (integer(kind=int64))
         call allocate_array(global_buf_int64, e)
+        global_buf_int64 = 0
       type is (real(kind=real32))
         call allocate_array(global_buf_real32, e)
+        global_buf_real32 = 0.
       type is (real(kind=real64))
         call allocate_array(global_buf_real64, e)
+        global_buf_real64 = 0.
       class default
         call error("unsupported type.")
     end select
@@ -964,12 +976,16 @@ subroutine domain_write_5d(fileobj, variable_name, vdata, unlim_dim_level, &
     select type(vdata)
       type is (integer(kind=int32))
         call allocate_array(global_buf_int32, e)
+        global_buf_int32 = 0
       type is (integer(kind=int64))
         call allocate_array(global_buf_int64, e)
+        global_buf_int64 = 0
       type is (real(kind=real32))
         call allocate_array(global_buf_real32, e)
+        global_buf_real32 = 0.
       type is (real(kind=real64))
         call allocate_array(global_buf_real64, e)
+        global_buf_real64 = 0.
       class default
         call error("unsupported type.")
     end select


### PR DESCRIPTION
**Description**
Initializes global buffers to zero.  This prevents the buffer from containing uninitialized values when it is passed to netCDF to be written, which appears to be the cause of the crashes in the linked issue.

Fixes #447

**How Has This Been Tested?**
I ran a 2-day simulation with a mask table, but since I was re-using someone else's work directory I don't know the specifics.  @nikizadehgfdl  and @ngs333, can you please try this branch in your tests?  If it passes, then I will remove the WIP label.

**Checklist:**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] `make distcheck` passes

