### PR TITLE
Modified fms2_io test to work by including fms2_io_init

### DIFF
--- a/test_fms/fms2_io/test_fms2_io.F90
+++ b/test_fms/fms2_io/test_fms2_io.F90
@@ -144,6 +144,7 @@ do i = 1,ntiles
 enddo
 ocn_layout = (/1, npes/)
 
+call fms2_io_init()
 !Run tests.
 if (tests(atmos)) then
   if (mod(npes,ntiles) .ne. 0) then

--- a/test_fms/fms2_io/test_fms2_io.sh
+++ b/test_fms/fms2_io/test_fms2_io.sh
@@ -30,4 +30,4 @@
 # make a dummy file for mpp_init to read
 printf "EOF\n&dummy\nEOF" | cat > input.nml
 # run the tests
-run_test test_fms2_io 6 skip
+run_test test_fms2_io 6


### PR DESCRIPTION
**Description**
Fixes the previously non-functional fms2_io test by including the fms2_io_init subroutine, which is required for functionality.

Fixes # (issue)

**How Has This Been Tested?**
Tested on Skylake.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

