### PR TITLE
FMS2_io: fix scalar reads/writes

### DIFF
--- a/fms2_io/include/domain_read.inc
+++ b/fms2_io/include/domain_read.inc
@@ -36,14 +36,10 @@ subroutine domain_read_0d(fileobj, variable_name, vdata, unlim_dim_level, corner
                                           !! where the data
                                           !! will be written to.
 
-  if (.not. is_variable_domain_decomposed(fileobj, variable_name, .true.)) then
-    call netcdf_read_data(fileobj, variable_name, vdata, &
+  call netcdf_read_data(fileobj, variable_name, vdata, &
                           unlim_dim_level=unlim_dim_level, corner=corner, &
                           broadcast=.true.)
-    return
-  else
-    call error("this branch should never be reached.")
-  endif
+
 end subroutine domain_read_0d
 
 
@@ -71,14 +67,10 @@ subroutine domain_read_1d(fileobj, variable_name, vdata, unlim_dim_level, &
                                                               !! will be written
                                                               !! in each dimension.
 
-  if (.not. is_variable_domain_decomposed(fileobj, variable_name, .true.)) then
-    call netcdf_read_data(fileobj, variable_name, vdata, &
+  call netcdf_read_data(fileobj, variable_name, vdata, &
                           unlim_dim_level=unlim_dim_level, corner=corner, &
                           edge_lengths=edge_lengths, broadcast=.true.)
-    return
-  else
-    call error("this branch should never be reached.")
-  endif
+
 end subroutine domain_read_1d
 
 

--- a/fms2_io/include/domain_write.inc
+++ b/fms2_io/include/domain_write.inc
@@ -35,13 +35,9 @@ subroutine domain_write_0d(fileobj, variable_name, vdata, unlim_dim_level, corne
                                           !! where the data
                                           !! will be written to.
 
-  if (.not. is_variable_domain_decomposed(fileobj, variable_name, .true.)) then
-    call compressed_write(fileobj, variable_name, vdata, &
+  call compressed_write(fileobj, variable_name, vdata, &
                           unlim_dim_level=unlim_dim_level, corner=corner)
-    return
-  else
-    call error("this branch should never be reached.")
-  endif
+
 end subroutine domain_write_0d
 
 
@@ -68,14 +64,10 @@ subroutine domain_write_1d(fileobj, variable_name, vdata, unlim_dim_level, &
                                                               !! will be written
                                                               !! in each dimension.
 
-  if (.not. is_variable_domain_decomposed(fileobj, variable_name, .true.)) then
-    call compressed_write(fileobj, variable_name, vdata, &
+  call compressed_write(fileobj, variable_name, vdata, &
                           unlim_dim_level=unlim_dim_level, corner=corner, &
                           edge_lengths=edge_lengths)
-    return
-  else
-    call error("this branch should never be reached.")
-  endif
+
 end subroutine domain_write_1d
 
 


### PR DESCRIPTION
**Description**
Remove the is_variable_domain_decomposed calls for 0d/1d domain writes/reads because 0d/1d variables are never going to be domain decomposed. 

Fixes #691 

**How Has This Been Tested?**
`make check` passes on skylake with intel. 

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

