### PR TITLE
Adds test for mpp_init_logfile 

### DIFF
--- a/mpp/include/mpp_util.inc
+++ b/mpp/include/mpp_util.inc
@@ -149,6 +149,21 @@
   end function stdlog
 
   !#####################################################################
+  ! <FUNCTION NAME="mpp_init_logfile">
+  !  <OVERVIEW>
+  !    Initialize the logfile.
+  !  </OVERVIEW>
+  !  <DESCRIPTION>
+  !    This function re-initializes the log files of the PEs. Re-initialization
+  !    means replacing if it already exists. It does not make new files if they don't
+  !    already exist. Only log files with names of format "<header>.pe_number.out",
+  !    where pe_number is the digit integer represeting the PE number, such as 000000 for the
+  !    root PE, 000001 for the next PE, etch. The <header> is the config file name prefix -
+  !    a module global normally set elsewhere, and frequetly is the integer simulation
+  !    timedate (e.g. 19480101).
+  !  </DESCRIPTION>
+  ! </FUNCTION>
+
   subroutine mpp_init_logfile()
   integer :: p
   logical :: exist

--- a/mpp/include/mpp_util.inc
+++ b/mpp/include/mpp_util.inc
@@ -148,22 +148,14 @@
 11  call mpp_error( FATAL, 'STDLOG: unable to open '//trim(etcfile)//'.' )
   end function stdlog
 
-  !#####################################################################
-  ! <FUNCTION NAME="mpp_init_logfile">
-  !  <OVERVIEW>
-  !    Initialize the logfile.
-  !  </OVERVIEW>
-  !  <DESCRIPTION>
-  !    This function re-initializes the log files of the PEs. Re-initialization
-  !    means replacing if it already exists. It does not make new files if they don't
-  !    already exist. Only log files with names of format "<header>.pe_number.out",
-  !    where pe_number is the digit integer represeting the PE number, such as 000000 for the
-  !    root PE, 000001 for the next PE, etch. The <header> is the config file name prefix -
-  !    a module global normally set elsewhere, and frequetly is the integer simulation
-  !    timedate (e.g. 19480101).
-  !  </DESCRIPTION>
-  ! </FUNCTION>
-
+  
+  !> \brief Subroutine mpp_init_logfile re-initializes the log files of the PEs.
+  !! Re-initialization means replacing if it already exists. It does not make new
+  !! files if they don't already exist. It only re-initializes log files with names of
+  !! format "<header>.pe_number.out", where pe_number is the digit integer represeting
+  !! the PE number, such as 000000 for the root PE, 000001 for the next PE,
+  !! etc. The <header> is the config file name prefix - a module global set
+  !! elsewhere, and frequetly is the integer simulation timedate (e.g. 19480101).
   subroutine mpp_init_logfile()
   integer :: p
   logical :: exist

--- a/mpp/mpp.F90
+++ b/mpp/mpp.F90
@@ -230,9 +230,7 @@ private
   public :: read_ascii_file, read_input_nml, mpp_clock_begin, mpp_clock_end
   public :: get_ascii_file_num_lines
   public :: mpp_record_time_start, mpp_record_time_end
-  !! TODO:
   public :: mpp_init_logfile
-
 
   !--- public interface from mpp_comm.h ------------------------------
   public :: mpp_chksum, mpp_max, mpp_min, mpp_sum, mpp_transmit, mpp_send, mpp_recv

--- a/mpp/mpp.F90
+++ b/mpp/mpp.F90
@@ -230,6 +230,9 @@ private
   public :: read_ascii_file, read_input_nml, mpp_clock_begin, mpp_clock_end
   public :: get_ascii_file_num_lines
   public :: mpp_record_time_start, mpp_record_time_end
+  !! TODO:
+  public :: mpp_init_logfile
+
 
   !--- public interface from mpp_comm.h ------------------------------
   public :: mpp_chksum, mpp_max, mpp_min, mpp_sum, mpp_transmit, mpp_send, mpp_recv

--- a/mpp/mpp.F90
+++ b/mpp/mpp.F90
@@ -230,7 +230,6 @@ private
   public :: read_ascii_file, read_input_nml, mpp_clock_begin, mpp_clock_end
   public :: get_ascii_file_num_lines
   public :: mpp_record_time_start, mpp_record_time_end
-  public :: mpp_init_logfile
 
   !--- public interface from mpp_comm.h ------------------------------
   public :: mpp_chksum, mpp_max, mpp_min, mpp_sum, mpp_transmit, mpp_send, mpp_recv

--- a/test_fms/mpp/Makefile.am
+++ b/test_fms/mpp/Makefile.am
@@ -42,7 +42,8 @@ check_PROGRAMS = test_mpp \
   test_system_clock \
   test_mpp_broadcast \
   test_clock_init \
-  test_domains_simple
+  test_domains_simple \
+  test_mpp_init_logfile   
 
 # These are the sources for the tests.
 test_mpp_SOURCES = test_mpp.F90
@@ -60,6 +61,7 @@ test_system_clock_SOURCES=test_system_clock.F90
 test_mpp_broadcast_SOURCES=test_mpp_broadcast.F90
 test_clock_init_SOURCES=test_clock_init.F90
 test_domains_simple_SOURCES = test_domains_simple.F90
+test_mpp_init_logfile_SOURCES=test_mpp_init_logfile.F90
 
 # Run the test programs.
 TESTS = test_mpp_domains2.sh \
@@ -71,7 +73,8 @@ TESTS = test_mpp_domains2.sh \
   test_mpp_get_ascii_lines2.sh \
   test_system_clock.sh \
   test_mpp_broadcast.sh \
-  test_clock_init.sh
+  test_clock_init.sh \
+  test_mpp_init_logfile.sh	 
 
 # These files will also be included in the distribution.
 EXTRA_DIST = input_base.nml \
@@ -87,7 +90,8 @@ EXTRA_DIST = input_base.nml \
   base_ascii_long \
   test_system_clock.sh \
   test_mpp_broadcast.sh \
-  test_clock_init.sh
+  test_clock_init.sh \
+  test_mpp_init_logfile.sh
 
 # Clean up
 CLEANFILES = include_files_mod.mod input.nml *.out* ascii*

--- a/test_fms/mpp/test_mpp_init_logfile.F90
+++ b/test_fms/mpp/test_mpp_init_logfile.F90
@@ -18,26 +18,28 @@
 !***********************************************************************
 
 !> @file
-!! @brief Tests the mpp_init_logfile interface
+!! @brief Tests the mpp_init_logfile interface.
+!! The files to be replaced are created and checked by the calling
+!! shell program test_mpp_init_logfile.sh.
+!!
 !! @author Miguel Zuniga
 !! @email gfdl.climate.model.info@noaa.gov
 
 program test_mpp_init_logfile
-#include <fms_platform.h>
 
   use mpp_mod, only : mpp_init, mpp_init_logfile
   use mpp_mod, only : mpp_init_test_logfile_init
 
   IMPLICIT NONE
 
-  integer :: my_mpp_init_level
   integer :: err_no
 
-  !Initialize mpp but have mpp_init() exit before log files are initalized.
-  my_mpp_init_level = mpp_init_test_logfile_init - 1
-  call mpp_init( test_level = my_mpp_init_level )
-  
+  !Initialize mpp but have mpp_init() exit right after log files are initalized.
+ 
+  call mpp_init( test_level =  mpp_init_test_logfile_init -1 )
+
   call mpp_init_logfile()
+  
   !! With the unifinished initialization, mpp_exit() is causing crash. Use MPI_FINALIZE:
   call MPI_FINALIZE(err_no)
 

--- a/test_fms/mpp/test_mpp_init_logfile.F90
+++ b/test_fms/mpp/test_mpp_init_logfile.F90
@@ -1,0 +1,44 @@
+!***********************************************************************
+!*                   GNU Lesser General Public License
+!*
+!* This file is part of the GFDL Flexible Modeling System (FMS).
+!*
+!* FMS is free software: you can redistribute it and/or modify it under
+!* the terms of the GNU Lesser General Public License as published by
+!* the Free Software Foundation, either version 3 of the License, or (at
+!* your option) any later version.
+!*
+!* FMS is distributed in the hope that it will be useful, but WITHOUT
+!* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+!* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+!* for more details.
+!*
+!* You should have received a copy of the GNU Lesser General Public
+!* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
+!***********************************************************************
+
+!> @file
+!! @brief Tests the mpp_init_logfile interface
+!! @author Miguel Zuniga
+!! @email gfdl.climate.model.info@noaa.gov
+
+program test_mpp_init_logfile
+#include <fms_platform.h>
+
+  use mpp_mod, only : mpp_init, mpp_init_logfile
+  use mpp_mod, only : mpp_init_test_logfile_init
+
+  IMPLICIT NONE
+
+  integer :: my_mpp_init_level
+  integer :: err_no
+
+  !Initialize mpp but have mpp_init() exit before log files are initalized.
+  my_mpp_init_level = mpp_init_test_logfile_init - 1
+  call mpp_init( test_level = my_mpp_init_level )
+  
+  call mpp_init_logfile()
+  !! With the unifinished initialization, mpp_exit() is causing crash. Use MPI_FINALIZE:
+  call MPI_FINALIZE(err_no)
+
+  end program test_mpp_init_logfile

--- a/test_fms/mpp/test_mpp_init_logfile.F90
+++ b/test_fms/mpp/test_mpp_init_logfile.F90
@@ -27,20 +27,18 @@
 
 program test_mpp_init_logfile
 
-  use mpp_mod, only : mpp_init, mpp_init_logfile
+  use mpp_mod, only : mpp_init
   use mpp_mod, only : mpp_init_test_logfile_init
 
   IMPLICIT NONE
 
   integer :: err_no
 
-  !Initialize mpp but have mpp_init() exit right after log files are initalized.
- 
-  call mpp_init( test_level =  mpp_init_test_logfile_init -1 )
+  ! Initialize mpp but have mpp_init() exit right after (or soon after) it is called.
+  ! Note mpp_init may write to te root log file once.
+  call mpp_init( test_level =  mpp_init_test_logfile_init)
 
-  call mpp_init_logfile()
-  
-  !! With the unifinished initialization, mpp_exit() is causing crash. Use MPI_FINALIZE:
+  ! With the unifinished initialization, mpp_exit() may cause a crash. Use MPI_FINALIZE:
   call MPI_FINALIZE(err_no)
 
-  end program test_mpp_init_logfile
+end program test_mpp_init_logfile

--- a/test_fms/mpp/test_mpp_init_logfile.sh
+++ b/test_fms/mpp/test_mpp_init_logfile.sh
@@ -1,0 +1,89 @@
+#!/bin/sh
+
+#***********************************************************************
+#                   GNU Lesser General Public License
+#
+# This file is part of the GFDL Flexible Modeling System (FMS).
+#
+# FMS is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or (at
+# your option) any later version.
+#
+# FMS is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
+#***********************************************************************
+
+# This is part of the GFDL FMS package. This is a shell script to
+# execute tests in the test_fms/mpp directory.
+
+# Set common test settings.
+. ../test_common.sh
+
+skip_test="no"
+
+echo "Calling test_mp_init_logfile"
+
+# Get the number of available CPUs on the system
+if [ $(command -v nproc) ]
+then
+    # Looks like a linux system
+    nProc=$(nproc)
+elif [ $(command -v sysctl) ]
+then
+    # Looks like a Mac OS X system
+    nProc=$(sysctl -n hw.physicalcpu)
+else
+    nProc=-1
+fi
+
+# Do we need to oversubscribe
+if [ ${nProc} -lt 0 ]
+then
+    # Couldn't get the number of CPUs, skip the test.
+    skip_test="skip"
+elif [ $nProc -lt 4 ]
+then
+    # Need to oversubscribe the MPI
+    run_test test_mpp_init_logfile 4 $skip_test "true"
+fi
+
+fprefix="logfile.00000"
+file0="${fprefix}""0.out"
+file1="${fprefix}""1.out"
+file2="${fprefix}""2.out"
+file3="${fprefix}""3.out"
+
+#Create two log files, each with some content.
+#echo "test_log_line" > logfile.000000.out
+#echo "test_log_line" > logfile.000002.out
+echo "test_log_line" > ${file0}
+echo "test_log_line" > ${file2}
+#Make sure other possible log files are not in the system.
+if test -f ${file1}; then
+    rm  ${file1}
+fi
+if test -f ${file3}; then
+    rm  ${file3}
+fi
+
+#Have mpp re-initialize the two log files created above:
+run_test test_mpp_init_logfile 4 $skip_test
+
+#Make sure the two "old" ones have been replaced and the
+#two possible new ones are not present.
+#TODO test number
+if [ $(wc -l < ${file0}) -ge 1  ] || [ $(wc -l < ${file2}) -ge 1  ] ||
+       [ -f ${file1} ] || [ -f ${file3} ]
+then
+  echo "ERROR: Test ? was unsuccessful."
+  exit 1
+else
+    echo "Test ? has passed"
+    exit 0
+fi

--- a/test_fms/mpp/test_mpp_init_logfile.sh
+++ b/test_fms/mpp/test_mpp_init_logfile.sh
@@ -58,10 +58,11 @@ file0="${fprefix}""0.out"
 file1="${fprefix}""1.out"
 file2="${fprefix}""2.out"
 file3="${fprefix}""3.out"
+fcontent="test_log_line_88gd!ok5"
 
 #Create two log files, each with some content.
-echo "test_log_line" > ${file0}
-echo "test_log_line" > ${file2}
+echo ${fcontent} > ${file0}
+echo ${fcontent} > ${file2}
 #Make sure other possible log files are not in the system.
 if test -f ${file1}; then
     rm  ${file1}
@@ -73,10 +74,13 @@ fi
 #Have mpp re-initialize the two log files created above:
 run_test test_mpp_init_logfile 4 $skip_test
 
-#Return sucess (0) only if the two "old" files have been replaced and the
+# Return sucess (0) only if the two "old" files have been replaced and the
 # the two possible new ones are not present. Otherwise retun failure (1).
-if [ $(wc -l < ${file0}) -ge 1  ] || [ $(wc -l < ${file2}) -ge 1  ] ||
-       [ -f ${file1} ] || [ -f ${file3} ]
+# Replacement is checked by the absence of the fcontent line.
+if [ $(grep  ${fcontent}  ${file0} | wc -l ) -ge 1 ] ||
+   [ $(grep  ${fcontent}  ${file1} | wc -l ) -ge 1 ] ||       
+   [ -f ${file1} ] ||
+   [ -f ${file3} ]
 then
   echo "ERROR: Test <number> was unsuccessful."
   exit 1

--- a/test_fms/mpp/test_mpp_init_logfile.sh
+++ b/test_fms/mpp/test_mpp_init_logfile.sh
@@ -73,8 +73,8 @@ fi
 #Have mpp re-initialize the two log files created above:
 run_test test_mpp_init_logfile 4 $skip_test
 
-#Make sure the two "old" ones have been replaced and the
-#two possible new ones are not present.
+#Return sucess (0) only if the two "old" files have been replaced and the
+# the two possible new ones are not present. Otherwise retun failure (1).
 if [ $(wc -l < ${file0}) -ge 1  ] || [ $(wc -l < ${file2}) -ge 1  ] ||
        [ -f ${file1} ] || [ -f ${file3} ]
 then

--- a/test_fms/mpp/test_mpp_init_logfile.sh
+++ b/test_fms/mpp/test_mpp_init_logfile.sh
@@ -60,8 +60,6 @@ file2="${fprefix}""2.out"
 file3="${fprefix}""3.out"
 
 #Create two log files, each with some content.
-#echo "test_log_line" > logfile.000000.out
-#echo "test_log_line" > logfile.000002.out
 echo "test_log_line" > ${file0}
 echo "test_log_line" > ${file2}
 #Make sure other possible log files are not in the system.
@@ -77,13 +75,12 @@ run_test test_mpp_init_logfile 4 $skip_test
 
 #Make sure the two "old" ones have been replaced and the
 #two possible new ones are not present.
-#TODO test number
 if [ $(wc -l < ${file0}) -ge 1  ] || [ $(wc -l < ${file2}) -ge 1  ] ||
        [ -f ${file1} ] || [ -f ${file3} ]
 then
-  echo "ERROR: Test ? was unsuccessful."
+  echo "ERROR: Test <number> was unsuccessful."
   exit 1
 else
-    echo "Test ? has passed"
+    echo "Test <number> has passed"
     exit 0
 fi


### PR DESCRIPTION
**Description**
This PR creates a unit test for the mpp interface mpp_init_logfile()

Fixes # (issue)

**How Has This Been Tested?**
On both the skylake server with intel compiler, and a home computer with gcc compiler, 
libFMS and the unit test applications were compiled. The unite tests for subdirectory FMS/est_fms/mpp were run via "make check" from the command line. Additionally, the unit test brought in with this PR was made made to run as expected under various conditions and the side effects on the files were verified to be as expected.

Note and warning: Interface mpp_init_logfile() did not have any documentation. I made an interpretation on how its expected to run and commented the interface to contain that documentation. In order to test from an external program, I made the interface public. Let me know if this is an issue.  

**Checklist:**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
- [X] New check tests, if applicable, are included
- [ ] `make distcheck` passes

