### PR TITLE
mpp: BOZ literal assignment

### DIFF
--- a/mpp/mpp_domains.F90
+++ b/mpp/mpp_domains.F90
@@ -646,7 +646,7 @@ module mpp_domains_mod
   integer,                                save :: a_sort_len=0        ! len sorted memory list
   integer,                                save :: n_addrs=0           ! num memory addresses used
 
-  integer(LONG_KIND), parameter :: ADDR2_BASE=Z'0000000000010000'
+  integer(LONG_KIND), parameter :: ADDR2_BASE = int(Z'0000000000010000', kind=LONG_KIND)
   integer, parameter :: MAX_ADDRS2=128
   integer(LONG_KIND),dimension(MAX_ADDRS2),save :: addrs2_sorted=-9999  ! list of sorted local addrs
   integer,           dimension(-1:MAX_ADDRS2),save :: addrs2_idx=-9999  ! idx of addr2 assoicated w/ d_comm
@@ -671,10 +671,10 @@ module mpp_domains_mod
   integer,                                         save           :: n_comm=0            ! num communicators used
 
   !     integer(LONG_KIND), parameter :: GT_BASE=2**8
-  integer(LONG_KIND), parameter :: GT_BASE=Z'0000000000000100'  ! Workaround for 64bit int init problem
+  integer(LONG_KIND), parameter :: GT_BASE = int(Z'0000000000000100', kind=LONG_KIND)
 
   !     integer(LONG_KIND), parameter :: KE_BASE=2**48
-  integer(LONG_KIND), parameter :: KE_BASE=Z'0001000000000000'  ! Workaround for 64bit int init problem
+  integer(LONG_KIND), parameter :: KE_BASE = int(Z'0001000000000000', kind=LONG_KIND)
 
   integer(LONG_KIND) :: domain_cnt=0
 

--- a/mpp/mpp_parameter.F90
+++ b/mpp/mpp_parameter.F90
@@ -117,7 +117,7 @@ module mpp_parameter_mod
 ! combination with the flag parameter defined above to create a unique identifier for
 ! each Domain+flags combination. Therefore, the value of any flag must not exceed DOMAIN_ID_BASE.
 ! integer(LONG_KIND), parameter :: DOMAIN_ID_BASE=INT( 2**(4*LONG_KIND),KIND=LONG_KIND )
-  integer(LONG_KIND), parameter :: DOMAIN_ID_BASE=Z'0000000100000000' ! Workaround for 64bit init problem
+  integer(LONG_KIND), parameter :: DOMAIN_ID_BASE = int(Z'0000000100000000', kind=LONG_KIND)
   integer, parameter :: NON_BITWISE_EXACT_SUM=0
   integer, parameter :: BITWISE_EXACT_SUM=1
   integer, parameter :: BITWISE_EFP_SUM=2


### PR DESCRIPTION
**Description**
Because BOZ literals (e.g. Z'00001000') are typeless, the standard does
not allow them to be assigned to variables, which do have prescibed
types.

While this has generally not been a problem in the past, GCC 10 now
forbids such assignments, which raises errors in the FMS build.

This patch resolves the issue by replacing assignments with an
`int(..,kind=...)` transfer.

Although this can be avoided with the `-fallow-invalid-boz` flag, the
following patch should avoid the need for any new flags.

Fixes #555 

**How Has This Been Tested?**
This was tested in the MOM6 test suite.  Only the OpenMP build could be tested, due to newer changes in FMS which seem to require OpenMP.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

I apologize but I am currently unable to get the `make distcheck` tests to pass.  The problems appear to be unrelated to the code change.  Hopefully someone on the FMS side can test this.  If the problem persists then I will look back into it.