### PR TITLE
Fixes mpp_domains_copy

### DIFF
--- a/mpp/include/mpp_domains_util.inc
+++ b/mpp/include/mpp_domains_util.inc
@@ -287,6 +287,10 @@
   end subroutine mpp_set_super_grid_indices
 
   !> @brief Modifies the indices of the input domain to create the supergrid domain
+  !> @example This is an example of how to use mpp_create_super_grid_domain
+  !! call mpp_copy_domain(domain_in, domain_out)
+  !! call super_grid_domain(domain_out)
+  !! domain_in is the original domain, domain_out is the domain with the supergrid indices
   subroutine mpp_create_super_grid_domain(domain)
     type(domain2D), intent(inout) :: domain !< Input domain
 

--- a/mpp/include/mpp_domains_util.inc
+++ b/mpp/include/mpp_domains_util.inc
@@ -276,6 +276,45 @@
     return
   end subroutine mpp_get_memory_domain2D
 
+  subroutine mpp_set_super_grid_indices(grid)
+   type(domain_axis_spec), intent(inout) :: grid
+
+   grid%begin = 2*grid%begin-1
+   grid%end = 2*grid%end+1
+   grid%size = grid%end-grid%begin+1
+
+  end subroutine mpp_set_super_grid_indices
+
+  subroutine mpp_create_super_grid(domain)
+    type(domain2D), intent(inout) :: domain
+    integer :: xbegin, ybegin
+    integer :: xend, yend
+    integer :: xsize, ysize
+
+    integer :: i
+
+    call mpp_get_global_domain(domain, xbegin=xbegin, xend=xend, ybegin=ybegin, yend=yend, xsize=xsize, ysize=ysize)
+    call mpp_set_global_domain (domain, 2*xbegin-1, 2*xend+1, 2*ybegin-1, 2*yend+1, 2*(xend-xbegin)+3, 2*(yend-ybegin)+3)
+
+    call mpp_get_compute_domain(domain, xbegin=xbegin, xend=xend, ybegin=ybegin, yend=yend, xsize=xsize, ysize=ysize)
+    call mpp_set_compute_domain (domain, 2*xbegin-1, 2*xend+1, 2*ybegin-1, 2*yend+1, 2*(xend-xbegin)+3, 2*(yend-ybegin)+3)
+
+    call mpp_get_data_domain(domain, xbegin=xbegin, xend=xend, ybegin=ybegin, yend=yend, xsize=xsize, ysize=ysize)
+    call mpp_set_data_domain (domain, 2*xbegin-1, 2*xend+1, 2*ybegin-1, 2*yend+1, 2*(xend-xbegin)+3, 2*(yend-ybegin)+3)
+
+    do i=1, size(domain%list(:))
+        call mpp_set_super_grid_indices(domain%list(i-1)%x(1)%global)
+        call mpp_set_super_grid_indices(domain%list(i-1)%y(1)%global)
+
+        call mpp_set_super_grid_indices(domain%list(i-1)%x(1)%compute)
+        call mpp_set_super_grid_indices(domain%list(i-1)%y(1)%compute)
+
+        !call mpp_set_super_grid_indices(domain%list(i-1)%x(1)%data)
+        !call mpp_set_super_grid_indices(domain%list(i-1)%y(1)%data)
+    enddo
+
+  end subroutine mpp_create_super_grid
+
   !#####################################################################
   subroutine mpp_set_compute_domain1D( domain, begin, end, size, is_global )
     type(domain1D), intent(inout) :: domain
@@ -1681,9 +1720,12 @@ end subroutine mpp_get_tile_compute_domains
   end subroutine mpp_set_domain_symmetry
 
 
-  subroutine mpp_copy_domain1D(domain_in, domain_out)
+  recursive subroutine mpp_copy_domain1D(domain_in, domain_out)
      type(domain1D),    intent(in) :: domain_in
      type(domain1D), intent(inout) :: domain_out
+     integer                       :: i
+     integer                       :: starting
+     integer                       :: ending
 
      domain_out%compute = domain_in%compute
      domain_out%data    = domain_in%data
@@ -1692,6 +1734,17 @@ end subroutine mpp_get_tile_compute_domains
      domain_out%cyclic  = domain_in%cyclic
      domain_out%pe      = domain_in%pe
      domain_out%pos     = domain_in%pos
