### PR TITLE
mpp_open print statements

### DIFF
--- a/mpp/include/mpp_io_read.inc
+++ b/mpp/include/mpp_io_read.inc
@@ -752,9 +752,10 @@
                     if (len.gt.MAX_ATT_LENGTH) call mpp_error(FATAL,'DIM ATT too long')
                     error=NF_GET_ATT_TEXT(ncid,i,trim(attname),mpp_file(unit)%Axis(dimid)%Att(j)%catt);
                     call netcdf_err( error, mpp_file(unit), attr=mpp_file(unit)%Axis(dimid)%att(j) )
-                    if( verbose .and. pe == 0 ) &
+                    if( verbose .and. pe == 0 ) then
                          print *, 'AXIS ',trim(mpp_file(unit)%Axis(dimid)%name),' ATT ',trim(attname)
                          print *, mpp_file(unit)%Axis(dimid)%Att(j)%catt(1:len)
+                    endif
                     ! store integers in float arrays
                     ! assume dimension data not packed
                  case (NF_SHORT)


### PR DESCRIPTION
**Description**
Sets an if block to avoid printing file attributes

Fixes #680 

**How Has This Been Tested?**
`make check` passes with intel on skylake

I looked at the output of the mpp_io unit tests. The attributes are no longer being printed :D

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

