### PR TITLE
Workarounds for PGI

### DIFF
--- a/axis_utils/axis_utils2.F90
+++ b/axis_utils/axis_utils2.F90
@@ -80,9 +80,9 @@ contains
     cart = "N"
     if (variable_exists(fileobj, axisname)) then
       if (variable_att_exists(fileobj, axisname, "cartesian_axis")) then
-        call get_variable_attribute(fileobj, axisname, "cartesian_axis", cart)
+        call get_variable_attribute(fileobj, axisname, "cartesian_axis", cart(1:1))
       elseif (variable_att_exists(fileobj, axisname, "axis")) then
-        call get_variable_attribute(fileobj, axisname, "axis", cart)
+        call get_variable_attribute(fileobj, axisname, "axis", cart(1:1))
       endif
       axis_cart = uppercase(cart)
       if (axis_cart .eq. 'X' .or. axis_cart .eq. 'Y' .or. axis_cart .eq. 'Z' &
@@ -188,14 +188,7 @@ contains
       if (dim_sizes(1) .ne. n+1) then
         call mpp_error(FATAL, "axis_edges: incorrect size of edge data.")
       endif
-      select type (edge_data)
-        type is (real(kind=r4_kind))
-          call read_data(fileobj, buffer, edge_data)
-        type is (real(kind=r8_kind))
-          call read_data(fileobj, buffer, edge_data)
-        class default
-          call mpp_error(FATAL, "axis_edges: unsupported kind.")
-      end select
+      call read_data(fileobj, buffer, edge_data)
     elseif (size(dim_sizes) .eq. 2) then
       if (dim_sizes(1) .ne. 2) then
         call mpp_error(FATAL, "axis_edges: first dimension of edge must be of size 2")

--- a/data_override/data_override.F90
+++ b/data_override/data_override.F90
@@ -97,7 +97,7 @@ type override_type
    character(len=3)                 :: gridname
    character(len=128)               :: fieldname
    integer                          :: t_index                 !< index for time interp
-   type(horiz_interp_type), pointer :: horz_interp(:) =>NULL() !< index for horizontal spatial interp
+   type(horiz_interp_type), allocatable :: horz_interp(:) !< index for horizontal spatial interp
    integer                          :: dims(4)                 !< dimensions(x,y,z,t) of the field in filename
    integer                          :: comp_domain(4)          !< istart,iend,jstart,jend for compute domain
    integer                          :: numthreads

--- a/fms2_io/netcdf_io.F90
+++ b/fms2_io/netcdf_io.F90
@@ -292,6 +292,12 @@ interface gather_data_bc
   module procedure gather_data_bc_3d
 end interface gather_data_bc
 
+!< The interface is needed to accomodate pgi because it can't handle class * and there was no other way around it
+interface is_valid
+  module procedure is_valid_r8
+  module procedure is_valid_r4
+end interface is_valid
+
 contains
 
 !> @brief Accepts the namelist fms2_io_nml variables relevant to netcdf_io_mod
@@ -1728,28 +1734,44 @@ function get_valid(fileobj, variable_name) &
 
 end function get_valid
 
-
-!> @brief Determine if a piece of data is "valid" (in the correct range.)
+!> @brief Determine if a piece of (r4) data is "valid" (in the correct range.)
 !! @return A flag telling if the data element is "valid."
-elemental function is_valid(datum, validobj) &
+elemental function is_valid_r8(datum, validobj) &
   result(valid_data)
 
-  class(*), intent(in) :: datum !< Unpacked data element.
+  real(kind=r8_kind), intent(in) :: datum !< Unpacked data element.
+  type(Valid_t), intent(in) :: validobj !< Valid object.
+  logical :: valid_data
+
+  valid_data = check_if_valid(datum, validobj)
+
+end function is_valid_r8
+
+!> @brief Determine if a piece of (r8) data is "valid" (in the correct range.)
+!! @return A flag telling if the data element is "valid."
+elemental function is_valid_r4(datum, validobj) &
+  result(valid_data)
+
+  real(kind=r4_kind), intent(in) :: datum !< Unpacked data element.
   type(Valid_t), intent(in) :: validobj !< Valid object.
   logical :: valid_data
 
   real(kind=r8_kind) :: rdatum
 
-  select type (datum)
-    type is (integer(kind=i4_kind))
-      rdatum = real(datum, kind=r8_kind)
-    type is (real(kind=r4_kind))
-      rdatum = real(datum, kind=r8_kind)
-    type is (real(kind=r8_kind))
-      rdatum = real(datum, kind=r8_kind)
- !  class default
- !    call error("unsupported type.")
-  end select
+  !< Convert the data to r8 so it can be compared correctly since validobj%*_val are defined as r8
+  rdatum = real(datum, kind=r8_kind)
+  valid_data = check_if_valid(rdatum, validobj)
+
+end function is_valid_r4
+
+!> @brief Determine if a piece of data is "valid" (in the correct range.)
+!! @return A flag telling if the data element is "valid."
+elemental function check_if_valid(rdatum, validobj) &
+  result(valid_data)
+
+  real(kind=r8_kind), intent(in) :: rdatum !< packed data element.
+  type(Valid_t), intent(in) :: validobj !< Valid object.
+  logical :: valid_data
 
   valid_data = .true.
   ! If the variable has a range (open or closed), valid values must be in that
@@ -1774,7 +1796,7 @@ elemental function is_valid(datum, validobj) &
       valid_data = .not. (rdatum .eq. validobj%missing_val .or. rdatum .eq. validobj%fill_val)
     endif
   endif
-end function is_valid
+end function check_if_valid
 
 
 !> @brief Gathers a compressed arrays size and offset for each pe.

--- a/fms2_io/netcdf_io.F90
+++ b/fms2_io/netcdf_io.F90
@@ -1973,15 +1973,20 @@ function get_variable_missing(fileobj, variable_name) &
   character(len=*), intent(in) :: variable_name
   real(kind=r8_kind) :: variable_missing
 
+  real(kind=r8_kind) :: variable_missing_1d(1) !< Workaround for pgi
+
   if (variable_att_exists(fileobj, variable_name, "_FillValue")) then
-    call get_variable_attribute(fileobj, variable_name, "_FillValue", variable_missing)
+    call get_variable_attribute(fileobj, variable_name, "_FillValue", variable_missing_1d)
   elseif (variable_att_exists(fileobj, variable_name, "missing_value")) then
-    call get_variable_attribute(fileobj, variable_name, "missing_value", variable_missing)
+    call get_variable_attribute(fileobj, variable_name, "missing_value", variable_missing_1d)
   elseif (variable_att_exists(fileobj, variable_name, "missing")) then
-    call get_variable_attribute(fileobj, variable_name, "missing", variable_missing)
+    call get_variable_attribute(fileobj, variable_name, "missing", variable_missing_1d)
   else
-    variable_missing = MPP_FILL_DOUBLE
+    variable_missing_1d = MPP_FILL_DOUBLE
   endif
+
+  variable_missing = variable_missing_1d(1)
+
 end function get_variable_missing
 
 


### PR DESCRIPTION
**Description**
This are hacks to get the ICE/OCEAN model working with pgi and fms2io

1. The call bellow was for some reason crashing [here](https://github.com/NOAA-GFDL/FMS/blob/main/fms2_io/include/get_variable_attribute.inc#L68) because pgi was not recognizing that 'cart' was a string. Changing it to ```cart(1:1)``` solved the "problem".
```F90
call get_variable_attribute(fileobj, axisname, "cartesian_axis", cart)
 ``` 
2. Similary the call bellow was failing because pgi was not recognizing that "variable_missing" was real. Changing it to variable_missing to a 1d variable magically solved the problem.
```F90
call get_variable_attribute(fileobj, variable_name, "_FillValue", variable_missing)
```
3. The code was also failing inside the read_data with `unsupported type` because PGI couldn't deal with the nested `select types`. Removing the `select type` in axis_utils and replacing it with simply a read_data call solved the "problem".
https://github.com/NOAA-GFDL/FMS/blob/81a5b6ea2559e2c31edbcab32a3230dfc31287be/axis_utils/axis_utils2.F90#L191-L198. 
4. PGI was failing with a seg_fault inside here. It seems like the pgi couldn't handle the mix of class * and the conversion to real. I couldn't find a way around this so I just created a "is_valid" interface #oldskool
https://github.com/NOAA-GFDL/FMS/blob/81a5b6ea2559e2c31edbcab32a3230dfc31287be/fms2_io/netcdf_io.F90#L1743-L1752

There may be other "issues" that were not hit with the experiment I was running. 

Fixes #704 

**How Has This Been Tested?**
`MOM6_SIS2_Baltic` experiment with pgi19 on gaea. We need to make sure all of the experiments run though...

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

