### PR TITLE
Change PUBLIC to PRIVATE in target_link_libraries between FMS and OpenMP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -285,7 +285,7 @@ foreach(kind ${kinds})
                                          MPI::MPI_Fortran)
 
   if(OpenMP_Fortran_FOUND)
-    target_link_libraries(${libTgt} PUBLIC OpenMP::OpenMP_Fortran)
+    target_link_libraries(${libTgt} PRIVATE OpenMP::OpenMP_Fortran)
   endif()
 
   add_library(FMS::${libTgt} ALIAS ${libTgt})


### PR DESCRIPTION
**Description**
This PR modifies `CMakeLists.txt` so that FMS OpenMP dependencies are `PRIVATE`.  This will prevent other CMake targets from inheriting unwanted FMS OpenMP dependencies when linking to FMS.

Fixes #693 

**How Has This Been Tested?**
The UFS Weather Model compiles with the modified FMS CMakeLists.txt with Intel on Orion.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