+
+     if (associated(domain_in%list)) then
+         starting = lbound(domain_in%list, 1)
+         ending = ubound(domain_in%list, 1)
+         allocate(domain_out%list(starting:ending))
+
+         do i = starting, ending
+            call mpp_copy_domain1D(domain_in%list(i), domain_out%list(i))
+         enddo
+
+     endif
 
   end subroutine mpp_copy_domain1D
 
@@ -1702,7 +1755,8 @@ end subroutine mpp_get_tile_compute_domains
      type(domain2D),    intent(in) :: domain_in
      type(domain2D), intent(inout) :: domain_out
 
-     integer :: n, ntiles
+     integer :: n, ntiles, i
+     integer :: starting(2), ending(2)
 
      domain_out%id             = domain_in%id
      domain_out%pe             = domain_in%pe
@@ -1730,9 +1784,104 @@ end subroutine mpp_get_tile_compute_domains
      enddo
      domain_out%tile_id = domain_in%tile_id
 
+     if (associated(domain_in%pearray)) then
+         starting = lbound(domain_in%pearray)
+         ending = ubound(domain_in%pearray)
+
+         allocate(domain_out%pearray(starting(1):ending(1), starting(2):ending(2)))
+         domain_out%pearray=domain_in%pearray
+     endif
+
+     if (associated(domain_in%tile_id)) then
+         starting(1) = lbound(domain_in%tile_id,1)
+         ending(1) = ubound(domain_in%tile_id,1)
+
+         allocate(domain_out%tile_id(starting(1):ending(1)))
+         domain_out%tile_id = domain_in%tile_id
+     endif
+
+     if (associated(domain_in%tile_id_all)) then
+         starting(1) = lbound(domain_in%tile_id_all,1)
+         ending(1) = ubound(domain_in%tile_id_all,1)
+
+         allocate(domain_out%tile_id_all(starting(1):ending(1)))
+         domain_out%tile_id_all = domain_in%tile_id_all
+     endif
+
+     if (associated(domain_in%list)) then
+         starting(1) = lbound(domain_in%list,1)
+         ending(1) = ubound(domain_in%list,1)
+
+         allocate(domain_out%list(starting(1):ending(1)))
+         do i = starting(1), ending(1)
+            call mpp_copy_domain2D_spec(domain_in%list(i),domain_out%list(i))
+         enddo
+     endif
+
      return
 
   end subroutine mpp_copy_domain2D
+
+  subroutine mpp_copy_domain2D_spec(domain2D_spec_in, domain2d_spec_out)
+  type(domain2D_spec), intent(in) :: domain2D_spec_in
+  type(domain2D_spec), intent(out) :: domain2D_spec_out
+
+  integer :: starting, ending, i
+
+  domain2D_spec_out%pe = domain2D_spec_in%pe
+  domain2D_spec_out%pos = domain2D_spec_in%pos
+  domain2D_spec_out%tile_root_pe = domain2D_spec_in%tile_root_pe
+
+  if (associated(domain2D_spec_in%tile_id)) then
+      starting = lbound(domain2D_spec_in%tile_id,1)
+      ending = ubound(domain2D_spec_in%tile_id,1)
+
+      allocate(domain2D_spec_out%tile_id(starting:ending))
+      domain2D_spec_out%tile_id = domain2D_spec_in%tile_id
+  endif
+
+  if (associated(domain2D_spec_in%x)) then
+      starting = lbound(domain2D_spec_in%x,1)
+      ending = ubound(domain2D_spec_in%x,1)
+
+      allocate(domain2D_spec_out%x(starting:ending))
+      do i = starting, ending
+         call mpp_copy_domain1D_spec(domain2D_spec_in%x(i), domain2D_spec_out%x(i))
+      enddo
+  endif
+
+  if (associated(domain2D_spec_in%y)) then
+      starting = lbound(domain2D_spec_in%y,1)
+      ending = ubound(domain2D_spec_in%y,1)
+
+      allocate(domain2D_spec_out%y(starting:ending))
+      do i = starting, ending
+         call mpp_copy_domain1D_spec(domain2D_spec_in%y(i), domain2D_spec_out%y(i))
+      enddo
+  endif
+
+  end subroutine mpp_copy_domain2D_spec
+
+  subroutine mpp_copy_domain1D_spec(domain1D_spec_in, domain1D_spec_out)
+     type(domain1D_spec), intent(in) :: domain1D_spec_in
+     type(domain1D_spec), intent(out) :: domain1D_spec_out
+
+     domain1D_spec_out%pos = domain1D_spec_in%pos
+
+     call mpp_copy_domain_axis_spec(domain1D_spec_in%compute, domain1D_spec_out%compute)
+     call mpp_copy_domain_axis_spec(domain1D_spec_in%global, domain1D_spec_out%global)
+  end subroutine mpp_copy_domain1D_spec
+
+  subroutine mpp_copy_domain_axis_spec(domain_axis_spec_in, domain_axis_spec_out)
+     type(domain_axis_spec), intent(in) :: domain_axis_spec_in
+     type(domain_axis_spec), intent(out) :: domain_axis_spec_out
+
+     domain_axis_spec_out%begin = domain_axis_spec_in%begin
+     domain_axis_spec_out%end = domain_axis_spec_in%end
+     domain_axis_spec_out%size = domain_axis_spec_in%size
+     domain_axis_spec_out%max_size = domain_axis_spec_in%max_size
+     domain_axis_spec_out%is_global = domain_axis_spec_in%is_global
+  end subroutine mpp_copy_domain_axis_spec
 
   !######################################################################
   subroutine set_group_update(group, domain)

