### PR TITLE
fms2io: domain write fix

### DIFF
--- a/fms2_io/include/domain_write.inc
+++ b/fms2_io/include/domain_write.inc
@@ -131,14 +131,16 @@ subroutine domain_write_2d(fileobj, variable_name, vdata, unlim_dim_level, &
   integer :: ydim_index
   integer :: ypos
   integer :: yc_size
-  real(kind=int32) :: fill_int32
-  real(kind=int64) :: fill_int64
-  real(kind=real32) :: fill_real32
-  real(kind=real64) :: fill_real64
-  integer :: xgmax, xgmin
-  integer :: ygmax, ygmin
-  logical :: extra_x_point
-  logical :: extra_y_point
+  real(kind=int32) :: fill_int32 !< Fill value of a int32 variable
+  real(kind=int64) :: fill_int64 !< Fill value of a int64 variable
+  real(kind=real32) :: fill_real32 !< Fill value of a real32 variable
+  real(kind=real64) :: fill_real64 !< Fill value of a real64 variable
+  integer :: xgmax !< Ending x index of the global io domain
+  integer :: xgmin !< Starting x index of the global io domain
+  integer :: ygmax !< Ending y index of the global io domain
+  integer :: ygmin !< Ending y index of the global io domain
+  logical :: extra_x_point !< if .true. it indicates that the x axis is "EAST"
+  logical :: extra_y_point !< if .true. it indicates that the y axis is "NORTH"
 
   if (.not. is_variable_domain_decomposed(fileobj, variable_name, .true., &
                                           xdim_index, ydim_index, xpos, ypos)) then
@@ -166,14 +168,22 @@ subroutine domain_write_2d(fileobj, variable_name, vdata, unlim_dim_level, &
     allocate(pe_jcsize(size(fileobj%pelist)))
     call mpp_get_compute_domains(io_domain, ybegin=pe_jsc, yend=pe_jec, ysize=pe_jcsize, &
                                  position=ypos)
+
+    !< Determine the size of the global io domain
     call mpp_get_global_domain(io_domain, ybegin=ygmin, yend=ygmax)
     call mpp_get_global_domain(io_domain, xbegin=xgmin, xend=xgmax)
+
+    !< If the x/y axis is NORTH/EAST add 1 to the size of the global io domain
     if (extra_x_point) xgmax = xgmax + 1
     if (extra_y_point) ygmax = ygmax + 1
 
     !Write the out the data.
+    !< Set e to equal the size of the global io domain
     e(xdim_index) = xgmax - xgmin + 1
-    e(ydim_index) = ygmax - xgmin + 1
+    e(ydim_index) = ygmax - ygmin + 1
+
+    !< Allocate a global buffer, get the fill value if it exists in the file, and initialize
+    !! the buffer to the fill value
     select type(vdata)
       type is (integer(kind=int32))
         call allocate_array(global_buf_int32, e)
@@ -204,6 +214,7 @@ subroutine domain_write_2d(fileobj, variable_name, vdata, unlim_dim_level, &
     end select
 
     do i = 1, size(fileobj%pelist)
+      !< Set c relative to the starting global io domain index
       c(xdim_index) = pe_isc(i) - xgmin + 1
       c(ydim_index) = pe_jsc(i) - ygmin + 1
       e(xdim_index) = pe_icsize(i)
@@ -420,14 +431,16 @@ subroutine domain_write_3d(fileobj, variable_name, vdata, unlim_dim_level, &
   integer :: ydim_index
   integer :: ypos
   integer :: yc_size
-  real(kind=int32) :: fill_int32
-  real(kind=int64) :: fill_int64
-  real(kind=real32) :: fill_real32
-  real(kind=real64) :: fill_real64
-  integer :: xgmin, xgmax
-  integer :: ygmin, ygmax
-  logical :: extra_x_point
-  logical :: extra_y_point
+  real(kind=int32) :: fill_int32 !< Fill value of a int32 variable
+  real(kind=int64) :: fill_int64 !< Fill value of a int64 variable
+  real(kind=real32) :: fill_real32 !< Fill value of a real32 variable
+  real(kind=real64) :: fill_real64 !< Fill value of a real64 variable
+  integer :: xgmax !< Ending x index of the global io domain
+  integer :: xgmin !< Starting x index of the global io domain
+  integer :: ygmax !< Ending y index of the global io domain
+  integer :: ygmin !< Ending y index of the global io domain
+  logical :: extra_x_point !< if .true. it indicates that the x axis is "EAST"
+  logical :: extra_y_point !< if .true. it indicates that the y axis is "NORTH"
 
   if (.not. is_variable_domain_decomposed(fileobj, variable_name, .true., &
                                           xdim_index, ydim_index, xpos, ypos)) then
@@ -456,14 +469,21 @@ subroutine domain_write_3d(fileobj, variable_name, vdata, unlim_dim_level, &
     call mpp_get_compute_domains(io_domain, ybegin=pe_jsc, yend=pe_jec, ysize=pe_jcsize, &
                                  position=ypos)
 
+    !< Determine the size of the global io domain
     call mpp_get_global_domain(io_domain, ybegin=ygmin, yend=ygmax)
     call mpp_get_global_domain(io_domain, xbegin=xgmin, xend=xgmax)
+
+    !< If the x/y axis is NORTH/EAST add 1 to the size of the global io domain
     if (extra_x_point) xgmax = xgmax + 1
     if (extra_y_point) ygmax = ygmax + 1
 
     !Write the out the data.
-    e(xdim_index) = maxval(pe_iec) - xgmin + 1
-    e(ydim_index) = maxval(pe_jec) - ygmin + 1
+    !< Set e to equal the size of the global io domain
+    e(xdim_index) = xgmax - xgmin + 1
+    e(ydim_index) = ygmax - ygmin + 1
+
+    !< Allocate a global buffer, get the fill value if it exists in the file, and initialize
+    !! the buffer to the fill value
     select type(vdata)
       type is (integer(kind=int32))
         call allocate_array(global_buf_int32, e)
@@ -494,6 +514,7 @@ subroutine domain_write_3d(fileobj, variable_name, vdata, unlim_dim_level, &
     end select
 
     do i = 1, size(fileobj%pelist)
+      !< Set c relative to the starting global io domain index
       c(xdim_index) = pe_isc(i) - xgmin + 1
       c(ydim_index) = pe_jsc(i) - ygmin + 1
       e(xdim_index) = pe_icsize(i)
@@ -710,14 +731,16 @@ subroutine domain_write_4d(fileobj, variable_name, vdata, unlim_dim_level, &
   integer :: ydim_index
   integer :: ypos
   integer :: yc_size
-  real(kind=int32) :: fill_int32
-  real(kind=int64) :: fill_int64
-  real(kind=real32) :: fill_real32
-  real(kind=real64) :: fill_real64
-  integer :: xgmin, xgmax
-  integer :: ygmin, ygmax
-  logical :: extra_x_point
-  logical :: extra_y_point
+  real(kind=int32) :: fill_int32 !< Fill value of a int32 variable
+  real(kind=int64) :: fill_int64 !< Fill value of a int64 variable
+  real(kind=real32) :: fill_real32 !< Fill value of a real32 variable
+  real(kind=real64) :: fill_real64 !< Fill value of a real64 variable
+  integer :: xgmax !< Ending x index of the global io domain
+  integer :: xgmin !< Starting x index of the global io domain
+  integer :: ygmax !< Ending y index of the global io domain
+  integer :: ygmin !< Ending y index of the global io domain
+  logical :: extra_x_point !< if .true. it indicates that the x axis is "EAST"
+  logical :: extra_y_point !< if .true. it indicates that the y axis is "NORTH"
 
   if (.not. is_variable_domain_decomposed(fileobj, variable_name, .true., &
                                           xdim_index, ydim_index, xpos, ypos)) then
@@ -745,15 +768,22 @@ subroutine domain_write_4d(fileobj, variable_name, vdata, unlim_dim_level, &
     allocate(pe_jcsize(size(fileobj%pelist)))
     call mpp_get_compute_domains(io_domain, ybegin=pe_jsc, yend=pe_jec, ysize=pe_jcsize, &
                                  position=ypos)
+
+    !< Determine the size of the global io domain
     call mpp_get_global_domain(io_domain, ybegin=ygmin, yend=ygmax)
     call mpp_get_global_domain(io_domain, xbegin=xgmin, xend=xgmax)
+
+    !< If the x/y axis is NORTH/EAST add 1 to the size of the global io domain
     if (extra_x_point) xgmax = xgmax + 1
     if (extra_y_point) ygmax = ygmax + 1
 
     !Write the out the data.
+    !< Set e to equal the size of the global io domain
     e(xdim_index) = xgmax - xgmin + 1
     e(ydim_index) = ygmax - ygmin + 1
 
+    !< Allocate a global buffer, get the fill value if it exists in the file, and initialize
+    !! the buffer to the fill value
     select type(vdata)
       type is (integer(kind=int32))
         call allocate_array(global_buf_int32, e)
@@ -784,6 +814,7 @@ subroutine domain_write_4d(fileobj, variable_name, vdata, unlim_dim_level, &
     end select
 
     do i = 1, size(fileobj%pelist)
+      !< Set c relative to the starting global io domain index
       c(xdim_index) = pe_isc(i) - xgmin + 1
       c(ydim_index) = pe_jsc(i) - ygmin + 1
       e(xdim_index) = pe_icsize(i)
@@ -1000,14 +1031,16 @@ subroutine domain_write_5d(fileobj, variable_name, vdata, unlim_dim_level, &
   integer :: ydim_index
   integer :: ypos
   integer :: yc_size
-  real(kind=int32) :: fill_int32
-  real(kind=int64) :: fill_int64
-  real(kind=real32) :: fill_real32
-  real(kind=real64) :: fill_real64
-  integer :: xgmin, xgmax
-  integer :: ygmin, ygmax
-  logical :: extra_x_point
-  logical :: extra_y_point
+  real(kind=int32) :: fill_int32 !< Fill value of a int32 variable
+  real(kind=int64) :: fill_int64 !< Fill value of a int64 variable
+  real(kind=real32) :: fill_real32 !< Fill value of a real32 variable
+  real(kind=real64) :: fill_real64 !< Fill value of a real64 variable
+  integer :: xgmax !< Ending x index of the global io domain
+  integer :: xgmin !< Starting x index of the global io domain
+  integer :: ygmax !< Ending y index of the global io domain
+  integer :: ygmin !< Ending y index of the global io domain
+  logical :: extra_x_point !< if .true. it indicates that the x axis is "EAST"
+  logical :: extra_y_point !< if .true. it indicates that the y axis is "NORTH"
 
   if (.not. is_variable_domain_decomposed(fileobj, variable_name, .true., &
                                           xdim_index, ydim_index, xpos, ypos)) then
@@ -1035,14 +1068,22 @@ subroutine domain_write_5d(fileobj, variable_name, vdata, unlim_dim_level, &
     allocate(pe_jcsize(size(fileobj%pelist)))
     call mpp_get_compute_domains(io_domain, ybegin=pe_jsc, yend=pe_jec, ysize=pe_jcsize, &
                                  position=ypos)
+
+    !< Determine the size of the global io domain
     call mpp_get_global_domain(io_domain, ybegin=ygmin, yend=ygmax)
     call mpp_get_global_domain(io_domain, xbegin=xgmin, xend=xgmax)
+
+    !< If the x/y axis is NORTH/EAST add 1 to the size of the global io domain
     if (extra_x_point) xgmax = xgmax + 1
     if (extra_y_point) ygmax = ygmax + 1
 
     !Write the out the data.
-    e(xdim_index) = maxval(pe_iec) - xgmin + 1
-    e(ydim_index) = maxval(pe_jec) - ygmin + 1
+    !< Set e to equal the size of the global io domain
+    e(xdim_index) = xgmax - xgmin + 1
+    e(ydim_index) = ygmax - ygmin + 1
+
+    !< Allocate a global buffer, get the fill value if it exists in the file, and initialize
+    !! the buffer to the fill value
     select type(vdata)
       type is (integer(kind=int32))
         call allocate_array(global_buf_int32, e)
@@ -1073,6 +1114,7 @@ subroutine domain_write_5d(fileobj, variable_name, vdata, unlim_dim_level, &
     end select
 
     do i = 1, size(fileobj%pelist)
+      !< Set c relative to the starting global io domain index
       c(xdim_index) = pe_isc(i) - xgmin + 1
       c(ydim_index) = pe_jsc(i) - ygmin + 1
       e(xdim_index) = pe_icsize(i)

--- a/fms2_io/include/domain_write.inc
+++ b/fms2_io/include/domain_write.inc
@@ -119,8 +119,6 @@ subroutine domain_write_2d(fileobj, variable_name, vdata, unlim_dim_level, &
   integer :: isd
   integer :: jsc
   integer :: jsd
-  integer :: min_pe_isc
-  integer :: min_pe_jsc
   integer, dimension(:), allocatable :: pe_icsize
   integer, dimension(:), allocatable :: pe_iec
   integer, dimension(:), allocatable :: pe_isc
@@ -133,6 +131,14 @@ subroutine domain_write_2d(fileobj, variable_name, vdata, unlim_dim_level, &
   integer :: ydim_index
   integer :: ypos
   integer :: yc_size
+  real(kind=int32) :: fill_int32
+  real(kind=int64) :: fill_int64
+  real(kind=real32) :: fill_real32
+  real(kind=real64) :: fill_real64
+  integer :: xgmax, xgmin
+  integer :: ygmax, ygmin
+  logical :: extra_x_point
+  logical :: extra_y_point
 
   if (.not. is_variable_domain_decomposed(fileobj, variable_name, .true., &
                                           xdim_index, ydim_index, xpos, ypos)) then
@@ -144,7 +150,7 @@ subroutine domain_write_2d(fileobj, variable_name, vdata, unlim_dim_level, &
   io_domain => mpp_get_io_domain(fileobj%domain)
   call domain_offsets(size(vdata, xdim_index), size(vdata, ydim_index), fileobj%domain, &
                       xpos, ypos, isd, isc, xc_size, jsd, jsc, yc_size, &
-                      buffer_includes_halos)
+                      buffer_includes_halos, extra_x_point=extra_x_point, extra_y_point=extra_y_point)
   c(:) = 1
   e(:) = shape(vdata)
 
@@ -155,33 +161,51 @@ subroutine domain_write_2d(fileobj, variable_name, vdata, unlim_dim_level, &
     allocate(pe_icsize(size(fileobj%pelist)))
     call mpp_get_compute_domains(io_domain, xbegin=pe_isc, xend=pe_iec, xsize=pe_icsize, &
                                  position=xpos)
-    min_pe_isc = minval(pe_isc)
     allocate(pe_jsc(size(fileobj%pelist)))
     allocate(pe_jec(size(fileobj%pelist)))
     allocate(pe_jcsize(size(fileobj%pelist)))
     call mpp_get_compute_domains(io_domain, ybegin=pe_jsc, yend=pe_jec, ysize=pe_jcsize, &
                                  position=ypos)
-    min_pe_jsc = minval(pe_jsc)
+    call mpp_get_global_domain(io_domain, ybegin=ygmin, yend=ygmax)
+    call mpp_get_global_domain(io_domain, xbegin=xgmin, xend=xgmax)
+    if (extra_x_point) xgmax = xgmax + 1
+    if (extra_y_point) ygmax = ygmax + 1
 
     !Write the out the data.
-    e(xdim_index) = maxval(pe_iec) - min_pe_isc + 1
-    e(ydim_index) = maxval(pe_jec) - min_pe_jsc + 1
+    e(xdim_index) = xgmax - xgmin + 1
+    e(ydim_index) = ygmax - xgmin + 1
     select type(vdata)
       type is (integer(kind=int32))
         call allocate_array(global_buf_int32, e)
+        global_buf_int32 = 0
+        if (get_fill_value(fileobj, variable_name, fill_int32, broadcast=.false.)) then
+            global_buf_int32 = fill_int32
+        endif
       type is (integer(kind=int64))
         call allocate_array(global_buf_int64, e)
+        global_buf_int64 = 0
+        if (get_fill_value(fileobj, variable_name, fill_int64, broadcast=.false.)) then
+            global_buf_int64 = fill_int64
+        endif
       type is (real(kind=real32))
         call allocate_array(global_buf_real32, e)
+        global_buf_real32 = 0.
+        if (get_fill_value(fileobj, variable_name, fill_real32, broadcast=.false.)) then
+            global_buf_real32 = fill_real32
+        endif
       type is (real(kind=real64))
         call allocate_array(global_buf_real64, e)
+        global_buf_real64 = 0.
+        if (get_fill_value(fileobj, variable_name, fill_real64, broadcast=.false.)) then
+            global_buf_real64 = fill_real64
+        endif
       class default
         call error("unsupported type.")
     end select
 
     do i = 1, size(fileobj%pelist)
-      c(xdim_index) = pe_isc(i) - min_pe_isc + 1
-      c(ydim_index) = pe_jsc(i) - min_pe_jsc + 1
+      c(xdim_index) = pe_isc(i) - xgmin + 1
+      c(ydim_index) = pe_jsc(i) - ygmin + 1
       e(xdim_index) = pe_icsize(i)
       e(ydim_index) = pe_jcsize(i)
       select type(vdata)
@@ -199,8 +223,8 @@ subroutine domain_write_2d(fileobj, variable_name, vdata, unlim_dim_level, &
               c(ydim_index) = 1
             endif
             call get_array_section(buf_int32, vdata, c, e)
-            c(xdim_index) = pe_isc(i) - min_pe_isc + 1
-            c(ydim_index) = pe_jsc(i) - min_pe_jsc + 1
+            c(xdim_index) = pe_isc(i) - xgmin + 1
+            c(ydim_index) = pe_jsc(i) - ygmin + 1
           else
             !Receive data from non-root ranks.
             call mpp_recv(buf_int32, size(buf_int32), fileobj%pelist(i), block=.true.)
@@ -222,8 +246,8 @@ subroutine domain_write_2d(fileobj, variable_name, vdata, unlim_dim_level, &
               c(ydim_index) = 1
             endif
             call get_array_section(buf_int64, vdata, c, e)
-            c(xdim_index) = pe_isc(i) - min_pe_isc + 1
-            c(ydim_index) = pe_jsc(i) - min_pe_jsc + 1
+            c(xdim_index) = pe_isc(i) - xgmin + 1
+            c(ydim_index) = pe_jsc(i) - ygmin + 1
           else
             !Receive data from non-root ranks.
             call mpp_recv(buf_int64, size(buf_int64), fileobj%pelist(i), block=.true.)
@@ -245,8 +269,8 @@ subroutine domain_write_2d(fileobj, variable_name, vdata, unlim_dim_level, &
               c(ydim_index) = 1
             endif
             call get_array_section(buf_real32, vdata, c, e)
-            c(xdim_index) = pe_isc(i) - min_pe_isc + 1
-            c(ydim_index) = pe_jsc(i) - min_pe_jsc + 1
+            c(xdim_index) = pe_isc(i) - xgmin + 1
+            c(ydim_index) = pe_jsc(i) - ygmin + 1
           else
             !Receive data from non-root ranks.
             call mpp_recv(buf_real32, size(buf_real32), fileobj%pelist(i), block=.true.)
@@ -268,8 +292,8 @@ subroutine domain_write_2d(fileobj, variable_name, vdata, unlim_dim_level, &
               c(ydim_index) = 1
             endif
             call get_array_section(buf_real64, vdata, c, e)
-            c(xdim_index) = pe_isc(i) - min_pe_isc + 1
-            c(ydim_index) = pe_jsc(i) - min_pe_jsc + 1
+            c(xdim_index) = pe_isc(i) - xgmin + 1
+            c(ydim_index) = pe_jsc(i) - ygmin + 1
           else
             !Receive data from non-root ranks.
             call mpp_recv(buf_real64, size(buf_real64), fileobj%pelist(i), block=.true.)
@@ -384,8 +408,6 @@ subroutine domain_write_3d(fileobj, variable_name, vdata, unlim_dim_level, &
   integer :: isd
   integer :: jsc
   integer :: jsd
-  integer :: min_pe_isc
-  integer :: min_pe_jsc
   integer, dimension(:), allocatable :: pe_icsize
   integer, dimension(:), allocatable :: pe_iec
   integer, dimension(:), allocatable :: pe_isc
@@ -398,6 +420,14 @@ subroutine domain_write_3d(fileobj, variable_name, vdata, unlim_dim_level, &
   integer :: ydim_index
   integer :: ypos
   integer :: yc_size
+  real(kind=int32) :: fill_int32
+  real(kind=int64) :: fill_int64
+  real(kind=real32) :: fill_real32
+  real(kind=real64) :: fill_real64
+  integer :: xgmin, xgmax
+  integer :: ygmin, ygmax
+  logical :: extra_x_point
+  logical :: extra_y_point
 
   if (.not. is_variable_domain_decomposed(fileobj, variable_name, .true., &
                                           xdim_index, ydim_index, xpos, ypos)) then
@@ -409,7 +439,7 @@ subroutine domain_write_3d(fileobj, variable_name, vdata, unlim_dim_level, &
   io_domain => mpp_get_io_domain(fileobj%domain)
   call domain_offsets(size(vdata, xdim_index), size(vdata, ydim_index), fileobj%domain, &
                       xpos, ypos, isd, isc, xc_size, jsd, jsc, yc_size, &
-                      buffer_includes_halos)
+                      buffer_includes_halos, extra_x_point=extra_x_point, extra_y_point=extra_y_point)
   c(:) = 1
   e(:) = shape(vdata)
 
@@ -420,33 +450,52 @@ subroutine domain_write_3d(fileobj, variable_name, vdata, unlim_dim_level, &
     allocate(pe_icsize(size(fileobj%pelist)))
     call mpp_get_compute_domains(io_domain, xbegin=pe_isc, xend=pe_iec, xsize=pe_icsize, &
                                  position=xpos)
-    min_pe_isc = minval(pe_isc)
     allocate(pe_jsc(size(fileobj%pelist)))
     allocate(pe_jec(size(fileobj%pelist)))
     allocate(pe_jcsize(size(fileobj%pelist)))
     call mpp_get_compute_domains(io_domain, ybegin=pe_jsc, yend=pe_jec, ysize=pe_jcsize, &
                                  position=ypos)
-    min_pe_jsc = minval(pe_jsc)
+
+    call mpp_get_global_domain(io_domain, ybegin=ygmin, yend=ygmax)
+    call mpp_get_global_domain(io_domain, xbegin=xgmin, xend=xgmax)
+    if (extra_x_point) xgmax = xgmax + 1
+    if (extra_y_point) ygmax = ygmax + 1
 
     !Write the out the data.
-    e(xdim_index) = maxval(pe_iec) - min_pe_isc + 1
-    e(ydim_index) = maxval(pe_jec) - min_pe_jsc + 1
+    e(xdim_index) = maxval(pe_iec) - xgmin + 1
+    e(ydim_index) = maxval(pe_jec) - ygmin + 1
     select type(vdata)
       type is (integer(kind=int32))
         call allocate_array(global_buf_int32, e)
+        global_buf_int32 = 0
+        if (get_fill_value(fileobj, variable_name, fill_int32, broadcast=.false.)) then
+            global_buf_int32 = fill_int32
+        endif
       type is (integer(kind=int64))
         call allocate_array(global_buf_int64, e)
+        global_buf_int64 = 0
+        if (get_fill_value(fileobj, variable_name, fill_int64, broadcast=.false.)) then
+            global_buf_int64 = fill_int64
+        endif
       type is (real(kind=real32))
         call allocate_array(global_buf_real32, e)
+        global_buf_real32 = 0.
+        if (get_fill_value(fileobj, variable_name, fill_real32, broadcast=.false.)) then
+            global_buf_real32 = fill_real32
+        endif
       type is (real(kind=real64))
         call allocate_array(global_buf_real64, e)
+        global_buf_real64 = 0.
+        if (get_fill_value(fileobj, variable_name, fill_real64, broadcast=.false.)) then
+            global_buf_real64 = fill_real64
+        endif
       class default
         call error("unsupported type.")
     end select
 
     do i = 1, size(fileobj%pelist)
-      c(xdim_index) = pe_isc(i) - min_pe_isc + 1
-      c(ydim_index) = pe_jsc(i) - min_pe_jsc + 1
+      c(xdim_index) = pe_isc(i) - xgmin + 1
+      c(ydim_index) = pe_jsc(i) - ygmin + 1
       e(xdim_index) = pe_icsize(i)
       e(ydim_index) = pe_jcsize(i)
       select type(vdata)
@@ -464,8 +513,8 @@ subroutine domain_write_3d(fileobj, variable_name, vdata, unlim_dim_level, &
               c(ydim_index) = 1
             endif
             call get_array_section(buf_int32, vdata, c, e)
-            c(xdim_index) = pe_isc(i) - min_pe_isc + 1
-            c(ydim_index) = pe_jsc(i) - min_pe_jsc + 1
+            c(xdim_index) = pe_isc(i) - xgmin + 1
+            c(ydim_index) = pe_jsc(i) - ygmin + 1
           else
             !Receive data from non-root ranks.
             call mpp_recv(buf_int32, size(buf_int32), fileobj%pelist(i), block=.true.)
@@ -487,8 +536,8 @@ subroutine domain_write_3d(fileobj, variable_name, vdata, unlim_dim_level, &
               c(ydim_index) = 1
             endif
             call get_array_section(buf_int64, vdata, c, e)
-            c(xdim_index) = pe_isc(i) - min_pe_isc + 1
-            c(ydim_index) = pe_jsc(i) - min_pe_jsc + 1
+            c(xdim_index) = pe_isc(i) - xgmin + 1
+            c(ydim_index) = pe_jsc(i) - ygmin + 1
           else
             !Receive data from non-root ranks.
             call mpp_recv(buf_int64, size(buf_int64), fileobj%pelist(i), block=.true.)
@@ -510,8 +559,8 @@ subroutine domain_write_3d(fileobj, variable_name, vdata, unlim_dim_level, &
               c(ydim_index) = 1
             endif
             call get_array_section(buf_real32, vdata, c, e)
-            c(xdim_index) = pe_isc(i) - min_pe_isc + 1
-            c(ydim_index) = pe_jsc(i) - min_pe_jsc + 1
+            c(xdim_index) = pe_isc(i) - xgmin + 1
+            c(ydim_index) = pe_jsc(i) - ygmin + 1
           else
             !Receive data from non-root ranks.
             call mpp_recv(buf_real32, size(buf_real32), fileobj%pelist(i), block=.true.)
@@ -533,8 +582,8 @@ subroutine domain_write_3d(fileobj, variable_name, vdata, unlim_dim_level, &
               c(ydim_index) = 1
             endif
             call get_array_section(buf_real64, vdata, c, e)
-            c(xdim_index) = pe_isc(i) - min_pe_isc + 1
-            c(ydim_index) = pe_jsc(i) - min_pe_jsc + 1
+            c(xdim_index) = pe_isc(i) - xgmin + 1
+            c(ydim_index) = pe_jsc(i) - ygmin + 1
           else
             !Receive data from non-root ranks.
             call mpp_recv(buf_real64, size(buf_real64), fileobj%pelist(i), block=.true.)
@@ -649,8 +698,6 @@ subroutine domain_write_4d(fileobj, variable_name, vdata, unlim_dim_level, &
   integer :: isd
   integer :: jsc
   integer :: jsd
-  integer :: min_pe_isc
-  integer :: min_pe_jsc
   integer, dimension(:), allocatable :: pe_icsize
   integer, dimension(:), allocatable :: pe_iec
   integer, dimension(:), allocatable :: pe_isc
@@ -663,6 +710,14 @@ subroutine domain_write_4d(fileobj, variable_name, vdata, unlim_dim_level, &
   integer :: ydim_index
   integer :: ypos
   integer :: yc_size
+  real(kind=int32) :: fill_int32
+  real(kind=int64) :: fill_int64
+  real(kind=real32) :: fill_real32
+  real(kind=real64) :: fill_real64
+  integer :: xgmin, xgmax
+  integer :: ygmin, ygmax
+  logical :: extra_x_point
+  logical :: extra_y_point
 
   if (.not. is_variable_domain_decomposed(fileobj, variable_name, .true., &
                                           xdim_index, ydim_index, xpos, ypos)) then
@@ -674,7 +729,7 @@ subroutine domain_write_4d(fileobj, variable_name, vdata, unlim_dim_level, &
   io_domain => mpp_get_io_domain(fileobj%domain)
   call domain_offsets(size(vdata, xdim_index), size(vdata, ydim_index), fileobj%domain, &
                       xpos, ypos, isd, isc, xc_size, jsd, jsc, yc_size, &
-                      buffer_includes_halos)
+                      buffer_includes_halos, extra_x_point=extra_x_point, extra_y_point=extra_y_point)
   c(:) = 1
   e(:) = shape(vdata)
 
@@ -685,33 +740,52 @@ subroutine domain_write_4d(fileobj, variable_name, vdata, unlim_dim_level, &
     allocate(pe_icsize(size(fileobj%pelist)))
     call mpp_get_compute_domains(io_domain, xbegin=pe_isc, xend=pe_iec, xsize=pe_icsize, &
                                  position=xpos)
-    min_pe_isc = minval(pe_isc)
     allocate(pe_jsc(size(fileobj%pelist)))
     allocate(pe_jec(size(fileobj%pelist)))
     allocate(pe_jcsize(size(fileobj%pelist)))
     call mpp_get_compute_domains(io_domain, ybegin=pe_jsc, yend=pe_jec, ysize=pe_jcsize, &
                                  position=ypos)
-    min_pe_jsc = minval(pe_jsc)
+    call mpp_get_global_domain(io_domain, ybegin=ygmin, yend=ygmax)
+    call mpp_get_global_domain(io_domain, xbegin=xgmin, xend=xgmax)
+    if (extra_x_point) xgmax = xgmax + 1
+    if (extra_y_point) ygmax = ygmax + 1
 
     !Write the out the data.
-    e(xdim_index) = maxval(pe_iec) - min_pe_isc + 1
-    e(ydim_index) = maxval(pe_jec) - min_pe_jsc + 1
+    e(xdim_index) = xgmax - xgmin + 1
+    e(ydim_index) = ygmax - ygmin + 1
+
     select type(vdata)
       type is (integer(kind=int32))
         call allocate_array(global_buf_int32, e)
+        global_buf_int32 = 0
+        if (get_fill_value(fileobj, variable_name, fill_int32, broadcast=.false.)) then
+            global_buf_int32 = fill_int32
+        endif
       type is (integer(kind=int64))
         call allocate_array(global_buf_int64, e)
+        global_buf_int64 = 0
+        if (get_fill_value(fileobj, variable_name, fill_int64, broadcast=.false.)) then
+            global_buf_int64 = fill_int64
+        endif
       type is (real(kind=real32))
         call allocate_array(global_buf_real32, e)
+        global_buf_real32 = 0.
+        if (get_fill_value(fileobj, variable_name, fill_real32, broadcast=.false.)) then
+            global_buf_real32 = fill_real32
+        endif
       type is (real(kind=real64))
         call allocate_array(global_buf_real64, e)
+        global_buf_real64 = 0.
+        if (get_fill_value(fileobj, variable_name, fill_real64, broadcast=.false.)) then
+            global_buf_real64 = fill_real64
+        endif
       class default
         call error("unsupported type.")
     end select
 
     do i = 1, size(fileobj%pelist)
-      c(xdim_index) = pe_isc(i) - min_pe_isc + 1
-      c(ydim_index) = pe_jsc(i) - min_pe_jsc + 1
+      c(xdim_index) = pe_isc(i) - xgmin + 1
+      c(ydim_index) = pe_jsc(i) - ygmin + 1
       e(xdim_index) = pe_icsize(i)
       e(ydim_index) = pe_jcsize(i)
       select type(vdata)
@@ -729,8 +803,8 @@ subroutine domain_write_4d(fileobj, variable_name, vdata, unlim_dim_level, &
               c(ydim_index) = 1
             endif
             call get_array_section(buf_int32, vdata, c, e)
-            c(xdim_index) = pe_isc(i) - min_pe_isc + 1
-            c(ydim_index) = pe_jsc(i) - min_pe_jsc + 1
+            c(xdim_index) = pe_isc(i) - xgmin + 1
+            c(ydim_index) = pe_jsc(i) - ygmin + 1
           else
             !Receive data from non-root ranks.
             call mpp_recv(buf_int32, size(buf_int32), fileobj%pelist(i), block=.true.)
@@ -752,8 +826,8 @@ subroutine domain_write_4d(fileobj, variable_name, vdata, unlim_dim_level, &
               c(ydim_index) = 1
             endif
             call get_array_section(buf_int64, vdata, c, e)
-            c(xdim_index) = pe_isc(i) - min_pe_isc + 1
-            c(ydim_index) = pe_jsc(i) - min_pe_jsc + 1
+            c(xdim_index) = pe_isc(i) - xgmin + 1
+            c(ydim_index) = pe_jsc(i) - ygmin + 1
           else
             !Receive data from non-root ranks.
             call mpp_recv(buf_int64, size(buf_int64), fileobj%pelist(i), block=.true.)
@@ -775,8 +849,8 @@ subroutine domain_write_4d(fileobj, variable_name, vdata, unlim_dim_level, &
               c(ydim_index) = 1
             endif
             call get_array_section(buf_real32, vdata, c, e)
-            c(xdim_index) = pe_isc(i) - min_pe_isc + 1
-            c(ydim_index) = pe_jsc(i) - min_pe_jsc + 1
+            c(xdim_index) = pe_isc(i) - xgmin + 1
+            c(ydim_index) = pe_jsc(i) - ygmin + 1
           else
             !Receive data from non-root ranks.
             call mpp_recv(buf_real32, size(buf_real32), fileobj%pelist(i), block=.true.)
@@ -798,8 +872,8 @@ subroutine domain_write_4d(fileobj, variable_name, vdata, unlim_dim_level, &
               c(ydim_index) = 1
             endif
             call get_array_section(buf_real64, vdata, c, e)
-            c(xdim_index) = pe_isc(i) - min_pe_isc + 1
-            c(ydim_index) = pe_jsc(i) - min_pe_jsc + 1
+            c(xdim_index) = pe_isc(i) - xgmin + 1
+            c(ydim_index) = pe_jsc(i) - ygmin + 1
           else
             !Receive data from non-root ranks.
             call mpp_recv(buf_real64, size(buf_real64), fileobj%pelist(i), block=.true.)
@@ -914,8 +988,6 @@ subroutine domain_write_5d(fileobj, variable_name, vdata, unlim_dim_level, &
   integer :: isd
   integer :: jsc
   integer :: jsd
-  integer :: min_pe_isc
-  integer :: min_pe_jsc
   integer, dimension(:), allocatable :: pe_icsize
   integer, dimension(:), allocatable :: pe_iec
   integer, dimension(:), allocatable :: pe_isc
@@ -928,6 +1000,14 @@ subroutine domain_write_5d(fileobj, variable_name, vdata, unlim_dim_level, &
   integer :: ydim_index
   integer :: ypos
   integer :: yc_size
+  real(kind=int32) :: fill_int32
+  real(kind=int64) :: fill_int64
+  real(kind=real32) :: fill_real32
+  real(kind=real64) :: fill_real64
+  integer :: xgmin, xgmax
+  integer :: ygmin, ygmax
+  logical :: extra_x_point
+  logical :: extra_y_point
 
   if (.not. is_variable_domain_decomposed(fileobj, variable_name, .true., &
                                           xdim_index, ydim_index, xpos, ypos)) then
@@ -939,7 +1019,7 @@ subroutine domain_write_5d(fileobj, variable_name, vdata, unlim_dim_level, &
   io_domain => mpp_get_io_domain(fileobj%domain)
   call domain_offsets(size(vdata, xdim_index), size(vdata, ydim_index), fileobj%domain, &
                       xpos, ypos, isd, isc, xc_size, jsd, jsc, yc_size, &
-                      buffer_includes_halos)
+                      buffer_includes_halos, extra_x_point=extra_x_point, extra_y_point=extra_y_point)
   c(:) = 1
   e(:) = shape(vdata)
 
@@ -950,33 +1030,51 @@ subroutine domain_write_5d(fileobj, variable_name, vdata, unlim_dim_level, &
     allocate(pe_icsize(size(fileobj%pelist)))
     call mpp_get_compute_domains(io_domain, xbegin=pe_isc, xend=pe_iec, xsize=pe_icsize, &
                                  position=xpos)
-    min_pe_isc = minval(pe_isc)
     allocate(pe_jsc(size(fileobj%pelist)))
     allocate(pe_jec(size(fileobj%pelist)))
     allocate(pe_jcsize(size(fileobj%pelist)))
     call mpp_get_compute_domains(io_domain, ybegin=pe_jsc, yend=pe_jec, ysize=pe_jcsize, &
                                  position=ypos)
-    min_pe_jsc = minval(pe_jsc)
+    call mpp_get_global_domain(io_domain, ybegin=ygmin, yend=ygmax)
+    call mpp_get_global_domain(io_domain, xbegin=xgmin, xend=xgmax)
+    if (extra_x_point) xgmax = xgmax + 1
+    if (extra_y_point) ygmax = ygmax + 1
 
     !Write the out the data.
-    e(xdim_index) = maxval(pe_iec) - min_pe_isc + 1
-    e(ydim_index) = maxval(pe_jec) - min_pe_jsc + 1
+    e(xdim_index) = maxval(pe_iec) - xgmin + 1
+    e(ydim_index) = maxval(pe_jec) - ygmin + 1
     select type(vdata)
       type is (integer(kind=int32))
         call allocate_array(global_buf_int32, e)
+        global_buf_int32 = 0
+        if (get_fill_value(fileobj, variable_name, fill_int32, broadcast=.false.)) then
+            global_buf_int32 = fill_int32
+        endif
       type is (integer(kind=int64))
         call allocate_array(global_buf_int64, e)
+        global_buf_int64 = 0
+        if (get_fill_value(fileobj, variable_name, fill_int64, broadcast=.false.)) then
+            global_buf_int64 = fill_int64
+        endif
       type is (real(kind=real32))
         call allocate_array(global_buf_real32, e)
+        global_buf_real32 = 0.
+        if (get_fill_value(fileobj, variable_name, fill_real32, broadcast=.false.)) then
+            global_buf_real32 = fill_real32
+        endif
       type is (real(kind=real64))
         call allocate_array(global_buf_real64, e)
+        global_buf_real64 = 0.
+        if (get_fill_value(fileobj, variable_name, fill_real64, broadcast=.false.)) then
+            global_buf_real64 = fill_real64
+        endif
       class default
         call error("unsupported type.")
     end select
 
     do i = 1, size(fileobj%pelist)
-      c(xdim_index) = pe_isc(i) - min_pe_isc + 1
-      c(ydim_index) = pe_jsc(i) - min_pe_jsc + 1
+      c(xdim_index) = pe_isc(i) - xgmin + 1
+      c(ydim_index) = pe_jsc(i) - ygmin + 1
       e(xdim_index) = pe_icsize(i)
       e(ydim_index) = pe_jcsize(i)
       select type(vdata)
@@ -994,8 +1092,8 @@ subroutine domain_write_5d(fileobj, variable_name, vdata, unlim_dim_level, &
               c(ydim_index) = 1
             endif
             call get_array_section(buf_int32, vdata, c, e)
-            c(xdim_index) = pe_isc(i) - min_pe_isc + 1
-            c(ydim_index) = pe_jsc(i) - min_pe_jsc + 1
+            c(xdim_index) = pe_isc(i) - xgmin + 1
+            c(ydim_index) = pe_jsc(i) - ygmin + 1
           else
             !Receive data from non-root ranks.
             call mpp_recv(buf_int32, size(buf_int32), fileobj%pelist(i), block=.true.)
@@ -1017,8 +1115,8 @@ subroutine domain_write_5d(fileobj, variable_name, vdata, unlim_dim_level, &
               c(ydim_index) = 1
             endif
             call get_array_section(buf_int64, vdata, c, e)
-            c(xdim_index) = pe_isc(i) - min_pe_isc + 1
-            c(ydim_index) = pe_jsc(i) - min_pe_jsc + 1
+            c(xdim_index) = pe_isc(i) - xgmin + 1
+            c(ydim_index) = pe_jsc(i) - ygmin + 1
           else
             !Receive data from non-root ranks.
             call mpp_recv(buf_int64, size(buf_int64), fileobj%pelist(i), block=.true.)
@@ -1040,8 +1138,8 @@ subroutine domain_write_5d(fileobj, variable_name, vdata, unlim_dim_level, &
               c(ydim_index) = 1
             endif
             call get_array_section(buf_real32, vdata, c, e)
-            c(xdim_index) = pe_isc(i) - min_pe_isc + 1
-            c(ydim_index) = pe_jsc(i) - min_pe_jsc + 1
+            c(xdim_index) = pe_isc(i) - xgmin + 1
+            c(ydim_index) = pe_jsc(i) - ygmin + 1
           else
             !Receive data from non-root ranks.
             call mpp_recv(buf_real32, size(buf_real32), fileobj%pelist(i), block=.true.)
@@ -1063,8 +1161,8 @@ subroutine domain_write_5d(fileobj, variable_name, vdata, unlim_dim_level, &
               c(ydim_index) = 1
             endif
             call get_array_section(buf_real64, vdata, c, e)
-            c(xdim_index) = pe_isc(i) - min_pe_isc + 1
-            c(ydim_index) = pe_jsc(i) - min_pe_jsc + 1
+            c(xdim_index) = pe_isc(i) - xgmin + 1
+            c(ydim_index) = pe_jsc(i) - ygmin + 1
           else
             !Receive data from non-root ranks.
             call mpp_recv(buf_real64, size(buf_real64), fileobj%pelist(i), block=.true.)

--- a/test_fms/fms2_io/Makefile.am
+++ b/test_fms/fms2_io/Makefile.am
@@ -20,16 +20,16 @@
 # This is an automake file for the test_fms/fms2_io directory of the FMS
 # package.
 
-# J.Liptak, R.Menzel
+# J.Liptak, R.Menzel, U.Ramirez
 
 # Find the fms_mod.mod file.
-AM_CPPFLAGS = -I${top_builddir}/mpp -I${top_builddir}/fms2_io
+AM_CPPFLAGS = -I${top_builddir}/mpp -I${top_builddir}/fms2_io -I${top_builddir}/fms
 
 # Link to the FMS library.
 LDADD = ${top_builddir}/libFMS/libFMS.la
 
 # Build this test program.
-check_PROGRAMS = test_fms2_io test_atmosphere_io test_io_simple
+check_PROGRAMS = test_fms2_io test_atmosphere_io test_io_simple test_io_with_mask
 
 # This is the source code for the test.
 test_fms2_io_SOURCES = argparse.F90 test_fms2_io.F90 create_atmosphere_domain.inc \
@@ -39,8 +39,9 @@ test_fms2_io_SOURCES = argparse.F90 test_fms2_io.F90 create_atmosphere_domain.in
 test_atmosphere_io_SOURCES = argparse.F90 setup.F90 test_atmosphere_io.F90 \
                              atmosphere_restart_file_test.inc
 test_io_simple_SOURCES = test_io_simple.F90 argparse.F90 setup.F90
+test_io_with_mask_SOURCES=test_io_with_mask.F90
 
-EXTRA_DIST = test_fms2_io.sh test_atmosphere_io.sh test_io_simple.sh
+EXTRA_DIST = test_fms2_io.sh test_atmosphere_io.sh test_io_simple.sh test_io_with_mask.sh
 
 argparse.mod: argparse.$(OBJEXT)
 setup.mod: setup.$(OBJEXT)
@@ -50,9 +51,9 @@ test_io_simple.$(OBJEXT): setup.mod
 test_fms2_io.$(OBJEXT): argparse.mod
 
 # Run the test program.
-TESTS = test_fms2_io.sh test_atmosphere_io.sh test_io_simple.sh
+TESTS = test_fms2_io.sh test_atmosphere_io.sh test_io_simple.sh test_io_with_mask.sh
 
 # Set srcdir as evironment variable to be reference in the job script
 TESTS_ENVIRONMENT = srcdir="$(top_srcdir)"
 
-CLEANFILES = *.mod *.nc *.nc.* input.nml logfile.000000.out
+CLEANFILES = *.mod *.nc *.nc.* input.nml logfile.000000.out the_mask

--- a/test_fms/fms2_io/test_io_with_mask.F90
+++ b/test_fms/fms2_io/test_io_with_mask.F90
@@ -23,12 +23,15 @@ program test_io_with_mask
 !! data when the domain contains a mask table. For the points that are
 !! masked out, no data should be writen.
 
-use   mpp_domains_mod
-use   mpp_mod
-use   fms2_io_mod
-use   fms_mod, only: fms_init, fms_end
-use   fms_io_mod, only: parse_mask_table
-use   netcdf
+use   mpp_domains_mod, only: mpp_domains_set_stack_size, mpp_define_domains, mpp_define_io_domain, &
+                             mpp_get_compute_domain,domain2d
+use   mpp_mod,         only: mpp_pe, mpp_root_pe, mpp_error, FATAL
+use   fms2_io_mod,     only: open_file, register_axis, register_variable_attribute, close_file, &
+                             FmsNetcdfDomainFile_t, write_data, register_field
+use   fms_mod,         only: fms_init, fms_end
+use   fms_io_mod,      only: parse_mask_table
+use   netcdf,          only: nf90_open, nf90_get_var, nf90_nowrite, NF90_NOERR, nf90_get_var, &
+                             nf90_close
 use,  intrinsic :: iso_fortran_env, only : real64
 
 implicit none

--- a/test_fms/fms2_io/test_io_with_mask.F90
+++ b/test_fms/fms2_io/test_io_with_mask.F90
@@ -1,0 +1,136 @@
+!***********************************************************************
+!*                   GNU Lesser General Public License
+!*
+!* This file is part of the GFDL Flexible Modeling System (FMS).
+!*
+!* FMS is free software: you can redistribute it and/or modify it under
+!* the terms of the GNU Lesser General Public License as published by
+!* the Free Software Foundation, either version 3 of the License, or (at
+!* your option) any later version.
+!*
+!* FMS is distributed in the hope that it will be useful, but WITHOUT
+!* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+!* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+!* for more details.
+!*
+!* You should have received a copy of the GNU Lesser General Public
+!* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
+!***********************************************************************
+
+program test_io_with_mask
+
+!> @brief  This programs tests fms2io/include/domain_write ability to write
+!! data when the domain contains a mask table. For the points that are
+!! masked out, no data should be writen.
+
+use   mpp_domains_mod
+use   mpp_mod
+use   fms2_io_mod
+use   fms_mod, only: fms_init, fms_end
+use   fms_io_mod, only: parse_mask_table
+use   netcdf
+use,  intrinsic :: iso_fortran_env, only : real64
+
+implicit none
+
+integer, dimension(2)                 :: layout = (/2,3/) !< Domain layout
+integer                               :: nlon             !< Number of points in x axis
+integer                               :: nlat             !< Number of points in y axis
+type(domain2d)                        :: Domain           !< Domain with mask table
+real, dimension(:), allocatable       :: x                !< x axis data
+real, dimension(:), allocatable       :: y                !< y axis data
+real(kind=real64), allocatable, dimension(:,:) :: sst     !< Data to be written
+real(kind=real64), allocatable, dimension(:,:) :: sst_in  !< Buffer where data will be read
+logical, allocatable, dimension(:,:)  :: parsed_mask      !< Parsed masked
+character(len=6), dimension(2)        :: names            !< Dimensions names
+type(FmsNetcdfDomainFile_t)           :: fileobj          !< fms2io fileobj for domain decomposed
+integer                               :: err              !< Return code.
+integer                               :: ncid             !< File ID for checking file.
+integer                               :: i, j             !< Helper integers
+integer                               :: is               !< Starting x index
+integer                               :: ie               !< Ending x index
+integer                               :: js               !< Starting y index
+integer                               :: je               !< Ending y index
+
+call fms_init
+
+nlon = 60
+nlat = 60
+
+!< Parse the mask table
+allocate(parsed_mask(layout(1), layout(2)))
+call parse_mask_table("the_mask", parsed_mask, 'test_io_with_mask')
+
+!< Create a domain nlonXnlat with mask
+call mpp_domains_set_stack_size(17280000)
+call mpp_define_domains( (/1,nlon,1,nlat/), layout, Domain, name='test_io_with_mask', maskmap=parsed_mask)
+call mpp_define_io_domain(Domain, (/1,1/))
+call mpp_get_compute_domain(Domain, is, ie, js, je)
+
+!< Set up the data
+allocate(x(nlon), y(nlat))
+allocate(sst(is:ie,js:je))
+
+do i=1,nlon
+  x(i) = i
+enddo
+do j=1,nlat
+  y(j) = j
+enddo
+
+sst = real(7., kind=real64)
+
+!< Open a netCDF file and initialize the file object.
+if (open_file(fileobj, "test_io_with_mask.nc", "overwrite", domain)) then
+    !< Register the axis
+    names(1) = "lon"
+    names(2) = "lat"
+    call register_axis(fileobj, "lon", "x")
+    call register_axis(fileobj, "lat", "y")
+
+    !< Register the variable and Write out the data
+    call register_field(fileobj, "sst", "double", names(1:2))
+    call register_variable_attribute(fileobj, "sst", "_FillValue", real(999., kind=real64))
+    call write_data(fileobj, "sst", sst)
+
+    !< Close the file
+    call close_file(fileobj)
+else
+   call mpp_error(FATAL, "test_io_with_mask: error opening the file for writting")
+endif
+
+!< Read the file back to check if it was done right!
+if (mpp_pe() .eq. mpp_root_pe()) then
+   err = nf90_open("test_io_with_mask.nc", nf90_nowrite, ncid)
+   if (err .ne. NF90_NOERR) call mpp_error(FATAL, "test_io_with_mask: error opening the file for reading")
+
+   allocate(sst_in(nlon,nlat))
+   err = nf90_get_var(ncid, 1, sst_in)
+   if (err .ne. NF90_NOERR) call mpp_error(FATAL, "test_io_with_mask: error reading from the file")
+
+   !< x: 1-30 y: 1-20 are masked out, so sst_in for this values has to be equal to the fill value
+   !! For the other points the data should be equal to real(7., kind=real64)
+
+   do i=1,nlon
+       do j=1,nlat
+          if (i > 30 .or. j > 20) then
+             if (sst_in(i,j) .ne. real(7., kind=real64)) then
+                 print *, 'i=', i, ' j=', j, ' sst_in=', sst_in(i,j)
+                 call mpp_error(FATAL, "test_io_with_mask: the unmasked data read in is not correct")
+             endif
+          else
+             if (sst_in(i,j) .ne. real(999., kind=real64)) then
+                 print *, 'i=', i, ' j=', j, ' sst_in=', sst_in(i,j)
+                 call mpp_error(FATAL, "test_io_with_mask: the masked data read in is not correct")
+             endif
+          endif
+       enddo
+   enddo
+
+   err = nf90_close(ncid)
+   if (err .ne. NF90_NOERR) call mpp_error(FATAL, "test_io_with_mask: error closing the file")
+endif
+
+call fms_end
+
+end program test_io_with_mask

--- a/test_fms/fms2_io/test_io_with_mask.sh
+++ b/test_fms/fms2_io/test_io_with_mask.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+
+#***********************************************************************
+#*                   GNU Lesser General Public License
+#*
+#* This file is part of the GFDL Flexible Modeling System (FMS).
+#*
+#* FMS is free software: you can redistribute it and/or modify it under
+#* the terms of the GNU Lesser General Public License as published by
+#* the Free Software Foundation, either version 3 of the License, or (at
+#* your option) any later version.
+#*
+#* FMS is distributed in the hope that it will be useful, but WITHOUT
+#* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+#* for more details.
+#*
+#* You should have received a copy of the GNU Lesser General Public
+#* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
+#***********************************************************************
+
+# This is part of the GFDL FMS package. This is a shell script to
+# execute tests in the test_fms/fms2_io directory.
+
+# Author: Uriel Ramirez 07/07/20
+#
+# Set common test settings.
+. ../test_common.sh
+
+# make an input.nml for mpp_init to read
+touch input.nml
+
+# make a masktable
+# This mask table masks out 1 rank (1st line), for a layout of 2,3 (2nd line)
+# 1,1 is the section that gets masked out
+# . ----- . ----- .
+# | (1,1) | (1,2) |
+# . ----- . ----- .
+# | (2,1) | (2,2) |
+# . ----- . ----- .
+# | (3,1) | (3,2) |
+# . ----- . ----- .
+printf "\n1\n2,3\n1,1" | cat > the_mask
+
+# For example, if you have a grid that is 60 by 60 and a layout of 2,3
+# You are going to need 6 ranks:
+   # rank 1 is going to handle: x: 1-30 y: 1-20
+   # rank 2 is going to handle: x: 31-60 y: 1-20
+   # rank 3 is going to handle: x: 1-30 y: 21-40
+   # rank 4 is going to handle: x: 31-60 y: 21-40
+   # rank 5 is going to handle: x: 1-30 y: 41-60
+   # rank 6 is going to handle: x: 31-60 y: 41-60
+# But with the mask table above, rank 0 is going to be masked out so you know need
+# 5 ranks and nothing is going to be done for x: 1-30 y: 1-20
+
+# run the tests
+run_test test_io_with_mask 5


### PR DESCRIPTION
**Description**
This PR:
1. Initializes the global buffer to the fill_value that is in the file 
2. Uses the global io domain to allocate the global buffer
3. Adds a unit test that writes a domain decomposed file with a mask

Fixes #447 

**How Has This Been Tested?**
Ran OM4p5_CORE2_IAF_COBALT_abio_csf_mle200 on GAEA with intel18 and prod: 

git clone -b RTS https://gitlab.gfdl.noaa.gov/mdt/xml mdt_xml_FMS2020.03
cd mdt_xml_FMS2020.03
fremake -x OM4_COBALT_postxanadu.xml -p ncrc4.intel18 -t prod MOM6_SIS2_compile
-------- Need to pull in my FMS changes or modify the xml to checkout out my branch
frerun -x OM4_COBALT_postxanadu.xml -p ncrc4.intel18 -t prod OM4p5_CORE2_IAF_COBALT_abio_csf_mle200 -r rts --no-transfer -u -s

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

