### PR TITLE
Change calendar attr from THIRTY_DAY_MONTHS to 360_DAY

### DIFF
--- a/time_manager/time_manager.F90
+++ b/time_manager/time_manager.F90
@@ -3272,7 +3272,7 @@ if(present(err_msg)) err_msg = ''
 if(ncal == NO_CALENDAR) then
   valid_calendar_types = 'NO_CALENDAR             '
 else if(ncal == THIRTY_DAY_MONTHS) then
-  valid_calendar_types = 'THIRTY_DAY_MONTHS       '
+  valid_calendar_types = '360_DAY                 '
 else if(ncal == JULIAN) then
   valid_calendar_types = 'JULIAN                  '
 else if(ncal == GREGORIAN) then


### PR DESCRIPTION
- The calendar attribute in netcdf files is not CF compliant when set to THIRTY_DAY_MONTHS. The attribute value should be 360_DAY.

**Description**
Changed the result of valid_calendar_types() from 'THIRTY_DAY_MONTHS' to '360_DAY' which has the desired effect of correcting the netcdf attribute without any other input or code changes. The new value is CF compliant: https://cfconventions.org/Data/cf-conventions/cf-conventions-1.8/cf-conventions.html#calendar

Fixes #573 

**How Has This Been Tested?**
Passes Travis-CI tests and submitted branch resolves the NOAA-GFDL/MOM6#1203 when MOM6 is run in NeverWorld2 configuration.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

