### PR TITLE
2021.02 Changelog and version numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ and this project uses `yyyy.rr[.pp]`, where `yyyy` is the year a patch is releas
 `rr` is a sequential release number (starting from `01`), and an optional two-digit
 sequential patch number (starting from `01`).
 
+## [2021.02] - 2021-05-17
+### Added
+- FMS2_IO: Added fms2_io support for boundary condition restarts. `register_restart_region_2d` and `register_restart_region_3d` were added to fms2_io’s `register_restart_field` interface and `read_restart_bc` and `write_restart_bc` subroutines were added to read and write boundary conditions restarts. See test_fms/fms2_io/test_bc_restart.F90 for sample usage.
+- FMS2_IO: Added fms2_io’s version of set_filename_appendix. The string sent in will be appended to the filename of a restart/history file before the *.nc or before *.tile if tile is in the filename.
+- FMS2_IO: Added workarounds to get fms2io code “working” with pgi
+- COUPLER_TYPES: Added fms2_io’s version of `register_restarts_2/3d` and `CT_restore_state_2/3d` to the `coupler_type_register_restarts` and `coupler_type_restore_state` interfaces in coupler_types. The fms_io’s versions were renamed as mpp_io_* and both versions may still be used. See test_fms/coupler/test_coupler_*d.F90 for sample usage.
+- MPP_DOMAINS: Added a subroutine `mpp_create_super_grid_domain`, which sets the indices of the input domain to match the supergrid domain.
+- TIME_MANAGER: New `set_date_gregorian` and `get_date_gregorian` function/subroutine that do not use coded_date and date_to_day arrays are added and set as default.  The original get_date_gregorian and set_date_gregorian have been renamed to `get_date_gregorian_old` and `set_date_gregorian_old` and can be used by adding `old_method=.true.` optional argument to set_date and get_date subroutine calls.  This is the first step out of three to remove the memory-consuming `coded_date` and `date_to_day` arrays from the time_manager_mod.
+- FMS GLOBAL MODULE: Adds a new module (libFMS.F90) to be used as a global import for all supported routines/types/variables within FMS. Also adds a separate module (fmsconstants.F90) to be used for constant values from `constants_mod`.
+- GRID2: Creates a new module, `grid2_mod` as a fms2_io alternative to `grid_mod`, and creates a new directory for it with the previously updated `mosaic2_mod`.
+### Changed
+- FMS2_IO: Adds logic so that the domain decomposition variable attribute is only added if the io_layout is not 1,1.
+###Removed
+- DIAG_MANAGER: Removed the variable attributes `_FillValue` and `missing_value` from the `time_bounds` variable to be cf compliant
+- FV3GFS: Removes the unused fv3gfs directory
+###Fixed
+- DIAG_MANAGER: Fixed a bug where the variable type of `Time` and `Time_bounds` were different (float vs double) when compiling with 32 bit reals
+- FMS2_IO: Fixed a bug where the code was crashing when you were trying to read/write scalar variables with the domain decomposed fileobj
+
 ## [2021.01] - 2021-03-08
 ### Added
 - MPP: A counter for timers to report how many times a timer section is run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,17 +13,27 @@ sequential patch number (starting from `01`).
 - FMS2_IO: Added workarounds to get fms2io code “working” with pgi
 - COUPLER_TYPES: Added fms2_io’s version of `register_restarts_2/3d` and `CT_restore_state_2/3d` to the `coupler_type_register_restarts` and `coupler_type_restore_state` interfaces in coupler_types. The fms_io’s versions were renamed as mpp_io_* and both versions may still be used. See test_fms/coupler/test_coupler_*d.F90 for sample usage.
 - MPP_DOMAINS: Added a subroutine `mpp_create_super_grid_domain`, which sets the indices of the input domain to match the supergrid domain.
