### PR TITLE
Creates empty nml file to prevent test from failing

### DIFF
--- a/test_fms/mpp/test_mpp_domains2.sh
+++ b/test_fms/mpp/test_mpp_domains2.sh
@@ -39,7 +39,7 @@ echo "1: Test simple functionality"
 run_test test_domains_simple 4 
 
 #echo "1: Test update nest domain"
-
+touch input.nml
 #sed "s/test_nest = .false./test_nest = .true./" $top_srcdir/test_fms/mpp/input_base.nml > input.nml
 run_test test_mpp_domains 2 skip
 


### PR DESCRIPTION
**Description**
Adds a line to create an empty namelist in one of the domain tests so that the test doesn't fail

Fixes #500 

**How Has This Been Tested?**
Tested with travis and on skylake with intel compiler

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

