### PR TITLE
Changes needed to get fms2io unit tests to run with AOCC

### DIFF
--- a/fms2_io/fms_netcdf_domain_io.F90
+++ b/fms2_io/fms_netcdf_domain_io.F90
@@ -556,21 +556,21 @@ subroutine save_domain_restart(fileobj, unlim_dim_level)
                                        fileobj%restart_vars(i)%data2d, is_decomposed)
       if (is_decomposed) then
         call register_variable_attribute(fileobj, fileobj%restart_vars(i)%varname, &
-                                         "checksum", chksum, str_len=len(chksum))
+                                         "checksum", chksum(1:len(chksum)), str_len=len(chksum))
       endif
     elseif (associated(fileobj%restart_vars(i)%data3d)) then
       chksum = compute_global_checksum(fileobj, fileobj%restart_vars(i)%varname, &
                                        fileobj%restart_vars(i)%data3d, is_decomposed)
       if (is_decomposed) then
         call register_variable_attribute(fileobj, fileobj%restart_vars(i)%varname, &
-                                         "checksum", chksum, str_len=len(chksum))
+                                         "checksum", chksum(1:len(chksum)), str_len=len(chksum))
       endif
     elseif (associated(fileobj%restart_vars(i)%data4d)) then
       chksum = compute_global_checksum(fileobj, fileobj%restart_vars(i)%varname, &
                                        fileobj%restart_vars(i)%data4d, is_decomposed)
       if (is_decomposed) then
         call register_variable_attribute(fileobj, fileobj%restart_vars(i)%varname, &
-                                         "checksum", chksum, str_len=len(chksum))
+                                         "checksum", chksum(1:len(chksum)), str_len=len(chksum))
       endif
     endif
   enddo
@@ -643,7 +643,7 @@ subroutine restore_domain_state(fileobj, unlim_dim_level)
       if (variable_att_exists(fileobj, fileobj%restart_vars(i)%varname, "checksum") .and. &
           is_decomposed) then
         call get_variable_attribute(fileobj, fileobj%restart_vars(i)%varname, &
-                                    "checksum", chksum_in_file)
+                                    "checksum", chksum_in_file(1:len(chksum_in_file)))
         if (.not. string_compare(trim(adjustl(chksum_in_file)), trim(adjustl(chksum)))) then
           call error("checksum attribute does not match data in file.")
         endif

--- a/test_fms/fms2_io/atmosphere_restart_file_test.inc
+++ b/test_fms/fms2_io/atmosphere_restart_file_test.inc
@@ -51,6 +51,8 @@ subroutine atmosphere_restart_file(domain, nz, nt, debug_flag)
   character(len=256) :: att
   character(len=256), dimension(:), allocatable :: buffer
   character(len=256), dimension(:), allocatable :: buffer2
+  character(len=256) :: str_buffer
+  character(len=256) :: str_buffer2
   logical :: debug
   integer :: err
   integer :: i
@@ -304,12 +306,12 @@ subroutine atmosphere_restart_file(domain, nz, nt, debug_flag)
       call mpp_error(fatal, "Did not read in strings correctly.")
     endif
   enddo
-  call read_data(fileobj, "strings", buffer2(1), corner=ndims)
-  if (trim(buffer2(1)) .ne. trim(buffer(ndims))) then
+  call read_data(fileobj, "strings", str_buffer, corner=ndims)
+  if (trim(str_buffer) .ne. trim(buffer(ndims))) then
     call mpp_error(fatal, "Scalar from array of strings read failed.")
   endif
-  call read_data(fileobj, "filename", buffer2(ndims))
-  if (trim(buffer2(ndims)) .ne. "file1.nc") then
+  call read_data(fileobj, "filename", str_buffer2)
+  if (trim(str_buffer2) .ne. "file1.nc") then
     call mpp_error(fatal, "Did not read in filename variable correctly.")
   endif
   deallocate(buffer)

--- a/test_fms/fms2_io/test_atmosphere_io.F90
+++ b/test_fms/fms2_io/test_atmosphere_io.F90
@@ -74,6 +74,8 @@ integer(kind=int64) :: var11_chksum
 integer(kind=int64) :: chksum
 character(len=256), dimension(:), allocatable :: string_buffer
 character(len=256), dimension(:), allocatable :: string_buffer2
+character(len=256) :: string_buffer3
+character(len=256) :: string_buffer4
 integer :: i
 integer :: ndims
 integer, dimension(:), allocatable :: dim_sizes
@@ -407,12 +409,12 @@ do i = 1, ndims
     call mpp_error(fatal, "Did not read in strings correctly.")
   endif
 enddo
-call read_data(fileobj, "var3", string_buffer2(1), corner=ndims)
-if (trim(string_buffer2(1)) .ne. trim(string_buffer(ndims))) then
+call read_data(fileobj, "var3", string_buffer3, corner=ndims)
+if (trim(string_buffer3) .ne. trim(string_buffer(ndims))) then
   call mpp_error(fatal, "Scalar from array of strings read failed.")
 endif
-call read_data(fileobj, "var2", string_buffer2(ndims))
-if (trim(string_buffer2(ndims)) .ne. "file1.nc") then
+call read_data(fileobj, "var2", string_buffer4)
+if (trim(string_buffer4) .ne. "file1.nc") then
   call mpp_error(fatal, "Did not read in filename variable correctly.")
 endif
 deallocate(string_buffer)


### PR DESCRIPTION
**Description**

- Adds `chksum(1:len(chksum))` in source code to avoid `unsupported type` error messages 
- Adds new string buffers to the unit tests avoid the array of strings inconsistency 

Fixes #616

**How Has This Been Tested?**
`make check` passes with intel, gcc, aocc

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

