### PR TITLE
Fms2io: Check null character in str_copy

### DIFF
--- a/fms2_io/fms_io_utils.F90
+++ b/fms2_io/fms_io_utils.F90
@@ -202,11 +202,13 @@ subroutine string_copy(dest, source, check_for_null)
 
   check_null = .false.
   if (present(check_for_null)) check_null = check_for_null
+
+  i = 0
   if (check_null) then
      i = index(source, char(0)) - 1
-  else
-     i = len_trim(source)
   endif
+
+  if (i < 1 ) i = len_trim(source)
 
   if (len_trim(source(1:i)) .gt. len(dest)) then
     call error("The input destination string is not big enough to" &

--- a/fms2_io/fms_io_utils.F90
+++ b/fms2_io/fms_io_utils.F90
@@ -202,18 +202,18 @@ subroutine string_copy(dest, source, check_for_null)
 
   check_null = .false.
   if (present(check_for_null)) check_null = check_for_null
-  if (len_trim(source) .gt. len(dest)) then
+  if (check_null) then
+     i = index(source, char(0)) - 1
+  else
+     i = len_trim(source)
+  endif
+
+  if (len_trim(source(1:i)) .gt. len(dest)) then
     call error("The input destination string is not big enough to" &
                  //" to hold the input source string.")
   endif
   dest = ""
-  dest = adjustl(trim(source))
-
-  if (check_null) then
-     i = 0
-     i = index(dest, char(0))
-     if (i > 0 ) dest = dest(1:i-1)
-  endif
+  dest = adjustl(trim(source(1:i)))
 
 end subroutine string_copy
 


### PR DESCRIPTION
**Description**
Fixes the logic that checks if a null character is present in str_copy. 

Fixes #575 

**How Has This Been Tested?**
`make check` passes in GAEA (intel19) /travis (gnu)

OM4p5_BLING_JRA55do1.4_cycle1 experiment with intel18, prod

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

