### PR TITLE
now require netCDF to have been built with HDF5

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -96,6 +96,18 @@ fi
 AC_CHECK_HEADERS([netcdf.h], [], [AC_MSG_ERROR([Can't find the netCDF C header file.  Set CPPFLAGS/CFLAGS])])
 AC_SEARCH_LIBS([nc_create], [netcdf], [], [AC_MSG_ERROR([Can't find the netCDF C library.  Set LDFLAGS/LIBS])])
 
+# Require netCDF-4 (with HDF5).
+AC_MSG_CHECKING([if netCDF was built with HDF5])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [[
+#include <netcdf_meta.h>
+#if !(NC_HAS_NC4)
+      choke me
+#endif]])], [nc_has_nc4=yes], [nc_has_nc4=no])
+AC_MSG_RESULT([$nc_has_nc4])
+if test $nc_has_nc4 = no; then
+  AC_MSG_ERROR([NetCDF must be built with HDF5.])
+fi
+
 # Check if Linux gettid is avaiable
 AC_CHECK_FUNCS([gettid], [], [])
 


### PR DESCRIPTION
**Description**
Check to ensure that netCDF was built with HDF5. This is required by the code, so checking in the configure will ensure we don't get link or runtime errors.

Fixes #466

**How Has This Been Tested?**
My GNU machine.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

