### PR TITLE
Fix typo in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -33,7 +33,8 @@ indent_style = space
 indent_size = 2
 trim_trailing_whitespace = true
 
-# Settings for specific files, or file patterns.  [{Makefile,*.am}]
+# Settings for specific files, or file patterns.
+[{Makefile,*.am}]
 indent_style = tab
 indent_size = 1
 


### PR DESCRIPTION
**Description**
Just fixes a small typo where a line was commented out so that the .editorconfig file works as intended.

Fixes #702 

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

