### PR TITLE
added include dependencies for mpp mod files

### DIFF
--- a/mpp/Makefile.am
+++ b/mpp/Makefile.am
@@ -25,6 +25,24 @@
 # Descend into include directory.
 SUBDIRS = include
 
+# These are the .inc files in the include directory.
+INCFILES = include/group_update_pack.inc include/mpp_comm_mpi.inc	\
+include/mpp_data_mpi.inc include/mpp_define_nest_domains.inc		\
+include/mpp_domains_misc.inc include/mpp_io_connect.inc			\
+include/mpp_io_unstructured_read.inc include/mpp_io_write.inc		\
+include/mpp_sum.inc include/mpp_util.inc include/mpp_util_sma.inc	\
+include/group_update_unpack.inc include/mpp_comm_nocomm.inc		\
+include/mpp_data_nocomm.inc include/mpp_domains_comm.inc		\
+include/mpp_domains_reduce.inc include/mpp_io_misc.inc			\
+include/mpp_io_unstructured_write.inc					\
+include/mpp_read_distributed_ascii.inc include/mpp_transmit.inc		\
+include/mpp_util_mpi.inc include/mpp_comm.inc				\
+include/mpp_comm_sma.inc include/mpp_data_sma.inc			\
+include/mpp_domains_define.inc include/mpp_domains_util.inc		\
+include/mpp_io_read.inc include/mpp_io_util.inc				\
+include/mpp_sum_ad.inc include/mpp_unstruct_domain.inc			\
+include/mpp_util_nocomm.inc
+
 # Include .h and .mod files.
 AM_CPPFLAGS = -I${top_srcdir}/include
 AM_CPPFLAGS += -I${top_srcdir}/mpp/include
@@ -37,7 +55,7 @@ libmpp_domains.la libmpp_io.la libmpp_c.la libmpp_memuse_c.la
 # Each convenience library depends on its source.
 libmpp_parameter_la_SOURCES = mpp_parameter.F90
 libmpp_la_SOURCES = mpp.F90
-libmpp_data_la_SOURCES = mpp_data.F90
+libmpp_data_la_SOURCES = mpp_data.F90 
 libmpp_utilities_la_SOURCES = mpp_utilities.F90
 libmpp_domains_la_SOURCES = mpp_domains.F90
 libmpp_io_la_SOURCES = mpp_io.F90
@@ -50,7 +68,7 @@ libmpp_memuse_c_la_SOURCES = mpp_memuse.c
 # Each mod file depends on the .o file.
 mpp_parameter_mod.mod: mpp_parameter.lo
 mpp_data_mod.mod: mpp_data.lo
-mpp_mod.mod: mpp.lo
+mpp_mod.mod: mpp.lo mpp_parameter.lo mpp_data.lo
 mpp_pset_mod.mod: mpp_pset.lo
 mpp_utilities_mod.mod: mpp_utilities.lo
 mpp_memutils_mod.mod: mpp_memutils.lo
@@ -58,16 +76,17 @@ mpp_efp_mod.mod: mpp_efp.lo
 mpp_domains_mod.mod: mpp_domains.lo
 mpp_io_mod.mod: mpp_io.lo
 
-# Some mods are dependant on other mods in this dir.
-mpp_data.lo: mpp_parameter_mod.mod
-mpp.lo: mpp_data_mod.mod
-mpp_utilities.lo: mpp_mod.mod mpp_efp_mod.mod
-mpp_memutils.lo: mpp_mod.mod
-mpp_pset.lo: mpp_mod.mod
-mpp_efp.lo: mpp_parameter_mod.mod mpp_mod.mod
+# Some mods are dependant on other mods in this dir. All mods depend
+# on the include files.
+mpp_data.lo: mpp_parameter_mod.mod $(INCFILES)
+mpp.lo: mpp_parameter_mod.mod mpp_data_mod.mod $(INCFILES)
+mpp_utilities.lo: mpp_mod.mod mpp_efp_mod.mod $(INCFILES)
+mpp_memutils.lo: mpp_mod.mod $(INCFILES)
+mpp_pset.lo: mpp_mod.mod $(INCFILES)
+mpp_efp.lo: mpp_parameter_mod.mod mpp_mod.mod $(INCFILES)
 mpp_domains.lo: mpp_data_mod.mod mpp_parameter_mod.mod mpp_mod.mod	\
-mpp_memutils_mod.mod mpp_pset_mod.mod mpp_efp_mod.mod
-mpp_io.lo: mpp_parameter_mod.mod mpp_mod.mod mpp_domains_mod.mod
+mpp_memutils_mod.mod mpp_pset_mod.mod mpp_efp_mod.mod $(INCFILES)
+mpp_io.lo: mpp_parameter_mod.mod mpp_mod.mod mpp_domains_mod.mod $(INCFILES)
 
 # Mod files are built and then installed as headers.
 MODFILES = mpp_parameter_mod.mod mpp_data_mod.mod mpp_mod.mod \


### PR DESCRIPTION
**Description**
This PR makes the build of the mod files in the mpp directory dependent on the include files. After this is merged, a programmer can edit one of the .inc files, and a simple "make" will rebuild the mpp directory automatically.

Part of #470

**How Has This Been Tested?**
Tested on my GNU/Linux machine.


**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

