### PR TITLE
2021.02 alpha2 bugfix?: updating timestamp . logic

### DIFF
--- a/fms/fms_io.F90
+++ b/fms/fms_io.F90
@@ -2510,9 +2510,7 @@ subroutine save_restart(fileObj, time_stamp, directory, append, time_level)
         if(len_trim(restartname)+len_trim(time_stamp) > 79) call mpp_error(FATAL, "fms_io(save_restart): " // &
           "Length of restart file name + time_stamp is greater than allowed character length of 79")
            has_dot = .false.
-           do i=1,len(time_stamp)
-              if (time_stamp(i:i) == ".") has_dot = .true.
-           enddo
+           if (time_stamp(len(time_stamp):len(time_stamp)) == ".") has_dot = .true.
            if (has_dot) then
               restartname = trim(time_stamp)//trim(restartname)
            else


### PR DESCRIPTION
**Description**
Changing the logic form checking anywhere in timestamp for a "." to specifically looking at the last char in the timestamp string.

Fixes #733 

**How Has This Been Tested?**
Tested with Intel with the SHiELD model using an intermediate restart run

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

