### PR TITLE
fix CMakelists.txt to work with add_subdirectory CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -312,16 +312,16 @@ export(EXPORT FMSExports
   FILE fms-targets.cmake)
 
 configure_package_config_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/FMSConfig.cmake.in ${CMAKE_BINARY_DIR}/fms-config.cmake
+  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/FMSConfig.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/fms-config.cmake
   INSTALL_DESTINATION ${CONFIG_INSTALL_DESTINATION})
-install(FILES ${CMAKE_BINARY_DIR}/fms-config.cmake
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/fms-config.cmake
   DESTINATION ${CONFIG_INSTALL_DESTINATION})
 
 write_basic_package_version_file(
-  ${CMAKE_BINARY_DIR}/fms-config-version.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/fms-config-version.cmake
   VERSION ${PROJECT_VERSION}
   COMPATIBILITY AnyNewerVersion)
-install(FILES ${CMAKE_BINARY_DIR}/fms-config-version.cmake
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/fms-config-version.cmake
   DESTINATION ${CONFIG_INSTALL_DESTINATION})
 
 install(EXPORT FMSExports

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -312,7 +312,7 @@ export(EXPORT FMSExports
   FILE fms-targets.cmake)
 
 configure_package_config_file(
-  ${CMAKE_SOURCE_DIR}/cmake/FMSConfig.cmake.in ${CMAKE_BINARY_DIR}/fms-config.cmake
+  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/FMSConfig.cmake.in ${CMAKE_BINARY_DIR}/fms-config.cmake
   INSTALL_DESTINATION ${CONFIG_INSTALL_DESTINATION})
 install(FILES ${CMAKE_BINARY_DIR}/fms-config.cmake
   DESTINATION ${CONFIG_INSTALL_DESTINATION})


### PR DESCRIPTION
**Description**
CMakelists.txt has been modified to 

1. successfully search for the `FMSConfig.cmake.in` configuration file when the top level source directory `$CMAKE_SOURCE_DIR` is different from the current source directory `$CMAKE_CURRENT_SOURCE_DIR`.
2.  install `FMSConfig.cmake` file in `${CMAKE_CURRENT_BINARY_DIR}`

Fixes #669 

**How Has This Been Tested?**
FMS builds within the UFS Weather Model cmake build

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