--- a/mpp/include/mpp_domains_util.inc
+++ b/mpp/include/mpp_domains_util.inc
@@ -276,8 +276,9 @@
     return
   end subroutine mpp_get_memory_domain2D
 
+  !> @brief Modifies the indices in the domain_axis_spec type to those of the supergrid
   subroutine mpp_set_super_grid_indices(grid)
-   type(domain_axis_spec), intent(inout) :: grid
+   type(domain_axis_spec), intent(inout) :: grid !< domain_axis_spec type
 
    grid%begin = 2*grid%begin-1
    grid%end = 2*grid%end+1
@@ -285,13 +286,17 @@
 
   end subroutine mpp_set_super_grid_indices
 
+  !> @brief Modifies the indices of the input domain to create the supergrid domain
   subroutine mpp_create_super_grid(domain)
-    type(domain2D), intent(inout) :: domain
-    integer :: xbegin, ybegin
-    integer :: xend, yend
-    integer :: xsize, ysize
+    type(domain2D), intent(inout) :: domain !< Input domain
 
-    integer :: i
+    integer :: xbegin !< Begining x indices
+    integer :: ybegin !< Begining y indices
+    integer :: xend   !< Ending x indices
+    integer :: yend   !< Ending y indices
+    integer :: xsize  !< Size of the x domain
+    integer :: ysize  !< Size of the y domain
+    integer :: i      !< For loops
 
     call mpp_get_global_domain(domain, xbegin=xbegin, xend=xend, ybegin=ybegin, yend=yend, xsize=xsize, ysize=ysize)
     call mpp_set_global_domain (domain, 2*xbegin-1, 2*xend+1, 2*ybegin-1, 2*yend+1, 2*(xend-xbegin)+3, 2*(yend-ybegin)+3)
@@ -309,6 +314,7 @@
         call mpp_set_super_grid_indices(domain%list(i-1)%x(1)%compute)
         call mpp_set_super_grid_indices(domain%list(i-1)%y(1)%compute)
 
+        !< There is no data domain in domain%list
         !call mpp_set_super_grid_indices(domain%list(i-1)%x(1)%data)
         !call mpp_set_super_grid_indices(domain%list(i-1)%y(1)%data)
     enddo
@@ -1719,13 +1725,14 @@ end subroutine mpp_get_tile_compute_domains
 
   end subroutine mpp_set_domain_symmetry
 
-
+  !> @brief Copies input 1d domain to the output 1d domain
   recursive subroutine mpp_copy_domain1D(domain_in, domain_out)
