### PR TITLE
Make version in libFMS.F90 private

### DIFF
--- a/libFMS.F90
+++ b/libFMS.F90
@@ -425,5 +425,6 @@ module fms
 
 #include <file_version.h>
   character(len=*), parameter, public :: version_FMS = version
+  private :: version
 
 end module fms


### PR DESCRIPTION
**Description**
Just makes version private (already made public via version_fms) to solve an issue with [#56](https://github.com/NOAA-GFDL/FMScoupler/pull/56)

**How Has This Been Tested?**
Passed make check and coupler test on amd with gcc

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

