### PR TITLE
Fix for grid2.F90: When the grid_spec.nc is the mosaic file 

### DIFF
--- a/mosaic2/grid2.F90
+++ b/mosaic2/grid2.F90
@@ -94,7 +94,8 @@ integer, parameter :: &
      MAX_FILE = 1024, & ! max length of the file names
      VERSION_0 = 0,   &
      VERSION_1 = 1,   &
-     VERSION_2 = 2
+     VERSION_2 = 2,   &
+     VERSION_3 = 3
 
 integer, parameter :: BUFSIZE = 1048576  ! This is used to control memory usage in get_grid_comp_area
                                          ! We may change this to a namelist variable is needed.
@@ -121,13 +122,14 @@ subroutine grid_init
    great_circle_algorithm = get_great_circle_algorithm()
    grid_version = get_grid_version(gridfileobj)
    if (grid_version == VERSION_2) call open_component_mosaics
+   if (grid_version == VERSION_3) call assign_component_mosaics
    module_is_initialized = .TRUE.
 end subroutine grid_init
 
 !> @brief Shutdown the grid2 module
 subroutine grid_end
    if (grid_spec_exists) then
-       if (grid_version == Version_2) call close_component_mosaics
+       if (grid_version == VERSION_2) call close_component_mosaics
        call close_file(gridfileobj)
    endif
 end subroutine grid_end
@@ -199,12 +201,21 @@ function get_grid_version(fileobj)
        get_grid_version = VERSION_1
     else if(variable_exists(fileobj, 'ocn_mosaic_file') ) then
        get_grid_version = VERSION_2
+    else if(variable_exists(fileobj, 'gridfiles') ) then
+       get_grid_version = VERSION_3
     else
        call mpp_error(FATAL, module_name//'/get_grid_version '//&
             'Can''t determine the version of the grid spec: none of "x_T", "geolon_t", or "ocn_mosaic_file" exist in file "'//trim(grid_file)//'"')
     endif
   endif
 end function get_grid_version
+
+!> @brief Assign the component mosaic files if grid_spec is Version 3
+subroutine assign_component_mosaics
+    mosaic_fileobj(1) = gridfileobj
+    mosaic_fileobj(2) = gridfileobj
+    mosaic_fileobj(3) = gridfileobj
+end subroutine assign_component_mosaics
 
 !> @brief Open the component mosaic files for atm, lnd, and ocn
 subroutine open_component_mosaics
@@ -243,7 +254,7 @@ subroutine get_grid_ntiles(component,ntiles)
   select case (grid_version)
   case(VERSION_0,VERSION_1)
      ntiles = 1
-  case(VERSION_2)
+  case(VERSION_2, VERSION_3)
      ntiles = get_mosaic_ntiles(mosaic_fileobj(get_component_number(trim(component))))
   end select
 end subroutine get_grid_ntiles
@@ -263,7 +274,7 @@ subroutine get_grid_size_for_all_tiles(component,nx,ny)
   case(VERSION_0,VERSION_1)
      call get_variable_size(gridfileobj, varname1, siz)
      nx(1) = siz(1); ny(1)=siz(2)
-  case(VERSION_2) ! mosaic file
+  case(VERSION_2, VERSION_3) ! mosaic file
      call get_mosaic_grid_sizes(mosaic_fileobj(get_component_number(trim(component))),nx,ny)
   end select
 end subroutine get_grid_size_for_all_tiles
@@ -314,7 +325,7 @@ subroutine get_grid_cell_area_SG(component, tile, cellarea, domain)
      end select
      ! convert area to m2
      cellarea = cellarea*4.*PI*radius**2
-  case(VERSION_2)
+  case(VERSION_2, VERSION_3)
      if (present(domain)) then
         call mpp_get_compute_domain(domain,xsize=nlon,ysize=nlat)
      else
@@ -379,7 +390,7 @@ subroutine get_grid_comp_area_SG(component,tile,area,domain)
         call mpp_error(FATAL, module_name//'/get_grid_comp_area'//&
              'Illegal component name "'//trim(component)//'": must be one of ATM, LND, or OCN')
      end select
-  case(VERSION_2) ! mosaic gridspec
+  case(VERSION_2, VERSION_3) ! mosaic gridspec
      select case (component)
      case ('ATM')
         ! just read the grid cell area and return
@@ -587,7 +598,7 @@ subroutine get_grid_cell_vertices_1D(component, tile, glonb, glatb)
         glatb(nlat+1) = y_vert_t(1,nlat,2)
         deallocate(x_vert_t, y_vert_t)
      end select
-  case(VERSION_2)
+  case(VERSION_2, VERSION_3)
      ! get the name of the grid file for the component and tile
      tilefile = read_file_name(mosaic_fileobj(get_component_number(trim(component))), 'gridfiles',tile)
      call open_grid_file(tilefileobj, grid_dir//tilefile)
@@ -715,7 +726,7 @@ subroutine get_grid_cell_vertices_2D(component, tile, lonb, latb, domain)
         latb(nlon+1,nlat+1) = y_vert_t(nlon,nlat,3)
         deallocate(x_vert_t, y_vert_t)
      end select
-  case(VERSION_2)
+  case(VERSION_2, VERSION_3)
      ! get the name of the grid file for the component and tile
      tilefile = read_file_name(mosaic_fileobj(get_component_number(trim(component))), 'gridfiles',tile)
      call open_grid_file(tilefileobj, grid_dir//tilefile)
@@ -839,7 +850,7 @@ subroutine get_grid_cell_centers_1D(component, tile, glon, glat)
         call read_data(gridfileobj, "grid_x_T", glon)
         call read_data(gridfileobj, "grid_y_T", glat)
      end select
-  case(VERSION_2)
+  case(VERSION_2, VERSION_3)
      ! get the name of the grid file for the component and tile
      tilefile = read_file_name(mosaic_fileobj(get_component_number(trim(component))), 'gridfiles',tile)
      call open_grid_file(tilefileobj, grid_dir//tilefile)
@@ -947,7 +958,7 @@ subroutine get_grid_cell_centers_2D(component, tile, lon, lat, domain)
         call read_data(gridfileobj, 'x_T', lon)
         call read_data(gridfileobj, 'y_T', lat)
      end select
-  case(VERSION_2) ! mosaic grid file
+  case(VERSION_2, VERSION_3) ! mosaic grid file
      ! get the name of the grid file for the component and tile
      tilefile = read_file_name(mosaic_fileobj(get_component_number(trim(component))), 'gridfiles',tile)
      call open_grid_file(tilefileobj, grid_dir//tilefile)


### PR DESCRIPTION
Added another grid version in grid2.F90 wherein grid_spec.nc is itself the mosaic file.

**Description**
Most(?) grid_spec.nc files contain references to mosaic files (lnd_mosaic_file, atm_mosaic_file, etc.). However, some grid_spec.nc files in use are themselves the mosaic file, containing the list of gridfiles, contacts etc. This change to mosaic2/grid2.F90 allows for this type of grid_spec.nc file by introducing a new version within the grid2.F90 file: VERSION_3

Fixes runtime error in models that use this type of grid_spec.nc (e.g. UFS).

**How Has This Been Tested?**
All tests pass for UFS (a model which uses this type of grid_spec.nc file.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

