### PR TITLE
Fms2 io fix

### DIFF
--- a/coupler/coupler_types.F90
+++ b/coupler/coupler_types.F90
@@ -3166,13 +3166,11 @@ contains
 
       do m = 1, var%bc(n)%num_fields
          if (file_is_open(f)) then
-            if( to_read ) then
+            if( to_read .and. variable_exists(bc_rest_files(f), var%bc(n)%field(m)%name)) then
                 !< If reading get the dimension names from the file
-                if (variable_exists(bc_rest_files(f), var%bc(n)%field(m)%name)) then
-                    allocate(dim_names(get_variable_num_dimensions(bc_rest_files(f), var%bc(n)%field(m)%name)))
-                    call get_variable_dimension_names(bc_rest_files(f), &
-                    & var%bc(n)%field(m)%name, dim_names)
-                endif !< If variable_exists
+                allocate(dim_names(get_variable_num_dimensions(bc_rest_files(f), var%bc(n)%field(m)%name)))
+                call get_variable_dimension_names(bc_rest_files(f), &
+                & var%bc(n)%field(m)%name, dim_names)
             else
                 !< If writing use dummy dimension names
                 allocate(dim_names(3))

--- a/coupler/coupler_types.F90
+++ b/coupler/coupler_types.F90
@@ -3270,10 +3270,10 @@ contains
 
     !< Add the dimension names as variable so that the combiner can work correctly
     call register_field(fileobj, dim_names(1), "double", (/dim_names(1)/))
-    call register_variable_attribute(fileobj, dim_names(1), "axis", "x", str_len=1)
+    call register_variable_attribute(fileobj, dim_names(1), "axis", "X", str_len=1)
 
     call register_field(fileobj, dim_names(2), "double", (/dim_names(2)/))
-    call register_variable_attribute(fileobj, dim_names(2), "axis", "y", str_len=1)
+    call register_variable_attribute(fileobj, dim_names(2), "axis", "Y", str_len=1)
 
   end subroutine register_axis_wrapper_write
 
@@ -3462,13 +3462,11 @@ contains
 
       do m = 1, var%bc(n)%num_fields
          if (file_is_open(f)) then
-            if( to_read ) then
+            if( to_read .and. variable_exists(bc_rest_files(f), var%bc(n)%field(m)%name)) then
                 !< If reading get the dimension names from the file
-                if (variable_exists(bc_rest_files(f), var%bc(n)%field(m)%name)) then
-                    allocate(dim_names(get_variable_num_dimensions(bc_rest_files(f), var%bc(n)%field(m)%name)))
-                    call get_variable_dimension_names(bc_rest_files(f), &
-                    & var%bc(n)%field(m)%name, dim_names)
-                endif !< If variable_exists
+                allocate(dim_names(get_variable_num_dimensions(bc_rest_files(f), var%bc(n)%field(m)%name)))
+                call get_variable_dimension_names(bc_rest_files(f), &
+                & var%bc(n)%field(m)%name, dim_names)
             else
                 !< If writing use dummy dimension names
                 allocate(dim_names(4))

--- a/fms2_io/fms_netcdf_domain_io.F90
+++ b/fms2_io/fms_netcdf_domain_io.F90
@@ -481,7 +481,7 @@ subroutine register_domain_decomposed_dimension(fileobj, dim_name, xory, domain_
 end subroutine register_domain_decomposed_dimension
 
 
-!> @brief Add a "domain_decomposed" attribute to certain variables because it is
+!> @brief Add a "domain_decomposed" attribute to the axis variables because it is
 !!        required by mppnccombine.
 !! @internal
 subroutine add_domain_attribute(fileobj, variable_name)
@@ -495,6 +495,12 @@ subroutine add_domain_attribute(fileobj, variable_name)
   integer :: eg
   integer :: s
   integer :: e
+  integer, dimension(2) :: io_layout !< Io_layout in the fileobj's domain
+
+  !< Don't add the "domain_decomposition" variable attribute if the io_layout is
+  !! 1,1, to avoid frecheck "failures"
+  io_layout = mpp_get_io_domain_layout(fileobj%domain)
+  if (io_layout(1)  .eq. 1 .and. io_layout(2) .eq. 1) return
 
   io_domain => mpp_get_io_domain(fileobj%domain)
   dpos = get_domain_decomposed_index(variable_name, fileobj%xdims, fileobj%nx)

--- a/test_fms/fms2_io/test_io_simple.F90
+++ b/test_fms/fms2_io/test_io_simple.F90
@@ -156,11 +156,7 @@ program test_io_simple
         if (varname .ne. "lon") stop 31
         if (xtype .ne. NF90_DOUBLE) stop 32
         if (ndims .ne. 1 .or. dimids(1) .ne. 1) stop 33
-        if (nAtts .ne. 1) stop 34
-        err = nf90_get_att(ncid, 1, "domain_decomposition", domain_decomposition)
-        if (err .ne. NF90_NOERR) stop 35
-        if (domain_decomposition(1) .ne. 1 .or. domain_decomposition(2) .ne. 96) stop 36
-        if (domain_decomposition(3) .ne. 1 .or. domain_decomposition(4) .ne. 96) stop 37
+        if (nAtts .ne. 0) stop 34
         err = nf90_get_var(ncid, 1, double_buffer_in)
         if (err .ne. NF90_NOERR) stop 38
         do j = 1, 96


### PR DESCRIPTION
**Description**
Fixes #711 -Fixes logic to prevent the `allocatable array or pointer is not allocated` crash
Fixes #712 - Adds logic so that the domain decomposition variable attribute is only added if the io_layout is not 1,1 and updates tests

Changes the "axis" attributes to be "X" and "Y" instead of "x" and "y" to be more CF compliant

**How Has This Been Tested?**
`make check` passes 

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

