### PR TITLE
Mpp get ascii lines unit test changes

### DIFF
--- a/test_fms/mpp/Makefile.am
+++ b/test_fms/mpp/Makefile.am
@@ -114,4 +114,4 @@ EXTRA_DIST = input_base.nml \
   test_peset.sh
 
 # Clean up
-CLEANFILES = include_files_mod.mod input.nml *.out* ascii*
+CLEANFILES = include_files_mod.mod input.nml *.out* ascii* test_numb*

--- a/test_fms/mpp/test_mpp_get_ascii_lines.F90
+++ b/test_fms/mpp/test_mpp_get_ascii_lines.F90
@@ -46,8 +46,11 @@ program test_get_ascii_lines
   character(len=INPUT_STR_LENGTH), allocatable :: file_contents(:)
   namelist /test_mpp_get_ascii_lines_nml/ test_number
 
+  open(30, file="test_numb2.nml", form="formatted", status="old")
+  read(30, nml = test_mpp_get_ascii_lines_nml)
+  close(30)
+
   call mpp_init(test_level=mpp_init_test_logfile_init)
-  read (input_nml_file, test_mpp_get_ascii_lines_nml, iostat=io_status)
   my_num_lines(test_number) = my_num_lines(test_number)+1 !!!!! Please See Note At End of File
   f_num_lines = get_ascii_file_num_lines(trim(file_name(test_number)), INPUT_STR_LENGTH)
   call assertEquals(f_num_lines, my_num_lines(test_number), trim(test_name(test_number)))
@@ -81,4 +84,4 @@ end program test_get_ascii_lines
 ! lines contained within the file. This is set up so that there are no attempts
 ! to read nml information from an array of dimension zero, as that results in a
 ! segmentation fault. This workaround may be addressed in future versions of
-! mpp, in which case this test must be adapted.
+! mpp, in which case this test must be adapted.                                                                                                                                                                                                                                                                                                                                                               

--- a/test_fms/mpp/test_mpp_get_ascii_lines.F90
+++ b/test_fms/mpp/test_mpp_get_ascii_lines.F90
@@ -84,4 +84,4 @@ end program test_get_ascii_lines
 ! lines contained within the file. This is set up so that there are no attempts
 ! to read nml information from an array of dimension zero, as that results in a
 ! segmentation fault. This workaround may be addressed in future versions of
-! mpp, in which case this test must be adapted.                                                                                                                                                                                                                                                                                                                                                               
+! mpp, in which case this test must be adapted.

--- a/test_fms/mpp/test_mpp_get_ascii_lines2.sh
+++ b/test_fms/mpp/test_mpp_get_ascii_lines2.sh
@@ -36,6 +36,7 @@ cp $top_srcdir/test_fms/mpp/base_ascii_0 ascii_0
 cp $top_srcdir/test_fms/mpp/base_ascii_skip ascii_skip
 cp $top_srcdir/test_fms/mpp/base_ascii_long ascii_long
 
+# Set up namelist to carry test_number.
 touch test_numb_base2.nml
 echo "&test_mpp_get_ascii_lines_nml" > test_numb_base2.nml
 echo "test_number = 0" >> test_numb_base2.nml
@@ -57,4 +58,4 @@ if [ "$err" -ne 1 ]; then
   exit 5
 else
    echo "Test 5 has passed"
-fi                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  
+fi

--- a/test_fms/mpp/test_mpp_get_ascii_lines2.sh
+++ b/test_fms/mpp/test_mpp_get_ascii_lines2.sh
@@ -36,15 +36,20 @@ cp $top_srcdir/test_fms/mpp/base_ascii_0 ascii_0
 cp $top_srcdir/test_fms/mpp/base_ascii_skip ascii_skip
 cp $top_srcdir/test_fms/mpp/base_ascii_long ascii_long
 
+touch test_numb_base2.nml
+echo "&test_mpp_get_ascii_lines_nml" > test_numb_base2.nml
+echo "test_number = <test_num>" >> test_numb_base2.nml
+echo "/" >> test_numb_base2.nml
+
 for tst in 1 2 3 4
 do
-sed "s/test_number = <test_num>/test_number = ${tst}/" $top_srcdir/test_fms/mpp/input_base.nml > input.nml
+sed "s/test_number = <test_num>/test_number = ${tst}/" $top_srcdir/test_fms/mpp/test_numb_base2.nml > test_numb2.nml
 echo "Running test ${tst}..."
 run_test test_mpp_get_ascii_lines 2 $skip_test
 echo "Test ${tst} has passed"
 done
 
-sed "s/test_number = <test_num>/test_number = 5/" $top_srcdir/test_fms/mpp/input_base.nml > input.nml
+sed "s/test_number = <test_num>/test_number = 5/" $top_srcdir/test_fms/mpp/test_numb_base2.nml > test_numb2.nml
 echo "Running test 5..."
 run_test test_mpp_get_ascii_lines 2 $skip_test || err=1
 if [ "$err" -ne 1 ]; then

--- a/test_fms/mpp/test_mpp_get_ascii_lines2.sh
+++ b/test_fms/mpp/test_mpp_get_ascii_lines2.sh
@@ -44,6 +44,8 @@ echo "test_number = <test_num>" >> test_numb_base2.nml
 echo "/" >> test_numb_base2.nml
 
 echo "write 1"
+cat test_numb_base2.nml
+
 
 for tst in 1 2 3 4
 do

--- a/test_fms/mpp/test_mpp_get_ascii_lines2.sh
+++ b/test_fms/mpp/test_mpp_get_ascii_lines2.sh
@@ -54,6 +54,7 @@ echo "Test ${tst} has passed"
 done
 
 echo "write 2"
