### PR TITLE
FMS2io: get valid bug fix plus unit test

### DIFF
--- a/fms2_io/netcdf_io.F90
+++ b/fms2_io/netcdf_io.F90
@@ -1555,12 +1555,14 @@ function get_valid(fileobj, variable_name) &
     !This routine makes use of netcdf's automatic type conversion to
     !store all range information in double precision.
     if (attribute_exists(fileobj%ncid, varid, "scale_factor")) then
-      call get_variable_attribute(fileobj, variable_name, "scale_factor", scale_factor)
+      call get_variable_attribute(fileobj, variable_name, "scale_factor", scale_factor, &
+                                  broadcast=.false.)
     else
       scale_factor = 1._real64
     endif
     if (attribute_exists(fileobj%ncid, varid, "add_offset")) then
-      call get_variable_attribute(fileobj, variable_name, "add_offset", add_offset)
+      call get_variable_attribute(fileobj, variable_name, "add_offset", add_offset, & 
+                                  broadcast=.false.)
     else
       add_offset = 0._real64
     endif
@@ -1570,19 +1572,22 @@ function get_valid(fileobj, variable_name) &
     !or minimum value is defined, valid%has_range is set to .true. (i.e. open ended ranges
     !are valid and should be tested within the is_valid function).
     if (attribute_exists(fileobj%ncid, varid, "valid_range")) then
-      call get_variable_attribute(fileobj, variable_name, "valid_range", buffer)
+      call get_variable_attribute(fileobj, variable_name, "valid_range", buffer, &
+                                  broadcast=.false.)
       valid%max_val = buffer(2)*scale_factor + add_offset
       valid%has_max = .true.
       valid%min_val = buffer(1)*scale_factor + add_offset
       valid%has_min = .true.
     else
       if (attribute_exists(fileobj%ncid, varid, "valid_max")) then
-        call get_variable_attribute(fileobj, variable_name, "valid_max", buffer(1))
+        call get_variable_attribute(fileobj, variable_name, "valid_max", buffer(1), &
+                                  broadcast=.false.)
         valid%max_val = buffer(1)*scale_factor + add_offset
         valid%has_max = .true.
       endif
       if (attribute_exists(fileobj%ncid, varid, "valid_min")) then
-        call get_variable_attribute(fileobj, variable_name, "valid_min", buffer(1))
+        call get_variable_attribute(fileobj, variable_name, "valid_min", buffer(1), &
+                                  broadcast=.false.)
         valid%min_val = buffer(1)*scale_factor + add_offset
         valid%has_min = .true.
       endif
@@ -1592,7 +1597,8 @@ function get_valid(fileobj, variable_name) &
 
     !Get the missing value from the file if it exists.
     if (attribute_exists(fileobj%ncid, varid, "missing_value")) then
-      call get_variable_attribute(fileobj, variable_name, "missing_value", buffer(1))
+      call get_variable_attribute(fileobj, variable_name, "missing_value", buffer(1), &
+                                  broadcast=.false.)
       valid%missing_val = buffer(1)*scale_factor + add_offset
       valid%has_missing = .true.
     endif
@@ -1606,7 +1612,8 @@ function get_valid(fileobj, variable_name) &
     !values are greater than the fill value). As before, valid%has_range is true
     !if either a maximum or minimum value is set.
     if (attribute_exists(fileobj%ncid, varid, "_FillValue")) then
-      call get_variable_attribute(fileobj, variable_name, "_FillValue", buffer(1))
+      call get_variable_attribute(fileobj, variable_name, "_FillValue", buffer(1), &
+                                  broadcast=.false.)
       valid%fill_val = buffer(1)*scale_factor + add_offset
       valid%has_fill = .true.
       xtype = get_variable_type(fileobj%ncid, varid)

