### PR TITLE
Adds a use_mpp_io ifdef to diag_util that was missing

### DIFF
--- a/diag_manager/diag_util.F90
+++ b/diag_manager/diag_util.F90
@@ -88,7 +88,9 @@ use,intrinsic :: iso_c_binding, only: c_double,c_float,c_int64_t, &
   USE mpp_mod, ONLY: mpp_npes
   USE fms_io_mod, ONLY: get_instance_filename, get_mosaic_tile_file_ug
   USE constants_mod, ONLY: SECONDS_PER_DAY, SECONDS_PER_HOUR, SECONDS_PER_MINUTE
-use fms2_io_mod
+#ifndef use_mpp_io
+  USE fms2_io_mod
+#endif
 #ifdef use_netCDF
   USE netcdf, ONLY: NF90_CHAR
 #endif
@@ -1823,8 +1825,9 @@ CONTAINS
     TYPE(domainUG) :: domainU
     INTEGER :: is, ie, last, ind
     character(len=2) :: fnum_domain
+#ifndef use_mpp_io
     class(FmsNetcdfFile_t), pointer    :: fileob
-
+#endif
     aux_present = .FALSE.
     match_aux_name = .FALSE.
     req_present = .FALSE.


### PR DESCRIPTION
**Description**
There were 2 `#ifdef`s missing from diag_util for use_mpp_io.  This adds them in

Fixes #505 

**How Has This Been Tested?**

**Checklist:**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] `make distcheck` passes

