### PR TITLE
Automated documentation hosting through GH pages

### DIFF
--- a/.github/workflows/update_docs.yml
+++ b/.github/workflows/update_docs.yml
@@ -18,10 +18,8 @@ jobs:
         uses: mattnotmitt/doxygen-action@v1
         with:
           doxyfile-path: 'gen_docs/Doxyfile'
-      - name: Create additional files
-        run: | # disables jekyll support and copies in readme for main page
-          touch gen_docs/html/.nojekyll
-          cp README.md gen_docs/html
+      - name: Copy readme
+        run: cp README.md gen_docs/html
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.github/workflows/update_docs.yml
+++ b/.github/workflows/update_docs.yml
@@ -13,7 +13,7 @@ jobs:
         run: | # do autotool's job of setting input/output paths since we don't need a full build environement
           mkdir gen_docs
           sed 's/@abs_top_builddir@\/docs/gen_docs/' docs/Doxyfile.in > gen_docs/Doxyfile
-          sed -i 's/@abs_top_srcdir@/`pwd`/' gen_docs/Doxyfile
+          sed -i 's/@abs_top_srcdir@/./' gen_docs/Doxyfile
       - name: Run Doxygen
         uses: mattnotmitt/doxygen-action@v1
         with:

--- a/.github/workflows/update_docs.yml
+++ b/.github/workflows/update_docs.yml
@@ -1,0 +1,21 @@
+name: Generate and host documentation 
+
+## manually run for now
+on: [workflow_dispatch]
+
+jobs:
+  update_docs:
+    runs-on: ubuntu-latest
+    container:
+      image: underwoo/ubuntu_libfms_gnu
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup repo 
+        run: |
+          autoreconf -if
+          ./configure --enable-docs
+      - name: Run Doxygen
+        uses: mattnotmitt/doxygen-action@v1
+        with:
+          doxyfile-path: 'docs/Doxyfile'

--- a/.github/workflows/update_docs.yml
+++ b/.github/workflows/update_docs.yml
@@ -20,8 +20,7 @@ jobs:
         with:
           doxyfile-path: 'docs/Doxyfile'
       - name: Deploy
-        used: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs
-        

--- a/.github/workflows/update_docs.yml
+++ b/.github/workflows/update_docs.yml
@@ -22,4 +22,4 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./gen_docs
+          publish_dir: ./gen_docs/html

--- a/.github/workflows/update_docs.yml
+++ b/.github/workflows/update_docs.yml
@@ -1,7 +1,7 @@
 name: Generate and deploy documentation on GH pages
 
 # update on releases or when triggered manually(must have write access)
-on: [release, workflow_dispatch]
+on: [release, workflow_dispatch, push]
 
 jobs:
   update_docs:
@@ -12,13 +12,16 @@ jobs:
       - name: Setup repo 
         run: | # do autotool's job of setting input/output paths since we don't need a full build environement
           mkdir gen_docs
-          cp README.md gen_docs
           sed 's/@abs_top_builddir@\/docs/gen_docs/' docs/Doxyfile.in > gen_docs/Doxyfile
           sed -i 's/@abs_top_srcdir@/./' gen_docs/Doxyfile
       - name: Run Doxygen
         uses: mattnotmitt/doxygen-action@v1
         with:
           doxyfile-path: 'gen_docs/Doxyfile'
+      - name: Create additional files
+        run: | # disables jekyll support and copies in readme for main page
+          touch gen_docs/html/.nojekyll
+          cp README.md gen_docs/html
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.github/workflows/update_docs.yml
+++ b/.github/workflows/update_docs.yml
@@ -1,7 +1,7 @@
 name: Generate and host documentation 
 
-## manually run for now
-on: [workflow_dispatch]
+## run on push for now
+on: [push]
 
 jobs:
   update_docs:
@@ -19,3 +19,9 @@ jobs:
         uses: mattnotmitt/doxygen-action@v1
         with:
           doxyfile-path: 'docs/Doxyfile'
+      - name: Deploy
+        used: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs
+        

--- a/.github/workflows/update_docs.yml
+++ b/.github/workflows/update_docs.yml
@@ -10,17 +10,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Setup repo 
-        run: | # do autotool's job since we don't need a full build environement
+        run: | # do autotool's job of setting input/output paths since we don't need a full build environement
           mkdir gen_docs
           buildDir="`pwd`\/gen_docs"