-     type(domain1D),    intent(in) :: domain_in
-     type(domain1D), intent(inout) :: domain_out
-     integer                       :: i
-     integer                       :: starting
-     integer                       :: ending
+     type(domain1D),    intent(in) :: domain_in  !< Input domain
+     type(domain1D), intent(inout) :: domain_out !< Output domain
+
+     integer                       :: i        !< For loop
+     integer                       :: starting !< Starting bounds
+     integer                       :: ending   !< Ending bounds
 
      domain_out%compute = domain_in%compute
      domain_out%data    = domain_in%data
@@ -1749,14 +1756,15 @@ end subroutine mpp_get_tile_compute_domains
   end subroutine mpp_copy_domain1D
 
   !#################################################################
-  !z1l: This is not fully implemented. The current purpose is to make
-  !     it work in read_data.
+  !> @brief Copies input 2d domain to the output 2d domain
   subroutine mpp_copy_domain2D(domain_in, domain_out)
-     type(domain2D),    intent(in) :: domain_in
-     type(domain2D), intent(inout) :: domain_out
+     type(domain2D),    intent(in) :: domain_in  !< Input domain
+     type(domain2D), intent(inout) :: domain_out !< Output domain
 
-     integer :: n, ntiles, i
-     integer :: starting(2), ending(2)
+     integer :: n,i          !< For loops
+     integer :: ntiles       !< Number of tiles
+     integer :: starting(2)  !< Starting bounds
+     integer :: ending(2)    !< Ending bounds
 
      domain_out%id             = domain_in%id
      domain_out%pe             = domain_in%pe
@@ -1822,11 +1830,14 @@ end subroutine mpp_get_tile_compute_domains
 
   end subroutine mpp_copy_domain2D
 
+  !> @brief Copies input 2d domain spec to the output 2d domain spec
   subroutine mpp_copy_domain2D_spec(domain2D_spec_in, domain2d_spec_out)
-  type(domain2D_spec), intent(in) :: domain2D_spec_in
-  type(domain2D_spec), intent(out) :: domain2D_spec_out
+  type(domain2D_spec), intent(in) :: domain2D_spec_in   !< Input
+  type(domain2D_spec), intent(out) :: domain2D_spec_out !< Output
 
-  integer :: starting, ending, i
+  integer :: starting  !< Starting bounds
+  integer :: ending    !< Ending bounds
+  integer :: i         !< For loop
 
   domain2D_spec_out%pe = domain2D_spec_in%pe
   domain2D_spec_out%pos = domain2D_spec_in%pos
@@ -1862,9 +1873,10 @@ end subroutine mpp_get_tile_compute_domains
 
   end subroutine mpp_copy_domain2D_spec
 
+  !> @brief Copies input 1d domain spec to the output 1d domain spec
   subroutine mpp_copy_domain1D_spec(domain1D_spec_in, domain1D_spec_out)
-     type(domain1D_spec), intent(in) :: domain1D_spec_in
-     type(domain1D_spec), intent(out) :: domain1D_spec_out
+     type(domain1D_spec), intent(in) :: domain1D_spec_in   !< Input
+     type(domain1D_spec), intent(out) :: domain1D_spec_out !< Output
 
      domain1D_spec_out%pos = domain1D_spec_in%pos
 
@@ -1872,9 +1884,10 @@ end subroutine mpp_get_tile_compute_domains
      call mpp_copy_domain_axis_spec(domain1D_spec_in%global, domain1D_spec_out%global)
   end subroutine mpp_copy_domain1D_spec
 
+  !> @brief Copies input domain_axis_spec to the output domain_axis_spec
   subroutine mpp_copy_domain_axis_spec(domain_axis_spec_in, domain_axis_spec_out)
-     type(domain_axis_spec), intent(in) :: domain_axis_spec_in
-     type(domain_axis_spec), intent(out) :: domain_axis_spec_out
+     type(domain_axis_spec), intent(in) :: domain_axis_spec_in   !< Input
+     type(domain_axis_spec), intent(out) :: domain_axis_spec_out !< Output
 
      domain_axis_spec_out%begin = domain_axis_spec_in%begin
      domain_axis_spec_out%end = domain_axis_spec_in%end

--- a/mpp/include/mpp_domains_util.inc
+++ b/mpp/include/mpp_domains_util.inc
@@ -1766,6 +1766,10 @@ end subroutine mpp_get_tile_compute_domains
      integer :: starting(2)  !< Starting bounds
      integer :: ending(2)    !< Ending bounds
 
