### PR TITLE
Replace grid_mod with grid2_mod in libFMS.F90

### DIFF
--- a/libFMS.F90
+++ b/libFMS.F90
@@ -253,9 +253,9 @@ module fms
                       calc_mosaic_grid_area, calc_mosaic_grid_great_circle_area, &
                       is_inside_polygon, &
                       mosaic2_get_mosaic_tile_grid => get_mosaic_tile_grid !overloaded in fms2_io
-  use grid_mod, only: get_grid_ntiles, get_grid_size, get_grid_cell_centers, &
+  use grid2_mod, only: get_grid_ntiles, get_grid_size, get_grid_cell_centers, &
                       get_grid_cell_vertices, get_grid_cell_Area, get_grid_comp_area, &
-                      define_cube_mosaic
+                      define_cube_mosaic, get_great_circle_algorithm, grid_init, grid_end
   use gradient_mod, only: gradient_cubic, calc_cubic_grid_info
 
   !> mpp


### PR DESCRIPTION
**Description**
Changes the `use grid_mod` in libFMS.F90 to `use grid2_mod` and adds in the new public routines.

**How Has This Been Tested?**
make check, coupler compile test

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