-          sed 's/\@abs_top_builddir\@\/docs/\$buildDir/' docs/Doxyfile.in > gen_docs/Doxyfile
-          sed -i s/\@abs_top_srcdir\@/'`pwd`'/ gen_docs/Doxyfile
+          sed 's/@abs_top_builddir@\/docs/\$buildDir/' docs/Doxyfile.in > docs/Doxyfile
+          sed -i s/@abs_top_srcdir@/'`pwd`'/ docs/Doxyfile
       - name: Run Doxygen
         uses: mattnotmitt/doxygen-action@v1
         with:
-          doxyfile-path: 'gen_docs/Doxyfile'
+          doxyfile-path: 'docs/Doxyfile'
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs
+          publish_dir: ./gen_docs

--- a/.github/workflows/update_docs.yml
+++ b/.github/workflows/update_docs.yml
@@ -1,7 +1,7 @@
 name: Generate and deploy documentation on GH pages
 
 # update on releases or when triggered manually(must have write access)
-on: [release, workflow_dispatch, push]
+on: [release, workflow_dispatch]
 
 jobs:
   update_docs:

--- a/.github/workflows/update_docs.yml
+++ b/.github/workflows/update_docs.yml
@@ -12,13 +12,12 @@ jobs:
       - name: Setup repo 
         run: | # do autotool's job of setting input/output paths since we don't need a full build environement
           mkdir gen_docs
-          buildDir="`pwd`\/gen_docs"
-          sed 's/@abs_top_builddir@\/docs/\$buildDir/' docs/Doxyfile.in > docs/Doxyfile
-          sed -i s/@abs_top_srcdir@/'`pwd`'/ docs/Doxyfile
+          sed 's/@abs_top_builddir@\/docs/gen_docs/' docs/Doxyfile.in > gen_docs/Doxyfile
+          sed -i 's/@abs_top_srcdir@/`pwd`/' gen_docs/Doxyfile
       - name: Run Doxygen
         uses: mattnotmitt/doxygen-action@v1
         with:
-          doxyfile-path: 'docs/Doxyfile'
+          doxyfile-path: 'gen_docs/Doxyfile'
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.github/workflows/update_docs.yml
+++ b/.github/workflows/update_docs.yml
@@ -13,7 +13,7 @@ jobs:
         run: | # do autotool's job since we don't need a full build environement
           mkdir gen_docs
           buildDir="`pwd`\/gen_docs"
-          sed 's/\@abs_top_builddir\@\/docs/\$buildDir/' docs/Doxygen.in > gen_docs/Doxyfile
+          sed 's/\@abs_top_builddir\@\/docs/\$buildDir/' docs/Doxyfile.in > gen_docs/Doxyfile
           sed -i s/\@abs_top_srcdir\@/'`pwd`'/ gen_docs/Doxyfile
       - name: Run Doxygen
         uses: mattnotmitt/doxygen-action@v1

--- a/.github/workflows/update_docs.yml
+++ b/.github/workflows/update_docs.yml
@@ -13,7 +13,7 @@ jobs:
         run: | # do autotool's job since we don't need a full build environement
           mkdir gen_docs
           buildDir="`pwd`\/gen_docs"
-          sed 's/\@abs_top_builddir\@\/docs/'$buildDir'/' docs/Doxygen.in > gen_docs/Doxyfile
+          sed 's/\@abs_top_builddir\@\/docs/\$buildDir/' docs/Doxygen.in > gen_docs/Doxyfile
           sed -i s/\@abs_top_srcdir\@/'`pwd`'/ gen_docs/Doxyfile
       - name: Run Doxygen
         uses: mattnotmitt/doxygen-action@v1

--- a/.github/workflows/update_docs.yml
+++ b/.github/workflows/update_docs.yml
@@ -13,6 +13,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Setup repo 
         run: |
+          alias doxygen="echo doxygen"
           autoreconf -if
           ./configure --enable-docs
       - name: Run Doxygen

--- a/.github/workflows/update_docs.yml
+++ b/.github/workflows/update_docs.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           doxyfile-path: 'gen_docs/Doxyfile'
       - name: Copy readme
-        run: cp README.md gen_docs/html
+        run: sudo cp README.md gen_docs/html
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.github/workflows/update_docs.yml
+++ b/.github/workflows/update_docs.yml
@@ -6,20 +6,19 @@ on: [push]
 jobs:
   update_docs:
     runs-on: ubuntu-latest
