### PR TITLE
Domain read fix

### DIFF
--- a/fms2_io/include/domain_read.inc
+++ b/fms2_io/include/domain_read.inc
@@ -129,6 +129,8 @@ subroutine domain_read_2d(fileobj, variable_name, vdata, unlim_dim_level, &
   real(kind=real32), dimension(:,:), allocatable :: buf_real32
   real(kind=real64), dimension(:,:), allocatable :: buf_real64
   logical :: buffer_includes_halos
+  integer :: xgmin
+  integer :: ygmin
 
   if (.not. is_variable_domain_decomposed(fileobj, variable_name, .true., &
                                           xdim_index, ydim_index, xpos, ypos)) then
@@ -151,12 +153,13 @@ subroutine domain_read_2d(fileobj, variable_name, vdata, unlim_dim_level, &
     allocate(pe_jcsize(size(fileobj%pelist)))
     call mpp_get_compute_domains(io_domain, xbegin=pe_isc, xsize=pe_icsize, position=xpos)
     call mpp_get_compute_domains(io_domain, ybegin=pe_jsc, ysize=pe_jcsize, position=ypos)
+    call mpp_get_global_domain(io_domain, ybegin=ygmin, xbegin=xgmin)
     do i = 1, size(fileobj%pelist)
       c(xdim_index) = pe_isc(i)
       c(ydim_index) = pe_jsc(i)
       if (fileobj%adjust_indices) then
-        c(xdim_index) = c(xdim_index) - pe_isc(1) + 1
-        c(ydim_index) = c(ydim_index) - pe_jsc(1) + 1
+        c(xdim_index) = c(xdim_index) - xgmin + 1
+        c(ydim_index) = c(ydim_index) - ygmin + 1
       endif
       e(xdim_index) = pe_icsize(i)
       e(ydim_index) = pe_jcsize(i)
@@ -343,6 +346,8 @@ subroutine domain_read_3d(fileobj, variable_name, vdata, unlim_dim_level, &
   real(kind=real32), dimension(:,:,:), allocatable :: buf_real32
   real(kind=real64), dimension(:,:,:), allocatable :: buf_real64
   logical :: buffer_includes_halos
+  integer :: xgmin
+  integer :: ygmin
 
   if (.not. is_variable_domain_decomposed(fileobj, variable_name, .true., &
                                           xdim_index, ydim_index, xpos, ypos)) then
@@ -365,12 +370,13 @@ subroutine domain_read_3d(fileobj, variable_name, vdata, unlim_dim_level, &
     allocate(pe_jcsize(size(fileobj%pelist)))
     call mpp_get_compute_domains(io_domain, xbegin=pe_isc, xsize=pe_icsize, position=xpos)
     call mpp_get_compute_domains(io_domain, ybegin=pe_jsc, ysize=pe_jcsize, position=ypos)
+    call mpp_get_global_domain(io_domain, ybegin=ygmin, xbegin=xgmin)
     do i = 1, size(fileobj%pelist)
       c(xdim_index) = pe_isc(i)
       c(ydim_index) = pe_jsc(i)
       if (fileobj%adjust_indices) then
-        c(xdim_index) = c(xdim_index) - pe_isc(1) + 1
-        c(ydim_index) = c(ydim_index) - pe_jsc(1) + 1
+        c(xdim_index) = c(xdim_index) - xgmin + 1
+        c(ydim_index) = c(ydim_index) - ygmin + 1
       endif
       e(xdim_index) = pe_icsize(i)
       e(ydim_index) = pe_jcsize(i)
@@ -557,6 +563,8 @@ subroutine domain_read_4d(fileobj, variable_name, vdata, unlim_dim_level, &
   real(kind=real32), dimension(:,:,:,:), allocatable :: buf_real32
   real(kind=real64), dimension(:,:,:,:), allocatable :: buf_real64
   logical :: buffer_includes_halos
+  integer :: xgmin
+  integer :: ygmin
 
   if (.not. is_variable_domain_decomposed(fileobj, variable_name, .true., &
                                           xdim_index, ydim_index, xpos, ypos)) then
@@ -579,12 +587,13 @@ subroutine domain_read_4d(fileobj, variable_name, vdata, unlim_dim_level, &
     allocate(pe_jcsize(size(fileobj%pelist)))
     call mpp_get_compute_domains(io_domain, xbegin=pe_isc, xsize=pe_icsize, position=xpos)
     call mpp_get_compute_domains(io_domain, ybegin=pe_jsc, ysize=pe_jcsize, position=ypos)
+    call mpp_get_global_domain(io_domain, ybegin=ygmin, xbegin=xgmin)
     do i = 1, size(fileobj%pelist)
       c(xdim_index) = pe_isc(i)
       c(ydim_index) = pe_jsc(i)
       if (fileobj%adjust_indices) then
-        c(xdim_index) = c(xdim_index) - pe_isc(1) + 1
-        c(ydim_index) = c(ydim_index) - pe_jsc(1) + 1
+        c(xdim_index) = c(xdim_index) - xgmin + 1
+        c(ydim_index) = c(ydim_index) - ygmin + 1
       endif
       e(xdim_index) = pe_icsize(i)
       e(ydim_index) = pe_jcsize(i)
@@ -771,6 +780,8 @@ subroutine domain_read_5d(fileobj, variable_name, vdata, unlim_dim_level, &
   real(kind=real32), dimension(:,:,:,:,:), allocatable :: buf_real32
   real(kind=real64), dimension(:,:,:,:,:), allocatable :: buf_real64
   logical :: buffer_includes_halos
+  integer :: xgmin
+  integer :: ygmin
 
   if (.not. is_variable_domain_decomposed(fileobj, variable_name, .true., &
                                           xdim_index, ydim_index, xpos, ypos)) then
@@ -793,13 +804,14 @@ subroutine domain_read_5d(fileobj, variable_name, vdata, unlim_dim_level, &
     allocate(pe_jcsize(size(fileobj%pelist)))
     call mpp_get_compute_domains(io_domain, xbegin=pe_isc, xsize=pe_icsize, position=xpos)
     call mpp_get_compute_domains(io_domain, ybegin=pe_jsc, ysize=pe_jcsize, position=ypos)
+    call mpp_get_global_domain(io_domain, ybegin=ygmin, xbegin=xgmin)
     do i = 1, size(fileobj%pelist)
       !Calculate the indices of the domain-decomposed chunk relative to its position in the file.
       c(xdim_index) = pe_isc(i)
       c(ydim_index) = pe_jsc(i)
       if (fileobj%adjust_indices) then
-        c(xdim_index) = c(xdim_index) - pe_isc(1) + 1
-        c(ydim_index) = c(ydim_index) - pe_jsc(1) + 1
+        c(xdim_index) = c(xdim_index) - xgmin + 1
+        c(ydim_index) = c(ydim_index) - ygmin + 1
       endif
       e(xdim_index) = pe_icsize(i)
       e(ydim_index) = pe_jcsize(i)

--- a/fms2_io/include/domain_read.inc
+++ b/fms2_io/include/domain_read.inc
@@ -129,8 +129,8 @@ subroutine domain_read_2d(fileobj, variable_name, vdata, unlim_dim_level, &
   real(kind=real32), dimension(:,:), allocatable :: buf_real32
   real(kind=real64), dimension(:,:), allocatable :: buf_real64
   logical :: buffer_includes_halos
-  integer :: xgmin
-  integer :: ygmin
+  integer :: xgmin !< Starting x index of global io domain
+  integer :: ygmin !< Starting y index of global io domain
 
   if (.not. is_variable_domain_decomposed(fileobj, variable_name, .true., &
                                           xdim_index, ydim_index, xpos, ypos)) then
@@ -153,7 +153,8 @@ subroutine domain_read_2d(fileobj, variable_name, vdata, unlim_dim_level, &
     allocate(pe_jcsize(size(fileobj%pelist)))
     call mpp_get_compute_domains(io_domain, xbegin=pe_isc, xsize=pe_icsize, position=xpos)
     call mpp_get_compute_domains(io_domain, ybegin=pe_jsc, ysize=pe_jcsize, position=ypos)
-    call mpp_get_global_domain(io_domain, ybegin=ygmin, xbegin=xgmin)
+    call mpp_get_global_domain(io_domain, xbegin=xgmin, position=xpos)
+    call mpp_get_global_domain(io_domain, ybegin=ygmin, position=ypos)
     do i = 1, size(fileobj%pelist)
       c(xdim_index) = pe_isc(i)
       c(ydim_index) = pe_jsc(i)
@@ -257,7 +258,7 @@ subroutine domain_read_2d(fileobj, variable_name, vdata, unlim_dim_level, &
           endif
           deallocate(buf_real64)
         class default
-          call error("unsupported type.")
+          call error("domain_read_2d: Unsupported type for variable: "//variable_name//" in file: "//trim(fileobj%path)//"")
       end select
     enddo
     deallocate(pe_isc)
@@ -293,7 +294,7 @@ subroutine domain_read_2d(fileobj, variable_name, vdata, unlim_dim_level, &
         call put_array_section(buf_real64, vdata, c, e)
         deallocate(buf_real64)
       class default
-        call error("unsupported type.")
+          call error("domain_read_2d: Unsupported type for variable: "//variable_name//" in file: "//trim(fileobj%path)//"")
     end select
   endif
 end subroutine domain_read_2d
@@ -346,8 +347,8 @@ subroutine domain_read_3d(fileobj, variable_name, vdata, unlim_dim_level, &
   real(kind=real32), dimension(:,:,:), allocatable :: buf_real32
   real(kind=real64), dimension(:,:,:), allocatable :: buf_real64
   logical :: buffer_includes_halos
-  integer :: xgmin
-  integer :: ygmin
+  integer :: xgmin !< Starting x index of global io domain
+  integer :: ygmin !< Starting y index of global io domain
 
   if (.not. is_variable_domain_decomposed(fileobj, variable_name, .true., &
                                           xdim_index, ydim_index, xpos, ypos)) then
@@ -370,7 +371,8 @@ subroutine domain_read_3d(fileobj, variable_name, vdata, unlim_dim_level, &
     allocate(pe_jcsize(size(fileobj%pelist)))
     call mpp_get_compute_domains(io_domain, xbegin=pe_isc, xsize=pe_icsize, position=xpos)
     call mpp_get_compute_domains(io_domain, ybegin=pe_jsc, ysize=pe_jcsize, position=ypos)
-    call mpp_get_global_domain(io_domain, ybegin=ygmin, xbegin=xgmin)
+    call mpp_get_global_domain(io_domain, xbegin=xgmin, position=xpos)
+    call mpp_get_global_domain(io_domain, ybegin=ygmin, position=ypos)
     do i = 1, size(fileobj%pelist)
       c(xdim_index) = pe_isc(i)
       c(ydim_index) = pe_jsc(i)
@@ -474,7 +476,7 @@ subroutine domain_read_3d(fileobj, variable_name, vdata, unlim_dim_level, &
           endif
           deallocate(buf_real64)
         class default
-          call error("unsupported type.")
+          call error("domain_read_3d: Unsupported type for variable: "//variable_name//" in file: "//trim(fileobj%path)//"")
       end select
     enddo
     deallocate(pe_isc)
@@ -510,7 +512,7 @@ subroutine domain_read_3d(fileobj, variable_name, vdata, unlim_dim_level, &
         call put_array_section(buf_real64, vdata, c, e)
         deallocate(buf_real64)
       class default
-        call error("unsupported type.")
+          call error("domain_read_3d: Unsupported type for variable: "//variable_name//" in file: "//trim(fileobj%path)//"")
     end select
   endif
 end subroutine domain_read_3d
@@ -563,8 +565,8 @@ subroutine domain_read_4d(fileobj, variable_name, vdata, unlim_dim_level, &
   real(kind=real32), dimension(:,:,:,:), allocatable :: buf_real32
   real(kind=real64), dimension(:,:,:,:), allocatable :: buf_real64
   logical :: buffer_includes_halos
-  integer :: xgmin
-  integer :: ygmin
+  integer :: xgmin !< Starting x index of global io domain
+  integer :: ygmin !< Starting y index of global io domain
 
   if (.not. is_variable_domain_decomposed(fileobj, variable_name, .true., &
                                           xdim_index, ydim_index, xpos, ypos)) then
@@ -587,7 +589,8 @@ subroutine domain_read_4d(fileobj, variable_name, vdata, unlim_dim_level, &
     allocate(pe_jcsize(size(fileobj%pelist)))
     call mpp_get_compute_domains(io_domain, xbegin=pe_isc, xsize=pe_icsize, position=xpos)
     call mpp_get_compute_domains(io_domain, ybegin=pe_jsc, ysize=pe_jcsize, position=ypos)
-    call mpp_get_global_domain(io_domain, ybegin=ygmin, xbegin=xgmin)
+    call mpp_get_global_domain(io_domain, xbegin=xgmin, position=xpos)
+    call mpp_get_global_domain(io_domain, ybegin=ygmin, position=ypos)
     do i = 1, size(fileobj%pelist)
       c(xdim_index) = pe_isc(i)
       c(ydim_index) = pe_jsc(i)
@@ -691,7 +694,7 @@ subroutine domain_read_4d(fileobj, variable_name, vdata, unlim_dim_level, &
           endif
           deallocate(buf_real64)
         class default
-          call error("unsupported type.")
+          call error("domain_read_4d: Unsupported type for variable: "//variable_name//" in file: "//trim(fileobj%path)//"")
       end select
     enddo
     deallocate(pe_isc)
@@ -727,7 +730,7 @@ subroutine domain_read_4d(fileobj, variable_name, vdata, unlim_dim_level, &
         call put_array_section(buf_real64, vdata, c, e)
         deallocate(buf_real64)
       class default
-        call error("unsupported type.")
+          call error("domain_read_4d: Unsupported type for variable: "//variable_name//" in file: "//trim(fileobj%path)//"")
     end select
   endif
 end subroutine domain_read_4d
@@ -780,8 +783,8 @@ subroutine domain_read_5d(fileobj, variable_name, vdata, unlim_dim_level, &
   real(kind=real32), dimension(:,:,:,:,:), allocatable :: buf_real32
   real(kind=real64), dimension(:,:,:,:,:), allocatable :: buf_real64
   logical :: buffer_includes_halos
-  integer :: xgmin
-  integer :: ygmin
+  integer :: xgmin !< Starting x index of global io domain
+  integer :: ygmin !< Starting y index of global io domain
 
   if (.not. is_variable_domain_decomposed(fileobj, variable_name, .true., &
                                           xdim_index, ydim_index, xpos, ypos)) then
@@ -804,7 +807,8 @@ subroutine domain_read_5d(fileobj, variable_name, vdata, unlim_dim_level, &
     allocate(pe_jcsize(size(fileobj%pelist)))
     call mpp_get_compute_domains(io_domain, xbegin=pe_isc, xsize=pe_icsize, position=xpos)
     call mpp_get_compute_domains(io_domain, ybegin=pe_jsc, ysize=pe_jcsize, position=ypos)
-    call mpp_get_global_domain(io_domain, ybegin=ygmin, xbegin=xgmin)
+    call mpp_get_global_domain(io_domain, xbegin=xgmin, position=xpos)
+    call mpp_get_global_domain(io_domain, ybegin=ygmin, position=ypos)
     do i = 1, size(fileobj%pelist)
       !Calculate the indices of the domain-decomposed chunk relative to its position in the file.
       c(xdim_index) = pe_isc(i)
@@ -910,7 +914,7 @@ subroutine domain_read_5d(fileobj, variable_name, vdata, unlim_dim_level, &
           endif
           deallocate(buf_real64)
         class default
-          call error("unsupported type.")
+          call error("domain_read_5d: Unsupported type for variable: "//variable_name//" in file: "//trim(fileobj%path)//"")
       end select
     enddo
     deallocate(pe_isc)
@@ -946,7 +950,7 @@ subroutine domain_read_5d(fileobj, variable_name, vdata, unlim_dim_level, &
         call put_array_section(buf_real64, vdata, c, e)
         deallocate(buf_real64)
       class default
-        call error("unsupported type.")
+          call error("domain_read_5d: Unsupported type for variable: "//variable_name//" in file: "//trim(fileobj%path)//"")
     end select
   endif
 end subroutine domain_read_5d

--- a/test_fms/fms2_io/test_io_with_mask.F90
+++ b/test_fms/fms2_io/test_io_with_mask.F90
@@ -27,7 +27,7 @@ use   mpp_domains_mod, only: mpp_domains_set_stack_size, mpp_define_domains, mpp
                              mpp_get_compute_domain,domain2d
 use   mpp_mod,         only: mpp_pe, mpp_root_pe, mpp_error, FATAL
 use   fms2_io_mod,     only: open_file, register_axis, register_variable_attribute, close_file, &
-                             FmsNetcdfDomainFile_t, write_data, register_field
+                             FmsNetcdfDomainFile_t, write_data, register_field, read_data
 use   fms_mod,         only: fms_init, fms_end
 use   fms_io_mod,      only: parse_mask_table
 use   netcdf,          only: nf90_open, nf90_get_var, nf90_nowrite, NF90_NOERR, nf90_get_var, &
@@ -133,6 +133,35 @@ if (mpp_pe() .eq. mpp_root_pe()) then
    err = nf90_close(ncid)
    if (err .ne. NF90_NOERR) call mpp_error(FATAL, "test_io_with_mask: error closing the file")
 endif
+
+!< Read the file back using fms2io
+sst_in = 0.
+if (open_file(fileobj, "test_io_with_mask.nc", "read", domain)) then
+   names(1) = "lon"
+   names(2) = "lat"
+   call register_axis(fileobj, "lon", "x")
+   call register_axis(fileobj, "lat", "y")
+
+   !< Register the variable and Write out the data
+   call register_field(fileobj, "sst", "double", names(1:2))
+
+   call read_data(fileobj, "sst", sst_in)
+   call close_file(fileobj)
+
+   print *, "sum: ", sum(sst_in)
+   do i=1,nlon
+       do j=1,nlat
+          if (i > 30 .or. j > 20) then
+             if (sst_in(i,j) .ne. real(7., kind=real64)) then
+                 print *, 'i=', i, ' j=', j, ' sst_in=', sst_in(i,j)
+                 call mpp_error(FATAL, "test_io_with_mask: the unmasked data read in is not correct")
+             endif
+          endif
+       enddo
+   enddo
+
+endif
+
 
 call fms_end
 


### PR DESCRIPTION
**Description**
This PR uses the **global io domain** indices when adjusting the indices relative to its position in the file.

Fixes #534 

**How Has This Been Tested?**
Passes the changes to the unit test on skylake + travis

Without the code changes, the test fails with the famous `FATAL from PE     0: NetCDF: Index exceeds dimension bound` error message

@wrongkindofdoctor Please test with your test case. 

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