+     if (associated(domain_out%x)) then
+         call mpp_error(FATAL, "mpp_copy_domain: domain_out is already set")
+     endif
+
      domain_out%id             = domain_in%id
      domain_out%pe             = domain_in%pe
      domain_out%fold           = domain_in%fold
@@ -1790,7 +1794,6 @@ end subroutine mpp_get_tile_compute_domains
         call mpp_copy_domain1D(domain_in%x(n), domain_out%x(n))
         call mpp_copy_domain1D(domain_in%y(n), domain_out%y(n))
      enddo
-     domain_out%tile_id = domain_in%tile_id
 
      if (associated(domain_in%pearray)) then
          starting = lbound(domain_in%pearray)

--- a/mpp/include/mpp_domains_util.inc
+++ b/mpp/include/mpp_domains_util.inc
@@ -287,7 +287,7 @@
   end subroutine mpp_set_super_grid_indices
 
   !> @brief Modifies the indices of the input domain to create the supergrid domain
-  subroutine mpp_create_super_grid(domain)
+  subroutine mpp_create_super_grid_domain(domain)
     type(domain2D), intent(inout) :: domain !< Input domain
 
     integer :: xbegin !< Begining x indices
@@ -319,7 +319,7 @@
         !call mpp_set_super_grid_indices(domain%list(i-1)%y(1)%data)
     enddo
 
-  end subroutine mpp_create_super_grid
+  end subroutine mpp_create_super_grid_domain
 
   !#####################################################################
   subroutine mpp_set_compute_domain1D( domain, begin, end, size, is_global )

--- a/mpp/mpp_domains.F90
+++ b/mpp/mpp_domains.F90
@@ -161,7 +161,7 @@ module mpp_domains_mod
   public :: mpp_clear_group_update
   public :: mpp_group_update_initialized, mpp_group_update_is_set
   public :: mpp_get_global_domains
-  public :: mpp_create_super_grid
+  public :: mpp_create_super_grid_domain
 
   !--- public interface from mpp_domains_reduce.h
   public :: mpp_global_field, mpp_global_max, mpp_global_min, mpp_global_sum

--- a/mpp/mpp_domains.F90
+++ b/mpp/mpp_domains.F90
@@ -161,6 +161,7 @@ module mpp_domains_mod
   public :: mpp_clear_group_update
   public :: mpp_group_update_initialized, mpp_group_update_is_set
   public :: mpp_get_global_domains
+  public :: mpp_create_super_grid
 
   !--- public interface from mpp_domains_reduce.h
   public :: mpp_global_field, mpp_global_max, mpp_global_min, mpp_global_sum

--- a/test_fms/mpp/Makefile.am
+++ b/test_fms/mpp/Makefile.am
@@ -27,6 +27,7 @@ LDADD = ${top_builddir}/libFMS/libFMS.la
 
 # Build these test programs.
 check_PROGRAMS = test_mpp \
+  test_super_grid \
   test_mpp_domains \
   test_redistribute_int \
   test_mpp_memuse \
@@ -120,6 +121,7 @@ test_mpp_global_field_ug_SOURCES = \
   compare_data_checksums_int.F90 \
   test_mpp_global_field_ug.F90
 test_mpp_global_sum_ad_SOURCES = test_mpp_global_sum_ad.F90
+test_super_grid_SOURCES = test_super_grid.F90
 
 # Run the test programs.
 TESTS = test_mpp_domains2.sh \
@@ -153,7 +155,8 @@ TESTS = test_mpp_domains2.sh \
   test_mpp_alltoall.sh \
   test_mpp_global_field.sh \
   test_mpp_global_field_ug.sh \
-  test_mpp_global_sum_ad.sh
+  test_mpp_global_sum_ad.sh \
+  test_super_grid.sh
 
 # These files will also be included in the distribution.
 EXTRA_DIST = input_base.nml \
@@ -191,7 +194,8 @@ EXTRA_DIST = input_base.nml \
   test_mpp_alltoall.sh \
   test_mpp_global_field.sh \
   test_mpp_global_field_ug.sh \
