### PR TITLE
Remove misc. ifdefs and add namelist flags

### DIFF
--- a/diag_integral/diag_integral.F90
+++ b/diag_integral/diag_integral.F90
@@ -107,11 +107,8 @@ use fms_mod,          only:  open_file, error_mesg, &
                              mpp_pe, mpp_root_pe,&
                              FATAL, write_version_number, &
                              stdlog
-#ifndef use_mpp_io
 use fms2_io_mod,      only:  file_exists
-#else
-use  fms_io_mod,      only:  file_exists=>file_exist
-#endif
+use fms_io_mod,       only:  file_exist
 use constants_mod,    only:  radius, constants_init
 use mpp_mod,          only:  mpp_sum, mpp_init
 use ensemble_manager_mod, only : get_ensemble_id, get_ensemble_size
@@ -220,11 +217,13 @@ integer             ::    &
        fields_per_print_line = 4   ! number of fields to write per line
                                    ! of output
 
+logical             ::    &        ! false is to use fms2_io true is mpp_io
+            use_mpp_io = .false.   ! only affects file_exist(s) calls 
 
 namelist / diag_integral_nml /      &
                                 output_interval, time_units,  &
                                 file_name, print_header, &
-                                fields_per_print_line
+                                fields_per_print_line, use_mpp_io
 
 !-------------------------------------------------------------------------------
 !------- public data ------
@@ -298,10 +297,7 @@ integer :: diag_unit = 0             ! unit number for output file
 logical :: module_is_initialized = .false.
                                      ! module is initialized ?
 
-
-
                            contains
-
 
 
 !###############################################################################
@@ -380,9 +376,16 @@ real,dimension(:,:), intent(in), optional :: blon, blat, area_in
 !-------------------------------------------------------------------------------
 !    read namelist.
 !-------------------------------------------------------------------------------
-      if ( file_exists('input.nml')) then
-        read (input_nml_file, nml=diag_integral_nml, iostat=io)
-        ierr = check_nml_error(io,'diag_integral_nml')
+      if(use_mpp_io) then
+        if ( file_exists('input.nml')) then
+          read (input_nml_file, nml=diag_integral_nml, iostat=io)
+          ierr = check_nml_error(io,'diag_integral_nml')
+        endif
+      else
+        if ( file_exist('input.nml')) then
+          read (input_nml_file, nml=diag_integral_nml, iostat=io)
+          ierr = check_nml_error(io,'diag_integral_nml')
+        endif
       endif
 
 !-------------------------------------------------------------------------------

--- a/diag_integral/diag_integral.F90
+++ b/diag_integral/diag_integral.F90
@@ -108,7 +108,6 @@ use fms_mod,          only:  open_file, error_mesg, &
                              FATAL, write_version_number, &
                              stdlog
 use fms2_io_mod,      only:  file_exists
-use fms_io_mod,       only:  file_exist
 use constants_mod,    only:  radius, constants_init
 use mpp_mod,          only:  mpp_sum, mpp_init
 use ensemble_manager_mod, only : get_ensemble_id, get_ensemble_size
@@ -217,13 +216,10 @@ integer             ::    &
        fields_per_print_line = 4   ! number of fields to write per line
                                    ! of output
 
-logical             ::    &        ! false is to use fms2_io true is mpp_io
-            use_mpp_io = .false.   ! only affects file_exist(s) calls 
-
 namelist / diag_integral_nml /      &
                                 output_interval, time_units,  &
                                 file_name, print_header, &
-                                fields_per_print_line, use_mpp_io
+                                fields_per_print_line
 
 !-------------------------------------------------------------------------------
 !------- public data ------
@@ -297,7 +293,10 @@ integer :: diag_unit = 0             ! unit number for output file
 logical :: module_is_initialized = .false.
                                      ! module is initialized ?
 
+
+
                            contains
+
 
 
 !###############################################################################
@@ -376,17 +375,10 @@ real,dimension(:,:), intent(in), optional :: blon, blat, area_in
 !-------------------------------------------------------------------------------
 !    read namelist.
 !-------------------------------------------------------------------------------
-      if(use_mpp_io) then
-        if ( file_exists('input.nml')) then
-          read (input_nml_file, nml=diag_integral_nml, iostat=io)
-          ierr = check_nml_error(io,'diag_integral_nml')
-        endif
-      else
-        if ( file_exist('input.nml')) then
-          read (input_nml_file, nml=diag_integral_nml, iostat=io)
-          ierr = check_nml_error(io,'diag_integral_nml')
-        endif
-      endif
+    if ( file_exists('input.nml')) then
+        read (input_nml_file, nml=diag_integral_nml, iostat=io)
+        ierr = check_nml_error(io,'diag_integral_nml')
+    endif
 
 !-------------------------------------------------------------------------------
 !    write version number and namelist to logfile.