--- a/test_fms/fms2_io/Makefile.am
+++ b/test_fms/fms2_io/Makefile.am
@@ -29,10 +29,11 @@ AM_CPPFLAGS = -I${top_builddir}/mpp -I${top_builddir}/fms2_io -I${top_builddir}/
 LDADD = ${top_builddir}/libFMS/libFMS.la
 
 # Build this test program.
-check_PROGRAMS = test_fms2_io test_atmosphere_io test_io_simple test_io_with_mask test_global_att \
+check_PROGRAMS = test_get_is_valid test_fms2_io test_atmosphere_io test_io_simple test_io_with_mask test_global_att \
                  test_get_mosaic_tile_grid
 
 # This is the source code for the test.
+test_get_is_valid_SOURCES = test_get_is_valid.F90
 test_fms2_io_SOURCES = argparse.F90 test_fms2_io.F90 create_atmosphere_domain.inc \
                        create_land_domain.inc create_ocean_domain.inc \
                        ocean_restart_file_test.inc land_compressed_restart_file_test.inc \

--- a/test_fms/fms2_io/test_get_is_valid.F90
+++ b/test_fms/fms2_io/test_get_is_valid.F90
@@ -1,0 +1,97 @@
+!***********************************************************************
+!*                   GNU Lesser General Public License
+!*
+!* This file is part of the GFDL Flexible Modeling System (FMS).
+!*
+!* FMS is free software: you can redistribute it and/or modify it under
+!* the terms of the GNU Lesser General Public License as published by
+!* the Free Software Foundation, either version 3 of the License, or (at
+!* your option) any later version.
+!*
+!* FMS is distributed in the hope that it will be useful, but WITHOUT
+!* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+!* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+!* for more details.
+!*
+!* You should have received a copy of the GNU Lesser General Public
+!* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
+!***********************************************************************
+
+!> @brief  This programs tests calls to fms2_io get_valid and is_valid
+
+program test_get_is_valid
+
+use   fms2_io_mod, only: fms2_io_init, open_file, FmsNetcdfFile_t, valid_t, &
+                         close_file, is_valid, get_valid
+use   mpp_mod    , only: mpp_init, mpp_exit, mpp_npes, mpp_get_current_pelist, &
+                         mpp_root_pe, mpp_pe, FATAL, mpp_error
+use   netcdf     , only: nf90_create, nf90_def_var, nf90_put_att, nf90_enddef, &
+                         nf90_close, nf90_clobber, nf90_64bit_offset, nf90_double
+
+use, intrinsic :: iso_fortran_env
+
+implicit none
+
+type(valid_t) :: valid_type               !> Fms2io valid object type
+type(FmsNetcdfFile_t) :: fileobj          !> Fms2io file obj
+real(kind=real64) :: sst(10,10)           !> Data
+integer :: mask_in(10,10)                 !> Array defining if sst(:,:) is valid (1) or not (0)
+integer :: ncid, varid, err               !> Netcdf integers needed
+integer, dimension(:), allocatable :: pes !> Current pelist
+
+call mpp_init()
+call fms2_io_init()
+
+allocate(pes(mpp_npes()))
+call mpp_get_current_pelist(pes)
+
+if (mpp_root_pe() .eq. mpp_pe()) then
+!> Create your own file with a variable to test with:
+   err = nf90_create('INPUT/test_file.nc', ior(nf90_clobber, nf90_64bit_offset), ncid)
+   err = nf90_def_var(ncid, 'sst', nf90_double,varid)
+   err = nf90_put_att(ncid, varid, "_FillValue", real(999,kind=real64))
+   err = nf90_put_att(ncid, varid, "missing_value", real(999,kind=real64))
+   err = nf90_enddef(ncid)
+   err = nf90_close(ncid)
+endif
+
+!> Open the file and set up the valid type
+if (open_file(fileobj, "INPUT/test_file.nc", "read", pelist=pes)) then
+   valid_type = get_valid(fileobj, "sst")
+   call close_file(fileobj)
+else
+   call mpp_error(FATAL, "test_get_valid: Error opening file")
+endif
+
+deallocate(pes)
+
+!> Error checking:
+if (.not. valid_type%has_fill) call mpp_error(FATAL, "test_get_valid: the fill valid_type%has_fill is not .true.")
+if (valid_type%fill_val .ne. real(999,kind=real64)) call mpp_error(FATAL, &
+        "test_get_valid: the fill value is not correct")
+
+if (.not. valid_type%has_missing) call mpp_error(FATAL, "test_get_valid: the fill valid_type%has_fill is not .true.")
+if (valid_type%missing_val .ne. real(999,kind=real64)) call mpp_error(FATAL, &
+        "test_get_valid: the fill value is not correct")
+
+if (.not. valid_type%has_range) call mpp_error(FATAL, "test_get_valid: the valid_type%has_range is not .true.")
+if (.not. valid_type%has_max) call mpp_error(FATAL, "test_get_valid: the valid_type%has_max is not .true.")
+if (valid_type%has_min) call mpp_error(FATAL, "test_get_valid: the valid_type%has_min is .true.")
+
+!> Now test is_valid
+
+!> Create some fake data
+mask_in = 1
+sst = real(0, kind=real64)
+sst(1,1) = real(999, kind=real64)
+
+!> Check where the data is valid
+where(is_valid(sst,valid_type)) mask_in = 0
+
+!> Error checking:
+!> The sum of mask_in should be 1 because only one value is equal to the fill_value
+if (sum(mask_in) .ne. 1) call mpp_error(FATAL, "test_is_valid: the mask should have a 1")
+
+call mpp_exit()
+
+end program test_get_is_valid

