### PR TITLE
Message to check which IO is used

### DIFF
--- a/fms/fms.F90
+++ b/fms/fms.F90
@@ -357,6 +357,7 @@ subroutine fms_init (localcomm )
 
  integer, intent(in), optional :: localcomm
  integer :: unit, ierr, io
+ integer :: logunitnum
 
     if (module_is_initialized) return    ! return silently if already called
     module_is_initialized = .true.
@@ -369,6 +370,14 @@ subroutine fms_init (localcomm )
     call mpp_domains_init
     call fms_io_init
     call fms2_io_init ()
+    logunitnum = stdlog()
+#ifdef use_mpp_io
+    call mpp_error("fms_init","You are using mpp_io for your FMS modules",NOTE)
+    write (logunitnum,*)"You are using mpp_io for your FMS modules"
+#else
+    call mpp_error("fms_init","You are using fms2_io for your FMS modules",NOTE)
+    write (logunitnum,*)"You are using fms2_io for your FMS modules"
+#endif
 !---- read namelist input ----
 
     call nml_error_init  ! first initialize namelist iostat error codes


### PR DESCRIPTION
**Description**
Write a message specifying which IO is used

Fixes #562 

**How Has This Been Tested?**
Compiled and run with SPEAR

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

