### PR TITLE
Fix to force fms2io to add the tile number to the filename if nested

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,39 @@
+#***********************************************************************
+#                   GNU Lesser General Public License
+#
+# This file is part of the GFDL FRE NetCDF tools package (FRE NCtools).
+#
+# FRE NCtools is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or (at
+# your option) any later version.
+#
+# FRE NCtools is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
+#**********************************************************************/
+
+# This is the preferred settings for files in the FRE NetCDF package
+# Please visit https://editorconfig.org for information on how to
+# configure your editor to use these settings.
+
+# This is the top-most EditorConfig file
+root = true
+
+# Settings for _all_ files
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+# Settings for specific files, or file patterns.  [{Makefile,*.am}]
+indent_style = tab
+indent_size = 1
+

--- a/.github/workflows/build_ubuntu_gnu.yml
+++ b/.github/workflows/build_ubuntu_gnu.yml
@@ -18,7 +18,7 @@ jobs:
       image: underwoo/ubuntu_libfms_gnu
       env:
         FCFLAGS: "${{ matrix.fcflags }}"
-
+        VERBOSE: 1
     steps:
     - name: Checkout code
       uses: actions/checkout@v2

--- a/fms2_io/fms_netcdf_domain_io.F90
+++ b/fms2_io/fms_netcdf_domain_io.F90
@@ -351,8 +351,11 @@ function open_domain_file(fileobj, path, mode, domain, nc_format, is_restart, do
 
   !Get the path of a "combined" file.
   io_layout = mpp_get_io_domain_layout(domain)
-  if (mpp_get_ntile_count(domain) .gt. 1) then
-    tile_id = mpp_get_tile_id(domain)
+  tile_id = mpp_get_tile_id(domain)
+
+  !< If the number of tiles is greater than 1 or if the current tile is greater
+  !than 1 add .tileX. to the filename
+  if (mpp_get_ntile_count(domain) .gt. 1 .or. tile_id(1) > 1) then
     call domain_tile_filepath_mangle(combined_filepath, path, tile_id(1))
   else
     call string_copy(combined_filepath, path)


### PR DESCRIPTION
**Description**
Checks if the current tile number if greater than 1 and if if is it add the title number to the filename. 

Fixes #655 

**How Has This Been Tested?**
A nested test case in Orion with intel, prod.
The filename are now:
atmos_4xdaily.nest02.tile7.nc

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