+- MOSAIC2/GRID2: Added a version of grid.F90 that is suitable for use with fms2_io called grid2.F90, and moved it into the mosaic2 folder along with mosaic2.F90
+- FMS_MOD: Added grid_init and grid_end calls for use with grid2.F90
 - TIME_MANAGER: New `set_date_gregorian` and `get_date_gregorian` function/subroutine that do not use coded_date and date_to_day arrays are added and set as default.  The original get_date_gregorian and set_date_gregorian have been renamed to `get_date_gregorian_old` and `set_date_gregorian_old` and can be used by adding `old_method=.true.` optional argument to set_date and get_date subroutine calls.  This is the first step out of three to remove the memory-consuming `coded_date` and `date_to_day` arrays from the time_manager_mod.
 - FMS GLOBAL MODULE: Adds a new module (libFMS.F90) to be used as a global import for all supported routines/types/variables within FMS. Also adds a separate module (fmsconstants.F90) to be used for constant values from `constants_mod`.
-- GRID2: Creates a new module, `grid2_mod` as a fms2_io alternative to `grid_mod`, and creates a new directory for it with the previously updated `mosaic2_mod`.
 ### Changed
 - FMS2_IO: Adds logic so that the domain decomposition variable attribute is only added if the io_layout is not 1,1.
+- FMS_IO: Moved get_great_circle_algorithm from fms_io to grid2.F90
+- FMS_IO: Moved routines and submodules that were not IO related to fms_mod
 ###Removed
 - DIAG_MANAGER: Removed the variable attributes `_FillValue` and `missing_value` from the `time_bounds` variable to be cf compliant
 - FV3GFS: Removes the unused fv3gfs directory
+- MOSAIC/GRID: Removed references in grid.F90 to fms_mod(replaced with mpp_mod direct calls)
+- MOSAIC/GRID: Moved mosaic/mosaic2.F90 to mosaic2 folder
 ###Fixed
 - DIAG_MANAGER: Fixed a bug where the variable type of `Time` and `Time_bounds` were different (float vs double) when compiling with 32 bit reals
 - FMS2_IO: Fixed a bug where the code was crashing when you were trying to read/write scalar variables with the domain decomposed fileobj
+### Tag Commit Hashes
+- 2021.02-alpha1 (1a653fcb86a826251e6c8d0a90db897377acc49e)
+- 2021.02-alpha2 (81a5b6ea2559e2c31edbcab32a3230dfc31287be)
+- 2021.02-beta1 (d7e564adee07073febeb263b89158f768d665689)
+- 2021.02-beta2 (9d55115a331685e4c6e01f2dfb3b770a9f80fa37)
 
 ## [2021.01] - 2021-03-08
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ cmake_minimum_required(VERSION 3.7...3.15 FATAL_ERROR)
 
 # Define the CMake project
 project(FMS
-  VERSION 2021.01
+  VERSION 2021.02.0
   DESCRIPTION  "GFDL FMS Library"
   HOMEPAGE_URL "https://www.gfdl.noaa.gov/fms"
   LANGUAGES C Fortran)

--- a/configure.ac
+++ b/configure.ac
@@ -25,7 +25,7 @@ AC_PREREQ([2.69])
 
 # Initialize with name, version, and support email address.
 AC_INIT([GFDL FMS Library],
-  [2021.01-dev],
+  [2021.02.0],
   [gfdl.climate.model.info@noaa.gov],
   [FMS],
   [https://www.gfdl.noaa.gov/fms])

--- a/libFMS/Makefile.am
+++ b/libFMS/Makefile.am
@@ -28,7 +28,7 @@ lib_LTLIBRARIES = libFMS.la
 # These linker flags specify libtool version info.
 # See http://www.gnu.org/software/libtool/manual/libtool.html#Libtool-versioning
 # for information regarding incrementing `-version-info`.
-libFMS_la_LDFLAGS = -version-info 7:0:0
+libFMS_la_LDFLAGS = -version-info 8:0:0
 
 # Add the convenience libraries to the FMS library.
 libFMS_la_LIBADD = $(top_builddir)/platform/libplatform.la


### PR DESCRIPTION
**Description**
Updates changelog for the 2021.02 release. Also adds the extra zero digit to the build version numbers.

Fixes #738

**How Has This Been Tested?**
No code changes.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

