### PR TITLE
update get_tile_string to include tiles 9 and 99

### DIFF
--- a/fms/fms_io.F90
+++ b/fms/fms_io.F90
@@ -7754,9 +7754,9 @@ function open_file(file, form, action, access, threading, recl, dist) result(uni
     integer,          intent(in)           :: tile
     character(len=*), intent(in), optional :: str2_in
 
-    if(tile > 0 .AND. tile < 9) then
+    if(tile > 0 .AND. tile <= 9) then
        write(str_out,'(a,i1)') trim(str_in), tile
-    else if(tile >= 10 .AND. tile < 99) then
+    else if(tile >= 10 .AND. tile <= 99) then
        write(str_out,'(a,i2)') trim(str_in), tile
     else
        call mpp_error(FATAL, "FMS_IO: get_tile_string: tile must be a positive number less than 100")


### PR DESCRIPTION
**Description**
I changed the if conditions within the ```get_tile_string``` subroutine to include tiles 9 and 99 in the bounds as they should be supported

Fixes #586

**How Has This Been Tested?**
Tested by the user  who originally reported the issue

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