--- a/diag_manager/diag_data.F90
+++ b/diag_manager/diag_data.F90
@@ -59,9 +59,7 @@ use platform_mod
   ! NF90_FILL_REAL has value of 9.9692099683868690e+36.
   USE netcdf, ONLY: NF_FILL_REAL => NF90_FILL_REAL
 #endif
-#ifndef use_mpp_io
 use fms2_io_mod
-#endif
   IMPLICIT NONE
 
   PUBLIC

--- a/field_manager/field_manager.F90
+++ b/field_manager/field_manager.F90
@@ -192,11 +192,8 @@ use    mpp_mod, only : mpp_error,   &
 use mpp_io_mod, only : mpp_io_init
 use    fms_mod, only : lowercase,   &
                        write_version_number
-#ifndef use_mpp_io
 use fms2_io_mod, only: file_exists
-#else
-use  fms_io_mod, only: file_exists=>file_exist
-#endif
+use  fms_io_mod, only: file_exist
 
 implicit none
 private
@@ -563,7 +560,9 @@ type (field_def), pointer        :: current_list_p     => NULL()
 type (field_def), pointer        :: root_p             => NULL()
 type (field_def), pointer        :: save_root_parent_p => NULL()
 type (field_def), target, save   :: root
+logical                          :: use_mpp_io = .false. ! uses fms2_io if false, mpp_io otherwise
 
+namelist /field_manager_nml/ use_mpp_io
 
 contains
 
@@ -666,21 +665,36 @@ if (.not.PRESENT(table_name)) then
 else
    tbl_name = trim(table_name)
 endif
-
-if (.not. file_exists(trim(tbl_name))) then
+! use correct file_exist version based on which io
+if( use_mpp_io) then
+  if (.not. file_exist(trim(tbl_name))) then
 !   <ERROR MSG="No field table available, so no fields are being registered." STATUS="NOTE">
 !      The field table does not exist.
 !   </ERROR>
