### PR TITLE
replaced fortran instrinsic kinds with portable kinds

### DIFF
--- a/axis_utils/axis_utils2.F90
+++ b/axis_utils/axis_utils2.F90
@@ -28,6 +28,7 @@ module axis_utils2_mod
   use fms2_io_mod, only: FmsNetcdfDomainFile_t, variable_att_exists, FmsNetcdfFile_t, &
                          get_variable_num_dimensions, get_variable_attribute,  &
                          get_variable_size, read_data, variable_exists
+  use platform_mod
 
   implicit none
 
@@ -136,10 +137,10 @@ contains
   integer :: ndims
   character(len=128) :: buffer
   integer, dimension(:), allocatable :: dim_sizes
-  real(kind=real32), dimension(:), allocatable :: r32
-  real(kind=real32), dimension(:,:), allocatable :: r322d
-  real(kind=real64), dimension(:), allocatable :: r64
-  real(kind=real64), dimension(:,:), allocatable :: r642d
+  real(kind=r4_kind), dimension(:), allocatable :: r32
+  real(kind=r4_kind), dimension(:,:), allocatable :: r322d
+  real(kind=r8_kind), dimension(:), allocatable :: r64
+  real(kind=r8_kind), dimension(:,:), allocatable :: r642d
   integer :: i
   integer :: n
   logical :: reproduce_null_char_bug !< Local flag indicating to reproduce the mpp_io bug where
@@ -188,9 +189,9 @@ contains
         call mpp_error(FATAL, "axis_edges: incorrect size of edge data.")
       endif
       select type (edge_data)
-        type is (real(kind=real32))
+        type is (real(kind=r4_kind))
           call read_data(fileobj, buffer, edge_data)
-        type is (real(kind=real64))
+        type is (real(kind=r8_kind))
           call read_data(fileobj, buffer, edge_data)
         class default
           call mpp_error(FATAL, "axis_edges: unsupported kind.")
@@ -203,13 +204,13 @@ contains
         call mpp_error(FATAL, "axis_edges: incorrect size of edge data.")
       endif
       select type (edge_data)
-        type is (real(kind=real32))
+        type is (real(kind=r4_kind))
           allocate(r322d(dim_sizes(1), dim_sizes(2)))
           call read_data(fileobj, buffer, r322d)
           edge_data(1:dim_sizes(2)) = r322d(1,:)
           edge_data(dim_sizes(2)+1) = r322d(2,dim_sizes(2))
           deallocate(r322d)
-        type is (real(kind=real64))
+        type is (real(kind=r8_kind))
           allocate(r642d(dim_sizes(1), dim_sizes(2)))
           call read_data(fileobj, buffer, r642d)
           edge_data(1:dim_sizes(2)) = r642d(1,:)
@@ -222,29 +223,29 @@ contains
     deallocate(dim_sizes)
   else
     select type (edge_data)
-      type is (real(kind=real32))
+      type is (real(kind=r4_kind))
         allocate(r32(n))
         call read_data(fileobj, name, r32)
         do i = 2, n
-          edge_data(i) = r32(i-1) + 0.5_real32*(r32(i) - r32(i-1))
+          edge_data(i) = r32(i-1) + 0.5_r4_kind*(r32(i) - r32(i-1))
         enddo
-        edge_data(1) = r32(1) - 0.5_real32*(r32(2) - r32(1))
+        edge_data(1) = r32(1) - 0.5_r4_kind*(r32(2) - r32(1))
         if (abs(edge_data(1)) .lt. 1.e-10) then
-          edge_data(1) = 0._real32
+          edge_data(1) = 0._r4_kind
         endif
-        edge_data(n+1) = r32(n) + 0.5_real32*(r32(n) - r32(n-1))
+        edge_data(n+1) = r32(n) + 0.5_r4_kind*(r32(n) - r32(n-1))
         deallocate(r32)
-      type is (real(kind=real64))
+      type is (real(kind=r8_kind))
         allocate(r64(n))
         call read_data(fileobj, name, r64)
         do i = 2, n
-          edge_data(i) = r64(i-1) + 0.5_real64*(r64(i) - r64(i-1))
+          edge_data(i) = r64(i-1) + 0.5_r8_kind*(r64(i) - r64(i-1))
         enddo
-        edge_data(1) = r64(1) - 0.5_real64*(r64(2) - r64(1))
+        edge_data(1) = r64(1) - 0.5_r8_kind*(r64(2) - r64(1))
         if (abs(edge_data(1)) .lt. 1.d-10) then
-          edge_data(1) = 0._real64
+          edge_data(1) = 0._r8_kind
         endif
-        edge_data(n+1) = r64(n) + 0.5_real64*(r64(n) - r64(n-1))
+        edge_data(n+1) = r64(n) + 0.5_r8_kind*(r64(n) - r64(n-1))
         deallocate(r64)
       class default
         call mpp_error(FATAL, "axis_edges: unsupported kind.")

--- a/fms2_io/fms_io_utils.F90
+++ b/fms2_io/fms_io_utils.F90
@@ -57,26 +57,26 @@ endtype char_linked_list
 
 
 interface allocate_array
-  module procedure allocate_array_int32_1d
-  module procedure allocate_array_int32_2d
-  module procedure allocate_array_int32_3d
-  module procedure allocate_array_int32_4d
-  module procedure allocate_array_int32_5d
-  module procedure allocate_array_int64_1d
-  module procedure allocate_array_int64_2d
-  module procedure allocate_array_int64_3d
-  module procedure allocate_array_int64_4d
-  module procedure allocate_array_int64_5d
-  module procedure allocate_array_real32_1d
-  module procedure allocate_array_real32_2d
-  module procedure allocate_array_real32_3d
-  module procedure allocate_array_real32_4d
-  module procedure allocate_array_real32_5d
-  module procedure allocate_array_real64_1d
-  module procedure allocate_array_real64_2d
-  module procedure allocate_array_real64_3d
-  module procedure allocate_array_real64_4d
-  module procedure allocate_array_real64_5d
+  module procedure allocate_array_i4_kind_1d
+  module procedure allocate_array_i4_kind_2d
+  module procedure allocate_array_i4_kind_3d
+  module procedure allocate_array_i4_kind_4d
+  module procedure allocate_array_i4_kind_5d
+  module procedure allocate_array_i8_kind_1d
+  module procedure allocate_array_i8_kind_2d
+  module procedure allocate_array_i8_kind_3d
+  module procedure allocate_array_i8_kind_4d
+  module procedure allocate_array_i8_kind_5d
+  module procedure allocate_array_r4_kind_1d
+  module procedure allocate_array_r4_kind_2d
+  module procedure allocate_array_r4_kind_3d
+  module procedure allocate_array_r4_kind_4d
+  module procedure allocate_array_r4_kind_5d
+  module procedure allocate_array_r8_kind_1d
+  module procedure allocate_array_r8_kind_2d
+  module procedure allocate_array_r8_kind_3d
+  module procedure allocate_array_r8_kind_4d
+  module procedure allocate_array_r8_kind_5d
   module procedure allocate_array_char_1d
   module procedure allocate_array_char_2d
   module procedure allocate_array_char_3d
@@ -87,50 +87,50 @@ end interface allocate_array
 
 
 interface put_array_section
-  module procedure put_array_section_int32_1d
-  module procedure put_array_section_int32_2d
-  module procedure put_array_section_int32_3d
-  module procedure put_array_section_int32_4d
-  module procedure put_array_section_int32_5d
-  module procedure put_array_section_int64_1d
-  module procedure put_array_section_int64_2d
-  module procedure put_array_section_int64_3d
-  module procedure put_array_section_int64_4d
-  module procedure put_array_section_int64_5d
-  module procedure put_array_section_real32_1d
-  module procedure put_array_section_real32_2d
-  module procedure put_array_section_real32_3d
-  module procedure put_array_section_real32_4d
-  module procedure put_array_section_real32_5d
-  module procedure put_array_section_real64_1d
-  module procedure put_array_section_real64_2d
-  module procedure put_array_section_real64_3d
-  module procedure put_array_section_real64_4d
-  module procedure put_array_section_real64_5d
+  module procedure put_array_section_i4_kind_1d
+  module procedure put_array_section_i4_kind_2d
+  module procedure put_array_section_i4_kind_3d
+  module procedure put_array_section_i4_kind_4d
+  module procedure put_array_section_i4_kind_5d
+  module procedure put_array_section_i8_kind_1d
+  module procedure put_array_section_i8_kind_2d
+  module procedure put_array_section_i8_kind_3d
+  module procedure put_array_section_i8_kind_4d
+  module procedure put_array_section_i8_kind_5d
+  module procedure put_array_section_r4_kind_1d
+  module procedure put_array_section_r4_kind_2d
+  module procedure put_array_section_r4_kind_3d
+  module procedure put_array_section_r4_kind_4d
+  module procedure put_array_section_r4_kind_5d
+  module procedure put_array_section_r8_kind_1d
+  module procedure put_array_section_r8_kind_2d
+  module procedure put_array_section_r8_kind_3d
+  module procedure put_array_section_r8_kind_4d
+  module procedure put_array_section_r8_kind_5d
 end interface put_array_section
 
 
 interface get_array_section
-  module procedure get_array_section_int32_1d
-  module procedure get_array_section_int32_2d
-  module procedure get_array_section_int32_3d
-  module procedure get_array_section_int32_4d
-  module procedure get_array_section_int32_5d
-  module procedure get_array_section_int64_1d
-  module procedure get_array_section_int64_2d
-  module procedure get_array_section_int64_3d
-  module procedure get_array_section_int64_4d
-  module procedure get_array_section_int64_5d
-  module procedure get_array_section_real32_1d
-  module procedure get_array_section_real32_2d
-  module procedure get_array_section_real32_3d
-  module procedure get_array_section_real32_4d
-  module procedure get_array_section_real32_5d
-  module procedure get_array_section_real64_1d
-  module procedure get_array_section_real64_2d
-  module procedure get_array_section_real64_3d
-  module procedure get_array_section_real64_4d
-  module procedure get_array_section_real64_5d
+  module procedure get_array_section_i4_kind_1d
+  module procedure get_array_section_i4_kind_2d
+  module procedure get_array_section_i4_kind_3d
+  module procedure get_array_section_i4_kind_4d
+  module procedure get_array_section_i4_kind_5d
+  module procedure get_array_section_i8_kind_1d
+  module procedure get_array_section_i8_kind_2d
+  module procedure get_array_section_i8_kind_3d
+  module procedure get_array_section_i8_kind_4d
+  module procedure get_array_section_i8_kind_5d
+  module procedure get_array_section_r4_kind_1d
+  module procedure get_array_section_r4_kind_2d
+  module procedure get_array_section_r4_kind_3d
+  module procedure get_array_section_r4_kind_4d
+  module procedure get_array_section_r4_kind_5d
+  module procedure get_array_section_r8_kind_1d
+  module procedure get_array_section_r8_kind_2d
+  module procedure get_array_section_r8_kind_3d
+  module procedure get_array_section_r8_kind_4d
+  module procedure get_array_section_r8_kind_5d
 end interface get_array_section
 
 

--- a/fms2_io/include/array_utils.inc
+++ b/fms2_io/include/array_utils.inc
@@ -18,7 +18,7 @@
 !***********************************************************************
 
 !> @brief Allocate arrays using an input array of sizes.
-subroutine allocate_array_int32_1d(buf, sizes)
+subroutine allocate_array_i4_kind_1d(buf, sizes)
 
   integer(kind=i4_kind), dimension(:), allocatable, intent(inout) :: buf !< Array that will be allocated.
   integer, dimension(1), intent(in) :: sizes !< Array of dimension sizes.
@@ -27,11 +27,11 @@ subroutine allocate_array_int32_1d(buf, sizes)
     deallocate(buf)
   endif
   allocate(buf(sizes(1)))
-end subroutine allocate_array_int32_1d
+end subroutine allocate_array_i4_kind_1d
 
 
 !> @brief Put a section of an array into a larger array.
-subroutine put_array_section_int32_1d(section, array, s, c)
+subroutine put_array_section_i4_kind_1d(section, array, s, c)
 
   integer(kind=i4_kind), dimension(:), intent(in) :: section !< Section to be inserted.
   integer(kind=i4_kind), dimension(:), intent(inout) :: array !< Array to insert the section in.
@@ -39,11 +39,11 @@ subroutine put_array_section_int32_1d(section, array, s, c)
   integer, dimension(1), intent(in) :: c !< Array of sizes.
 
   array(s(1):s(1)+c(1)-1 ) = section(:)
-end subroutine put_array_section_int32_1d
+end subroutine put_array_section_i4_kind_1d
 
 
 !> @brief Get a section of larger array.
-subroutine get_array_section_int32_1d(section, array, s, c)
+subroutine get_array_section_i4_kind_1d(section, array, s, c)
 
   integer(kind=i4_kind), dimension(:), intent(inout) :: section !< Section to be extracted.
   integer(kind=i4_kind), dimension(:), intent(in) :: array !< Array to extract the section from.
@@ -51,11 +51,11 @@ subroutine get_array_section_int32_1d(section, array, s, c)
   integer, dimension(1), intent(in) :: c !< Array of sizes.
 
   section(:) = array(s(1):s(1)+c(1)-1 )
-end subroutine get_array_section_int32_1d
+end subroutine get_array_section_i4_kind_1d
 
 
 !> @brief Allocate arrays using an input array of sizes.
-subroutine allocate_array_int32_2d(buf, sizes)
+subroutine allocate_array_i4_kind_2d(buf, sizes)
 
   integer(kind=i4_kind), dimension(:,:), allocatable, intent(inout) :: buf !< Array that will be allocated.
   integer, dimension(2), intent(in) :: sizes !< Array of dimension sizes.
@@ -64,11 +64,11 @@ subroutine allocate_array_int32_2d(buf, sizes)
     deallocate(buf)
   endif
   allocate(buf(sizes(1),sizes(2)))
-end subroutine allocate_array_int32_2d
+end subroutine allocate_array_i4_kind_2d
 
 
 !> @brief Put a section of an array into a larger array.
