### PR TITLE
simple test for mpp_domains

### DIFF
--- a/test_fms/mpp/Makefile.am
+++ b/test_fms/mpp/Makefile.am
@@ -37,7 +37,8 @@ check_PROGRAMS = test_mpp \
   test_mpp_print_memuse_stats_stderr \
   test_mpp_print_memuse_stats_file \
   test_mpp_memutils_begin_2x \
-  test_mpp_memutils_end_before_begin
+  test_mpp_memutils_end_before_begin \
+  test_domains_simple
 
 # These are the sources for the tests.
 test_mpp_SOURCES = test_mpp.F90
@@ -50,6 +51,7 @@ test_mpp_print_memuse_stats_stderr_SOURCES=test_mpp_print_memuse_stats_stderr.F9
 test_mpp_print_memuse_stats_file_SOURCES=test_mpp_print_memuse_stats_file.F90
 test_mpp_memutils_begin_2x_SOURCES=test_mpp_memutils_begin_2x.F90
 test_mpp_memutils_end_before_begin_SOURCES=test_mpp_memutils_end_before_begin.F90
+test_domains_simple_SOURCES = test_domains_simple.F90
 
 # Run the test programs.
 TESTS = test_mpp_domains2.sh \

--- a/test_fms/mpp/test_domains_simple.F90
+++ b/test_fms/mpp/test_domains_simple.F90
@@ -19,8 +19,8 @@
 
 !> @file
 
-!> This is a simple test of MPP layouts and a simple domain. In
-!> testing it should be run with 4 pes.
+!> This is a simple test of MPP layouts and a simple 1D and 2D
+!> domain. In testing it should be run with 4 pes.
 
 !> @author Ed Hartnett 6/22/20
 program test_domains_simple

--- a/test_fms/mpp/test_domains_simple.F90
+++ b/test_fms/mpp/test_domains_simple.F90
@@ -1,0 +1,49 @@
+!***********************************************************************
+!*                   GNU Lesser General Public License
+!*
+!* This file is part of the GFDL Flexible Modeling System (FMS).
+!*
+!* FMS is free software: you can redistribute it and/or modify it under
+!* the terms of the GNU Lesser General Public License as published by
+!* the Free Software Foundation, either version 3 of the License, or (at
+!* your option) any later version.
+!*
+!* FMS is distributed in the hope that it will be useful, but WITHOUT
+!* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+!* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+!* for more details.
+!*
+!* You should have received a copy of the GNU Lesser General Public
+!* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
+!***********************************************************************
+program test_domains_simple
+  use mpp_mod
+  use mpp_domains_mod
+
+  implicit none
+#include "../../include/fms_platform.h"
+  integer :: pe, npes
+  integer :: nx=128, ny=128, nz=40, stackmax=4000000
+  integer :: layout(2)
+  type(domain2D) :: domain
+  
+  call mpp_init()
+
+  pe = mpp_pe()
+  npes = mpp_npes()
+
+  !--- initialize mpp domains
+  call mpp_domains_init(MPP_DEBUG)
+  call mpp_domains_set_stack_size(stackmax)
+
+  call mpp_define_layout( (/1,nx,1,ny/), npes, layout )
+  if (npes .eq. 4) then
+     if (layout(1) .ne. 2 .or. layout(2) .ne. 2) call mpp_error(FATAL, 'bad layout values')
+  endif
+  
+  call mpp_define_domains( (/1,nx,1,ny/), layout, domain )
+  
+  call mpp_domains_exit()
+  call mpp_exit()
+
+end program test_domains_simple

--- a/test_fms/mpp/test_domains_simple.F90
+++ b/test_fms/mpp/test_domains_simple.F90
@@ -18,7 +18,9 @@
 !***********************************************************************
 
 !> @file
-!> This is a simple test of MPP layouts and a simple domain.
+
+!> This is a simple test of MPP layouts and a simple domain. In
+!> testing it should be run with 4 pes.
 
 !> @author Ed Hartnett 6/22/20
 program test_domains_simple
@@ -28,7 +30,7 @@ program test_domains_simple
   implicit none
 #include "../../include/fms_platform.h"
   integer :: pe, npes
