### PR TITLE
modify chksum to chksum(1:16) in register_variable_attribute calls in fms2_io

### DIFF
--- a/fms2_io/fms_netcdf_domain_io.F90
+++ b/fms2_io/fms_netcdf_domain_io.F90
@@ -556,21 +556,21 @@ subroutine save_domain_restart(fileobj, unlim_dim_level)
                                        fileobj%restart_vars(i)%data2d, is_decomposed)
       if (is_decomposed) then
         call register_variable_attribute(fileobj, fileobj%restart_vars(i)%varname, &
-                                         "checksum", chksum, str_len=len(chksum))
+                                         "checksum", chksum(1:16), str_len=len(chksum))
       endif
     elseif (associated(fileobj%restart_vars(i)%data3d)) then
       chksum = compute_global_checksum(fileobj, fileobj%restart_vars(i)%varname, &
                                        fileobj%restart_vars(i)%data3d, is_decomposed)
       if (is_decomposed) then
         call register_variable_attribute(fileobj, fileobj%restart_vars(i)%varname, &
-                                         "checksum", chksum, str_len=len(chksum))
+                                         "checksum", chksum(1:16), str_len=len(chksum))
       endif
     elseif (associated(fileobj%restart_vars(i)%data4d)) then
       chksum = compute_global_checksum(fileobj, fileobj%restart_vars(i)%varname, &
                                        fileobj%restart_vars(i)%data4d, is_decomposed)
       if (is_decomposed) then
         call register_variable_attribute(fileobj, fileobj%restart_vars(i)%varname, &
-                                         "checksum", chksum, str_len=len(chksum))
+                                         "checksum", chksum(1:16), str_len=len(chksum))
       endif
     endif
   enddo
@@ -855,4 +855,3 @@ include "domain_write.inc"
 
 
 end module fms_netcdf_domain_io_mod
-


### PR DESCRIPTION
**Description**
The ``chksum`` variable is changed to ``chksum(1:16)`` in ``register_variable_attribute`` calls in ``fms2_io``.  This resolves the "unsupported type" error in fms2_io unit tests with the AOCC compiler.

Fixes #616 

**How Has This Been Tested?**

- Make distcheck passes on Skylake with Intel and GCC.
- fms2_io unit tests no longer fail with "FATAL from PE 1: unsupported type" errors with the AOCC compiler

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