-subroutine put_array_section_int32_2d(section, array, s, c)
+subroutine put_array_section_i4_kind_2d(section, array, s, c)
 
   integer(kind=i4_kind), dimension(:,:), intent(in) :: section !< Section to be inserted.
   integer(kind=i4_kind), dimension(:,:), intent(inout) :: array !< Array to insert the section in.
@@ -76,11 +76,11 @@ subroutine put_array_section_int32_2d(section, array, s, c)
   integer, dimension(2), intent(in) :: c !< Array of sizes.
 
   array(s(1):s(1)+c(1)-1 ,s(2):s(2)+c(2)-1 ) = section(:,:)
-end subroutine put_array_section_int32_2d
+end subroutine put_array_section_i4_kind_2d
 
 
 !> @brief Get a section of larger array.
-subroutine get_array_section_int32_2d(section, array, s, c)
+subroutine get_array_section_i4_kind_2d(section, array, s, c)
 
   integer(kind=i4_kind), dimension(:,:), intent(inout) :: section !< Section to be extracted.
   integer(kind=i4_kind), dimension(:,:), intent(in) :: array !< Array to extract the section from.
@@ -88,11 +88,11 @@ subroutine get_array_section_int32_2d(section, array, s, c)
   integer, dimension(2), intent(in) :: c !< Array of sizes.
 
   section(:,:) = array(s(1):s(1)+c(1)-1 ,s(2):s(2)+c(2)-1 )
-end subroutine get_array_section_int32_2d
+end subroutine get_array_section_i4_kind_2d
 
 
 !> @brief Allocate arrays using an input array of sizes.
-subroutine allocate_array_int32_3d(buf, sizes)
+subroutine allocate_array_i4_kind_3d(buf, sizes)
 
   integer(kind=i4_kind), dimension(:,:,:), allocatable, intent(inout) :: buf !< Array that will be allocated.
   integer, dimension(3), intent(in) :: sizes !< Array of dimension sizes.
@@ -101,11 +101,11 @@ subroutine allocate_array_int32_3d(buf, sizes)
     deallocate(buf)
   endif
   allocate(buf(sizes(1),sizes(2),sizes(3)))
-end subroutine allocate_array_int32_3d
+end subroutine allocate_array_i4_kind_3d
 
 
 !> @brief Put a section of an array into a larger array.
-subroutine put_array_section_int32_3d(section, array, s, c)
+subroutine put_array_section_i4_kind_3d(section, array, s, c)
 
   integer(kind=i4_kind), dimension(:,:,:), intent(in) :: section !< Section to be inserted.
   integer(kind=i4_kind), dimension(:,:,:), intent(inout) :: array !< Array to insert the section in.
@@ -113,11 +113,11 @@ subroutine put_array_section_int32_3d(section, array, s, c)
   integer, dimension(3), intent(in) :: c !< Array of sizes.
 
   array(s(1):s(1)+c(1)-1 ,s(2):s(2)+c(2)-1 ,s(3):s(3)+c(3)-1 ) = section(:,:,:)
-end subroutine put_array_section_int32_3d
+end subroutine put_array_section_i4_kind_3d
 
 
 !> @brief Get a section of larger array.
-subroutine get_array_section_int32_3d(section, array, s, c)
+subroutine get_array_section_i4_kind_3d(section, array, s, c)
 
   integer(kind=i4_kind), dimension(:,:,:), intent(inout) :: section !< Section to be extracted.
   integer(kind=i4_kind), dimension(:,:,:), intent(in) :: array !< Array to extract the section from.
@@ -125,11 +125,11 @@ subroutine get_array_section_int32_3d(section, array, s, c)
   integer, dimension(3), intent(in) :: c !< Array of sizes.
 
   section(:,:,:) = array(s(1):s(1)+c(1)-1 ,s(2):s(2)+c(2)-1 ,s(3):s(3)+c(3)-1 )
-end subroutine get_array_section_int32_3d
+end subroutine get_array_section_i4_kind_3d
 
 
 !> @brief Allocate arrays using an input array of sizes.
-subroutine allocate_array_int32_4d(buf, sizes)
+subroutine allocate_array_i4_kind_4d(buf, sizes)
 
   integer(kind=i4_kind), dimension(:,:,:,:), allocatable, intent(inout) :: buf !< Array that will be allocated.
   integer, dimension(4), intent(in) :: sizes !< Array of dimension sizes.
@@ -138,11 +138,11 @@ subroutine allocate_array_int32_4d(buf, sizes)
     deallocate(buf)
   endif
   allocate(buf(sizes(1),sizes(2),sizes(3),sizes(4)))
-end subroutine allocate_array_int32_4d
+end subroutine allocate_array_i4_kind_4d
 
 
 !> @brief Put a section of an array into a larger array.
-subroutine put_array_section_int32_4d(section, array, s, c)
+subroutine put_array_section_i4_kind_4d(section, array, s, c)
 
   integer(kind=i4_kind), dimension(:,:,:,:), intent(in) :: section !< Section to be inserted.
   integer(kind=i4_kind), dimension(:,:,:,:), intent(inout) :: array !< Array to insert the section in.
@@ -150,11 +150,11 @@ subroutine put_array_section_int32_4d(section, array, s, c)
   integer, dimension(4), intent(in) :: c !< Array of sizes.
 
   array(s(1):s(1)+c(1)-1 ,s(2):s(2)+c(2)-1 ,s(3):s(3)+c(3)-1 ,s(4):s(4)+c(4)-1 ) = section(:,:,:,:)
-end subroutine put_array_section_int32_4d
+end subroutine put_array_section_i4_kind_4d
 
 
 !> @brief Get a section of larger array.
-subroutine get_array_section_int32_4d(section, array, s, c)
+subroutine get_array_section_i4_kind_4d(section, array, s, c)
 
   integer(kind=i4_kind), dimension(:,:,:,:), intent(inout) :: section !< Section to be extracted.
   integer(kind=i4_kind), dimension(:,:,:,:), intent(in) :: array !< Array to extract the section from.
@@ -162,11 +162,11 @@ subroutine get_array_section_int32_4d(section, array, s, c)
   integer, dimension(4), intent(in) :: c !< Array of sizes.
 
   section(:,:,:,:) = array(s(1):s(1)+c(1)-1 ,s(2):s(2)+c(2)-1 ,s(3):s(3)+c(3)-1 ,s(4):s(4)+c(4)-1 )
-end subroutine get_array_section_int32_4d
+end subroutine get_array_section_i4_kind_4d
 
 
 !> @brief Allocate arrays using an input array of sizes.
-subroutine allocate_array_int32_5d(buf, sizes)
+subroutine allocate_array_i4_kind_5d(buf, sizes)
 
   integer(kind=i4_kind), dimension(:,:,:,:,:), allocatable, intent(inout) :: buf !< Array that will be allocated.
   integer, dimension(5), intent(in) :: sizes !< Array of dimension sizes.
@@ -175,11 +175,11 @@ subroutine allocate_array_int32_5d(buf, sizes)
     deallocate(buf)
   endif
   allocate(buf(sizes(1),sizes(2),sizes(3),sizes(4),sizes(5)))
-end subroutine allocate_array_int32_5d
+end subroutine allocate_array_i4_kind_5d
 
 
 !> @brief Put a section of an array into a larger array.
-subroutine put_array_section_int32_5d(section, array, s, c)
+subroutine put_array_section_i4_kind_5d(section, array, s, c)
 
   integer(kind=i4_kind), dimension(:,:,:,:,:), intent(in) :: section !< Section to be inserted.
   integer(kind=i4_kind), dimension(:,:,:,:,:), intent(inout) :: array !< Array to insert the section in.
@@ -187,11 +187,11 @@ subroutine put_array_section_int32_5d(section, array, s, c)
   integer, dimension(5), intent(in) :: c !< Array of sizes.
 
   array(s(1):s(1)+c(1)-1 ,s(2):s(2)+c(2)-1 ,s(3):s(3)+c(3)-1 ,s(4):s(4)+c(4)-1 ,s(5):s(5)+c(5)-1 ) = section(:,:,:,:,:)
-end subroutine put_array_section_int32_5d
+end subroutine put_array_section_i4_kind_5d
 
 
 !> @brief Get a section of larger array.
-subroutine get_array_section_int32_5d(section, array, s, c)
+subroutine get_array_section_i4_kind_5d(section, array, s, c)
 
   integer(kind=i4_kind), dimension(:,:,:,:,:), intent(inout) :: section !< Section to be extracted.
   integer(kind=i4_kind), dimension(:,:,:,:,:), intent(in) :: array !< Array to extract the section from.
@@ -199,11 +199,11 @@ subroutine get_array_section_int32_5d(section, array, s, c)
   integer, dimension(5), intent(in) :: c !< Array of sizes.
 
   section(:,:,:,:,:) = array(s(1):s(1)+c(1)-1 ,s(2):s(2)+c(2)-1 ,s(3):s(3)+c(3)-1 ,s(4):s(4)+c(4)-1 ,s(5):s(5)+c(5)-1 )
-end subroutine get_array_section_int32_5d
+end subroutine get_array_section_i4_kind_5d
 
 
 !> @brief Allocate arrays using an input array of sizes.
-subroutine allocate_array_int64_1d(buf, sizes)
+subroutine allocate_array_i8_kind_1d(buf, sizes)
 
   integer(kind=i8_kind), dimension(:), allocatable, intent(inout) :: buf !< Array that will be allocated.
   integer, dimension(1), intent(in) :: sizes !< Array of dimension sizes.
@@ -212,11 +212,11 @@ subroutine allocate_array_int64_1d(buf, sizes)
     deallocate(buf)
   endif
   allocate(buf(sizes(1)))
-end subroutine allocate_array_int64_1d
+end subroutine allocate_array_i8_kind_1d
 
 
 !> @brief Put a section of an array into a larger array.
-subroutine put_array_section_int64_1d(section, array, s, c)
+subroutine put_array_section_i8_kind_1d(section, array, s, c)
 
   integer(kind=i8_kind), dimension(:), intent(in) :: section !< Section to be inserted.
   integer(kind=i8_kind), dimension(:), intent(inout) :: array !< Array to insert the section in.
@@ -224,11 +224,11 @@ subroutine put_array_section_int64_1d(section, array, s, c)
   integer, dimension(1), intent(in) :: c !< Array of sizes.
 
   array(s(1):s(1)+c(1)-1 ) = section(:)
-end subroutine put_array_section_int64_1d
+end subroutine put_array_section_i8_kind_1d
 
 
 !> @brief Get a section of larger array.
-subroutine get_array_section_int64_1d(section, array, s, c)
+subroutine get_array_section_i8_kind_1d(section, array, s, c)
 
   integer(kind=i8_kind), dimension(:), intent(inout) :: section !< Section to be extracted.
   integer(kind=i8_kind), dimension(:), intent(in) :: array !< Array to extract the section from.
@@ -236,11 +236,11 @@ subroutine get_array_section_int64_1d(section, array, s, c)
   integer, dimension(1), intent(in) :: c !< Array of sizes.
 
   section(:) = array(s(1):s(1)+c(1)-1 )
-end subroutine get_array_section_int64_1d
+end subroutine get_array_section_i8_kind_1d
 
 
 !> @brief Allocate arrays using an input array of sizes.
-subroutine allocate_array_int64_2d(buf, sizes)
+subroutine allocate_array_i8_kind_2d(buf, sizes)
 
   integer(kind=i8_kind), dimension(:,:), allocatable, intent(inout) :: buf !< Array that will be allocated.
   integer, dimension(2), intent(in) :: sizes !< Array of dimension sizes.
@@ -249,11 +249,11 @@ subroutine allocate_array_int64_2d(buf, sizes)
     deallocate(buf)
   endif
   allocate(buf(sizes(1),sizes(2)))
-end subroutine allocate_array_int64_2d
+end subroutine allocate_array_i8_kind_2d
 
 
 !> @brief Put a section of an array into a larger array.
-subroutine put_array_section_int64_2d(section, array, s, c)
+subroutine put_array_section_i8_kind_2d(section, array, s, c)
 
   integer(kind=i8_kind), dimension(:,:), intent(in) :: section !< Section to be inserted.
   integer(kind=i8_kind), dimension(:,:), intent(inout) :: array !< Array to insert the section in.
@@ -261,11 +261,11 @@ subroutine put_array_section_int64_2d(section, array, s, c)
   integer, dimension(2), intent(in) :: c !< Array of sizes.
 
   array(s(1):s(1)+c(1)-1 ,s(2):s(2)+c(2)-1 ) = section(:,:)
-end subroutine put_array_section_int64_2d
+end subroutine put_array_section_i8_kind_2d
 
 
 !> @brief Get a section of larger array.
-subroutine get_array_section_int64_2d(section, array, s, c)
+subroutine get_array_section_i8_kind_2d(section, array, s, c)
 
   integer(kind=i8_kind), dimension(:,:), intent(inout) :: section !< Section to be extracted.
   integer(kind=i8_kind), dimension(:,:), intent(in) :: array !< Array to extract the section from.
@@ -273,11 +273,11 @@ subroutine get_array_section_int64_2d(section, array, s, c)
   integer, dimension(2), intent(in) :: c !< Array of sizes.
 
   section(:,:) = array(s(1):s(1)+c(1)-1 ,s(2):s(2)+c(2)-1 )
-end subroutine get_array_section_int64_2d
+end subroutine get_array_section_i8_kind_2d
 
 
 !> @brief Allocate arrays using an input array of sizes.
-subroutine allocate_array_int64_3d(buf, sizes)
+subroutine allocate_array_i8_kind_3d(buf, sizes)
 
   integer(kind=i8_kind), dimension(:,:,:), allocatable, intent(inout) :: buf !< Array that will be allocated.
   integer, dimension(3), intent(in) :: sizes !< Array of dimension sizes.
@@ -286,11 +286,11 @@ subroutine allocate_array_int64_3d(buf, sizes)
     deallocate(buf)
   endif
   allocate(buf(sizes(1),sizes(2),sizes(3)))
-end subroutine allocate_array_int64_3d
+end subroutine allocate_array_i8_kind_3d
 
 
 !> @brief Put a section of an array into a larger array.
