### PR TITLE
R4 chksum bugfix

### DIFF
--- a/mpp/include/mpp_chksum.h
+++ b/mpp/include/mpp_chksum.h
@@ -23,7 +23,7 @@ function MPP_CHKSUM_( var, pelist , mask_val)
 !result is LONG_KIND, which will actually be int ifdef no_8byte_integers
   !optional mask_val is masked away in checksum_int.h function via PACK()
   integer(LONG_KIND) :: MPP_CHKSUM_
-  integer(LONG_KIND) :: mold(1)
+  integer(MPP_TRANSFER_KIND_) :: mold(1)
       MPP_TYPE_, intent(in) :: var MPP_RANK_
       integer, intent(in), optional :: pelist(:)
   MPP_TYPE_, intent(in),optional :: mask_val

--- a/mpp/include/mpp_comm.inc
+++ b/mpp/include/mpp_comm.inc
@@ -139,6 +139,8 @@
 
 #undef MPP_CHKSUM_
 #define MPP_CHKSUM_ mpp_chksum_r8_1d
+#undef MPP_TRANSFER_KIND_
+#define MPP_TRANSFER_KIND_ LONG_KIND
 #undef MPP_TYPE_
 #define MPP_TYPE_ real(DOUBLE_KIND)
 #undef MPP_RANK_
@@ -147,6 +149,8 @@
 
 #undef MPP_CHKSUM_
 #define MPP_CHKSUM_ mpp_chksum_r8_2d
+#undef MPP_TRANSFER_KIND_
+#define MPP_TRANSFER_KIND_ LONG_KIND
 #undef MPP_TYPE_
 #define MPP_TYPE_ real(DOUBLE_KIND)
 #undef MPP_RANK_
@@ -155,6 +159,8 @@
 
 #undef MPP_CHKSUM_
 #define MPP_CHKSUM_ mpp_chksum_r8_3d
+#undef MPP_TRANSFER_KIND_
+#define MPP_TRANSFER_KIND_ LONG_KIND
 #undef MPP_TYPE_
 #define MPP_TYPE_ real(DOUBLE_KIND)
 #undef MPP_RANK_
@@ -163,6 +169,8 @@
 
 #undef MPP_CHKSUM_
 #define MPP_CHKSUM_ mpp_chksum_r8_4d
+#undef MPP_TRANSFER_KIND_
+#define MPP_TRANSFER_KIND_ LONG_KIND
 #undef MPP_TYPE_
 #define MPP_TYPE_ real(DOUBLE_KIND)
 #undef MPP_RANK_
@@ -171,6 +179,8 @@
 
 #undef MPP_CHKSUM_
 #define MPP_CHKSUM_ mpp_chksum_r8_5d
+#undef MPP_TRANSFER_KIND_
+#define MPP_TRANSFER_KIND_ LONG_KIND
 #undef MPP_TYPE_
 #define MPP_TYPE_ real(DOUBLE_KIND)
 #undef MPP_RANK_
@@ -180,6 +190,8 @@
 #ifdef OVERLOAD_C8
 #undef MPP_CHKSUM_
 #define MPP_CHKSUM_ mpp_chksum_c8_0d
+#undef MPP_TRANSFER_KIND_
+#define MPP_TRANSFER_KIND_ LONG_KIND
 #undef MPP_TYPE_
 #define MPP_TYPE_ complex(DOUBLE_KIND)
 #undef MPP_RANK_
@@ -188,6 +200,8 @@
 
 #undef MPP_CHKSUM_
 #define MPP_CHKSUM_ mpp_chksum_c8_1d
+#undef MPP_TRANSFER_KIND_
+#define MPP_TRANSFER_KIND_ LONG_KIND
 #undef MPP_TYPE_
 #define MPP_TYPE_ complex(DOUBLE_KIND)
 #undef MPP_RANK_
@@ -196,6 +210,8 @@
 
 #undef MPP_CHKSUM_
 #define MPP_CHKSUM_ mpp_chksum_c8_2d
+#undef MPP_TRANSFER_KIND_
+#define MPP_TRANSFER_KIND_ LONG_KIND
 #undef MPP_TYPE_
 #define MPP_TYPE_ complex(DOUBLE_KIND)
 #undef MPP_RANK_
@@ -204,6 +220,8 @@
 
 #undef MPP_CHKSUM_
 #define MPP_CHKSUM_ mpp_chksum_c8_3d
+#undef MPP_TRANSFER_KIND_
+#define MPP_TRANSFER_KIND_ LONG_KIND
 #undef MPP_TYPE_
 #define MPP_TYPE_ complex(DOUBLE_KIND)
 #undef MPP_RANK_
@@ -212,6 +230,8 @@
 
 #undef MPP_CHKSUM_
 #define MPP_CHKSUM_ mpp_chksum_c8_4d
+#undef MPP_TRANSFER_KIND_
+#define MPP_TRANSFER_KIND_ LONG_KIND
 #undef MPP_TYPE_
 #define MPP_TYPE_ complex(DOUBLE_KIND)
 #undef MPP_RANK_
@@ -220,6 +240,8 @@
 
 #undef MPP_CHKSUM_
 #define MPP_CHKSUM_ mpp_chksum_c8_5d
+#undef MPP_TRANSFER_KIND_
+#define MPP_TRANSFER_KIND_ LONG_KIND
 #undef MPP_TYPE_
 #define MPP_TYPE_ complex(DOUBLE_KIND)
 #undef MPP_RANK_