-    container:
-      image: underwoo/ubuntu_libfms_gnu
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Setup repo 
-        run: |
-          alias doxygen="echo doxygen"
-          autoreconf -if
-          ./configure --enable-docs
+        run: | # do autotool's job since we don't need a full build environement
+          mkdir gen_docs
+          buildDir="`pwd`\/gen_docs"
+          sed s/@abs_top_builddir@\/docs/$buildDir/ docs/Doxygen.in > gen_docs/Doxyfile
+          sed -i s/@abs_top_srcdir@/`pwd`/ gen_docs/Doxyfile
       - name: Run Doxygen
         uses: mattnotmitt/doxygen-action@v1
         with:
-          doxyfile-path: 'docs/Doxyfile'
+          doxyfile-path: 'gen_docs/Doxyfile'
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.github/workflows/update_docs.yml
+++ b/.github/workflows/update_docs.yml
@@ -1,7 +1,7 @@
-name: Generate and host documentation 
+name: Generate and deploy documentation on GH pages
 
-## run on push for now
-on: [push]
+# update on releases or when triggered manually(must have write access)
+on: [release, workflow_dispatch]
 
 jobs:
   update_docs:
@@ -12,6 +12,7 @@ jobs:
       - name: Setup repo 
         run: | # do autotool's job of setting input/output paths since we don't need a full build environement
           mkdir gen_docs
+          cp README.md gen_docs
           sed 's/@abs_top_builddir@\/docs/gen_docs/' docs/Doxyfile.in > gen_docs/Doxyfile
           sed -i 's/@abs_top_srcdir@/./' gen_docs/Doxyfile
       - name: Run Doxygen

--- a/.github/workflows/update_docs.yml
+++ b/.github/workflows/update_docs.yml
@@ -13,8 +13,8 @@ jobs:
         run: | # do autotool's job since we don't need a full build environement
           mkdir gen_docs
           buildDir="`pwd`\/gen_docs"
-          sed s/@abs_top_builddir@\/docs/$buildDir/ docs/Doxygen.in > gen_docs/Doxyfile
-          sed -i s/@abs_top_srcdir@/`pwd`/ gen_docs/Doxyfile
+          sed 's/\@abs_top_builddir\@\/docs/'$buildDir'/' docs/Doxygen.in > gen_docs/Doxyfile
+          sed -i s/\@abs_top_srcdir\@/'`pwd`'/ gen_docs/Doxyfile
       - name: Run Doxygen
         uses: mattnotmitt/doxygen-action@v1
         with:

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -798,8 +798,7 @@ WARN_LOGFILE           = doxywarn.log
 # directories like /usr/src/myproject. Separate the files or directories with
 # spaces.
 # Note: If this tag is empty the current directory is searched.
-# up two dirs from FMS/build/docs
-INPUT                  = @abs_top_srcdir@
+INPUT                  = @abs_top_srcdir@ README.md
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -77,7 +77,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-#OUTPUT_DIRECTORY       =
+OUTPUT_DIRECTORY       = @abs_top_builddir@/docs
 
 # If the CREATE_SUBDIRS tag is set to YES then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and
@@ -799,7 +799,7 @@ WARN_LOGFILE           = doxywarn.log
 # spaces.
 # Note: If this tag is empty the current directory is searched.
 # up two dirs from FMS/build/docs
-INPUT                  = ../..
+INPUT                  = @abs_top_srcdir@
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -1077,7 +1077,7 @@ GENERATE_HTML          = YES
 # The default directory is: html.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_OUTPUT            = .
+HTML_OUTPUT            = @abs_top_builddir@/docs
 
 # The HTML_FILE_EXTENSION tag can be used to specify the file extension for each
 # generated HTML page (for example: .htm, .php, .asp).

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -1077,7 +1077,7 @@ GENERATE_HTML          = YES
 # The default directory is: html.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_OUTPUT            = @abs_top_builddir@/docs
+HTML_OUTPUT            =
 
 # The HTML_FILE_EXTENSION tag can be used to specify the file extension for each
 # generated HTML page (for example: .htm, .php, .asp).


### PR DESCRIPTION
**Description**
Adds a github action that generates the documentation via doxygen and deploys it via Github Pages. The action is set to update the docs when run manually by users with write access and on version releases.

Essentially the generated docs are pushed to the 'gh-pages' branch and will then be automatically hosted at https://noaa-gfdl.github.io/FMS or a different url if set in the repo settings.

There also may be some changes to be made in the repo's settings for the first deployment(described [here](https://github.com/marketplace/actions/github-pages-action#%EF%B8%8F-first-deployment-with-github_token)), but on my fork I didn't need to make any changes.

**How Has This Been Tested?**
site deployed from my branch: https://rem1776.github.io/FMS 

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