-subroutine put_array_section_int64_3d(section, array, s, c)
+subroutine put_array_section_i8_kind_3d(section, array, s, c)
 
   integer(kind=i8_kind), dimension(:,:,:), intent(in) :: section !< Section to be inserted.
   integer(kind=i8_kind), dimension(:,:,:), intent(inout) :: array !< Array to insert the section in.
@@ -298,11 +298,11 @@ subroutine put_array_section_int64_3d(section, array, s, c)
   integer, dimension(3), intent(in) :: c !< Array of sizes.
 
   array(s(1):s(1)+c(1)-1 ,s(2):s(2)+c(2)-1 ,s(3):s(3)+c(3)-1 ) = section(:,:,:)
-end subroutine put_array_section_int64_3d
+end subroutine put_array_section_i8_kind_3d
 
 
 !> @brief Get a section of larger array.
-subroutine get_array_section_int64_3d(section, array, s, c)
+subroutine get_array_section_i8_kind_3d(section, array, s, c)
 
   integer(kind=i8_kind), dimension(:,:,:), intent(inout) :: section !< Section to be extracted.
   integer(kind=i8_kind), dimension(:,:,:), intent(in) :: array !< Array to extract the section from.
@@ -310,11 +310,11 @@ subroutine get_array_section_int64_3d(section, array, s, c)
   integer, dimension(3), intent(in) :: c !< Array of sizes.
 
   section(:,:,:) = array(s(1):s(1)+c(1)-1 ,s(2):s(2)+c(2)-1 ,s(3):s(3)+c(3)-1 )
-end subroutine get_array_section_int64_3d
+end subroutine get_array_section_i8_kind_3d
 
 
 !> @brief Allocate arrays using an input array of sizes.
-subroutine allocate_array_int64_4d(buf, sizes)
+subroutine allocate_array_i8_kind_4d(buf, sizes)
 
   integer(kind=i8_kind), dimension(:,:,:,:), allocatable, intent(inout) :: buf !< Array that will be allocated.
   integer, dimension(4), intent(in) :: sizes !< Array of dimension sizes.
@@ -323,11 +323,11 @@ subroutine allocate_array_int64_4d(buf, sizes)
     deallocate(buf)
   endif
   allocate(buf(sizes(1),sizes(2),sizes(3),sizes(4)))
-end subroutine allocate_array_int64_4d
+end subroutine allocate_array_i8_kind_4d
 
 
 !> @brief Put a section of an array into a larger array.
-subroutine put_array_section_int64_4d(section, array, s, c)
+subroutine put_array_section_i8_kind_4d(section, array, s, c)
 
   integer(kind=i8_kind), dimension(:,:,:,:), intent(in) :: section !< Section to be inserted.
   integer(kind=i8_kind), dimension(:,:,:,:), intent(inout) :: array !< Array to insert the section in.
@@ -335,11 +335,11 @@ subroutine put_array_section_int64_4d(section, array, s, c)
   integer, dimension(4), intent(in) :: c !< Array of sizes.
 
   array(s(1):s(1)+c(1)-1 ,s(2):s(2)+c(2)-1 ,s(3):s(3)+c(3)-1 ,s(4):s(4)+c(4)-1 ) = section(:,:,:,:)
-end subroutine put_array_section_int64_4d
+end subroutine put_array_section_i8_kind_4d
 
 
 !> @brief Get a section of larger array.
-subroutine get_array_section_int64_4d(section, array, s, c)
+subroutine get_array_section_i8_kind_4d(section, array, s, c)
 
   integer(kind=i8_kind), dimension(:,:,:,:), intent(inout) :: section !< Section to be extracted.
   integer(kind=i8_kind), dimension(:,:,:,:), intent(in) :: array !< Array to extract the section from.
@@ -347,11 +347,11 @@ subroutine get_array_section_int64_4d(section, array, s, c)
   integer, dimension(4), intent(in) :: c !< Array of sizes.
 
   section(:,:,:,:) = array(s(1):s(1)+c(1)-1 ,s(2):s(2)+c(2)-1 ,s(3):s(3)+c(3)-1 ,s(4):s(4)+c(4)-1 )
-end subroutine get_array_section_int64_4d
+end subroutine get_array_section_i8_kind_4d
 
 
 !> @brief Allocate arrays using an input array of sizes.
-subroutine allocate_array_int64_5d(buf, sizes)
+subroutine allocate_array_i8_kind_5d(buf, sizes)
 
   integer(kind=i8_kind), dimension(:,:,:,:,:), allocatable, intent(inout) :: buf !< Array that will be allocated.
   integer, dimension(5), intent(in) :: sizes !< Array of dimension sizes.
@@ -360,11 +360,11 @@ subroutine allocate_array_int64_5d(buf, sizes)
     deallocate(buf)
   endif
   allocate(buf(sizes(1),sizes(2),sizes(3),sizes(4),sizes(5)))
-end subroutine allocate_array_int64_5d
+end subroutine allocate_array_i8_kind_5d
 
 
 !> @brief Put a section of an array into a larger array.
-subroutine put_array_section_int64_5d(section, array, s, c)
+subroutine put_array_section_i8_kind_5d(section, array, s, c)
 
   integer(kind=i8_kind), dimension(:,:,:,:,:), intent(in) :: section !< Section to be inserted.
   integer(kind=i8_kind), dimension(:,:,:,:,:), intent(inout) :: array !< Array to insert the section in.
@@ -372,11 +372,11 @@ subroutine put_array_section_int64_5d(section, array, s, c)
   integer, dimension(5), intent(in) :: c !< Array of sizes.
 
   array(s(1):s(1)+c(1)-1 ,s(2):s(2)+c(2)-1 ,s(3):s(3)+c(3)-1 ,s(4):s(4)+c(4)-1 ,s(5):s(5)+c(5)-1 ) = section(:,:,:,:,:)
-end subroutine put_array_section_int64_5d
+end subroutine put_array_section_i8_kind_5d
 
 
 !> @brief Get a section of larger array.
-subroutine get_array_section_int64_5d(section, array, s, c)
+subroutine get_array_section_i8_kind_5d(section, array, s, c)
 
   integer(kind=i8_kind), dimension(:,:,:,:,:), intent(inout) :: section !< Section to be extracted.
   integer(kind=i8_kind), dimension(:,:,:,:,:), intent(in) :: array !< Array to extract the section from.
@@ -384,11 +384,11 @@ subroutine get_array_section_int64_5d(section, array, s, c)
   integer, dimension(5), intent(in) :: c !< Array of sizes.
 
   section(:,:,:,:,:) = array(s(1):s(1)+c(1)-1 ,s(2):s(2)+c(2)-1 ,s(3):s(3)+c(3)-1 ,s(4):s(4)+c(4)-1 ,s(5):s(5)+c(5)-1 )
-end subroutine get_array_section_int64_5d
+end subroutine get_array_section_i8_kind_5d
 
 
 !> @brief Allocate arrays using an input array of sizes.
-subroutine allocate_array_real32_1d(buf, sizes)
+subroutine allocate_array_r4_kind_1d(buf, sizes)
 
   real(kind=r4_kind), dimension(:), allocatable, intent(inout) :: buf !< Array that will be allocated.
   integer, dimension(1), intent(in) :: sizes !< Array of dimension sizes.
@@ -397,11 +397,11 @@ subroutine allocate_array_real32_1d(buf, sizes)
     deallocate(buf)
   endif
   allocate(buf(sizes(1)))
-end subroutine allocate_array_real32_1d
+end subroutine allocate_array_r4_kind_1d
 
 
 !> @brief Put a section of an array into a larger array.
-subroutine put_array_section_real32_1d(section, array, s, c)
+subroutine put_array_section_r4_kind_1d(section, array, s, c)
 
   real(kind=r4_kind), dimension(:), intent(in) :: section !< Section to be inserted.
   real(kind=r4_kind), dimension(:), intent(inout) :: array !< Array to insert the section in.
@@ -409,11 +409,11 @@ subroutine put_array_section_real32_1d(section, array, s, c)
   integer, dimension(1), intent(in) :: c !< Array of sizes.
 
   array(s(1):s(1)+c(1)-1 ) = section(:)
-end subroutine put_array_section_real32_1d
+end subroutine put_array_section_r4_kind_1d
 
 
 !> @brief Get a section of larger array.
-subroutine get_array_section_real32_1d(section, array, s, c)
+subroutine get_array_section_r4_kind_1d(section, array, s, c)
 
   real(kind=r4_kind), dimension(:), intent(inout) :: section !< Section to be extracted.
   real(kind=r4_kind), dimension(:), intent(in) :: array !< Array to extract the section from.
@@ -421,11 +421,11 @@ subroutine get_array_section_real32_1d(section, array, s, c)
   integer, dimension(1), intent(in) :: c !< Array of sizes.
 
   section(:) = array(s(1):s(1)+c(1)-1 )
-end subroutine get_array_section_real32_1d
+end subroutine get_array_section_r4_kind_1d
 
 
 !> @brief Allocate arrays using an input array of sizes.
-subroutine allocate_array_real32_2d(buf, sizes)
+subroutine allocate_array_r4_kind_2d(buf, sizes)
 
   real(kind=r4_kind), dimension(:,:), allocatable, intent(inout) :: buf !< Array that will be allocated.
   integer, dimension(2), intent(in) :: sizes !< Array of dimension sizes.
@@ -434,11 +434,11 @@ subroutine allocate_array_real32_2d(buf, sizes)
     deallocate(buf)
   endif
   allocate(buf(sizes(1),sizes(2)))
-end subroutine allocate_array_real32_2d
+end subroutine allocate_array_r4_kind_2d
 
 
 !> @brief Put a section of an array into a larger array.
-subroutine put_array_section_real32_2d(section, array, s, c)
+subroutine put_array_section_r4_kind_2d(section, array, s, c)
 
   real(kind=r4_kind), dimension(:,:), intent(in) :: section !< Section to be inserted.
   real(kind=r4_kind), dimension(:,:), intent(inout) :: array !< Array to insert the section in.
@@ -446,11 +446,11 @@ subroutine put_array_section_real32_2d(section, array, s, c)
   integer, dimension(2), intent(in) :: c !< Array of sizes.
 
   array(s(1):s(1)+c(1)-1 ,s(2):s(2)+c(2)-1 ) = section(:,:)
-end subroutine put_array_section_real32_2d
+end subroutine put_array_section_r4_kind_2d
 
 
 !> @brief Get a section of larger array.
-subroutine get_array_section_real32_2d(section, array, s, c)
+subroutine get_array_section_r4_kind_2d(section, array, s, c)
 
   real(kind=r4_kind), dimension(:,:), intent(inout) :: section !< Section to be extracted.
   real(kind=r4_kind), dimension(:,:), intent(in) :: array !< Array to extract the section from.
@@ -458,11 +458,11 @@ subroutine get_array_section_real32_2d(section, array, s, c)
   integer, dimension(2), intent(in) :: c !< Array of sizes.
 
   section(:,:) = array(s(1):s(1)+c(1)-1 ,s(2):s(2)+c(2)-1 )
-end subroutine get_array_section_real32_2d
+end subroutine get_array_section_r4_kind_2d
 
 
 !> @brief Allocate arrays using an input array of sizes.
-subroutine allocate_array_real32_3d(buf, sizes)
+subroutine allocate_array_r4_kind_3d(buf, sizes)
 
   real(kind=r4_kind), dimension(:,:,:), allocatable, intent(inout) :: buf !< Array that will be allocated.
   integer, dimension(3), intent(in) :: sizes !< Array of dimension sizes.
@@ -471,11 +471,11 @@ subroutine allocate_array_real32_3d(buf, sizes)
     deallocate(buf)
   endif
   allocate(buf(sizes(1),sizes(2),sizes(3)))
-end subroutine allocate_array_real32_3d
+end subroutine allocate_array_r4_kind_3d
 
 
 !> @brief Put a section of an array into a larger array.
-subroutine put_array_section_real32_3d(section, array, s, c)
+subroutine put_array_section_r4_kind_3d(section, array, s, c)
 
   real(kind=r4_kind), dimension(:,:,:), intent(in) :: section !< Section to be inserted.
   real(kind=r4_kind), dimension(:,:,:), intent(inout) :: array !< Array to insert the section in.
@@ -483,11 +483,11 @@ subroutine put_array_section_real32_3d(section, array, s, c)
   integer, dimension(3), intent(in) :: c !< Array of sizes.
 
   array(s(1):s(1)+c(1)-1 ,s(2):s(2)+c(2)-1 ,s(3):s(3)+c(3)-1 ) = section(:,:,:)
-end subroutine put_array_section_real32_3d
+end subroutine put_array_section_r4_kind_3d
 
 
 !> @brief Get a section of larger array.
-subroutine get_array_section_real32_3d(section, array, s, c)
+subroutine get_array_section_r4_kind_3d(section, array, s, c)
 
   real(kind=r4_kind), dimension(:,:,:), intent(inout) :: section !< Section to be extracted.
   real(kind=r4_kind), dimension(:,:,:), intent(in) :: array !< Array to extract the section from.
@@ -495,11 +495,11 @@ subroutine get_array_section_real32_3d(section, array, s, c)
   integer, dimension(3), intent(in) :: c !< Array of sizes.
 
   section(:,:,:) = array(s(1):s(1)+c(1)-1 ,s(2):s(2)+c(2)-1 ,s(3):s(3)+c(3)-1 )
-end subroutine get_array_section_real32_3d
+end subroutine get_array_section_r4_kind_3d
 
 
 !> @brief Allocate arrays using an input array of sizes.
-subroutine allocate_array_real32_4d(buf, sizes)
+subroutine allocate_array_r4_kind_4d(buf, sizes)
 
   real(kind=r4_kind), dimension(:,:,:,:), allocatable, intent(inout) :: buf !< Array that will be allocated.
   integer, dimension(4), intent(in) :: sizes !< Array of dimension sizes.
@@ -508,11 +508,11 @@ subroutine allocate_array_real32_4d(buf, sizes)
     deallocate(buf)
   endif
   allocate(buf(sizes(1),sizes(2),sizes(3),sizes(4)))
-end subroutine allocate_array_real32_4d
+end subroutine allocate_array_r4_kind_4d
 
 
 !> @brief Put a section of an array into a larger array.