--- a/test_fms/fms2_io/test_get_is_valid.F90
+++ b/test_fms/fms2_io/test_get_is_valid.F90
@@ -47,7 +47,7 @@ call mpp_get_current_pelist(pes)
 
 if (mpp_root_pe() .eq. mpp_pe()) then
 !> Create your own file with a variable to test with:
-   err = nf90_create('INPUT/test_file.nc', ior(nf90_clobber, nf90_64bit_offset), ncid)
+   err = nf90_create('test_file.nc', ior(nf90_clobber, nf90_64bit_offset), ncid)
    err = nf90_def_var(ncid, 'sst', nf90_double,varid)
    err = nf90_put_att(ncid, varid, "_FillValue", real(999,kind=real64))
    err = nf90_put_att(ncid, varid, "missing_value", real(999,kind=real64))
@@ -56,7 +56,7 @@ if (mpp_root_pe() .eq. mpp_pe()) then
 endif
 
 !> Open the file and set up the valid type
-if (open_file(fileobj, "INPUT/test_file.nc", "read", pelist=pes)) then
+if (open_file(fileobj, "test_file.nc", "read", pelist=pes)) then
    valid_type = get_valid(fileobj, "sst")
    call close_file(fileobj)
 else

--- a/test_fms/fms2_io/test_io_simple.sh
+++ b/test_fms/fms2_io/test_io_simple.sh
@@ -35,3 +35,7 @@ run_test test_io_simple 6
 
 echo "Test the get_mosaic_tile_grid functionality"
 run_test test_get_mosaic_tile_grid 6
+
+echo "Test the get_valid is_valid functionality"
+run_test test_get_is_valid 1
+run_test test_get_is_valid 2


### PR DESCRIPTION
**Description**
This PR:
1. Modifies get_valid so that there are no mpp_broadcasts inside a `if (fileobj%is_root)`
2. Adds a unit test to test get_valid and is_valid

Without the source code change the unit test fails when you are running with [2 cores](https://github.com/uramirez8707/FMS/blob/6a2e41c03b8ef5b32d0d6b205dce3a6c91f8c85c/test_fms/fms2_io/test_io_simple.sh#L41)

Fixes #585

**How Has This Been Tested?**
`make check` passes on skylake with intel20 and on travis 

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