-  test_mpp_global_sum_ad.sh
+  test_mpp_global_sum_ad.sh \
+  test_super_grid.sh
 
 fill_halo.mod: fill_halo.$(OBJEXT)
 compare_data_checksums.mod: compare_data_checksums.$(OBJEXT)

--- a/test_fms/mpp/test_super_grid.F90
+++ b/test_fms/mpp/test_super_grid.F90
@@ -18,7 +18,7 @@
 !***********************************************************************
 
 !> @brief  This programs tests mpp_copy_domains and makes sure the domain was
-!>         copied correctly tests mpp_create_super_grid and makes sure the
+!>         copied correctly tests mpp_create_super_grid_domain and makes sure the
 !>         domain is correct
 program test_super_grid
 use   fms_mod,            only: fms_init, fms_end
@@ -27,7 +27,7 @@ use   mpp_domains_mod,    only: domain2d, mpp_define_domains, mpp_copy_domain
 use   mpp_domains_mod,    only: mpp_get_data_domain
 use   mpp_domains_mod,    only: mpp_get_compute_domain, mpp_get_compute_domains
 use   mpp_domains_mod,    only: mpp_get_global_domain, mpp_get_global_domains
-use   mpp_domains_mod,    only: mpp_create_super_grid
+use   mpp_domains_mod,    only: mpp_create_super_grid_domain
 
 implicit none
 