-subroutine put_array_section_real32_4d(section, array, s, c)
+subroutine put_array_section_r4_kind_4d(section, array, s, c)
 
   real(kind=r4_kind), dimension(:,:,:,:), intent(in) :: section !< Section to be inserted.
   real(kind=r4_kind), dimension(:,:,:,:), intent(inout) :: array !< Array to insert the section in.
@@ -520,11 +520,11 @@ subroutine put_array_section_real32_4d(section, array, s, c)
   integer, dimension(4), intent(in) :: c !< Array of sizes.
 
   array(s(1):s(1)+c(1)-1 ,s(2):s(2)+c(2)-1 ,s(3):s(3)+c(3)-1 ,s(4):s(4)+c(4)-1 ) = section(:,:,:,:)
-end subroutine put_array_section_real32_4d
+end subroutine put_array_section_r4_kind_4d
 
 
 !> @brief Get a section of larger array.
-subroutine get_array_section_real32_4d(section, array, s, c)
+subroutine get_array_section_r4_kind_4d(section, array, s, c)
 
   real(kind=r4_kind), dimension(:,:,:,:), intent(inout) :: section !< Section to be extracted.
   real(kind=r4_kind), dimension(:,:,:,:), intent(in) :: array !< Array to extract the section from.
@@ -532,11 +532,11 @@ subroutine get_array_section_real32_4d(section, array, s, c)
   integer, dimension(4), intent(in) :: c !< Array of sizes.
 
   section(:,:,:,:) = array(s(1):s(1)+c(1)-1 ,s(2):s(2)+c(2)-1 ,s(3):s(3)+c(3)-1 ,s(4):s(4)+c(4)-1 )
-end subroutine get_array_section_real32_4d
+end subroutine get_array_section_r4_kind_4d
 
 
 !> @brief Allocate arrays using an input array of sizes.
-subroutine allocate_array_real32_5d(buf, sizes)
+subroutine allocate_array_r4_kind_5d(buf, sizes)
 
   real(kind=r4_kind), dimension(:,:,:,:,:), allocatable, intent(inout) :: buf !< Array that will be allocated.
   integer, dimension(5), intent(in) :: sizes !< Array of dimension sizes.
@@ -545,11 +545,11 @@ subroutine allocate_array_real32_5d(buf, sizes)
     deallocate(buf)
   endif
   allocate(buf(sizes(1),sizes(2),sizes(3),sizes(4),sizes(5)))
-end subroutine allocate_array_real32_5d
+end subroutine allocate_array_r4_kind_5d
 
 
 !> @brief Put a section of an array into a larger array.
-subroutine put_array_section_real32_5d(section, array, s, c)
+subroutine put_array_section_r4_kind_5d(section, array, s, c)
 
   real(kind=r4_kind), dimension(:,:,:,:,:), intent(in) :: section !< Section to be inserted.
   real(kind=r4_kind), dimension(:,:,:,:,:), intent(inout) :: array !< Array to insert the section in.
@@ -557,11 +557,11 @@ subroutine put_array_section_real32_5d(section, array, s, c)
   integer, dimension(5), intent(in) :: c !< Array of sizes.
 
   array(s(1):s(1)+c(1)-1 ,s(2):s(2)+c(2)-1 ,s(3):s(3)+c(3)-1 ,s(4):s(4)+c(4)-1 ,s(5):s(5)+c(5)-1 ) = section(:,:,:,:,:)
-end subroutine put_array_section_real32_5d
+end subroutine put_array_section_r4_kind_5d
 
 
 !> @brief Get a section of larger array.
-subroutine get_array_section_real32_5d(section, array, s, c)
+subroutine get_array_section_r4_kind_5d(section, array, s, c)
 
   real(kind=r4_kind), dimension(:,:,:,:,:), intent(inout) :: section !< Section to be extracted.
   real(kind=r4_kind), dimension(:,:,:,:,:), intent(in) :: array !< Array to extract the section from.
@@ -569,11 +569,11 @@ subroutine get_array_section_real32_5d(section, array, s, c)
   integer, dimension(5), intent(in) :: c !< Array of sizes.
 
   section(:,:,:,:,:) = array(s(1):s(1)+c(1)-1 ,s(2):s(2)+c(2)-1 ,s(3):s(3)+c(3)-1 ,s(4):s(4)+c(4)-1 ,s(5):s(5)+c(5)-1 )
-end subroutine get_array_section_real32_5d
+end subroutine get_array_section_r4_kind_5d
 
 
 !> @brief Allocate arrays using an input array of sizes.
-subroutine allocate_array_real64_1d(buf, sizes)
+subroutine allocate_array_r8_kind_1d(buf, sizes)
 
   real(kind=r8_kind), dimension(:), allocatable, intent(inout) :: buf !< Array that will be allocated.
   integer, dimension(1), intent(in) :: sizes !< Array of dimension sizes.
@@ -582,11 +582,11 @@ subroutine allocate_array_real64_1d(buf, sizes)
     deallocate(buf)
   endif
   allocate(buf(sizes(1)))
-end subroutine allocate_array_real64_1d
+end subroutine allocate_array_r8_kind_1d
 
 
 !> @brief Put a section of an array into a larger array.
-subroutine put_array_section_real64_1d(section, array, s, c)
+subroutine put_array_section_r8_kind_1d(section, array, s, c)
 
   real(kind=r8_kind), dimension(:), intent(in) :: section !< Section to be inserted.
   real(kind=r8_kind), dimension(:), intent(inout) :: array !< Array to insert the section in.
@@ -594,11 +594,11 @@ subroutine put_array_section_real64_1d(section, array, s, c)
   integer, dimension(1), intent(in) :: c !< Array of sizes.
 
   array(s(1):s(1)+c(1)-1 ) = section(:)
-end subroutine put_array_section_real64_1d
+end subroutine put_array_section_r8_kind_1d
 
 
 !> @brief Get a section of larger array.
-subroutine get_array_section_real64_1d(section, array, s, c)
+subroutine get_array_section_r8_kind_1d(section, array, s, c)
 
   real(kind=r8_kind), dimension(:), intent(inout) :: section !< Section to be extracted.
   real(kind=r8_kind), dimension(:), intent(in) :: array !< Array to extract the section from.
@@ -606,11 +606,11 @@ subroutine get_array_section_real64_1d(section, array, s, c)
   integer, dimension(1), intent(in) :: c !< Array of sizes.
 
   section(:) = array(s(1):s(1)+c(1)-1 )
-end subroutine get_array_section_real64_1d
+end subroutine get_array_section_r8_kind_1d
 
 
 !> @brief Allocate arrays using an input array of sizes.
-subroutine allocate_array_real64_2d(buf, sizes)
+subroutine allocate_array_r8_kind_2d(buf, sizes)
 
   real(kind=r8_kind), dimension(:,:), allocatable, intent(inout) :: buf !< Array that will be allocated.
   integer, dimension(2), intent(in) :: sizes !< Array of dimension sizes.
@@ -619,11 +619,11 @@ subroutine allocate_array_real64_2d(buf, sizes)
     deallocate(buf)
   endif
   allocate(buf(sizes(1),sizes(2)))
-end subroutine allocate_array_real64_2d
+end subroutine allocate_array_r8_kind_2d
 
 
 !> @brief Put a section of an array into a larger array.
-subroutine put_array_section_real64_2d(section, array, s, c)
+subroutine put_array_section_r8_kind_2d(section, array, s, c)
 
   real(kind=r8_kind), dimension(:,:), intent(in) :: section !< Section to be inserted.
   real(kind=r8_kind), dimension(:,:), intent(inout) :: array !< Array to insert the section in.
@@ -631,11 +631,11 @@ subroutine put_array_section_real64_2d(section, array, s, c)
   integer, dimension(2), intent(in) :: c !< Array of sizes.
 
   array(s(1):s(1)+c(1)-1 ,s(2):s(2)+c(2)-1 ) = section(:,:)
-end subroutine put_array_section_real64_2d
+end subroutine put_array_section_r8_kind_2d
 
 
 !> @brief Get a section of larger array.
-subroutine get_array_section_real64_2d(section, array, s, c)
+subroutine get_array_section_r8_kind_2d(section, array, s, c)
 
   real(kind=r8_kind), dimension(:,:), intent(inout) :: section !< Section to be extracted.
   real(kind=r8_kind), dimension(:,:), intent(in) :: array !< Array to extract the section from.
@@ -643,11 +643,11 @@ subroutine get_array_section_real64_2d(section, array, s, c)
   integer, dimension(2), intent(in) :: c !< Array of sizes.
 
   section(:,:) = array(s(1):s(1)+c(1)-1 ,s(2):s(2)+c(2)-1 )
-end subroutine get_array_section_real64_2d
+end subroutine get_array_section_r8_kind_2d
 
 
 !> @brief Allocate arrays using an input array of sizes.
-subroutine allocate_array_real64_3d(buf, sizes)
+subroutine allocate_array_r8_kind_3d(buf, sizes)
 
   real(kind=r8_kind), dimension(:,:,:), allocatable, intent(inout) :: buf !< Array that will be allocated.
   integer, dimension(3), intent(in) :: sizes !< Array of dimension sizes.
@@ -656,11 +656,11 @@ subroutine allocate_array_real64_3d(buf, sizes)
     deallocate(buf)
   endif
   allocate(buf(sizes(1),sizes(2),sizes(3)))
-end subroutine allocate_array_real64_3d
+end subroutine allocate_array_r8_kind_3d
 
 
 !> @brief Put a section of an array into a larger array.
-subroutine put_array_section_real64_3d(section, array, s, c)
+subroutine put_array_section_r8_kind_3d(section, array, s, c)
 
   real(kind=r8_kind), dimension(:,:,:), intent(in) :: section !< Section to be inserted.
   real(kind=r8_kind), dimension(:,:,:), intent(inout) :: array !< Array to insert the section in.
@@ -668,11 +668,11 @@ subroutine put_array_section_real64_3d(section, array, s, c)
   integer, dimension(3), intent(in) :: c !< Array of sizes.
 
   array(s(1):s(1)+c(1)-1 ,s(2):s(2)+c(2)-1 ,s(3):s(3)+c(3)-1 ) = section(:,:,:)
-end subroutine put_array_section_real64_3d
+end subroutine put_array_section_r8_kind_3d
 
 
 !> @brief Get a section of larger array.
-subroutine get_array_section_real64_3d(section, array, s, c)
+subroutine get_array_section_r8_kind_3d(section, array, s, c)
 
   real(kind=r8_kind), dimension(:,:,:), intent(inout) :: section !< Section to be extracted.
   real(kind=r8_kind), dimension(:,:,:), intent(in) :: array !< Array to extract the section from.
@@ -680,11 +680,11 @@ subroutine get_array_section_real64_3d(section, array, s, c)
   integer, dimension(3), intent(in) :: c !< Array of sizes.
 
   section(:,:,:) = array(s(1):s(1)+c(1)-1 ,s(2):s(2)+c(2)-1 ,s(3):s(3)+c(3)-1 )
-end subroutine get_array_section_real64_3d
+end subroutine get_array_section_r8_kind_3d
 
 
 !> @brief Allocate arrays using an input array of sizes.
-subroutine allocate_array_real64_4d(buf, sizes)
+subroutine allocate_array_r8_kind_4d(buf, sizes)
 
   real(kind=r8_kind), dimension(:,:,:,:), allocatable, intent(inout) :: buf !< Array that will be allocated.
   integer, dimension(4), intent(in) :: sizes !< Array of dimension sizes.
@@ -693,11 +693,11 @@ subroutine allocate_array_real64_4d(buf, sizes)
     deallocate(buf)
   endif
   allocate(buf(sizes(1),sizes(2),sizes(3),sizes(4)))
-end subroutine allocate_array_real64_4d
+end subroutine allocate_array_r8_kind_4d
 
 
 !> @brief Put a section of an array into a larger array.
-subroutine put_array_section_real64_4d(section, array, s, c)
+subroutine put_array_section_r8_kind_4d(section, array, s, c)
 
   real(kind=r8_kind), dimension(:,:,:,:), intent(in) :: section !< Section to be inserted.
   real(kind=r8_kind), dimension(:,:,:,:), intent(inout) :: array !< Array to insert the section in.
@@ -705,11 +705,11 @@ subroutine put_array_section_real64_4d(section, array, s, c)
   integer, dimension(4), intent(in) :: c !< Array of sizes.
 
   array(s(1):s(1)+c(1)-1 ,s(2):s(2)+c(2)-1 ,s(3):s(3)+c(3)-1 ,s(4):s(4)+c(4)-1 ) = section(:,:,:,:)
-end subroutine put_array_section_real64_4d
+end subroutine put_array_section_r8_kind_4d
 
 
 !> @brief Get a section of larger array.
-subroutine get_array_section_real64_4d(section, array, s, c)
+subroutine get_array_section_r8_kind_4d(section, array, s, c)
 
   real(kind=r8_kind), dimension(:,:,:,:), intent(inout) :: section !< Section to be extracted.
   real(kind=r8_kind), dimension(:,:,:,:), intent(in) :: array !< Array to extract the section from.
@@ -717,11 +717,11 @@ subroutine get_array_section_real64_4d(section, array, s, c)
   integer, dimension(4), intent(in) :: c !< Array of sizes.
 
   section(:,:,:,:) = array(s(1):s(1)+c(1)-1 ,s(2):s(2)+c(2)-1 ,s(3):s(3)+c(3)-1 ,s(4):s(4)+c(4)-1 )
-end subroutine get_array_section_real64_4d
+end subroutine get_array_section_r8_kind_4d
 
 
 !> @brief Allocate arrays using an input array of sizes.
-subroutine allocate_array_real64_5d(buf, sizes)
+subroutine allocate_array_r8_kind_5d(buf, sizes)
 
   real(kind=r8_kind), dimension(:,:,:,:,:), allocatable, intent(inout) :: buf !< Array that will be allocated.
   integer, dimension(5), intent(in) :: sizes !< Array of dimension sizes.
@@ -730,11 +730,11 @@ subroutine allocate_array_real64_5d(buf, sizes)
     deallocate(buf)
   endif
   allocate(buf(sizes(1),sizes(2),sizes(3),sizes(4),sizes(5)))
