### PR TITLE
Update release version numbers with "-dev"

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@ AC_PREREQ([2.59])
 
 # Initialize with name, version, and support email address.
 AC_INIT([GFDL FMS Library],
-  [2019.01.03],
+  [2019.01.03-dev],
   [gfdl.climate.model.info@noaa.gov],
   [FMS],
   [https://www.gfdl.noaa.gov/fms])

--- a/libFMS/Makefile.am
+++ b/libFMS/Makefile.am
@@ -9,7 +9,7 @@ lib_LTLIBRARIES = libFMS.la
 # These linker flags specify libtool version info.
 # See http://www.gnu.org/software/libtool/manual/libtool.html#Libtool-versioning
 # for information regarding incrementing `-version-info`.
-libFMS_la_LDFLAGS = -version-info 2:3:0-dev
+libFMS_la_LDFLAGS = -version-info 2:3:1
 
 # Add the convenience libraries to the FMS library.
 libFMS_la_LIBADD = ${top_builddir}/platform/libplatform.la

--- a/libFMS/Makefile.am
+++ b/libFMS/Makefile.am
@@ -9,7 +9,7 @@ lib_LTLIBRARIES = libFMS.la
 # These linker flags specify libtool version info.
 # See http://www.gnu.org/software/libtool/manual/libtool.html#Libtool-versioning
 # for information regarding incrementing `-version-info`.
-libFMS_la_LDFLAGS = -version-info 2:3:0
+libFMS_la_LDFLAGS = -version-info 2:3:0-dev
 
 # Add the convenience libraries to the FMS library.
 libFMS_la_LIBADD = ${top_builddir}/platform/libplatform.la


### PR DESCRIPTION
**Description**
Post-release procedure. 
Updates version numbers in release/2019.01 branch with "-dev" suffix in configure.ac and Makefile.am

Fixes # (issue)
#532 

**How Has This Been Tested?**

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [ ] `make distcheck` passes