@@ -230,6 +252,8 @@
 #ifdef OVERLOAD_R4
 #undef MPP_CHKSUM_
 #define MPP_CHKSUM_ mpp_chksum_r4_0d
+#undef MPP_TRANSFER_KIND_
+#define MPP_TRANSFER_KIND_ INT_KIND
 #undef MPP_TYPE_
 #define MPP_TYPE_ real(FLOAT_KIND)
 #undef MPP_RANK_
@@ -238,6 +262,8 @@
 
 #undef MPP_CHKSUM_
 #define MPP_CHKSUM_ mpp_chksum_r4_1d
+#undef MPP_TRANSFER_KIND_
+#define MPP_TRANSFER_KIND_ INT_KIND
 #undef MPP_TYPE_
 #define MPP_TYPE_ real(FLOAT_KIND)
 #undef MPP_RANK_
@@ -246,6 +272,8 @@
 
 #undef MPP_CHKSUM_
 #define MPP_CHKSUM_ mpp_chksum_r4_2d
+#undef MPP_TRANSFER_KIND_
+#define MPP_TRANSFER_KIND_ INT_KIND
 #undef MPP_TYPE_
 #define MPP_TYPE_ real(FLOAT_KIND)
 #undef MPP_RANK_
@@ -254,6 +282,8 @@
 
 #undef MPP_CHKSUM_
 #define MPP_CHKSUM_ mpp_chksum_r4_3d
+#undef MPP_TRANSFER_KIND_
+#define MPP_TRANSFER_KIND_ INT_KIND
 #undef MPP_TYPE_
 #define MPP_TYPE_ real(FLOAT_KIND)
 #undef MPP_RANK_
@@ -262,6 +292,8 @@
 
 #undef MPP_CHKSUM_
 #define MPP_CHKSUM_ mpp_chksum_r4_4d
+#undef MPP_TRANSFER_KIND_
+#define MPP_TRANSFER_KIND_ INT_KIND
 #undef MPP_TYPE_
 #define MPP_TYPE_ real(FLOAT_KIND)
 #undef MPP_RANK_
@@ -270,6 +302,8 @@
 
 #undef MPP_CHKSUM_
 #define MPP_CHKSUM_ mpp_chksum_r4_5d
+#undef MPP_TRANSFER_KIND_
+#define MPP_TRANSFER_KIND_ INT_KIND
 #undef MPP_TYPE_
 #define MPP_TYPE_ real(FLOAT_KIND)
 #undef MPP_RANK_
@@ -280,6 +314,8 @@
 #ifdef OVERLOAD_C4
 #undef MPP_CHKSUM_
 #define MPP_CHKSUM_ mpp_chksum_c4_0d
+#undef MPP_TRANSFER_KIND_
+#define MPP_TRANSFER_KIND_ INT_KIND
 #undef MPP_TYPE_
 #define MPP_TYPE_ complex(FLOAT_KIND)
 #undef MPP_RANK_
@@ -288,6 +324,8 @@
 
 #undef MPP_CHKSUM_
 #define MPP_CHKSUM_ mpp_chksum_c4_1d
+#undef MPP_TRANSFER_KIND_
+#define MPP_TRANSFER_KIND_ INT_KIND
 #undef MPP_TYPE_
 #define MPP_TYPE_ complex(FLOAT_KIND)
 #undef MPP_RANK_
@@ -296,6 +334,8 @@
 
 #undef MPP_CHKSUM_
 #define MPP_CHKSUM_ mpp_chksum_c4_2d
+#undef MPP_TRANSFER_KIND_
+#define MPP_TRANSFER_KIND_ INT_KIND
 #undef MPP_TYPE_
 #define MPP_TYPE_ complex(FLOAT_KIND)
 #undef MPP_RANK_
@@ -304,6 +344,8 @@
 
 #undef MPP_CHKSUM_
 #define MPP_CHKSUM_ mpp_chksum_c4_3d
+#undef MPP_TRANSFER_KIND_
+#define MPP_TRANSFER_KIND_ INT_KIND
 #undef MPP_TYPE_
 #define MPP_TYPE_ complex(FLOAT_KIND)
 #undef MPP_RANK_
@@ -312,6 +354,8 @@
 
 #undef MPP_CHKSUM_
 #define MPP_CHKSUM_ mpp_chksum_c4_4d
+#undef MPP_TRANSFER_KIND_
+#define MPP_TRANSFER_KIND_ INT_KIND
 #undef MPP_TYPE_
 #define MPP_TYPE_ complex(FLOAT_KIND)
 #undef MPP_RANK_
@@ -320,6 +364,8 @@
 
 #undef MPP_CHKSUM_
 #define MPP_CHKSUM_ mpp_chksum_c4_5d
+#undef MPP_TRANSFER_KIND_
+#define MPP_TRANSFER_KIND_ INT_KIND
 #undef MPP_TYPE_
 #define MPP_TYPE_ complex(FLOAT_KIND)
 #undef MPP_RANK_


### PR DESCRIPTION
**Description**
Added a new macro to properly define the 'mold' argument to the F90 transfer intrinsic. This new macro allows mpp_chksum to work correctly for both 32 and 64 bit inputs.

Fixes #471 

**How Has This Been Tested?**
A standalone unit test was developed to demonstrate and eventually solve the problem. This unit test will become a part of the standard unit test suite in another commit/PR. The update was also tested in a doubly-periodic model where it was previously failing.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