-end subroutine allocate_array_real64_5d
+end subroutine allocate_array_r8_kind_5d
 
 
 !> @brief Put a section of an array into a larger array.
-subroutine put_array_section_real64_5d(section, array, s, c)
+subroutine put_array_section_r8_kind_5d(section, array, s, c)
 
   real(kind=r8_kind), dimension(:,:,:,:,:), intent(in) :: section !< Section to be inserted.
   real(kind=r8_kind), dimension(:,:,:,:,:), intent(inout) :: array !< Array to insert the section in.
@@ -742,11 +742,11 @@ subroutine put_array_section_real64_5d(section, array, s, c)
   integer, dimension(5), intent(in) :: c !< Array of sizes.
 
   array(s(1):s(1)+c(1)-1 ,s(2):s(2)+c(2)-1 ,s(3):s(3)+c(3)-1 ,s(4):s(4)+c(4)-1 ,s(5):s(5)+c(5)-1 ) = section(:,:,:,:,:)
-end subroutine put_array_section_real64_5d
+end subroutine put_array_section_r8_kind_5d
 
 
 !> @brief Get a section of larger array.
-subroutine get_array_section_real64_5d(section, array, s, c)
+subroutine get_array_section_r8_kind_5d(section, array, s, c)
 
   real(kind=r8_kind), dimension(:,:,:,:,:), intent(inout) :: section !< Section to be extracted.
   real(kind=r8_kind), dimension(:,:,:,:,:), intent(in) :: array !< Array to extract the section from.
@@ -754,4 +754,4 @@ subroutine get_array_section_real64_5d(section, array, s, c)
   integer, dimension(5), intent(in) :: c !< Array of sizes.
 
   section(:,:,:,:,:) = array(s(1):s(1)+c(1)-1 ,s(2):s(2)+c(2)-1 ,s(3):s(3)+c(3)-1 ,s(4):s(4)+c(4)-1 ,s(5):s(5)+c(5)-1 )
-end subroutine get_array_section_real64_5d
+end subroutine get_array_section_r8_kind_5d

