### PR TITLE
Fixes domain tests so they run

### DIFF
--- a/affinity/affinity.c
+++ b/affinity/affinity.c
@@ -100,7 +100,7 @@ int get_cpuset(int fsz, int *output, int pe, _Bool debug)
   if (debug) {
     for (cpu=0;cpu < CPU_SETSIZE;cpu++) {
       if (CPU_ISSET(cpu,&coremask)) {
-        printf("=> get_cpuset - pe %d: %d\n",pe, cpu);
+        fprintf(stderr,"=> get_cpuset - pe %d: %d\n",pe, cpu);
       }
     }
   }

--- a/affinity/fms_affinity.F90
+++ b/affinity/fms_affinity.F90
@@ -140,7 +140,7 @@ contains
     !--- get cpuset for this MPI-rank
     retcode = get_cpuset(cpuset_sz, cpu_set, mpp_pe(), debug_cpuset)
     if (retcode == -1) then
-      call error_mesg('fms_affinity_set',trim(component)//' cpu_set size > allocated storage',FATAL)
+      call error_mesg('fms_affinity_set',trim(component)//' cpu_set size > allocated storage',MSG_TYPE)
     elseif ( (retcode == cpuset_sz/2) .and. (retcode == nthreads) ) then
       call error_mesg('fms_affinity_set',trim(component)//' affinity assumes hyper-threading hardware disabled',NOTE)
     elseif (retcode < cpuset_sz) then

--- a/test_fms/mpp/input_base.nml
+++ b/test_fms/mpp/input_base.nml
@@ -2,6 +2,9 @@
 test_number = <test_num>
 /
 
+&fms_affinity_nml
+strict = .false.
+/
 
 &test_mpp_domains_nml
 nx=64

--- a/test_fms/mpp/test_mpp_domains.F90
+++ b/test_fms/mpp/test_mpp_domains.F90
@@ -54,7 +54,7 @@ program test_mpp_domains
   use mpp_domains_mod, only : mpp_get_UG_compute_domain, mpp_pass_SG_to_UG, mpp_pass_UG_to_SG
   use mpp_domains_mod, only : mpp_get_ug_global_domain, mpp_global_field_ug, mpp_get_tile_id
   use mpp_memutils_mod, only : mpp_memuse_begin, mpp_memuse_end
-  use fms_affinity_mod, only : fms_affinity_set
+  use fms_affinity_mod, only : fms_affinity_set, fms_affinity_init
 
 
   implicit none
@@ -177,6 +177,7 @@ program test_mpp_domains
   end if
   call mpp_domains_set_stack_size(stackmax)
 
+  call fms_affinity_init()
 !$  call omp_set_num_threads(nthreads)
 !$OMP PARALLEL
 !$  call fms_affinity_set("test_mpp_domains", .FALSE., omp_get_num_threads())

--- a/test_fms/mpp/test_mpp_domains2.sh
+++ b/test_fms/mpp/test_mpp_domains2.sh
@@ -96,10 +96,10 @@ sed "s/test_interface = .false./test_interface = .true./" $top_srcdir/test_fms/m
 #If the system is Darwin it will be skipped because it fails
 run_test test_mpp_domains 2 $is_darwin
 
-echo "14: Test Check Parallel"
-echo "Does not work on Darwin or elsewhere"
-sed "s/check_parallel = .false./check_parallel = .true./" $top_srcdir/test_fms/mpp/input_base.nml > input.nml
-run_test test_mpp_domains 6
+#echo "14: Test Check Parallel"
+#echo "Does not work on Darwin or elsewhere"
+#sed "s/check_parallel = .false./check_parallel = .true./" $top_srcdir/test_fms/mpp/input_base.nml > input.nml
+#run_test test_mpp_domains 6
 
 echo "15: Test Get Nbr"
 sed "s/test_get_nbr = .false./test_get_nbr = .true./" $top_srcdir/test_fms/mpp/input_base.nml > input.nml

--- a/test_fms/mpp/test_mpp_domains2.sh
+++ b/test_fms/mpp/test_mpp_domains2.sh
@@ -35,32 +35,32 @@ then
     is_travis='skip'
 fi
 
-#echo "1: Test update nest domain"
+echo "1: Test update nest domain"
 
-#sed "s/test_nest = .false./test_nest = .true./" $top_srcdir/test_fms/mpp/input_base.nml > input.nml
-run_test test_mpp_domains 2 skip
+sed "s/test_nest = .false./test_nest = .true./" $top_srcdir/test_fms/mpp/input_base.nml > input.nml
+run_test test_mpp_domains 16
 
 #echo "2:  Test Subset Update"
 #sed "s/test_subset = .false./test_subset = .true./" $top_srcdir/test_fms/mpp/input_base.nml > input.nml
-run_test test_mpp_domains 2 skip
+#run_test test_mpp_domains 30
 
 echo "3: Test Halosize Performance"
 sed "s/test_halosize_performance = .false./test_halosize_performance = .true./" $top_srcdir/test_fms/mpp/input_base.nml > input.nml
 #If the system is Darwin it will be skipped because it fails
 run_test test_mpp_domains 2 $is_darwin
 
-#echo "4: Test Edge Update"
-#sed "s/test_edge_update = .false./test_edge_update = .true./" $top_srcdir/test_fms/mpp/input_base.nml > input.nml
-run_test test_mpp_domains 2 skip
+echo "4: Test Edge Update"
+sed "s/test_edge_update = .false./test_edge_update = .true./" $top_srcdir/test_fms/mpp/input_base.nml > input.nml
+run_test test_mpp_domains 2
 
 #echo "5: Test Nonsym Edge"
 #sed "s/test_nonsym_edge = .false./test_nonsym_edge = .true./" $top_srcdir/test_fms/mpp/input_base.nml > input.nml
-run_test test_mpp_domains 2 skip
+#run_test test_mpp_domains 2
 
 echo "6: Test Performance"
 sed "s/test_performance = .false./test_performance = .true./" $top_srcdir/test_fms/mpp/input_base.nml > input.nml
 #If the system is Darwin or TRAVIS it will be skipped because it fails
-run_test test_mpp_domains 6 $is_darwin $is_travis
+run_test test_mpp_domains 6 $is_darwin
 
 echo "7: Test Global Sum"
 sed "s/test_global_sum = .false./test_global_sum = .true./" $top_srcdir/test_fms/mpp/input_base.nml > input.nml
@@ -70,21 +70,21 @@ run_test test_mpp_domains 2 $is_dawin
 echo "8: Test Cubic Grid Redistribute"
 sed "s/test_cubic_grid_redistribute = .false./test_cubic_grid_redistribute = .true./" $top_srcdir/test_fms/mpp/input_base.nml > input.nml
 #If the system is Darwin or TRAVIS it will be skipped because it fails
-run_test test_mpp_domains 6 $is_darwin $is_travis
+run_test test_mpp_domains 6 $is_darwin
 
 echo "9: Test Boundary"
 sed "s/test_boundary = .false./test_boundary = .true./" $top_srcdir/test_fms/mpp/input_base.nml > input.nml
 #If the system is Darwin or TRAVIS it will be skipped because it fails
-run_test test_mpp_domains 6 $is_darwin $is_travis
+run_test test_mpp_domains 2 $is_darwin
 
 echo "10: Test Adjoint"
 sed "s/test_adjoint = .false./test_adjoint = .true./" $top_srcdir/test_fms/mpp/input_base.nml > input.nml
 #If the system is Darwin it will be skipped because it fails
 run_test test_mpp_domains 2 $is_darwin
 
-#echo "11: Test Unstruct"
-#sed "s/test_unstruct = .false./test_unstruct = .true./" $top_srcdir/test_fms/mpp/input_base.nml > input.nml
-run_test test_mpp_domains 2 skip
+echo "11: Test Unstruct"
+sed "s/test_unstruct = .false./test_unstruct = .true./" $top_srcdir/test_fms/mpp/input_base.nml > input.nml
+run_test test_mpp_domains 2
 
 echo "12: Test Group"
 sed "s/test_group = .false./test_group = .true./" $top_srcdir/test_fms/mpp/input_base.nml > input.nml
@@ -96,10 +96,10 @@ sed "s/test_interface = .false./test_interface = .true./" $top_srcdir/test_fms/m
 #If the system is Darwin it will be skipped because it fails
 run_test test_mpp_domains 2 $is_darwin
 
-#echo "14: Test Check Parallel"
-#echo "Does not work on Darwin or elsewhere"
-#sed "s/check_parallel = .false./check_parallel = .true./" $top_srcdir/test_fms/mpp/input_base.nml > input.nml
-run_test test_mpp_domains 6 skip
+echo "14: Test Check Parallel"
+echo "Does not work on Darwin or elsewhere"
+sed "s/check_parallel = .false./check_parallel = .true./" $top_srcdir/test_fms/mpp/input_base.nml > input.nml
+run_test test_mpp_domains 6
 
 echo "15: Test Get Nbr"
 sed "s/test_get_nbr = .false./test_get_nbr = .true./" $top_srcdir/test_fms/mpp/input_base.nml > input.nml

--- a/test_fms/mpp/test_mpp_domains2.sh
+++ b/test_fms/mpp/test_mpp_domains2.sh
@@ -49,9 +49,9 @@ sed "s/test_halosize_performance = .false./test_halosize_performance = .true./" 
 #If the system is Darwin it will be skipped because it fails
 run_test test_mpp_domains 2 $is_darwin
 
-echo "4: Test Edge Update"
-sed "s/test_edge_update = .false./test_edge_update = .true./" $top_srcdir/test_fms/mpp/input_base.nml > input.nml
-run_test test_mpp_domains 2
+#echo "4: Test Edge Update"
+#sed "s/test_edge_update = .false./test_edge_update = .true./" $top_srcdir/test_fms/mpp/input_base.nml > input.nml
+#run_test test_mpp_domains 2
 
 #echo "5: Test Nonsym Edge"
 #sed "s/test_nonsym_edge = .false./test_nonsym_edge = .true./" $top_srcdir/test_fms/mpp/input_base.nml > input.nml

--- a/test_fms/test_common.sh.in
+++ b/test_fms/test_common.sh.in
@@ -59,6 +59,5 @@ run_test()
     fi
 
     # Run test
-    ulimit -s unlimited
     $mpi_launcher $oversubscribe $npes ./${1}
 }

--- a/test_fms/test_common.sh.in
+++ b/test_fms/test_common.sh.in
@@ -59,5 +59,6 @@ run_test()
     fi
 
     # Run test
+    ulimit -s unlimited
     $mpi_launcher $oversubscribe $npes ./${1}
 }


### PR DESCRIPTION
**Description**
Updates test_mpp_domains2.sh so 13 of the 15 tests will now run for CI.  There are also two minor updates in FMS/affinity.  One to have the debug_cpuset print unbuffered and the other to override for a safety check when strict=.false.

Fixes #484

**How Has This Been Tested?**
autotools tests were run on a skylake test system and on the NOAA RDHPCS system gaea

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

