### PR TITLE
fms2io: optional argument to not add ".res" to filename

### DIFF
--- a/fms2_io/fms_netcdf_domain_io.F90
+++ b/fms2_io/fms_netcdf_domain_io.F90
@@ -317,7 +317,7 @@ end function is_dimension_registered
 
 !> @brief Open a domain netcdf file.
 !! @return Flag telling if the open completed successfully.
-function open_domain_file(fileobj, path, mode, domain, nc_format, is_restart) &
+function open_domain_file(fileobj, path, mode, domain, nc_format, is_restart, add_res_to_filename) &
   result(success)
 
   type(FmsNetcdfDomainFile_t),intent(inout) :: fileobj !< File object.
@@ -335,6 +335,8 @@ function open_domain_file(fileobj, path, mode, domain, nc_format, is_restart) &
   logical, intent(in), optional :: is_restart !< Flag telling if this file
                                               !! is a restart file.  Defaults
                                               !! to false.
+  logical, intent(in), optional :: add_res_to_filename !< Flag telling if ".res" should
+                                              !! be added to the filename
   logical :: success
 
   integer, dimension(2) :: io_layout
@@ -376,19 +378,19 @@ function open_domain_file(fileobj, path, mode, domain, nc_format, is_restart) &
 
   !Open the distibuted files.
   success = netcdf_file_open(fileobj, distributed_filepath, mode, nc_format, pelist, &
-                             is_restart)
+                             is_restart, add_res_to_filename)
   if (string_compare(mode, "read", .true.) .or. string_compare(mode, "append", .true.)) then
     if (success) then
       if (.not. string_compare(distributed_filepath, combined_filepath)) then
         success2 = netcdf_file_open(fileobj2, combined_filepath, mode, nc_format, pelist, &
-                                    is_restart)
+                                    is_restart, add_res_to_filename)
         if (success2) then
           call error("you have both combined and distributed files.")
         endif
       endif
     else
       success = netcdf_file_open(fileobj, combined_filepath, mode, nc_format, pelist, &
-                                 is_restart)
+                                 is_restart, add_res_to_filename)
       !If the file is combined and the layout is not (1,1) set the adjust_indices flag to false
       if (success .and. (io_layout(1)*io_layout(2) .gt. 1)) fileobj%adjust_indices = .false.
     endif

--- a/fms2_io/fms_netcdf_domain_io.F90
+++ b/fms2_io/fms_netcdf_domain_io.F90
@@ -317,7 +317,7 @@ end function is_dimension_registered
 
 !> @brief Open a domain netcdf file.
 !! @return Flag telling if the open completed successfully.
-function open_domain_file(fileobj, path, mode, domain, nc_format, is_restart, add_res_to_filename) &
+function open_domain_file(fileobj, path, mode, domain, nc_format, is_restart, dont_add_res_to_filename) &
   result(success)
 
   type(FmsNetcdfDomainFile_t),intent(inout) :: fileobj !< File object.
@@ -335,8 +335,8 @@ function open_domain_file(fileobj, path, mode, domain, nc_format, is_restart, ad
   logical, intent(in), optional :: is_restart !< Flag telling if this file
                                               !! is a restart file.  Defaults
                                               !! to false.
-  logical, intent(in), optional :: add_res_to_filename !< Flag telling if ".res" should
-                                              !! be added to the filename
+  logical, intent(in), optional :: dont_add_res_to_filename !< Flag indicating not to add
+                                              !! ".res" to the filename
   logical :: success
 
   integer, dimension(2) :: io_layout
@@ -378,19 +378,19 @@ function open_domain_file(fileobj, path, mode, domain, nc_format, is_restart, ad
 
   !Open the distibuted files.
   success = netcdf_file_open(fileobj, distributed_filepath, mode, nc_format, pelist, &
-                             is_restart, add_res_to_filename)
+                             is_restart, dont_add_res_to_filename)
   if (string_compare(mode, "read", .true.) .or. string_compare(mode, "append", .true.)) then
     if (success) then
       if (.not. string_compare(distributed_filepath, combined_filepath)) then
         success2 = netcdf_file_open(fileobj2, combined_filepath, mode, nc_format, pelist, &
-                                    is_restart, add_res_to_filename)
+                                    is_restart, dont_add_res_to_filename)
         if (success2) then
           call error("you have both combined and distributed files.")
         endif
       endif
     else
       success = netcdf_file_open(fileobj, combined_filepath, mode, nc_format, pelist, &
-                                 is_restart, add_res_to_filename)
+                                 is_restart, dont_add_res_to_filename)
       !If the file is combined and the layout is not (1,1) set the adjust_indices flag to false
       if (success .and. (io_layout(1)*io_layout(2) .gt. 1)) fileobj%adjust_indices = .false.
     endif

