### PR TITLE
Adds --enable-mpp-io flag to configuration script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ env:
   - FCFLAGS_ADD='' DISTCHECK_CONFIGURE_FLAGS='--without-openmp'
   - FCFLAGS_ADD='' DISTCHECK_CONFIGURE_FLAGS='--enable-mixed-mode'
   - FCFLAGS_ADD='-fdefault-real-8 -fdefault-double-8 -fcray-pointer -ffree-line-length-none' DISTCHECK_CONFIGURE_FLAGS='--disable-setting-flags'
+  - FCFLAGS_ADD='' DISTCHECK_CONFIGURE_FLAGS='--enable-mpp-io'
 
 # Travis sets CC to gcc, but we need to ensure it is not set, so we can use mpicc
 before_install:

--- a/configure.ac
+++ b/configure.ac
@@ -66,6 +66,12 @@ AC_ARG_ENABLE([setting-flags],
 AS_IF([test ${enable_setting_flags:-yes} = yes],
   [enable_setting_flags=yes],
   [enable_setting_flags=no])
+AC_ARG_ENABLE([mpp-io],
+  [AS_HELP_STRING([--enable-mpp-io],
+    [Compile using mpp-io. Otherwise compiles using fms2_io.])])
+AS_IF([test ${enable_mpp_io:-no} = no],
+  [enable_mpp_io=no],
+  [enable_mpp_io=yes])
 
 # Does the user want to build documentation?
 AC_MSG_CHECKING([whether documentation should be build (requires doxygen)])
@@ -200,6 +206,11 @@ if test $enable_setting_flags = yes; then
   fi
   if test ! -z "$OPENMP_FCFLAGS"; then
     FCFLAGS="$FCFLAGS $OPENMP_FCFLAGS"
+  fi
+
+  # Add mpp io flags
+  if test $enable_mpp_io = yes; then
+    CPPFLAGS="-Duse_mpp_io $CPPFLAGS"
   fi
 fi
 


### PR DESCRIPTION
**Description**
Adds an argument to configuration script that enables compilation with mpp-io. Also adds build with mpp-io enabled in travis.

Fixes #505 

**How Has This Been Tested?**
Tested on travis and on skylake (with intel compiler)

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