-  integer :: nx=128, ny=128, nz=40, stackmax=4000000
+  integer :: nx=128, ny=128, nz=40
   integer :: layout(2)
   type(domain2D) :: domain
   
@@ -39,7 +41,6 @@ program test_domains_simple
 
   !--- initialize mpp domains
   call mpp_domains_init(MPP_DEBUG)
-  call mpp_domains_set_stack_size(stackmax)
 
   call mpp_define_layout( (/1,nx,1,ny/), npes, layout )
   if (npes .eq. 4) then

--- a/test_fms/mpp/test_domains_simple.F90
+++ b/test_fms/mpp/test_domains_simple.F90
@@ -32,7 +32,8 @@ program test_domains_simple
   integer :: pe, npes
   integer :: nx=128, ny=128, nz=40
   integer :: layout(2)
-  type(domain2D) :: domain
+  type(domain2D) :: domain_2D
+  type(domain1D) :: domain_1D
   
   call mpp_init()
 
@@ -42,14 +43,25 @@ program test_domains_simple
   !--- initialize mpp domains
   call mpp_domains_init(MPP_DEBUG)
 
-  call mpp_define_layout( (/1,nx,1,ny/), npes, layout )
+  ! Define a layout.
+  call mpp_define_layout((/1, nx, 1, ny/), npes, layout)
+
+  ! Check results when run on 4 pes.
   if (npes .eq. 4) then
      if (layout(1) .ne. 2 .or. layout(2) .ne. 2) call mpp_error(FATAL, 'bad layout values')
   endif
-  
-  call mpp_define_domains( (/1,nx,1,ny/), layout, domain )
-  
+
+  ! Define a 1D domain.
+  !call mpp_define_domains((/1, nx/), 4, domain_1D)
+  call mpp_define_domains((/1, nx/), 4, domain_1D, pelist=(/0, 1, 2, 3/))
+
+  ! Define a 2D domain.
+  call mpp_define_domains((/1, nx, 1, ny/), layout, domain_2D)
+
+  ! Clean up domains.
   call mpp_domains_exit()
+
+  ! Finalize MPP.
   call mpp_exit()
 
 end program test_domains_simple

--- a/test_fms/mpp/test_domains_simple.F90
+++ b/test_fms/mpp/test_domains_simple.F90
@@ -29,19 +29,19 @@ program test_domains_simple
 
   implicit none
 #include "../../include/fms_platform.h"
-  integer :: pe, npes
-  integer :: nx=40, ny=40, nz=40
-  integer :: layout(2)
-  type(domain2D) :: domain_2D
-  type(domain1D) :: domain_1D
-  integer :: is, ie, js, je
+  integer :: pe, npes     !> This pe and the total number of pes.
+  integer :: nx=40, ny=40 !> Size of our 2D domain. 
+  integer :: layout(2)    !> Layout of our 2D domain.
+  type(domain2D) :: domain_2D !> A 2D domain.
+  type(domain1D) :: domain_1D !> A 1D domain.
+  integer :: is, ie, js, je   !> For checking domains.
   
   call mpp_init()
 
   pe = mpp_pe()
   npes = mpp_npes()
 
-  !--- initialize mpp domains
+  ! Initialize mpp domains.
   call mpp_domains_init(MPP_DEBUG)
 
   ! Define a layout.
@@ -52,9 +52,13 @@ program test_domains_simple
      if (layout(1) .ne. 2 .or. layout(2) .ne. 2) call mpp_error(FATAL, 'bad layout values')
   endif
 
-  ! Define a 1D domain.
+  ! Define a 1D domain - but this doesn't work because the pelist is missing.
   !call mpp_define_domains((/1, nx/), 4, domain_1D)
+
+  ! Define a 1D domain.
   call mpp_define_domains((/1, nx/), 4, domain_1D, pelist=(/0, 1, 2, 3/))
+
+  ! Get the values of the compute domain.
   call mpp_get_compute_domain(domain_1D, is, ie)
   
   ! Check results when run on 4 pes.
@@ -65,8 +69,9 @@ program test_domains_simple
 
   ! Define a 2D domain.
   call mpp_define_domains((/1, nx, 1, ny/), layout, domain_2D)
