### PR TITLE
check gettid with cmake 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,6 +186,13 @@ list(APPEND fms_defs
   use_libMPI
   use_netCDF)
 
+# check gettid
+include(CheckFunctionExists)
+check_function_exists(gettid HAVE_GETTID)
+if(HAVE_GETTID)
+  list(APPEND fms_defs HAVE_GETTID)
+endif()
+
 # Additional (optional) compiler definitions
 if(GFS_PHYS)
   list(APPEND fms_defs GFS_PHYS)


### PR DESCRIPTION
**Description**
This PR modifies CMakeLists.txt to check for the function ``gettid`` 

Fixes #643 

**How Has This Been Tested?**
CMake build has been tested on Skylake with Intel compilers and with GCC in a Docker container with Ubuntu 20.04

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