--- a/fms2_io/fms_netcdf_unstructured_domain_io.F90
+++ b/fms2_io/fms_netcdf_unstructured_domain_io.F90
@@ -66,7 +66,7 @@ contains
 !> @brief Open a netcdf file that is associated with an unstructured domain.
 !! @return Flag telling if the open completed successfully.
 function open_unstructured_domain_file(fileobj, path, mode, domain, nc_format, &
-                                       is_restart, add_res_to_filename) &
+                                       is_restart, dont_add_res_to_filename) &
   result(success)
 
   type(FmsNetcdfUnstructuredDomainFile_t), intent(inout) :: fileobj !< File object.
@@ -84,8 +84,8 @@ function open_unstructured_domain_file(fileobj, path, mode, domain, nc_format, &
   logical, intent(in), optional :: is_restart !< Flag telling if this file
                                               !! is a restart file.  Defaults
                                               !! to false.
-  logical, intent(in), optional :: add_res_to_filename !< Flag telling if ".res" should
-                                              !! be added to the filename
+  logical, intent(in), optional :: dont_add_res_to_filename !< Flag indicating not to add
+                                              !! ".res" to the filename
   logical :: success
 
   type(domainug), pointer :: io_domain
@@ -114,7 +114,7 @@ function open_unstructured_domain_file(fileobj, path, mode, domain, nc_format, &
   success = .false.
   if (string_compare(mode, "read", .true.) .or. string_compare(mode, "append", .true.)) then
     !Only for reading: attempt to open non-distributed files.
-    success = netcdf_file_open(fileobj, buf, mode, nc_format, pelist, is_restart, add_res_to_filename)
+    success = netcdf_file_open(fileobj, buf, mode, nc_format, pelist, is_restart, dont_add_res_to_filename)
   endif
   if (.not. success) then
     !Add the domain tile id to the file name (if necessary).
@@ -125,7 +125,7 @@ function open_unstructured_domain_file(fileobj, path, mode, domain, nc_format, &
     endif
 
     !Open distributed files.
-    success = netcdf_file_open(fileobj, buf, mode, nc_format, pelist, is_restart, add_res_to_filename)
+    success = netcdf_file_open(fileobj, buf, mode, nc_format, pelist, is_restart, dont_add_res_to_filename)
   endif
   deallocate(pelist)
 

--- a/fms2_io/fms_netcdf_unstructured_domain_io.F90
+++ b/fms2_io/fms_netcdf_unstructured_domain_io.F90
@@ -66,7 +66,7 @@ contains
 !> @brief Open a netcdf file that is associated with an unstructured domain.
 !! @return Flag telling if the open completed successfully.
 function open_unstructured_domain_file(fileobj, path, mode, domain, nc_format, &
-                                       is_restart) &
+                                       is_restart, add_res_to_filename) &
   result(success)
 
   type(FmsNetcdfUnstructuredDomainFile_t), intent(inout) :: fileobj !< File object.
@@ -84,6 +84,8 @@ function open_unstructured_domain_file(fileobj, path, mode, domain, nc_format, &
   logical, intent(in), optional :: is_restart !< Flag telling if this file
                                               !! is a restart file.  Defaults
                                               !! to false.
+  logical, intent(in), optional :: add_res_to_filename !< Flag telling if ".res" should
+                                              !! be added to the filename
   logical :: success
 
   type(domainug), pointer :: io_domain
@@ -112,7 +114,7 @@ function open_unstructured_domain_file(fileobj, path, mode, domain, nc_format, &
   success = .false.
   if (string_compare(mode, "read", .true.) .or. string_compare(mode, "append", .true.)) then
     !Only for reading: attempt to open non-distributed files.
-    success = netcdf_file_open(fileobj, buf, mode, nc_format, pelist, is_restart)
+    success = netcdf_file_open(fileobj, buf, mode, nc_format, pelist, is_restart, add_res_to_filename)
   endif
   if (.not. success) then
     !Add the domain tile id to the file name (if necessary).
@@ -123,7 +125,7 @@ function open_unstructured_domain_file(fileobj, path, mode, domain, nc_format, &
     endif
 
     !Open distributed files.
-    success = netcdf_file_open(fileobj, buf, mode, nc_format, pelist, is_restart)
+    success = netcdf_file_open(fileobj, buf, mode, nc_format, pelist, is_restart, add_res_to_filename)
   endif
   deallocate(pelist)
 

--- a/fms2_io/netcdf_io.F90
+++ b/fms2_io/netcdf_io.F90
@@ -425,7 +425,7 @@ end function get_variable_type
 
 !> @brief Open a netcdf file.
 !! @return .true. if open succeeds, or else .false.
-function netcdf_file_open(fileobj, path, mode, nc_format, pelist, is_restart, add_res_to_filename) &
+function netcdf_file_open(fileobj, path, mode, nc_format, pelist, is_restart, dont_add_res_to_filename) &
   result(success)
 
   class(FmsNetcdfFile_t), intent(inout) :: fileobj !< File object.
@@ -449,15 +449,15 @@ function netcdf_file_open(fileobj, path, mode, nc_format, pelist, is_restart, ad
   logical, intent(in), optional :: is_restart !< Flag telling if this file
                                               !! is a restart file.  Defaults
                                               !! to false.
-  logical, intent(in), optional :: add_res_to_filename !< Flag telling if ".res" should
-                                              !! be added to the filename
+  logical, intent(in), optional :: dont_add_res_to_filename !< Flag indicating not to add
+                                              !! ".res" to the filename
   logical :: success
 
   integer :: nc_format_param
   integer :: err
   character(len=256) :: buf
   logical :: is_res
-  logical :: add_res
+  logical :: dont_add_res
 
   if (allocated(fileobj%is_open)) then
     if (fileobj%is_open) then
@@ -470,11 +470,12 @@ function netcdf_file_open(fileobj, path, mode, nc_format, pelist, is_restart, ad
   if (present(is_restart)) then
     is_res = is_restart
   endif
-  if (present(add_res_to_filename)) then
-    add_res = add_res_to_filename
+  dont_add_res = .false.
+  if (present(dont_add_res_to_filename)) then
+    dont_add_res = dont_add_res_to_filename
   endif
 
-  if (is_res .and. add_res) then
+  if (is_res .and. .not. dont_add_res) then
     call restart_filepath_mangle(buf, trim(path))
   else
     call string_copy(buf, trim(path))

--- a/fms2_io/netcdf_io.F90
+++ b/fms2_io/netcdf_io.F90
@@ -425,7 +425,7 @@ end function get_variable_type
 
 !> @brief Open a netcdf file.
 !! @return .true. if open succeeds, or else .false.
-function netcdf_file_open(fileobj, path, mode, nc_format, pelist, is_restart) &
+function netcdf_file_open(fileobj, path, mode, nc_format, pelist, is_restart, add_res_to_filename) &
   result(success)
 
   class(FmsNetcdfFile_t), intent(inout) :: fileobj !< File object.
@@ -449,12 +449,15 @@ function netcdf_file_open(fileobj, path, mode, nc_format, pelist, is_restart) &
   logical, intent(in), optional :: is_restart !< Flag telling if this file
                                               !! is a restart file.  Defaults
                                               !! to false.
+  logical, intent(in), optional :: add_res_to_filename !< Flag telling if ".res" should
+                                              !! be added to the filename
   logical :: success
 
   integer :: nc_format_param
   integer :: err
   character(len=256) :: buf
   logical :: is_res
+  logical :: add_res
 
   if (allocated(fileobj%is_open)) then
     if (fileobj%is_open) then
@@ -467,7 +470,11 @@ function netcdf_file_open(fileobj, path, mode, nc_format, pelist, is_restart) &
   if (present(is_restart)) then
     is_res = is_restart
   endif
-  if (is_res) then
+  if (present(add_res_to_filename)) then
+    add_res = add_res_to_filename
+  endif
+
+  if (is_res .and. add_res) then
     call restart_filepath_mangle(buf, trim(path))
   else
     call string_copy(buf, trim(path))

--- a/fms2_io/netcdf_io.F90
+++ b/fms2_io/netcdf_io.F90
@@ -466,7 +466,7 @@ function netcdf_file_open(fileobj, path, mode, nc_format, pelist, is_restart, do
     endif
   endif
   !< Only add ".res" to the file path if is_restart is set to true
-  !! dont_add_res_to_filename is set to false.
+  !! and dont_add_res_to_filename is set to false.
   is_res = .false.
   if (present(is_restart)) then
     is_res = is_restart

--- a/fms2_io/netcdf_io.F90
+++ b/fms2_io/netcdf_io.F90
@@ -457,7 +457,7 @@ function netcdf_file_open(fileobj, path, mode, nc_format, pelist, is_restart, do
   integer :: err
   character(len=256) :: buf
   logical :: is_res
-  logical :: dont_add_res
+  logical :: dont_add_res !< flag indicated to not add ".res" to the filename
 
   if (allocated(fileobj%is_open)) then
     if (fileobj%is_open) then
@@ -465,7 +465,8 @@ function netcdf_file_open(fileobj, path, mode, nc_format, pelist, is_restart, do
       return
     endif
   endif
-  !Add ".res" to the file path if necessary.
+  !< Only add ".res" to the file path if is_restart is set to true
+  !! dont_add_res_to_filename is set to false.
   is_res = .false.
   if (present(is_restart)) then
     is_res = is_restart

--- a/fms2_io/netcdf_io.F90
+++ b/fms2_io/netcdf_io.F90
@@ -1751,7 +1751,7 @@ include "compressed_read.inc"
 
 
 !> @brief Wrapper to distinguish interfaces.
-function netcdf_file_open_wrap(fileobj, path, mode, nc_format, pelist, is_restart) &
+function netcdf_file_open_wrap(fileobj, path, mode, nc_format, pelist, is_restart, dont_add_res_to_filename) &
   result(success)
 
   type(FmsNetcdfFile_t), intent(inout) :: fileobj !< File object.
@@ -1773,9 +1773,11 @@ function netcdf_file_open_wrap(fileobj, path, mode, nc_format, pelist, is_restar
   logical, intent(in), optional :: is_restart !< Flag telling if this file
                                               !! is a restart file.  Defaults
                                               !! to false.
+  logical, intent(in), optional :: dont_add_res_to_filename !< Flag indicating not to add
+                                               !! ".res" to the filename
   logical :: success
 
-  success = netcdf_file_open(fileobj, path, mode, nc_format, pelist, is_restart)
+  success = netcdf_file_open(fileobj, path, mode, nc_format, pelist, is_restart, dont_add_res_to_filename)
 end function netcdf_file_open_wrap
 
 


### PR DESCRIPTION

**Description**
Adds optional argument to open_file indicating whether '.res' should be added to the filename

Fixes #462 

**How Has This Been Tested?**
Passes make check in gaea with intel16 and travis
@laurenchilutti should test this with her fv3 test cases

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