--- a/fms2_io/include/compressed_write.inc
+++ b/fms2_io/include/compressed_write.inc
@@ -99,10 +99,10 @@ subroutine compressed_write_1d(fileobj, variable_name, cdata, unlim_dim_level, &
   integer, dimension(1) :: c
   integer, dimension(1) :: e
   integer :: i
-  integer(kind=int32), dimension(:), allocatable :: buf_int32
-  integer(kind=int64), dimension(:), allocatable :: buf_int64
-  real(kind=real32), dimension(:), allocatable :: buf_real32
-  real(kind=real64), dimension(:), allocatable :: buf_real64
+  integer(kind=i4_kind), dimension(:), allocatable :: buf_i4_kind
+  integer(kind=i8_kind), dimension(:), allocatable :: buf_i8_kind
+  real(kind=r4_kind), dimension(:), allocatable :: buf_r4_kind
+  real(kind=r8_kind), dimension(:), allocatable :: buf_r8_kind
 
   compressed_dim_index = get_variable_compressed_dimension_index(fileobj, variable_name)
 
@@ -126,34 +126,34 @@ subroutine compressed_write_1d(fileobj, variable_name, cdata, unlim_dim_level, &
                                edge_lengths=e)
       else
         select type(cdata)
-          type is (integer(kind=int32))
-            call allocate_array(buf_int32, e)
-            call mpp_recv(buf_int32, size(buf_int32), fileobj%pelist(i), block=.true.)
-            call netcdf_write_data(fileobj, variable_name, buf_int32, &
+          type is (integer(kind=i4_kind))
+            call allocate_array(buf_i4_kind, e)
+            call mpp_recv(buf_i4_kind, size(buf_i4_kind), fileobj%pelist(i), block=.true.)
+            call netcdf_write_data(fileobj, variable_name, buf_i4_kind, &
                                    unlim_dim_level=unlim_dim_level, corner=c, &
                                    edge_lengths=e)
-            deallocate(buf_int32)
-          type is (integer(kind=int64))
-            call allocate_array(buf_int64, e)
-            call mpp_recv(buf_int64, size(buf_int64), fileobj%pelist(i), block=.true.)
-            call netcdf_write_data(fileobj, variable_name, buf_int64, &
+            deallocate(buf_i4_kind)
+          type is (integer(kind=i8_kind))
+            call allocate_array(buf_i8_kind, e)
+            call mpp_recv(buf_i8_kind, size(buf_i8_kind), fileobj%pelist(i), block=.true.)
+            call netcdf_write_data(fileobj, variable_name, buf_i8_kind, &
                                    unlim_dim_level=unlim_dim_level, corner=c, &
                                    edge_lengths=e)
-            deallocate(buf_int64)
-          type is (real(kind=real32))
-            call allocate_array(buf_real32, e)
-            call mpp_recv(buf_real32, size(buf_real32), fileobj%pelist(i), block=.true.)
-            call netcdf_write_data(fileobj, variable_name, buf_real32, &
+            deallocate(buf_i8_kind)
+          type is (real(kind=r4_kind))
+            call allocate_array(buf_r4_kind, e)
+            call mpp_recv(buf_r4_kind, size(buf_r4_kind), fileobj%pelist(i), block=.true.)
+            call netcdf_write_data(fileobj, variable_name, buf_r4_kind, &
                                    unlim_dim_level=unlim_dim_level, corner=c, &
                                    edge_lengths=e)
-            deallocate(buf_real32)
-          type is (real(kind=real64))
-            call allocate_array(buf_real64, e)
-            call mpp_recv(buf_real64, size(buf_real64), fileobj%pelist(i), block=.true.)
-            call netcdf_write_data(fileobj, variable_name, buf_real64, &
+            deallocate(buf_r4_kind)
+          type is (real(kind=r8_kind))
+            call allocate_array(buf_r8_kind, e)
+            call mpp_recv(buf_r8_kind, size(buf_r8_kind), fileobj%pelist(i), block=.true.)
+            call netcdf_write_data(fileobj, variable_name, buf_r8_kind, &
                                    unlim_dim_level=unlim_dim_level, corner=c, &
                                    edge_lengths=e)
-            deallocate(buf_real64)
+            deallocate(buf_r8_kind)
           class default
             call error("unsupported type.")
         end select
@@ -161,13 +161,13 @@ subroutine compressed_write_1d(fileobj, variable_name, cdata, unlim_dim_level, &
     enddo
   else
     select type(cdata)
-      type is (integer(kind=int32))
+      type is (integer(kind=i4_kind))
         call mpp_send(cdata, size(cdata), fileobj%io_root)
-      type is (integer(kind=int64))
+      type is (integer(kind=i8_kind))
         call mpp_send(cdata, size(cdata), fileobj%io_root)
-      type is (real(kind=real32))
+      type is (real(kind=r4_kind))
         call mpp_send(cdata, size(cdata), fileobj%io_root)
-      type is (real(kind=real64))
+      type is (real(kind=r8_kind))
         call mpp_send(cdata, size(cdata), fileobj%io_root)
       class default
         call error("unsupported type.")
@@ -205,10 +205,10 @@ subroutine compressed_write_2d(fileobj, variable_name, cdata, unlim_dim_level, &
   integer, dimension(2) :: c
   integer, dimension(2) :: e
   integer :: i
-  integer(kind=int32), dimension(:,:), allocatable :: buf_int32
-  integer(kind=int64), dimension(:,:), allocatable :: buf_int64
-  real(kind=real32), dimension(:,:), allocatable :: buf_real32
-  real(kind=real64), dimension(:,:), allocatable :: buf_real64
+  integer(kind=i4_kind), dimension(:,:), allocatable :: buf_i4_kind
+  integer(kind=i8_kind), dimension(:,:), allocatable :: buf_i8_kind
+  real(kind=r4_kind), dimension(:,:), allocatable :: buf_r4_kind
+  real(kind=r8_kind), dimension(:,:), allocatable :: buf_r8_kind
 
   compressed_dim_index = get_variable_compressed_dimension_index(fileobj, variable_name)
   if (compressed_dim_index(1) .eq. dimension_not_found) then
@@ -231,34 +231,34 @@ subroutine compressed_write_2d(fileobj, variable_name, cdata, unlim_dim_level, &
                                edge_lengths=e)
       else
         select type(cdata)
-          type is (integer(kind=int32))
-            call allocate_array(buf_int32, e)
-            call mpp_recv(buf_int32, size(buf_int32), fileobj%pelist(i), block=.true.)
-            call netcdf_write_data(fileobj, variable_name, buf_int32, &
+          type is (integer(kind=i4_kind))
+            call allocate_array(buf_i4_kind, e)
+            call mpp_recv(buf_i4_kind, size(buf_i4_kind), fileobj%pelist(i), block=.true.)
+            call netcdf_write_data(fileobj, variable_name, buf_i4_kind, &
                                    unlim_dim_level=unlim_dim_level, corner=c, &
                                    edge_lengths=e)
-            deallocate(buf_int32)
-          type is (integer(kind=int64))
-            call allocate_array(buf_int64, e)
-            call mpp_recv(buf_int64, size(buf_int64), fileobj%pelist(i), block=.true.)
-            call netcdf_write_data(fileobj, variable_name, buf_int64, &
+            deallocate(buf_i4_kind)
+          type is (integer(kind=i8_kind))
+            call allocate_array(buf_i8_kind, e)
+            call mpp_recv(buf_i8_kind, size(buf_i8_kind), fileobj%pelist(i), block=.true.)
+            call netcdf_write_data(fileobj, variable_name, buf_i8_kind, &
                                    unlim_dim_level=unlim_dim_level, corner=c, &
                                    edge_lengths=e)
-            deallocate(buf_int64)
-          type is (real(kind=real32))
-            call allocate_array(buf_real32, e)
-            call mpp_recv(buf_real32, size(buf_real32), fileobj%pelist(i), block=.true.)
-            call netcdf_write_data(fileobj, variable_name, buf_real32, &
+            deallocate(buf_i8_kind)
+          type is (real(kind=r4_kind))
+            call allocate_array(buf_r4_kind, e)
+            call mpp_recv(buf_r4_kind, size(buf_r4_kind), fileobj%pelist(i), block=.true.)
+            call netcdf_write_data(fileobj, variable_name, buf_r4_kind, &
                                    unlim_dim_level=unlim_dim_level, corner=c, &
                                    edge_lengths=e)
-            deallocate(buf_real32)
-          type is (real(kind=real64))
-            call allocate_array(buf_real64, e)
-            call mpp_recv(buf_real64, size(buf_real64), fileobj%pelist(i), block=.true.)
-            call netcdf_write_data(fileobj, variable_name, buf_real64, &
+            deallocate(buf_r4_kind)
+          type is (real(kind=r8_kind))
+            call allocate_array(buf_r8_kind, e)
+            call mpp_recv(buf_r8_kind, size(buf_r8_kind), fileobj%pelist(i), block=.true.)
+            call netcdf_write_data(fileobj, variable_name, buf_r8_kind, &
                                    unlim_dim_level=unlim_dim_level, corner=c, &
                                    edge_lengths=e)
-            deallocate(buf_real64)
+            deallocate(buf_r8_kind)
           class default
             call error("unsupported type.")
         end select
@@ -266,13 +266,13 @@ subroutine compressed_write_2d(fileobj, variable_name, cdata, unlim_dim_level, &
     enddo
   else
     select type(cdata)
-      type is (integer(kind=int32))
+      type is (integer(kind=i4_kind))
         call mpp_send(cdata, size(cdata), fileobj%io_root)
-      type is (integer(kind=int64))
+      type is (integer(kind=i8_kind))
         call mpp_send(cdata, size(cdata), fileobj%io_root)
-      type is (real(kind=real32))
+      type is (real(kind=r4_kind))
         call mpp_send(cdata, size(cdata), fileobj%io_root)
-      type is (real(kind=real64))
+      type is (real(kind=r8_kind))
         call mpp_send(cdata, size(cdata), fileobj%io_root)
       class default
         call error("unsupported type.")
@@ -310,10 +310,10 @@ subroutine compressed_write_3d(fileobj, variable_name, cdata, unlim_dim_level, &
   integer, dimension(3) :: c
   integer, dimension(3) :: e
   integer :: i
-  integer(kind=int32), dimension(:,:,:), allocatable :: buf_int32
-  integer(kind=int64), dimension(:,:,:), allocatable :: buf_int64
-  real(kind=real32), dimension(:,:,:), allocatable :: buf_real32
-  real(kind=real64), dimension(:,:,:), allocatable :: buf_real64
+  integer(kind=i4_kind), dimension(:,:,:), allocatable :: buf_i4_kind
+  integer(kind=i8_kind), dimension(:,:,:), allocatable :: buf_i8_kind
+  real(kind=r4_kind), dimension(:,:,:), allocatable :: buf_r4_kind
+  real(kind=r8_kind), dimension(:,:,:), allocatable :: buf_r8_kind
 
   compressed_dim_index = get_variable_compressed_dimension_index(fileobj, variable_name)
   if (compressed_dim_index(1) .eq. dimension_not_found) then
@@ -336,34 +336,34 @@ subroutine compressed_write_3d(fileobj, variable_name, cdata, unlim_dim_level, &
                                edge_lengths=e)
       else
         select type(cdata)
-          type is (integer(kind=int32))
-            call allocate_array(buf_int32, e)
-            call mpp_recv(buf_int32, size(buf_int32), fileobj%pelist(i), block=.true.)
-            call netcdf_write_data(fileobj, variable_name, buf_int32, &
+          type is (integer(kind=i4_kind))
+            call allocate_array(buf_i4_kind, e)
+            call mpp_recv(buf_i4_kind, size(buf_i4_kind), fileobj%pelist(i), block=.true.)
+            call netcdf_write_data(fileobj, variable_name, buf_i4_kind, &
                                    unlim_dim_level=unlim_dim_level, corner=c, &
                                    edge_lengths=e)
-            deallocate(buf_int32)
-          type is (integer(kind=int64))
-            call allocate_array(buf_int64, e)
-            call mpp_recv(buf_int64, size(buf_int64), fileobj%pelist(i), block=.true.)
-            call netcdf_write_data(fileobj, variable_name, buf_int64, &
+            deallocate(buf_i4_kind)
+          type is (integer(kind=i8_kind))
+            call allocate_array(buf_i8_kind, e)
+            call mpp_recv(buf_i8_kind, size(buf_i8_kind), fileobj%pelist(i), block=.true.)
+            call netcdf_write_data(fileobj, variable_name, buf_i8_kind, &
                                    unlim_dim_level=unlim_dim_level, corner=c, &
                                    edge_lengths=e)
-            deallocate(buf_int64)
-          type is (real(kind=real32))
-            call allocate_array(buf_real32, e)
-            call mpp_recv(buf_real32, size(buf_real32), fileobj%pelist(i), block=.true.)
-            call netcdf_write_data(fileobj, variable_name, buf_real32, &
+            deallocate(buf_i8_kind)
+          type is (real(kind=r4_kind))
+            call allocate_array(buf_r4_kind, e)
+            call mpp_recv(buf_r4_kind, size(buf_r4_kind), fileobj%pelist(i), block=.true.)
+            call netcdf_write_data(fileobj, variable_name, buf_r4_kind, &
                                    unlim_dim_level=unlim_dim_level, corner=c, &
                                    edge_lengths=e)
-            deallocate(buf_real32)
-          type is (real(kind=real64))
-            call allocate_array(buf_real64, e)
-            call mpp_recv(buf_real64, size(buf_real64), fileobj%pelist(i), block=.true.)
-            call netcdf_write_data(fileobj, variable_name, buf_real64, &
+            deallocate(buf_r4_kind)
+          type is (real(kind=r8_kind))
+            call allocate_array(buf_r8_kind, e)
+            call mpp_recv(buf_r8_kind, size(buf_r8_kind), fileobj%pelist(i), block=.true.)
+            call netcdf_write_data(fileobj, variable_name, buf_r8_kind, &
                                    unlim_dim_level=unlim_dim_level, corner=c, &
                                    edge_lengths=e)
-            deallocate(buf_real64)
+            deallocate(buf_r8_kind)
           class default
             call error("unsupported type.")
         end select
@@ -371,13 +371,13 @@ subroutine compressed_write_3d(fileobj, variable_name, cdata, unlim_dim_level, &
     enddo
   else
     select type(cdata)
-      type is (integer(kind=int32))
+      type is (integer(kind=i4_kind))
         call mpp_send(cdata, size(cdata), fileobj%io_root)
-      type is (integer(kind=int64))
+      type is (integer(kind=i8_kind))
         call mpp_send(cdata, size(cdata), fileobj%io_root)
-      type is (real(kind=real32))
+      type is (real(kind=r4_kind))
         call mpp_send(cdata, size(cdata), fileobj%io_root)
-      type is (real(kind=real64))
+      type is (real(kind=r8_kind))
         call mpp_send(cdata, size(cdata), fileobj%io_root)
       class default
         call error("unsupported type.")
@@ -415,10 +415,10 @@ subroutine compressed_write_4d(fileobj, variable_name, cdata, unlim_dim_level, &
   integer, dimension(4) :: c
   integer, dimension(4) :: e
   integer :: i
-  integer(kind=int32), dimension(:,:,:,:), allocatable :: buf_int32
-  integer(kind=int64), dimension(:,:,:,:), allocatable :: buf_int64
-  real(kind=real32), dimension(:,:,:,:), allocatable :: buf_real32
-  real(kind=real64), dimension(:,:,:,:), allocatable :: buf_real64
+  integer(kind=i4_kind), dimension(:,:,:,:), allocatable :: buf_i4_kind
+  integer(kind=i8_kind), dimension(:,:,:,:), allocatable :: buf_i8_kind
+  real(kind=r4_kind), dimension(:,:,:,:), allocatable :: buf_r4_kind
+  real(kind=r8_kind), dimension(:,:,:,:), allocatable :: buf_r8_kind
 
   compressed_dim_index = get_variable_compressed_dimension_index(fileobj, variable_name)
   if (compressed_dim_index(1) .eq. dimension_not_found) then
@@ -441,34 +441,34 @@ subroutine compressed_write_4d(fileobj, variable_name, cdata, unlim_dim_level, &
                                edge_lengths=e)
       else
         select type(cdata)
-          type is (integer(kind=int32))
-            call allocate_array(buf_int32, e)
-            call mpp_recv(buf_int32, size(buf_int32), fileobj%pelist(i), block=.true.)
-            call netcdf_write_data(fileobj, variable_name, buf_int32, &
+          type is (integer(kind=i4_kind))
+            call allocate_array(buf_i4_kind, e)
+            call mpp_recv(buf_i4_kind, size(buf_i4_kind), fileobj%pelist(i), block=.true.)
+            call netcdf_write_data(fileobj, variable_name, buf_i4_kind, &
                                    unlim_dim_level=unlim_dim_level, corner=c, &
                                    edge_lengths=e)
-            deallocate(buf_int32)
-          type is (integer(kind=int64))
-            call allocate_array(buf_int64, e)
-            call mpp_recv(buf_int64, size(buf_int64), fileobj%pelist(i), block=.true.)
-            call netcdf_write_data(fileobj, variable_name, buf_int64, &
+            deallocate(buf_i4_kind)
+          type is (integer(kind=i8_kind))
+            call allocate_array(buf_i8_kind, e)
+            call mpp_recv(buf_i8_kind, size(buf_i8_kind), fileobj%pelist(i), block=.true.)
+            call netcdf_write_data(fileobj, variable_name, buf_i8_kind, &
                                    unlim_dim_level=unlim_dim_level, corner=c, &
                                    edge_lengths=e)
-            deallocate(buf_int64)
-          type is (real(kind=real32))
-            call allocate_array(buf_real32, e)
-            call mpp_recv(buf_real32, size(buf_real32), fileobj%pelist(i), block=.true.)
-            call netcdf_write_data(fileobj, variable_name, buf_real32, &
+            deallocate(buf_i8_kind)
+          type is (real(kind=r4_kind))
+            call allocate_array(buf_r4_kind, e)
+            call mpp_recv(buf_r4_kind, size(buf_r4_kind), fileobj%pelist(i), block=.true.)
+            call netcdf_write_data(fileobj, variable_name, buf_r4_kind, &
                                    unlim_dim_level=unlim_dim_level, corner=c, &
                                    edge_lengths=e)
-            deallocate(buf_real32)
-          type is (real(kind=real64))
-            call allocate_array(buf_real64, e)
-            call mpp_recv(buf_real64, size(buf_real64), fileobj%pelist(i), block=.true.)
-            call netcdf_write_data(fileobj, variable_name, buf_real64, &
+            deallocate(buf_r4_kind)
+          type is (real(kind=r8_kind))
+            call allocate_array(buf_r8_kind, e)
+            call mpp_recv(buf_r8_kind, size(buf_r8_kind), fileobj%pelist(i), block=.true.)
+            call netcdf_write_data(fileobj, variable_name, buf_r8_kind, &
                                    unlim_dim_level=unlim_dim_level, corner=c, &
                                    edge_lengths=e)
-            deallocate(buf_real64)
+            deallocate(buf_r8_kind)
           class default
             call error("unsupported type.")
         end select
@@ -476,13 +476,13 @@ subroutine compressed_write_4d(fileobj, variable_name, cdata, unlim_dim_level, &
     enddo
   else
     select type(cdata)
-      type is (integer(kind=int32))
+      type is (integer(kind=i4_kind))
         call mpp_send(cdata, size(cdata), fileobj%io_root)
-      type is (integer(kind=int64))
+      type is (integer(kind=i8_kind))
         call mpp_send(cdata, size(cdata), fileobj%io_root)
-      type is (real(kind=real32))
+      type is (real(kind=r4_kind))
         call mpp_send(cdata, size(cdata), fileobj%io_root)
-      type is (real(kind=real64))
+      type is (real(kind=r8_kind))
         call mpp_send(cdata, size(cdata), fileobj%io_root)
       class default
         call error("unsupported type.")
@@ -520,10 +520,10 @@ subroutine compressed_write_5d(fileobj, variable_name, cdata, unlim_dim_level, &
   integer, dimension(5) :: c
   integer, dimension(5) :: e
   integer :: i
-  integer(kind=int32), dimension(:,:,:,:,:), allocatable :: buf_int32
-  integer(kind=int64), dimension(:,:,:,:,:), allocatable :: buf_int64
-  real(kind=real32), dimension(:,:,:,:,:), allocatable :: buf_real32
-  real(kind=real64), dimension(:,:,:,:,:), allocatable :: buf_real64
+  integer(kind=i4_kind), dimension(:,:,:,:,:), allocatable :: buf_i4_kind
+  integer(kind=i8_kind), dimension(:,:,:,:,:), allocatable :: buf_i8_kind
+  real(kind=r4_kind), dimension(:,:,:,:,:), allocatable :: buf_r4_kind
+  real(kind=r8_kind), dimension(:,:,:,:,:), allocatable :: buf_r8_kind
 
   compressed_dim_index = get_variable_compressed_dimension_index(fileobj, variable_name)
   if (compressed_dim_index(1) .eq. dimension_not_found) then
@@ -546,34 +546,34 @@ subroutine compressed_write_5d(fileobj, variable_name, cdata, unlim_dim_level, &
                                edge_lengths=e)
       else
         select type(cdata)
-          type is (integer(kind=int32))
-            call allocate_array(buf_int32, e)
-            call mpp_recv(buf_int32, size(buf_int32), fileobj%pelist(i), block=.true.)
-            call netcdf_write_data(fileobj, variable_name, buf_int32, &
+          type is (integer(kind=i4_kind))
+            call allocate_array(buf_i4_kind, e)
+            call mpp_recv(buf_i4_kind, size(buf_i4_kind), fileobj%pelist(i), block=.true.)
+            call netcdf_write_data(fileobj, variable_name, buf_i4_kind, &
                                    unlim_dim_level=unlim_dim_level, corner=c, &
                                    edge_lengths=e)
-            deallocate(buf_int32)
-          type is (integer(kind=int64))
-            call allocate_array(buf_int64, e)
-            call mpp_recv(buf_int64, size(buf_int64), fileobj%pelist(i), block=.true.)
-            call netcdf_write_data(fileobj, variable_name, buf_int64, &
+            deallocate(buf_i4_kind)
+          type is (integer(kind=i8_kind))
+            call allocate_array(buf_i8_kind, e)
+            call mpp_recv(buf_i8_kind, size(buf_i8_kind), fileobj%pelist(i), block=.true.)
+            call netcdf_write_data(fileobj, variable_name, buf_i8_kind, &
                                    unlim_dim_level=unlim_dim_level, corner=c, &
                                    edge_lengths=e)
-            deallocate(buf_int64)
-          type is (real(kind=real32))
-            call allocate_array(buf_real32, e)
-            call mpp_recv(buf_real32, size(buf_real32), fileobj%pelist(i), block=.true.)
-            call netcdf_write_data(fileobj, variable_name, buf_real32, &
+            deallocate(buf_i8_kind)
+          type is (real(kind=r4_kind))
+            call allocate_array(buf_r4_kind, e)
+            call mpp_recv(buf_r4_kind, size(buf_r4_kind), fileobj%pelist(i), block=.true.)
+            call netcdf_write_data(fileobj, variable_name, buf_r4_kind, &
                                    unlim_dim_level=unlim_dim_level, corner=c, &
                                    edge_lengths=e)
-            deallocate(buf_real32)
-          type is (real(kind=real64))
-            call allocate_array(buf_real64, e)
-            call mpp_recv(buf_real64, size(buf_real64), fileobj%pelist(i), block=.true.)
-            call netcdf_write_data(fileobj, variable_name, buf_real64, &
+            deallocate(buf_r4_kind)
+          type is (real(kind=r8_kind))
+            call allocate_array(buf_r8_kind, e)
+            call mpp_recv(buf_r8_kind, size(buf_r8_kind), fileobj%pelist(i), block=.true.)
+            call netcdf_write_data(fileobj, variable_name, buf_r8_kind, &
                                    unlim_dim_level=unlim_dim_level, corner=c, &
                                    edge_lengths=e)
-            deallocate(buf_real64)
+            deallocate(buf_r8_kind)
           class default
             call error("unsupported type.")
         end select
@@ -581,13 +581,13 @@ subroutine compressed_write_5d(fileobj, variable_name, cdata, unlim_dim_level, &
     enddo
   else
     select type(cdata)
-      type is (integer(kind=int32))
+      type is (integer(kind=i4_kind))
         call mpp_send(cdata, size(cdata), fileobj%io_root)
-      type is (integer(kind=int64))
+      type is (integer(kind=i8_kind))
         call mpp_send(cdata, size(cdata), fileobj%io_root)
-      type is (real(kind=real32))
+      type is (real(kind=r4_kind))
         call mpp_send(cdata, size(cdata), fileobj%io_root)
-      type is (real(kind=real64))
+      type is (real(kind=r8_kind))
         call mpp_send(cdata, size(cdata), fileobj%io_root)
       class default
         call error("unsupported type.")

--- a/fms2_io/include/get_global_attribute.inc
+++ b/fms2_io/include/get_global_attribute.inc
@@ -42,22 +42,22 @@ subroutine get_global_attribute_0d(fileobj, &
                                    trim(attribute_name), &
                                    charbuf(1))
                 call string_copy(attribute_value, charbuf(1), check_for_null=.true.)
-            type is (integer(kind=int32))
+            type is (integer(kind=i4_kind))
                 err = nf90_get_att(fileobj%ncid, &
                                    nf90_global, &
                                    trim(attribute_name), &
                                    attribute_value)
-            type is (integer(kind=int64))
+            type is (integer(kind=i8_kind))
                 err = nf90_get_att(fileobj%ncid, &
                                    nf90_global, &
                                    trim(attribute_name), &
                                    attribute_value)
-            type is (real(kind=real32))
+            type is (real(kind=r4_kind))
                 err = nf90_get_att(fileobj%ncid, &
                                    nf90_global, &
                                    trim(attribute_name), &
                                    attribute_value)
-            type is (real(kind=real64))
+            type is (real(kind=r8_kind))
                 err = nf90_get_att(fileobj%ncid, &
                                    nf90_global, &
                                    trim(attribute_name), &
@@ -79,22 +79,22 @@ subroutine get_global_attribute_0d(fileobj, &
                                fileobj%io_root, &
                                pelist=fileobj%pelist)
             call string_copy(attribute_value, charbuf(1), check_for_null=.true.)
-        type is (integer(kind=int32))
+        type is (integer(kind=i4_kind))
             call mpp_broadcast(attribute_value, &
 
                                fileobj%io_root, &
                                pelist=fileobj%pelist)
-        type is (integer(kind=int64))
+        type is (integer(kind=i8_kind))
             call mpp_broadcast(attribute_value, &
 
                                fileobj%io_root, &
                                pelist=fileobj%pelist)
-        type is (real(kind=real32))
+        type is (real(kind=r4_kind))
             call mpp_broadcast(attribute_value, &
 
                                fileobj%io_root, &
                                pelist=fileobj%pelist)
-        type is (real(kind=real64))
+        type is (real(kind=r8_kind))
             call mpp_broadcast(attribute_value, &
 
                                fileobj%io_root, &
@@ -121,22 +121,22 @@ subroutine get_global_attribute_1d(fileobj, &
     integer :: err
     if (fileobj%is_root) then
         select type(attribute_value)
-            type is (integer(kind=int32))
+            type is (integer(kind=i4_kind))
                 err = nf90_get_att(fileobj%ncid, &
                                    nf90_global, &
                                    trim(attribute_name), &
                                    attribute_value)
-            type is (integer(kind=int64))
+            type is (integer(kind=i8_kind))
                 err = nf90_get_att(fileobj%ncid, &
                                    nf90_global, &
                                    trim(attribute_name), &
                                    attribute_value)
-            type is (real(kind=real32))
+            type is (real(kind=r4_kind))
                 err = nf90_get_att(fileobj%ncid, &
                                    nf90_global, &
                                    trim(attribute_name), &
                                    attribute_value)
-            type is (real(kind=real64))
+            type is (real(kind=r8_kind))
                 err = nf90_get_att(fileobj%ncid, &
                                    nf90_global, &
                                    trim(attribute_name), &
@@ -153,22 +153,22 @@ subroutine get_global_attribute_1d(fileobj, &
         endif
     endif
     select type(attribute_value)
-        type is (integer(kind=int32))
+        type is (integer(kind=i4_kind))
             call mpp_broadcast(attribute_value, &
                                size(attribute_value), &
                                fileobj%io_root, &
                                pelist=fileobj%pelist)
-        type is (integer(kind=int64))
+        type is (integer(kind=i8_kind))
             call mpp_broadcast(attribute_value, &
                                size(attribute_value), &
                                fileobj%io_root, &
                                pelist=fileobj%pelist)
-        type is (real(kind=real32))
+        type is (real(kind=r4_kind))
             call mpp_broadcast(attribute_value, &
                                size(attribute_value), &
                                fileobj%io_root, &
                                pelist=fileobj%pelist)
-        type is (real(kind=real64))
+        type is (real(kind=r8_kind))
             call mpp_broadcast(attribute_value, &
                                size(attribute_value), &
                                fileobj%io_root, &

--- a/fms2_io/include/register_variable_attribute.inc
+++ b/fms2_io/include/register_variable_attribute.inc
@@ -31,10 +31,10 @@ subroutine register_variable_attribute_0d(fileobj, variable_name, attribute_name
   integer :: err
   integer :: axtype
   integer :: xtype
-  integer(kind=int32), dimension(2) :: i32_range
-  integer(kind=int64), dimension(2) :: i64_range
-  real(kind=real32), dimension(2) :: r32_range
-  real(kind=real64), dimension(2) :: r64_range
+  integer(kind=i4_kind), dimension(2) :: i32_range
+  integer(kind=i8_kind), dimension(2) :: i64_range
+  real(kind=r4_kind), dimension(2) :: r32_range
+  real(kind=r8_kind), dimension(2) :: r64_range
 
   if (fileobj%is_root) then
     call set_netcdf_mode(fileobj%ncid, define_mode)
@@ -44,16 +44,16 @@ subroutine register_variable_attribute_0d(fileobj, variable_name, attribute_name
         if (.not. present(str_len)) call error("register_variable_attribute_0d: Need to include str length")
         err = nf90_put_att(fileobj%ncid, varid, trim(attribute_name), &
                            trim(attribute_value(1:str_len)))
-      type is (integer(kind=int32))
+      type is (integer(kind=i4_kind))
         err = nf90_put_att(fileobj%ncid, varid, trim(attribute_name), &
                            attribute_value)
-      type is (integer(kind=int64))
+      type is (integer(kind=i8_kind))
         err = nf90_put_att(fileobj%ncid, varid, trim(attribute_name), &
                            attribute_value)
-      type is (real(kind=real32))
+      type is (real(kind=r4_kind))
         err = nf90_put_att(fileobj%ncid, varid, trim(attribute_name), &
                            attribute_value)
-      type is (real(kind=real64))
+      type is (real(kind=r8_kind))
         err = nf90_put_att(fileobj%ncid, varid, trim(attribute_name), &
                            attribute_value)
       class default
@@ -79,28 +79,28 @@ subroutine register_variable_attribute_0d(fileobj, variable_name, attribute_name
     if (string_compare(attribute_name, "_FillValue")) then
       if (attribute_exists(fileobj%ncid, varid, "valid_range")) then
         select type(attribute_value)
-          type is (integer(kind=int32))
+          type is (integer(kind=i4_kind))
             call get_variable_attribute(fileobj, variable_name, "valid_range", &
                                         i32_range, .false.)
             if (attribute_value .lt. i32_range(1) .or. &
                 attribute_value .gt. i32_range(2)) then
               call error("_FillValue inside valid_range.")
             endif
-          type is (integer(kind=int64))
+          type is (integer(kind=i8_kind))
             call get_variable_attribute(fileobj, variable_name, "valid_range", &
                                         i64_range, .false.)
             if (attribute_value .lt. i64_range(1) .or. &
                 attribute_value .gt. i64_range(2)) then
               call error("_FillValue inside valid_range.")
             endif
-          type is (real(kind=real32))
+          type is (real(kind=r4_kind))
             call get_variable_attribute(fileobj, variable_name, "valid_range", &
                                         r32_range, .false.)
             if (attribute_value .lt. r32_range(1) .or. &
                 attribute_value .gt. r32_range(2)) then
               call error("_FillValue inside valid_range.")
             endif
-          type is (real(kind=real64))
+          type is (real(kind=r8_kind))
             call get_variable_attribute(fileobj, variable_name, "valid_range", &
                                         r64_range, .false.)
             if (attribute_value .lt. r64_range(1) .or. &
@@ -140,16 +140,16 @@ subroutine register_variable_attribute_1d(fileobj, variable_name, attribute_name
     call set_netcdf_mode(fileobj%ncid, define_mode)
     varid = get_variable_id(fileobj%ncid, trim(variable_name))
     select type(attribute_value)
-      type is (integer(kind=int32))
+      type is (integer(kind=i4_kind))
         err = nf90_put_att(fileobj%ncid, varid, trim(attribute_name), &
                            attribute_value)
-      type is (integer(kind=int64))
+      type is (integer(kind=i8_kind))
         err = nf90_put_att(fileobj%ncid, varid, trim(attribute_name), &
                            attribute_value)
-      type is (real(kind=real32))
+      type is (real(kind=r4_kind))
         err = nf90_put_att(fileobj%ncid, varid, trim(attribute_name), &
                            attribute_value)
-      type is (real(kind=real64))
+      type is (real(kind=r8_kind))
         err = nf90_put_att(fileobj%ncid, varid, trim(attribute_name), &
                            attribute_value)
       class default

--- a/fms2_io/netcdf_io.F90
+++ b/fms2_io/netcdf_io.F90
@@ -1804,7 +1804,7 @@ subroutine netcdf_add_variable_wrap(fileobj, variable_name, variable_type, dimen
   type(FmsNetcdfFile_t), intent(in) :: fileobj !< File object.
   character(len=*), intent(in) :: variable_name !< Variable name.
   character(len=*), intent(in) :: variable_type !< Variable type.  Allowed
-                                                !! values are: "int", "i8_kind",
+                                                !! values are: "int", "int64",
                                                 !! "float", or "double".
   character(len=*), dimension(:), intent(in), optional :: dimensions !< Dimension names.
 

--- a/fms2_io/netcdf_io.F90
+++ b/fms2_io/netcdf_io.F90
@@ -744,7 +744,7 @@ subroutine netcdf_add_variable(fileobj, variable_name, variable_type, dimensions
   class(FmsNetcdfFile_t), intent(in) :: fileobj !< File object.
   character(len=*), intent(in) :: variable_name !< Variable name.
   character(len=*), intent(in) :: variable_type !< Variable type.  Allowed
-                                                !! values are: "char", "int", "i8_kind",
+                                                !! values are: "char", "int", "int64",
                                                 !! "float", or "double".
   character(len=*), dimension(:), intent(in), optional :: dimensions !< Dimension names.
 
@@ -758,8 +758,8 @@ subroutine netcdf_add_variable(fileobj, variable_name, variable_type, dimensions
     call set_netcdf_mode(fileobj%ncid, define_mode)
     if (string_compare(variable_type, "int", .true.)) then
       vtype = nf90_int
-    elseif (string_compare(variable_type, "i8_kind", .true.)) then
-      vtype = nf90_i8_kind
+    elseif (string_compare(variable_type, "int64", .true.)) then
+      vtype = nf90_int64
     elseif (string_compare(variable_type, "float", .true.)) then
       vtype = nf90_float
     elseif (string_compare(variable_type, "double", .true.)) then

--- a/fms2_io/netcdf_io.F90
+++ b/fms2_io/netcdf_io.F90
@@ -744,7 +744,7 @@ subroutine netcdf_add_variable(fileobj, variable_name, variable_type, dimensions
   class(FmsNetcdfFile_t), intent(in) :: fileobj !< File object.
   character(len=*), intent(in) :: variable_name !< Variable name.
   character(len=*), intent(in) :: variable_type !< Variable type.  Allowed
-                                                !! values are: "char", "int", "int64",
+                                                !! values are: "char", "int", "i8_kind",
                                                 !! "float", or "double".
   character(len=*), dimension(:), intent(in), optional :: dimensions !< Dimension names.
 
@@ -758,8 +758,8 @@ subroutine netcdf_add_variable(fileobj, variable_name, variable_type, dimensions
     call set_netcdf_mode(fileobj%ncid, define_mode)
     if (string_compare(variable_type, "int", .true.)) then
       vtype = nf90_int
-    elseif (string_compare(variable_type, "int64", .true.)) then
-      vtype = nf90_int64
+    elseif (string_compare(variable_type, "i8_kind", .true.)) then
+      vtype = nf90_i8_kind
     elseif (string_compare(variable_type, "float", .true.)) then
       vtype = nf90_float
     elseif (string_compare(variable_type, "double", .true.)) then
@@ -1804,7 +1804,7 @@ subroutine netcdf_add_variable_wrap(fileobj, variable_name, variable_type, dimen
   type(FmsNetcdfFile_t), intent(in) :: fileobj !< File object.
   character(len=*), intent(in) :: variable_name !< Variable name.
   character(len=*), intent(in) :: variable_type !< Variable type.  Allowed
-                                                !! values are: "int", "int64",
+                                                !! values are: "int", "i8_kind",
                                                 !! "float", or "double".
   character(len=*), dimension(:), intent(in), optional :: dimensions !< Dimension names.
 

--- a/test_fms/data_override/test_get_grid_v1.F90
+++ b/test_fms/data_override/test_get_grid_v1.F90
@@ -28,9 +28,10 @@ use mpp_mod,         only: mpp_init, mpp_exit, mpp_root_pe, mpp_pe, mpp_error, F
 use mpp_domains_mod, only: mpp_define_domains, mpp_define_io_domain, mpp_get_compute_domain, &
                            domain2d
 use fms2_io_mod,     only: fms2_io_init
+use platform_mod
 
 use get_grid_version_fms2io_mod, only : get_grid_version_1, deg_to_radian
-use,  intrinsic :: iso_fortran_env, only : real64
+use,  intrinsic :: iso_fortran_env, only : r8_kind
 
 implicit none
 
@@ -47,8 +48,8 @@ real                                             :: lat_in(1), lon_in(1) !< Lat 
 real, dimension(:,:,:), allocatable              :: lat_vert_in, lon_vert_in !<Lat and lon vertices
 
 
-lat_in = real(55.5, kind=real64)
-lon_in = real(44.5, kind=real64)
+lat_in = real(55.5, kind=r8_kind)
+lon_in = real(44.5, kind=r8_kind)
 
 call mpp_init
 call fms2_io_init
@@ -103,8 +104,8 @@ call get_grid_version_1("grid_spec.nc", "ocn", Domain, is, ie, js, je, lon, lat,
 
 !< Try again with ocean, "new_grid"
 allocate(lat_vert_in(1,1,4), lon_vert_in(1,1,4))
-lat_vert_in = real(55.5, kind=real64)
-lon_vert_in = real(65.5, kind=real64)
+lat_vert_in = real(55.5, kind=r8_kind)
+lon_vert_in = real(65.5, kind=r8_kind)
 
 !< Create a new grid_spec file with "x_T" instead of "geolon_t"
 if (mpp_pe() .eq. mpp_root_pe()) then

--- a/test_fms/data_override/test_get_grid_v1.F90
+++ b/test_fms/data_override/test_get_grid_v1.F90
@@ -31,7 +31,6 @@ use fms2_io_mod,     only: fms2_io_init
 use platform_mod
 
 use get_grid_version_fms2io_mod, only : get_grid_version_1, deg_to_radian
-use,  intrinsic :: iso_fortran_env, only : r8_kind
 
 implicit none
 

--- a/test_fms/fms2_io/land_compressed_restart_file_test.inc
+++ b/test_fms/fms2_io/land_compressed_restart_file_test.inc
@@ -31,13 +31,13 @@ subroutine land_compressed_restart_file(nz, nt, debug_flag)
   integer, dimension(:), allocatable :: npes_nelems
   integer :: nx
   integer :: total_nx
-  real(kind=real64), dimension(:,:), allocatable :: temperature_data
-  real(kind=real64), dimension(:), allocatable :: cdim_data
-  real(kind=real64), dimension(:), allocatable :: lev_data
-  integer(kind=int64) :: out_chksum
+  real(kind=r8_kind), dimension(:,:), allocatable :: temperature_data
+  real(kind=r8_kind), dimension(:), allocatable :: cdim_data
+  real(kind=r8_kind), dimension(:), allocatable :: lev_data
+  integer(kind=i8_kind) :: out_chksum
   integer :: ndims
   integer, dimension(:), allocatable :: dim_sizes
-  integer(kind=int64) :: in_chksum
+  integer(kind=i8_kind) :: in_chksum
   logical :: debug
   integer :: err
   integer :: i
@@ -93,10 +93,10 @@ subroutine land_compressed_restart_file(nz, nt, debug_flag)
                             pelist=pelist, nc_format="netcdf4", is_restart=.true.))
 
   !Add some global attributes to the restart file.
-  call register_global_attribute(fileobj, "globalatt1", real(7., kind=real64))
-  call register_global_attribute(fileobj, "globalatt2", real(4., kind=real32))
-  call register_global_attribute(fileobj, "globalatt3", int(3, kind=int32))
-  call register_global_attribute(fileobj, "globalatt4", int(2, kind=int64))
+  call register_global_attribute(fileobj, "globalatt1", real(7., kind=r8_kind))
+  call register_global_attribute(fileobj, "globalatt2", real(4., kind=r4_kind))
+  call register_global_attribute(fileobj, "globalatt3", int(3, kind=i4_kind))
+  call register_global_attribute(fileobj, "globalatt4", int(2, kind=i8_kind))
   call register_global_attribute(fileobj, "globalatt5", "some text", str_len=len_trim("some text"))
 
   !Add dimensions and corresponding variables to the file.

--- a/test_fms/fms2_io/land_unstructured_restart_file_test.inc
+++ b/test_fms/fms2_io/land_unstructured_restart_file_test.inc
@@ -30,13 +30,13 @@ subroutine land_unstructured_restart_file(domain, nz, nt, debug_flag)
   integer :: s
   integer, dimension(:), allocatable :: s2
   integer :: nx
-  real(kind=real64), dimension(:), allocatable :: tile_data
-  real(kind=real64), dimension(:), allocatable :: lev_data
-  real(kind=real64), dimension(:,:), allocatable :: temperature_data
-  integer(kind=int64) :: out_chksum
+  real(kind=r8_kind), dimension(:), allocatable :: tile_data
+  real(kind=r8_kind), dimension(:), allocatable :: lev_data
+  real(kind=r8_kind), dimension(:,:), allocatable :: temperature_data
+  integer(kind=i8_kind) :: out_chksum
   integer :: ndims
   integer, dimension(:), allocatable :: dim_sizes
-  integer(kind=int64) :: in_chksum
+  integer(kind=i8_kind) :: in_chksum
   logical :: debug
   integer :: err
   integer :: i
@@ -90,10 +90,10 @@ subroutine land_unstructured_restart_file(domain, nz, nt, debug_flag)
                             domain, nc_format="classic", is_restart=.true.))
 
   !Add some global attributes to the restart file.
-  call register_global_attribute(fileobj, "globalatt1", real(7., kind=real64))
-  call register_global_attribute(fileobj, "globalatt2", real(4., kind=real32))
-  call register_global_attribute(fileobj, "globalatt3", int(3, kind=int32))
-  call register_global_attribute(fileobj, "globalatt4", int(2, kind=int64))
+  call register_global_attribute(fileobj, "globalatt1", real(7., kind=r8_kind))
+  call register_global_attribute(fileobj, "globalatt2", real(4., kind=r4_kind))
+  call register_global_attribute(fileobj, "globalatt3", int(3, kind=i4_kind))
+  call register_global_attribute(fileobj, "globalatt4", int(2, kind=i8_kind))
   call register_global_attribute(fileobj, "globalatt5", "some text", str_len=len_trim("some text"))
 
   !Add dimensions and corresponding variables to the file.

--- a/test_fms/fms2_io/setup.F90
+++ b/test_fms/fms2_io/setup.F90
@@ -18,7 +18,7 @@
 !***********************************************************************
 
 module setup
-use, intrinsic :: iso_fortran_env, only : real32, real64, int32, error_unit
+use, intrinsic :: iso_fortran_env, only : error_unit
 use mpi
 use argparse
 use mpp_mod
@@ -497,7 +497,7 @@ end subroutine create_tripolar_domain
 
 subroutine create_data_double_1d(array, xsize)
 
-  real(kind=real64), dimension(:), allocatable, intent(inout) :: array
+  real(kind=r8_kind), dimension(:), allocatable, intent(inout) :: array
   integer, intent(in), optional :: xsize
 
   integer :: i
@@ -510,14 +510,14 @@ subroutine create_data_double_1d(array, xsize)
   endif
   do i = 1, size(array)
     call random_number(array(i))
-    array(i) = array(i) + real(mpp_pe(), kind=real64)
+    array(i) = array(i) + real(mpp_pe(), kind=r8_kind)
   enddo
 end subroutine create_data_double_1d
 
 
 subroutine create_data_double_2d(array, sizes)
 
-  real(kind=real64), dimension(:,:), allocatable, intent(inout) :: array
+  real(kind=r8_kind), dimension(:,:), allocatable, intent(inout) :: array
   integer, dimension(2), intent(in), optional :: sizes
 
   integer :: i
@@ -532,7 +532,7 @@ subroutine create_data_double_2d(array, sizes)
   do j = 1, size(array, 2)
     do i = 1, size(array, 1)
       call random_number(array(i,j))
-      array(i,j) = array(i,j) + real(mpp_pe(), kind=real64)
+      array(i,j) = array(i,j) + real(mpp_pe(), kind=r8_kind)
     enddo
   enddo
 end subroutine create_data_double_2d
@@ -540,12 +540,12 @@ end subroutine create_data_double_2d
 
 subroutine create_data_int_2d(array, sizes)
 
-  integer(kind=int32), dimension(:,:), allocatable, intent(inout) :: array
+  integer(kind=i4_kind), dimension(:,:), allocatable, intent(inout) :: array
   integer, dimension(2), intent(in), optional :: sizes
 
   integer :: i
   integer :: j
-  real(kind=real32) :: r
+  real(kind=r4_kind) :: r
 
   if (present(sizes)) then
     if (allocated(array)) then
@@ -556,7 +556,7 @@ subroutine create_data_int_2d(array, sizes)
   do j = 1, size(array, 2)
     do i = 1, size(array, 1)
       call random_number(r)
-      array(i,j) = int(10.*r, kind=int32) + mpp_pe()
+      array(i,j) = int(10.*r, kind=i4_kind) + mpp_pe()
     enddo
   enddo
 end subroutine create_data_int_2d
@@ -564,7 +564,7 @@ end subroutine create_data_int_2d
 
 subroutine create_data_double_3d(array, sizes)
 
-  real(kind=real64), dimension(:,:,:), allocatable, intent(inout) :: array
+  real(kind=r8_kind), dimension(:,:,:), allocatable, intent(inout) :: array
   integer, dimension(3), intent(in), optional :: sizes
 
   integer :: i
@@ -581,7 +581,7 @@ subroutine create_data_double_3d(array, sizes)
     do j = 1, size(array, 2)
       do i = 1, size(array, 1)
         call random_number(array(i,j,k))
-        array(i,j,k) = array(i,j,k) + real(mpp_pe(), kind=real64)
+        array(i,j,k) = array(i,j,k) + real(mpp_pe(), kind=r8_kind)
       enddo
     enddo
   enddo

--- a/test_fms/fms2_io/test_atmosphere_io.F90
+++ b/test_fms/fms2_io/test_atmosphere_io.F90
@@ -18,7 +18,7 @@
 !***********************************************************************
 
 program test_atmosphere_io
-use, intrinsic :: iso_fortran_env, only : real32, real64, int32, int64, error_unit, output_unit
+use, intrinsic :: iso_fortran_env, only : error_unit, output_unit
 use mpi
 use fms2_io_mod
 use mpp_domains_mod

--- a/test_fms/fms2_io/test_fms2_io.F90
+++ b/test_fms/fms2_io/test_fms2_io.F90
@@ -209,8 +209,8 @@ end subroutine mpi_check
 
 subroutine chksum_match(out_chksum, in_chksum, var_name, debug)
 
-  integer(kind=int64), intent(in) :: out_chksum
-  integer(kind=int64), intent(in) :: in_chksum
+  integer(kind=i8_kind), intent(in) :: out_chksum
+  integer(kind=i8_kind), intent(in) :: in_chksum
   character(len=*), intent(in) :: var_name
   logical, intent(in) :: debug
 

--- a/test_fms/fms2_io/test_get_is_valid.F90
+++ b/test_fms/fms2_io/test_get_is_valid.F90
@@ -29,12 +29,13 @@ use   netcdf     , only: nf90_create, nf90_def_var, nf90_put_att, nf90_enddef, &
                          nf90_close, nf90_clobber, nf90_64bit_offset, nf90_double
 
 use, intrinsic :: iso_fortran_env
+use platform_mod
 
 implicit none
 
 type(valid_t) :: valid_type               !> Fms2io valid object type
 type(FmsNetcdfFile_t) :: fileobj          !> Fms2io file obj
-real(kind=real64) :: sst(10,10)           !> Data
+real(kind=r8_kind) :: sst(10,10)           !> Data
 integer :: mask_in(10,10)                 !> Array defining if sst(:,:) is valid (1) or not (0)
 integer :: ncid, varid, err               !> Netcdf integers needed
 integer, dimension(:), allocatable :: pes !> Current pelist
@@ -49,8 +50,8 @@ if (mpp_root_pe() .eq. mpp_pe()) then
 !> Create your own file with a variable to test with:
    err = nf90_create('test_file.nc', ior(nf90_clobber, nf90_64bit_offset), ncid)
    err = nf90_def_var(ncid, 'sst', nf90_double,varid)
-   err = nf90_put_att(ncid, varid, "_FillValue", real(999,kind=real64))
-   err = nf90_put_att(ncid, varid, "missing_value", real(999,kind=real64))
+   err = nf90_put_att(ncid, varid, "_FillValue", real(999,kind=r8_kind))
+   err = nf90_put_att(ncid, varid, "missing_value", real(999,kind=r8_kind))
    err = nf90_enddef(ncid)
    err = nf90_close(ncid)
 endif
@@ -70,11 +71,11 @@ deallocate(pes)
 
 !> Error checking:
 if (.not. valid_type%has_fill) call mpp_error(FATAL, "test_get_valid: the fill valid_type%has_fill is not .true.")
-if (valid_type%fill_val .ne. real(999,kind=real64)) call mpp_error(FATAL, &
+if (valid_type%fill_val .ne. real(999,kind=r8_kind)) call mpp_error(FATAL, &
         "test_get_valid: the fill value is not correct")
 
 if (.not. valid_type%has_missing) call mpp_error(FATAL, "test_get_valid: the fill valid_type%has_fill is not .true.")
-if (valid_type%missing_val .ne. real(999,kind=real64)) call mpp_error(FATAL, &
+if (valid_type%missing_val .ne. real(999,kind=r8_kind)) call mpp_error(FATAL, &
         "test_get_valid: the fill value is not correct")
 
 if (.not. valid_type%has_range) call mpp_error(FATAL, "test_get_valid: the valid_type%has_range is not .true.")
@@ -85,8 +86,8 @@ if (valid_type%has_min) call mpp_error(FATAL, "test_get_valid: the valid_type%ha
 
 !> Create some fake data
 mask_in = 1
-sst = real(0, kind=real64)
-sst(1,1) = real(999, kind=real64)
+sst = real(0, kind=r8_kind)
+sst(1,1) = real(999, kind=r8_kind)
 
 !> Check where the data is valid
 !> Set the mask_in to 0 wherever sst is valid

--- a/test_fms/fms2_io/test_io_simple.F90
+++ b/test_fms/fms2_io/test_io_simple.F90
@@ -22,7 +22,7 @@
 !> \author Ed Hartnett, 6/10/20
 
 program test_io_simple
-  use, intrinsic :: iso_fortran_env, only : real32, real64, int32, int64, error_unit, output_unit
+  use, intrinsic :: iso_fortran_env, only : error_unit, output_unit
   use mpi
   use fms2_io_mod
   use netcdf_io_mod

--- a/test_fms/mpp/test_global_arrays.F90
+++ b/test_fms/mpp/test_global_arrays.F90
@@ -333,8 +333,8 @@ function checkResultReal4(res)
     checkResultReal4 = .true.
   else
     call mpp_recv(tres,2, root)
-    checkResultReal4 = checkResultReal4 .and. (abs((res(1)-tres(1))/res(1)) .lt. 1e-5) .and. &
-                       (abs((res(2)-tres(2))/res(2)) .lt. 1e-5)
+    checkResultReal4 = checkResultReal4 .and. (abs((res(1)-tres(1))/res(1)) .lt. 1e-4) .and. &
+                       (abs((res(2)-tres(2))/res(2)) .lt. 1e-4)
   end if
   deallocate(tres)
 end function checkResultReal4
@@ -381,13 +381,13 @@ function checkSumReal4(gsum)
       call mpp_recv(recv, 2, i)
       nsum = nsum + recv(1)
       ! also check for matching global sum
-      if( abs((recv(2)-gsum)/gsum) .gt. 1e-5) then
+      if( abs((recv(2)-gsum)/gsum) .gt. 1e-4) then
         checkSumReal4 = .false.
         deallocate(recv)
         return
       endif
     end do
-    checkSumReal4 = (abs((nsum-gsum)/gsum) .lt. 1e-5)
+    checkSumReal4 = (abs((nsum-gsum)/gsum) .lt. 1e-4)
   else
     recv(1) = SUM(dataR4)
     recv(2) = gsum


### PR DESCRIPTION


**Description**
* replaced fortran intrinsic kinds with portable kindsdefined in platform.mod in fms2_io files, test routines, and axis_utils2 for consistency with mixed precision updates
* changed subroutine names to match portable kind names

Fixes #674 

**How Has This Been Tested?**


**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

