### PR TITLE
Removed use_mpp_io build from autotools and travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -118,27 +118,7 @@ jobs:
         - autoreconf -i
         - ./configure ${DISTCHECK_CONFIGURE_FLAGS}
         - make -j distcheck
-#build_with_autotools_mpp_io
-    - name: build_with_autotools_mpp_io
-      env:
-        - FCFLAGS_ADD='' DISTCHECK_CONFIGURE_FLAGS='--enable-mpp-io'
-
-      before_install:
-        - test -n "$CC" && unset CC
-
-      before_script:
-        - export CC=mpicc
-        - export FC=mpif90
-        - export CPPFLAGS="-I/usr/include -Duse_LARGEFILE -DMAXFIELDMETHODS_=500"
-        - export FCFLAGS="-Waliasing -fno-range-check ${FCFLAGS_ADD}"
-        - export LDFLAGS='-L/usr/lib'
-        - export VERBOSE=1
-
-      script:
-        - autoreconf -i
-        - ./configure ${DISTCHECK_CONFIGURE_FLAGS}
-        - make -j distcheck
-
+#build_with_cmake
     - name: build_with_cmake
       env:
         - FCFLAGS_ADD='' DISTCHECK_CONFIGURE_FLAGS=''

--- a/configure.ac
+++ b/configure.ac
@@ -66,12 +66,6 @@ AC_ARG_ENABLE([setting-flags],
 AS_IF([test ${enable_setting_flags:-yes} = yes],
   [enable_setting_flags=yes],
   [enable_setting_flags=no])
-AC_ARG_ENABLE([mpp-io],
-  [AS_HELP_STRING([--enable-mpp-io],
-    [Compile using mpp-io. Otherwise compiles using fms2_io.])])
-AS_IF([test ${enable_mpp_io:-no} = no],
-  [enable_mpp_io=no],
-  [enable_mpp_io=yes])
 
 # Does the user want to build documentation?
 AC_MSG_CHECKING([whether documentation should be build (requires doxygen)])
@@ -218,11 +212,6 @@ if test $enable_setting_flags = yes; then
   fi
   if test ! -z "$OPENMP_FCFLAGS"; then
     FCFLAGS="$FCFLAGS $OPENMP_FCFLAGS"
-  fi
-
-  # Add mpp io flags
-  if test $enable_mpp_io = yes; then
-    AC_DEFINE([use_mpp_io], [1], [Set to compile using mpp_io])
   fi
 fi
 


### PR DESCRIPTION
**Description**
Removes use_mpp_io from auto tools and travis since the flag is being replaced by a namelist switch

Fixes #569

**How Has This Been Tested?**
Tested on skylake with intel

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

