### PR TITLE
Fix deallocate of unallocated pointers

### DIFF
--- a/mpp/include/mpp_unstruct_domain.inc
+++ b/mpp/include/mpp_unstruct_domain.inc
@@ -698,6 +698,9 @@ subroutine deallocate_unstruct_pass_type(domain)
      call deallocate_unstruct_overlap_type(domain%UG2SG%recv(n))
   enddo
 
+  ! SG2UG%{send,recv} point to the same memory as UG2SG%{send,recv}
+  ! respectively.  Thus, we only need to `deallocate` one, and nullify
+  ! the other set.
   if(associated(domain%UG2SG%send)) then
     deallocate(domain%UG2SG%send)
     nullify(domain%UG2SG%send)

--- a/mpp/include/mpp_unstruct_domain.inc
+++ b/mpp/include/mpp_unstruct_domain.inc
@@ -687,20 +687,27 @@ subroutine deallocate_unstruct_overlap_type(overlap)
 end subroutine deallocate_unstruct_overlap_type
 
 !------------------------------------------------------------------
-subroutine deallocate_unstruct_pass_type(passobj)
-  type(unstruct_pass_type), intent(inout) :: passobj
+subroutine deallocate_unstruct_pass_type(domain)
+  type(domainUG), intent(inout) :: domain
   integer :: n
 
-  do n = 1, passobj%nsend
-     call deallocate_unstruct_overlap_type(passobj%send(n))
+  do n = 1, domain%UG2SG%nsend
+     call deallocate_unstruct_overlap_type(domain%UG2SG%send(n))
   enddo
-  do n = 1, passobj%nrecv
-     call deallocate_unstruct_overlap_type(passobj%recv(n))
+  do n = 1, domain%UG2SG%nrecv
+     call deallocate_unstruct_overlap_type(domain%UG2SG%recv(n))
   enddo
 
-  if(associated(passobj%send)) deallocate(passobj%send)
-  if(associated(passobj%recv)) deallocate(passobj%recv)
-
+  if(associated(domain%UG2SG%send)) then
+    deallocate(domain%UG2SG%send)
+    nullify(domain%UG2SG%send)
+    nullify(domain%SG2UG%recv)
+  end if
+  if(associated(domain%UG2SG%recv)) then
+    deallocate(domain%UG2SG%recv)
+    nullify(domain%UG2SG%recv)
+    nullify(domain%SG2UG%send)
+  end if
 end subroutine deallocate_unstruct_pass_type
 
 !------------------------------------------------------------------
@@ -726,8 +733,7 @@ subroutine mpp_deallocate_domainUG(domain)
         domain%io_domain => null()
     endif
 
-    call deallocate_unstruct_pass_type(domain%SG2UG)
-    call deallocate_unstruct_pass_type(domain%UG2SG)
+    call deallocate_unstruct_pass_type(domain)
 
     if (associated(domain%grid_index)) then
         deallocate(domain%grid_index)

--- a/test_fms/fms/Makefile.am
+++ b/test_fms/fms/Makefile.am
@@ -40,3 +40,8 @@ TESTS = test_fms_io2.sh
 
 # These will also be included in the distribution.
 EXTRA_DIST = test_fms_io2.sh
+
+CLEANFILES = input.nml logfile.*.out
+
+clean-local:
+	rm -rf RESTART

--- a/test_fms/fms/test_fms_io2.sh
+++ b/test_fms/fms/test_fms_io2.sh
@@ -27,6 +27,17 @@
 # Set common test settings.
 . ../test_common.sh
 
-# These tests are skipped in bats files.
-run_test test_fms_io 2 skip
-run_test test_unstructured_fms_io 2 skip
+# Create the base input.nml file needed for the tests
+cat <<_EOF > input.nml
+&test_fms_io_nml
+  io_layout = 1,1
+/
+_EOF
+
+# Test the structured grid
+rm -rf RESTART && mkdir RESTART
+run_test test_fms_io 6
+
+# Ensure the restart directory is empty
+rm -rf RESTART && mkdir RESTART
+run_test test_unstructured_fms_io 6

--- a/test_fms/fms/test_unstructured_fms_io.F90
+++ b/test_fms/fms/test_unstructured_fms_io.F90
@@ -833,7 +833,9 @@ contains
                                                        "compressed c", &
                                                        "C", &
                                                        compressed_c_axis_size, &
-                                                       unstructured_domain)
+                                                       unstructured_domain, &
+                                                       dimlen_name="C", &
+                                                       dimlen_lname="C compressed")
         allocate(compressed_c_axis_size_per_rank(io_domain_npes))
         compressed_c_axis_size_per_rank = 0
         do i = 1,io_domain_npes
@@ -867,7 +869,9 @@ contains
                                                        "compressed h", &
                                                        "H", &
                                                        compressed_h_axis_size, &
-                                                       unstructured_domain)
+                                                       unstructured_domain, &
+                                                       dimlen_name="H", &
+                                                       dimlen_lname="H compressed")
         allocate(compressed_h_axis_size_per_rank(io_domain_npes))
         compressed_h_axis_size_per_rank = 0
         do i = 1,io_domain_npes


### PR DESCRIPTION
**Description**
This commit fixes the test_fms/fms tests so they now run correctly.  This required fixes to two calls to fms_io_unstructured_register_restart_axis and reworks deallocate_unstruct_pass_type to correcly deallocate and nullify pointers

Fixes #649

**How Has This Been Tested?**
Ran tests on Mac OS X 10.12 and through the CI process

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [ ] `make distcheck` passes