+cat test_numb_base2.nml
 
 sed "s/test_number = <test_num>/test_number = 5/" $top_srcdir/test_fms/mpp/test_numb_base2.nml > test_numb2.nml
 echo "Running test 5..."

--- a/test_fms/mpp/test_mpp_get_ascii_lines2.sh
+++ b/test_fms/mpp/test_mpp_get_ascii_lines2.sh
@@ -46,7 +46,7 @@ echo "/" >> test_numb_base2.nml
 echo "write 1"
 cat test_numb_base2.nml
 
-
+cp $top_srcdir/test_fms/mpp/input_base.nml input.nml
 for tst in 1 2 3 4
 do
 sed "s/test_number = <test_num>/test_number = ${tst}/" test_numb_base2.nml > test_numb2.nml

--- a/test_fms/mpp/test_mpp_get_ascii_lines2.sh
+++ b/test_fms/mpp/test_mpp_get_ascii_lines2.sh
@@ -49,7 +49,7 @@ cat test_numb_base2.nml
 
 for tst in 1 2 3 4
 do
-sed "s/test_number = <test_num>/test_number = ${tst}/" $top_srcdir/test_fms/mpp/test_numb_base2.nml > test_numb2.nml
+sed "s/test_number = <test_num>/test_number = ${tst}/" test_numb_base2.nml > test_numb2.nml
 echo "Running test ${tst}..."
 run_test test_mpp_get_ascii_lines 2 $skip_test
 echo "Test ${tst} has passed"

--- a/test_fms/mpp/test_mpp_get_ascii_lines2.sh
+++ b/test_fms/mpp/test_mpp_get_ascii_lines2.sh
@@ -50,6 +50,8 @@ cat test_numb_base2.nml
 for tst in 1 2 3 4
 do
 sed "s/test_number = <test_num>/test_number = ${tst}/" test_numb_base2.nml > test_numb2.nml
+echo "write inside***"
+cat test_numb_base2.nml
 echo "Running test ${tst}..."
 run_test test_mpp_get_ascii_lines 2 $skip_test
 echo "Test ${tst} has passed"

--- a/test_fms/mpp/test_mpp_get_ascii_lines2.sh
+++ b/test_fms/mpp/test_mpp_get_ascii_lines2.sh
@@ -36,31 +36,20 @@ cp $top_srcdir/test_fms/mpp/base_ascii_0 ascii_0
 cp $top_srcdir/test_fms/mpp/base_ascii_skip ascii_skip
 cp $top_srcdir/test_fms/mpp/base_ascii_long ascii_long
 
-echo "write 0"
-
 touch test_numb_base2.nml
 echo "&test_mpp_get_ascii_lines_nml" > test_numb_base2.nml
-echo "test_number = <test_num>" >> test_numb_base2.nml
+echo "test_number = 0" >> test_numb_base2.nml
 echo "/" >> test_numb_base2.nml
 
-echo "write 1"
-cat test_numb_base2.nml
-
-cp $top_srcdir/test_fms/mpp/input_base.nml input.nml
 for tst in 1 2 3 4
 do
-sed "s/test_number = <test_num>/test_number = ${tst}/" test_numb_base2.nml > test_numb2.nml
-echo "write inside***"
-cat test_numb_base2.nml
-echo "Running test ${tst}..."
-run_test test_mpp_get_ascii_lines 2 $skip_test
-echo "Test ${tst} has passed"
+  sed "s/test_number = [0-9]/test_number = ${tst}/" test_numb_base2.nml > test_numb2.nml
+  echo "Running test ${tst}..."
+  run_test test_mpp_get_ascii_lines 2 $skip_test
+  echo "Test ${tst} has passed"
 done
 
-echo "write 2"
-cat test_numb_base2.nml
-
-sed "s/test_number = <test_num>/test_number = 5/" $top_srcdir/test_fms/mpp/test_numb_base2.nml > test_numb2.nml
+sed "s/test_number = [0-9]/test_number = 5/" test_numb_base2.nml > test_numb2.nml
 echo "Running test 5..."
 run_test test_mpp_get_ascii_lines 2 $skip_test || err=1
 if [ "$err" -ne 1 ]; then
@@ -68,4 +57,4 @@ if [ "$err" -ne 1 ]; then
   exit 5
 else
    echo "Test 5 has passed"
-fi
+fi                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  

--- a/test_fms/mpp/test_mpp_get_ascii_lines2.sh
+++ b/test_fms/mpp/test_mpp_get_ascii_lines2.sh
@@ -36,10 +36,14 @@ cp $top_srcdir/test_fms/mpp/base_ascii_0 ascii_0
 cp $top_srcdir/test_fms/mpp/base_ascii_skip ascii_skip
 cp $top_srcdir/test_fms/mpp/base_ascii_long ascii_long
 
+echo "write 0"
+
 touch test_numb_base2.nml
 echo "&test_mpp_get_ascii_lines_nml" > test_numb_base2.nml
 echo "test_number = <test_num>" >> test_numb_base2.nml
 echo "/" >> test_numb_base2.nml
+
+echo "write 1"
 
 for tst in 1 2 3 4
 do
@@ -48,6 +52,8 @@ echo "Running test ${tst}..."
 run_test test_mpp_get_ascii_lines 2 $skip_test
 echo "Test ${tst} has passed"
 done
+
+echo "write 2"
 
 sed "s/test_number = <test_num>/test_number = 5/" $top_srcdir/test_fms/mpp/test_numb_base2.nml > test_numb2.nml
 echo "Running test 5..."


### PR DESCRIPTION
**Description**
Changed the way this test interacts with the input nml to ensure there would be no issues when used in parallel. Now, this test has its own nml that it creates.

Fixes # (issue)

**How Has This Been Tested?**
Skylake, TravisCI

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

