### PR TITLE
Add check to configure to skip tests failing from netcdf 4.7.4

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -277,7 +277,6 @@ AC_SUBST([AM_CPPFLAGS])
 AC_SUBST([AM_LDFLAGS])
 AC_SUBST([NOUNDEFINED])
 
-
 # These files will be created when the configure script is run.
 AC_CONFIG_FILES([Makefile
         include/Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -349,5 +349,5 @@ AC_OUTPUT()
 
 ## if tests are being skipped, output warning at end of output
 if [ test "`nc-config --version`" == "netCDF 4.7.4" ]; then
-  AC_MSG_RESULT([Warning: skipping netCDF v4.7.4 incompatible fms2_io tests])
+  AC_MSG_RESULT([Warning: netCDF v4.7.4 is loaded. Incompatible fms2_io tests will be skipped and there may be netCDF issues with model runs.])
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -277,6 +277,7 @@ AC_SUBST([AM_CPPFLAGS])
 AC_SUBST([AM_LDFLAGS])
 AC_SUBST([NOUNDEFINED])
 
+
 # These files will be created when the configure script is run.
 AC_CONFIG_FILES([Makefile
         include/Makefile
@@ -336,3 +337,14 @@ AC_CONFIG_FILES([Makefile
         FMS.pc
         ])
 AC_OUTPUT()
+
+# Check if netcdf is version 4.7.4 to skip failing fms2_io tests
+AC_MSG_CHECKING([if netCDF 4.7.4 is loaded])
+if [ test "`nc-config --version`" == "netCDF 4.7.4" ]; then
+  AM_CONDITIONAL([SKIP_FMS2_IO_TESTS], true )
+  AC_MSG_RESULT([yes]) 
+  AC_MSG_RESULT([Warning: skipping netCDF v4.7.4 incompatible fms2_io tests])
+else
+  AM_CONDITIONAL([SKIP_FMS2_IO_TESTS], false )
+  AC_MSG_RESULT([no])
+fi

--- a/configure.ac
+++ b/configure.ac
@@ -262,6 +262,16 @@ if test -n "$fc_version_info"; then
   FC_VERSION="$FC_VERSION ( $fc_version_info )"
 fi
 
+# Check if netcdf is version 4.7.4 to skip failing fms2_io tests
+AC_MSG_CHECKING([if netCDF 4.7.4 is loaded])
+if [ test "`nc-config --version`" == "netCDF 4.7.4" ]; then
+  AM_CONDITIONAL([SKIP_FMS2_IO_TESTS], true )
+  AC_MSG_RESULT([yes]) 
+else
+  AM_CONDITIONAL([SKIP_FMS2_IO_TESTS], false )
+  AC_MSG_RESULT([no])
+fi
+
 #####
 # Create output variables from various
 # shell variables, for use in generating
@@ -337,13 +347,7 @@ AC_CONFIG_FILES([Makefile
         ])
 AC_OUTPUT()
 
-# Check if netcdf is version 4.7.4 to skip failing fms2_io tests
-AC_MSG_CHECKING([if netCDF 4.7.4 is loaded])
+## if tests are being skipped, output warning at end of output
 if [ test "`nc-config --version`" == "netCDF 4.7.4" ]; then
-  AM_CONDITIONAL([SKIP_FMS2_IO_TESTS], true )
-  AC_MSG_RESULT([yes]) 
   AC_MSG_RESULT([Warning: skipping netCDF v4.7.4 incompatible fms2_io tests])
-else
-  AM_CONDITIONAL([SKIP_FMS2_IO_TESTS], false )
-  AC_MSG_RESULT([no])
 fi

--- a/test_fms/fms2_io/Makefile.am
+++ b/test_fms/fms2_io/Makefile.am
@@ -56,7 +56,15 @@ test_fms2_io.$(OBJEXT): argparse.mod
 # Run the test program.
 TESTS = test_fms2_io.sh test_atmosphere_io.sh test_io_simple.sh test_io_with_mask.sh test_global_att.sh
 
+# skips tests that fail if using netCDF 4.7.4
+if SKIP_FMS2_IO_TESTS
+skipflag="skip"
+else
+skipflag=""
+endif
+
 # Set srcdir as evironment variable to be reference in the job script
-TESTS_ENVIRONMENT = srcdir="$(top_srcdir)"
+TESTS_ENVIRONMENT = srcdir="$(top_srcdir)"; \
+	            netcdf_version_skip=${skipflag}
 
 CLEANFILES = *.mod *.nc *.nc.* input.nml logfile.000000.out the_mask

--- a/test_fms/fms2_io/test_atmosphere_io.sh
+++ b/test_fms/fms2_io/test_atmosphere_io.sh
@@ -27,4 +27,4 @@
 # make an input.nml for mpp_init to read
 printf "EOF\n&dummy\nEOF" | cat > input.nml
 # run the tests
-run_test test_atmosphere_io 6
+run_test test_atmosphere_io 6 $netcdf_version_skip

--- a/test_fms/fms2_io/test_fms2_io.sh
+++ b/test_fms/fms2_io/test_fms2_io.sh
@@ -30,4 +30,4 @@
 # make a dummy file for mpp_init to read
 printf "EOF\n&dummy\nEOF" | cat > input.nml
 # run the tests
-run_test test_fms2_io 6
+run_test test_fms2_io 6 $netcdf_version_skip

--- a/test_fms/fms2_io/test_global_att.sh
+++ b/test_fms/fms2_io/test_global_att.sh
@@ -29,5 +29,4 @@
 touch input.nml
 
 # run the tests
-run_test test_global_att 1
-
+run_test test_global_att 1 $netcdf_version_skip


### PR DESCRIPTION
**Description**
Adds a check to configure.ac to skip 3 tests from fms2_io that fail from a known bug when netcdf 4.7.4 is loaded.

Fixes #607 

**How Has This Been Tested?**
Tested on skylake with intel 20

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