-if (mpp_pe() == mpp_root_pe()) then
-  if (verb .gt. verb_level_warn) then
-    call mpp_error(NOTE, trim(warn_header)//                       &
-         'No field table ('//trim(tbl_name)//') available, so no fields are being registered.')
+    if (mpp_pe() == mpp_root_pe()) then
+      if (verb .gt. verb_level_warn) then
+        call mpp_error(NOTE, trim(warn_header)//                       &
+           'No field table ('//trim(tbl_name)//') available, so no fields are being registered.')
+      endif
+    endif
+    if(present(nfields)) nfields = 0
+    return
+  endif
+else
+  if (.not. file_exists(trim(tbl_name))) then
+!   <ERROR MSG="No field table available, so no fields are being registered." STATUS="NOTE">
+!      The field table does not exist.
+!   </ERROR>
+    if (mpp_pe() == mpp_root_pe()) then
+      if (verb .gt. verb_level_warn) then
+        call mpp_error(NOTE, trim(warn_header)//                       &
+           'No field table ('//trim(tbl_name)//') available, so no fields are being registered.')
+      endif
+    endif
+    if(present(nfields)) nfields = 0
+    return
   endif
 endif
-if(present(nfields)) nfields = 0
-return
-endif
-
 iunit = get_unit()
 open(iunit, file=trim(tbl_name), action='READ', iostat=io_status)
 if(io_status/=0) call mpp_error(FATAL, 'field_manager_mod: Error in opening file '//trim(tbl_name))

--- a/test_fms/data_override/test_data_override_ongrid.F90
+++ b/test_fms/data_override/test_data_override_ongrid.F90
@@ -55,12 +55,11 @@ real, allocatable, dimension(:,:,:)   :: runoff_in        !< Data to be written 
 real                                  :: expected_result  !< Expected result from data_override
 integer                               :: nhalox=2, nhaloy=2
 integer                               :: io_status
-logical                               :: use_mpp_io = .false. !< false to use fms2_io, otherwise use mpp_io 
 
-namelist / test_data_override_ongrid_nml / nhalox, nhaloy, use_mpp_io
+namelist / test_data_override_ongrid_nml / nhalox, nhaloy
 
 call mpp_init
-if(.not. use_mpp_io) call fms2_io_init
+call fms2_io_init
 
 read (input_nml_file, test_data_override_ongrid_nml, iostat=io_status)
 if (io_status > 0) call mpp_error(FATAL,'=>test_data_override_ongrid: Error reading input.nml')

--- a/test_fms/data_override/test_data_override_ongrid.F90
+++ b/test_fms/data_override/test_data_override_ongrid.F90
@@ -27,9 +27,7 @@ use   mpp_domains_mod,   only: mpp_define_domains, mpp_define_io_domain, mpp_get
 use   mpp_mod,           only: mpp_init, mpp_exit, mpp_pe, mpp_root_pe, mpp_error, FATAL, &
                                input_nml_file
 use   data_override_mod, only: data_override_init, data_override
-#ifndef use_mpp_io
 use   fms2_io_mod,       only: fms2_io_init
-#endif
 use   time_manager_mod,  only: set_calendar_type, time_type, set_date, NOLEAP
 use   mpi,               only: mpi_barrier, mpi_comm_world
 use   netcdf,            only: nf90_create, nf90_def_dim, nf90_def_var, nf90_enddef, nf90_put_var, &
@@ -57,13 +55,12 @@ real, allocatable, dimension(:,:,:)   :: runoff_in        !< Data to be written 
 real                                  :: expected_result  !< Expected result from data_override
 integer                               :: nhalox=2, nhaloy=2
 integer                               :: io_status
+logical                               :: use_mpp_io = .false. !< false to use fms2_io, otherwise use mpp_io 
 
-namelist / test_data_override_ongrid_nml / nhalox, nhaloy
+namelist / test_data_override_ongrid_nml / nhalox, nhaloy, use_mpp_io
 
 call mpp_init
-#ifndef use_mpp_io
-call fms2_io_init
-#endif
+if(.not. use_mpp_io) call fms2_io_init
 
 read (input_nml_file, test_data_override_ongrid_nml, iostat=io_status)
 if (io_status > 0) call mpp_error(FATAL,'=>test_data_override_ongrid: Error reading input.nml')

--- a/test_fms/fms2_io/test_atmosphere_io.F90
+++ b/test_fms/fms2_io/test_atmosphere_io.F90
@@ -18,7 +18,6 @@
 !***********************************************************************
 
 program test_atmosphere_io
-#ifndef use_mpp_io
 use, intrinsic :: iso_fortran_env, only : real32, real64, int32, int64, error_unit, output_unit
 use mpi
 use fms2_io_mod
@@ -600,5 +599,4 @@ endif
 
 
 
-#endif
 end program test_atmosphere_io

--- a/test_fms/fms2_io/test_fms2_io.F90
+++ b/test_fms/fms2_io/test_fms2_io.F90
@@ -18,7 +18,6 @@
 !***********************************************************************
 
 program main
-#ifndef use_mpp_io
 use, intrinsic :: iso_fortran_env
 use argparse
 use mpi
@@ -235,5 +234,4 @@ subroutine chksum_match(out_chksum, in_chksum, var_name, debug)
   endif
 end subroutine chksum_match
 
-#endif
 end program main

--- a/test_fms/fms2_io/test_get_mosaic_tile_grid.F90
+++ b/test_fms/fms2_io/test_get_mosaic_tile_grid.F90
@@ -19,7 +19,6 @@
 
 !> @brief  This programs tests test_get_mosaic_tile_grid.
 program test_get_mosaic_tile_grid
-#ifndef use_mpp_io
 use   mpp_mod,         only: mpp_npes, mpp_pe, mpp_root_pe, mpp_error, FATAL
 use   mpp_domains_mod, only: domain2d, mpp_define_mosaic, mpp_define_io_domain
 use   fms2_io_mod,     only: get_mosaic_tile_grid
@@ -119,5 +118,4 @@ call fms_end
 contains
 
 include "create_atmosphere_domain.inc"
-#endif
 end program

--- a/test_fms/fms2_io/test_global_att.F90
+++ b/test_fms/fms2_io/test_global_att.F90
@@ -18,7 +18,6 @@
 !***********************************************************************
 
 program test_global_att
-#ifndef use_mpp_io
 use   fms2_io_mod
 use   mpp_mod
 use, intrinsic :: iso_fortran_env, only : real32, real64, int32, int64
@@ -102,5 +101,4 @@ if (trim(buf_str) /= "some text") then
     call mpp_error(FATAL, "test_global_att: error reading buf_str")
 endif
 call mpp_exit()
-#endif
 end program

--- a/test_fms/fms2_io/test_io_simple.F90
+++ b/test_fms/fms2_io/test_io_simple.F90
@@ -22,7 +22,6 @@
 !> \author Ed Hartnett, 6/10/20
 
 program test_io_simple
-#ifndef use_mpp_io
   use, intrinsic :: iso_fortran_env, only : real32, real64, int32, int64, error_unit, output_unit
   use mpi
   use fms2_io_mod
@@ -177,5 +176,4 @@ program test_io_simple
   end do
 
   call cleanup(test_params)
-#endif
 end program test_io_simple

--- a/test_fms/fms2_io/test_io_with_mask.F90
+++ b/test_fms/fms2_io/test_io_with_mask.F90
@@ -18,7 +18,6 @@
 !***********************************************************************
 
 program test_io_with_mask
-#ifndef use_mpp_io
 !> @brief  This programs tests fms2io/include/domain_write ability to write
 !! data when the domain contains a mask table. For the points that are
 !! masked out, no data should be writen. 
@@ -170,5 +169,4 @@ endif
 
 
 call fms_end
-#endif
 end program test_io_with_mask


### PR DESCRIPTION
**Description**
Takes out some ifdefs added in #557 and adds a namelist flag to field_manager, diag_integral, diag_data, and test_data_override_ongrid

Fixes #569 

**How Has This Been Tested?**
Make check on skylake with intel20

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