+
+  ! Get the values of the 2D compute domain.
   call mpp_get_compute_domain(domain_2D, xbegin = is, xend = ie, ybegin = js, yend = je)
-  print *, pe, is, ie, js, je
 
   ! Check results when run on 4 pes.
   if (npes .eq. 4) then

--- a/test_fms/mpp/test_domains_simple.F90
+++ b/test_fms/mpp/test_domains_simple.F90
@@ -30,10 +30,11 @@ program test_domains_simple
   implicit none
 #include "../../include/fms_platform.h"
   integer :: pe, npes
-  integer :: nx=128, ny=128, nz=40
+  integer :: nx=40, ny=40, nz=40
   integer :: layout(2)
   type(domain2D) :: domain_2D
   type(domain1D) :: domain_1D
+  integer :: is, ie, js, je
   
   call mpp_init()
 
@@ -54,9 +55,32 @@ program test_domains_simple
   ! Define a 1D domain.
   !call mpp_define_domains((/1, nx/), 4, domain_1D)
   call mpp_define_domains((/1, nx/), 4, domain_1D, pelist=(/0, 1, 2, 3/))
+  call mpp_get_compute_domain(domain_1D, is, ie)
+  
+  ! Check results when run on 4 pes.
+  if (npes .eq. 4) then
+     if (is .ne. pe * 10 + 1) call mpp_error(FATAL, 'bad domain start value')
+     if (ie .ne. 10 * (pe + 1)) call mpp_error(FATAL, 'bad domain end value')
+  endif
 
   ! Define a 2D domain.
   call mpp_define_domains((/1, nx, 1, ny/), layout, domain_2D)
+  call mpp_get_compute_domain(domain_2D, xbegin = is, xend = ie, ybegin = js, yend = je)
+  print *, pe, is, ie, js, je
+
+  ! Check results when run on 4 pes.
+  if (npes .eq. 4) then
+     if (pe .eq. 0 .or. pe .eq. 2) then
+        if (is .ne. 1 .or. ie .ne. 20) call mpp_error(FATAL, 'bad 2D domain')
+     else
+       if (is .ne. 21 .or. ie .ne. 40) call mpp_error(FATAL, 'bad 2D domain')
+     endif
+     if (pe .eq. 0 .or. pe .eq. 1) then
+        if (js .ne. 1 .or. je .ne. 20) call mpp_error(FATAL, 'bad 2D domain')
+     else
+        if (js .ne. 21 .or. je .ne. 40) call mpp_error(FATAL, 'bad 2D domain')
+     endif
+  endif
 
   ! Clean up domains.
   call mpp_domains_exit()

--- a/test_fms/mpp/test_domains_simple.F90
+++ b/test_fms/mpp/test_domains_simple.F90
@@ -16,6 +16,11 @@
 !* You should have received a copy of the GNU Lesser General Public
 !* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
 !***********************************************************************
+
+!> @file
+!> This is a simple test of MPP layouts and a simple domain.
+
+!> @author Ed Hartnett 6/22/20
 program test_domains_simple
   use mpp_mod
   use mpp_domains_mod

--- a/test_fms/mpp/test_mpp_domains2.sh
+++ b/test_fms/mpp/test_mpp_domains2.sh
@@ -35,6 +35,9 @@ then
     is_travis='skip'
 fi
 
+echo "1: Test simple functionality"
+run_test test_domains_simple 4 
+
 #echo "1: Test update nest domain"
 
 #sed "s/test_nest = .false./test_nest = .true./" $top_srcdir/test_fms/mpp/input_base.nml > input.nml


### PR DESCRIPTION
**Description**
More simple testing. There is a bunch of mpp_domain tests, but they are all skipped. Well, that's a bummer because I am working on this code for PIO integration, and I need some tests to figure out what is going on.

I hope that someday you fix your broken tests. In the meantime, here's a simple test, which works now, and which I can add to as needed to confirm that I understand what mpp domains are all about.

Part of #244 and #100 

**How Has This Been Tested?**
Tested on my GNU/Linux box.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

