### PR TITLE
Adds logic to look for a . in the timestamp in fms_io for compatibilty with fms2_io

### DIFF
--- a/fms/fms_io.F90
+++ b/fms/fms_io.F90
@@ -2508,7 +2508,7 @@ subroutine save_restart(fileObj, time_stamp, directory, append, time_level)
         if(len_trim(restartname)+len_trim(time_stamp) > 79) call mpp_error(FATAL, "fms_io(save_restart): " // &
           "Length of restart file name + time_stamp is greater than allowed character length of 79")
            has_dot = .false.
-           do i=1,len(trim(time_stamp))
+           do i=1,len(time_stamp)
               if (time_stamp(i:i) == ".") has_dot = .true.
            enddo
            if (has_dot) then

--- a/fms/fms_io.F90
+++ b/fms/fms_io.F90
@@ -2492,7 +2492,7 @@ subroutine save_restart(fileObj, time_stamp, directory, append, time_level)
   character(len=80)  :: restartname          ! The restart file name (no dir).
   character(len=336) :: restartpath          ! The restart file path (dir/file).
   integer :: i !< For looping
-  logical :: has_dot
+  logical :: has_dot !< For determining if the time_stamp has a .
   ! This approach is taken rather than interface overloading in order to preserve
   ! use of the register_restart_field infrastructure
 
@@ -2509,7 +2509,7 @@ subroutine save_restart(fileObj, time_stamp, directory, append, time_level)
           "Length of restart file name + time_stamp is greater than allowed character length of 79")
            has_dot = .false.
            do i=1,len(trim(time_stamp))
-              if (time_stamp(i:i) == ".") had_dot = .true.
+              if (time_stamp(i:i) == ".") has_dot = .true.
            enddo
            if (has_dot) then
               restartname = trim(time_stamp)//trim(restartname)

--- a/fms/fms_io.F90
+++ b/fms/fms_io.F90
@@ -2491,7 +2491,8 @@ subroutine save_restart(fileObj, time_stamp, directory, append, time_level)
   character(len=256) :: dir
   character(len=80)  :: restartname          ! The restart file name (no dir).
   character(len=336) :: restartpath          ! The restart file path (dir/file).
-
+  integer :: i !< For looping
+  logical :: has_dot
   ! This approach is taken rather than interface overloading in order to preserve
   ! use of the register_restart_field infrastructure
 
@@ -2506,7 +2507,15 @@ subroutine save_restart(fileObj, time_stamp, directory, append, time_level)
      if (PRESENT(time_stamp)) then
         if(len_trim(restartname)+len_trim(time_stamp) > 79) call mpp_error(FATAL, "fms_io(save_restart): " // &
           "Length of restart file name + time_stamp is greater than allowed character length of 79")
-        restartname = trim(time_stamp)//"."//trim(restartname)
+           has_dot = .false.
+           do i=1,len(trim(time_stamp))
+              if (time_stamp(i:i) == ".") had_dot = .true.
+           enddo
+           if (has_dot) then
+              restartname = trim(time_stamp)//trim(restartname)
+           else
+              restartname = trim(time_stamp)//"."//trim(restartname)
+           endif
      endif
   end if
   if(len_trim(dir) > 0) then


### PR DESCRIPTION
…

**Description**
Allows for fms_io to accept a timestamp that either has a "." on the end (compatible with fms2_io) or doesn't have a "." at the end (current fms_io behavior).  This will allow fms_io to create file names that are correct using the fms2_io interface. 

Fixes #699 

**How Has This Been Tested?**
Build with `make dist` with intel compiler on amd test machine.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [ ] `make distcheck` passes