@@ -46,7 +46,7 @@ call mpp_define_domains( (/1,nlon,1,nlat/), layout, Domain, xhalo=2, yhalo=2, na
 call mpp_copy_domain(Domain, Domain2)
 call compare_domains(Domain, Domain2, supergrid=.false.)
 
-call mpp_create_super_grid(Domain2)
+call mpp_create_super_grid_domain(Domain2)
 call compare_domains(Domain, Domain2, supergrid=.true.)
 
 call fms_end()

--- a/test_fms/mpp/test_super_grid.F90
+++ b/test_fms/mpp/test_super_grid.F90
@@ -1,0 +1,161 @@
+!***********************************************************************
+!*                   GNU Lesser General Public License
+!*
+!* This file is part of the GFDL Flexible Modeling System (FMS).
+!*
+!* FMS is free software: you can redistribute it and/or modify it under
+!* the terms of the GNU Lesser General Public License as published by
+!* the Free Software Foundation, either version 3 of the License, or (at
+!* your option) any later version.
+!*
+!* FMS is distributed in the hope that it will be useful, but WITHOUT
+!* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+!* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+!* for more details.
+!*
+!* You should have received a copy of the GNU Lesser General Public
+!* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
+!***********************************************************************
+
+!> @brief  This programs tests mpp_copy_domains and makes sure the domain was
+!>         copied correctly tests mpp_create_super_grid and makes sure the
+!>         domain is correct
+program test_super_grid
+use   fms_mod,            only: fms_init, fms_end
+use   mpp_mod,            only: mpp_error, mpp_pe, mpp_root_pe, mpp_npes, FATAL
+use   mpp_domains_mod,    only: domain2d, mpp_define_domains, mpp_copy_domain
+use   mpp_domains_mod,    only: mpp_get_data_domain
+use   mpp_domains_mod,    only: mpp_get_compute_domain, mpp_get_compute_domains
+use   mpp_domains_mod,    only: mpp_get_global_domain, mpp_get_global_domains
+use   mpp_domains_mod,    only: mpp_create_super_grid
+
+implicit none
+
+type(domain2d)                     :: Domain            !< Domain
+type(domain2d)                     :: Domain2           !< Domain
+integer                            :: nlon              !< Number of points in x direction
+integer                            :: nlat              !< Number of points in y direction
+integer, dimension(2)              :: layout = (/1,6/)  !< Domain layout
+
+call fms_init()
+
+nlon = 360
+nlat = 90
+
+call mpp_define_domains( (/1,nlon,1,nlat/), layout, Domain, xhalo=2, yhalo=2, name='test_supergrid')
+call mpp_copy_domain(Domain, Domain2)
+call compare_domains(Domain, Domain2, supergrid=.false.)
+
+call mpp_create_super_grid(Domain2)
+call compare_domains(Domain, Domain2, supergrid=.true.)
+
+call fms_end()
+
+contains
+
+subroutine compare_domains(Domain, Domain2, supergrid)
+ type(domain2d), intent(inout)      :: Domain            !< Domain
+ type(domain2d), intent(inout)      :: Domain2           !< Domain
+ logical,        intent(in)         :: supergrid         !< Flag indicating if comparing supergrid
+
+ integer, allocatable               :: pe_indices (:,:)  !< Indices for current pe
+ integer, allocatable               :: pe_indices2(:,:)  !< Indices for current pe
+ integer, allocatable               :: pes_indices(:,:)  !< Indices for all pes in the pelist
+ integer, allocatable               :: pes_indices2(:,:) !< Indices for all pes in the pelist
+
+ allocate(pes_indices (mpp_npes(),6))
+ allocate(pes_indices2(mpp_npes(),6))
+ allocate(pe_indices (1,6))
+ allocate(pe_indices2(1,6))
+
+ !< Check if the pe_indices are the same for the two domains
+ !> Compute Domain:
+ call mpp_get_compute_domain(Domain, xbegin=pe_indices (1,1), xend=pe_indices (1,2), &
+                                   & ybegin=pe_indices (1,3), yend=pe_indices (1,4), &
+                                   & xsize =pe_indices (1,5), ysize=pe_indices(1,6))
+ if(supergrid) call get_expected_indices(pe_indices)
+
+ call mpp_get_compute_domain(Domain2, xbegin=pe_indices2(1,1), xend=pe_indices2(1,2), &
+                                   &  ybegin=pe_indices2(1,3), yend=pe_indices2(1,4), &
+                                   &  xsize =pe_indices2(1,5), ysize=pe_indices2(1,6))
+ call compare_pe_indices(pe_indices, pe_indices2, "compute domain")
+
+ !> Data Domain:
+ call mpp_get_data_domain(Domain, xbegin=pe_indices (1,1), xend=pe_indices (1,2), &
+                                   & ybegin=pe_indices (1,3), yend=pe_indices (1,4), &
+                                   & xsize =pe_indices (1,5), ysize=pe_indices(1,6))
+ if(supergrid) call get_expected_indices(pe_indices)
+
+ call mpp_get_data_domain(Domain2, xbegin=pe_indices2(1,1), xend=pe_indices2(1,2), &
+                                   &  ybegin=pe_indices2(1,3), yend=pe_indices2(1,4), &
+                                   &  xsize =pe_indices2(1,5), ysize=pe_indices2(1,6))
+ call compare_pe_indices(pe_indices, pe_indices2, "data domain")
+
+ !> Global Domain:
+ call mpp_get_global_domain(Domain, xbegin=pe_indices (1,1), xend=pe_indices (1,2), &
+                                   & ybegin=pe_indices (1,3), yend=pe_indices (1,4), &
+                                   & xsize =pe_indices (1,5), ysize=pe_indices(1,6))
+ if(supergrid) call get_expected_indices(pe_indices)
+
+ call mpp_get_global_domain(Domain2, xbegin=pe_indices2(1,1), xend=pe_indices2(1,2), &
+                                   &  ybegin=pe_indices2(1,3), yend=pe_indices2(1,4), &
+                                   &  xsize =pe_indices2(1,5), ysize=pe_indices2(1,6))
+ call compare_pe_indices(pe_indices, pe_indices2, "global domain")
+
+ !> Compute Domains (get the indices for all of the ranks)
+ call mpp_get_compute_domains(Domain,  xbegin=pes_indices (:,1), xend=pes_indices (:,2), &
+                                     & ybegin=pes_indices (:,3), yend=pes_indices (:,4), &
+                                     & xsize =pes_indices (:,5), ysize=pes_indices (:,6))
+ if(supergrid) call get_expected_indices(pes_indices)
+
+ call mpp_get_compute_domains(Domain2, xbegin=pes_indices2(:,1), xend=pes_indices2(:,2), &
+                                     & ybegin=pes_indices2(:,3), yend=pes_indices2(:,4), &
+                                     & xsize =pes_indices2(:,5), ysize=pes_indices2(:,6))
+ call compare_pe_indices(pes_indices, pes_indices2, "compute domains")
+
+ !> Global Domains (get the indices for all of the ranks)
+ call mpp_get_global_domains(Domain,  xbegin=pes_indices (:,1), xend=pes_indices (:,2), &
+                                     & ybegin=pes_indices (:,3), yend=pes_indices (:,4), &
+                                     & xsize =pes_indices (:,5), ysize=pes_indices(:,6))
+ if(supergrid) call get_expected_indices(pes_indices)
+
+ call mpp_get_global_domains(Domain2, xbegin=pes_indices2(:,1), xend=pes_indices2(:,2), &
+                                     & ybegin=pes_indices2(:,3), yend=pes_indices2(:,4), &
+                                     & xsize =pes_indices2(:,5), ysize=pes_indices2(:,6))
+ call compare_pe_indices(pes_indices, pes_indices2, "global domains")
+
+end subroutine compare_domains
+
+subroutine get_expected_indices(pe_indices)
+  integer, intent(inout) :: pe_indices(:,:)  !< Indices from original domain
+
+  integer :: i !< For do loop
+
+  do i=1, size(pe_indices,1)
+     pe_indices(i,1) = 2*pe_indices(i,1)-1 !< xbegin
+     pe_indices(i,2) = 2*pe_indices(i,2)+1 !< xend
+     pe_indices(i,3) = 2*pe_indices(i,3)-1 !< ybegin
+     pe_indices(i,4) = 2*pe_indices(i,4)+1 !< yend
+     pe_indices(i,5) = pe_indices(i,2) - pe_indices(i,1) +1 !< xsize
+     pe_indices(i,6) = pe_indices(i,4) - pe_indices(i,3) +1 !< ysize
+  enddo
+
+end subroutine get_expected_indices
+
+subroutine compare_pe_indices(pe_indices, pe_indices2, domain_type)
+  integer, intent(in) :: pe_indices(:,:)  !< Indices from original domain
+  integer, intent(in) :: pe_indices2(:,:) !< Indices from new domain
+  character(len=*), intent(in) :: domain_type !< Type of domain "data", "compute", and "global"
+
+  integer :: i,j !< For do loop
+
+  do i = 1, size(pe_indices, 1)
+     do j = 1, size(pe_indices,2)
+        if (pe_indices(i, j) .ne. pe_indices2(i, j)) then
+           call mpp_error(FATAL, "Compare pe_indices: the "//trim(domain_type)//" pe_indices are not the same ")
+        endif
+     enddo
+  enddo
+end subroutine compare_pe_indices
+
+end program test_super_grid

--- a/test_fms/mpp/test_super_grid.sh
+++ b/test_fms/mpp/test_super_grid.sh
@@ -22,7 +22,7 @@
 # This is part of the GFDL FMS package. This is a shell script to
 # execute tests in the test_fms/mpp directory.
 
-# Lauren Chilutti 09/09/2020
+# U Ramirez 03/16/2021
 
 # Set common test settings.
 . ../test_common.sh

--- a/test_fms/mpp/test_super_grid.sh
+++ b/test_fms/mpp/test_super_grid.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+#***********************************************************************
+#                   GNU Lesser General Public License
+#
+# This file is part of the GFDL Flexible Modeling System (FMS).
+#
+# FMS is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or (at
+# your option) any later version.
+#
+# FMS is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
+#***********************************************************************
+
+# This is part of the GFDL FMS package. This is a shell script to
+# execute tests in the test_fms/mpp directory.
+
+# Lauren Chilutti 09/09/2020
+
+# Set common test settings.
+. ../test_common.sh
+
+touch input.nml
+run_test test_super_grid 6


### PR DESCRIPTION
**Description**
This PR:

1. Finishes implementing mpp_copy_domain, so that it can work correctly (Fixes #689)
2. Creates a subroutine call mpp_create_super_grid that sets all of the indices correctly (Fixes #690)
3. Adds a unit test that tests if the copy and the supergrid worked correctly 
Without the source code changes the test fails on the `mpp_get_compute_domains` call on `domain2` because domain2%list is never set ...

**How Has This Been Tested?**
`make check` passes
`mpp_create_supergrid` was implemented in https://github.com/NOAA-GFDL/FMScoupler/pull/52 and it works now ... 

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

