### PR TITLE
Modified get/set_date_gregorian tests

### DIFF
--- a/test_fms/time_manager/test_time_manager.F90
+++ b/test_fms/time_manager/test_time_manager.F90
@@ -618,9 +618,9 @@ program test_time_manager
 
   if(test20) then
     write(outunit,'(/,a)') '#################################  test20  #################################'
-    write(errunit,'(/,a)') ' ====================================================='
-    write(errunit,'(a)')   '  Test get/set_date_gregorian with get/set_date_gregorian_old'
-    write(errunit,'(a,/)') ' ====================================================='
+    write(outunit,'(/,a)') ' ====================================================='
+    write(outunit,'(a)')   '  Test get/set_date_gregorian with get/set_date_gregorian_old'
+    write(outunit,'(a,/)') ' ====================================================='
     call set_calendar_type(GREGORIAN)
     call get_coded_date( coded_date, date_to_day ) ! assign coded_date and date_to_day used by get/set_date_gregorian_old
 

--- a/test_fms/time_manager/test_time_manager.F90
+++ b/test_fms/time_manager/test_time_manager.F90
@@ -49,9 +49,14 @@ program test_time_manager
  character(len=8) :: test_name
  character(len=256) :: out_msg
 
-logical :: test1 =.true.,test2 =.true.,test3 =.true.,test4 =.true.,test5 =.true.,test6 =.true.,test7 =.true.,test8 =.true.
-logical :: test9 =.true.,test10=.true.,test11=.true.,test12=.true.,test13=.true.,test14=.true.,test15=.true.,test16=.true.
-logical :: test17=.true.,test18=.true.,test19=.true.,test20=.true.
+ !: for gregorian calendar
+ integer, parameter :: days_in_400_year_period = 146097
+ integer, dimension(days_in_400_year_period) :: coded_date
+ integer, dimension(400,12,31) :: date_to_day
+
+ logical :: test1 =.true.,test2 =.true.,test3 =.true.,test4 =.true.,test5 =.true.,test6 =.true.,test7 =.true.,test8 =.true.
+ logical :: test9 =.true.,test10=.true.,test11=.true.,test12=.true.,test13=.true.,test14=.true.,test15=.true.,test16=.true.
+ logical :: test17=.true.,test18=.true.,test19=.true.,test20=.true.
 
  namelist / test_nml / test1 ,test2 ,test3 ,test4 ,test5 ,test6 ,test7 ,test8,  &
                        test9 ,test10,test11,test12,test13,test14,test15,test16, &
@@ -608,12 +613,16 @@ logical :: test17=.true.,test18=.true.,test19=.true.,test20=.true.
   write(outunit,'(a,i6)') ' ticks_per_second=',get_ticks_per_second()
 
  !==============================================================================================
- !  Tests the new set/get_date_gregorian by comparing against the old set/get_date_gregorian invoked with old_method=.true.
+ !  Tests the new set/get_date_gregorian by comparing against the old set/get_date_gregorian added to this test program
  !  This test loops through every day up to year 3200
 
   if(test20) then
     write(outunit,'(/,a)') '#################################  test20  #################################'
+    write(errunit,'(/,a)') ' ====================================================='
+    write(errunit,'(a)')   '  Test get/set_date_gregorian with get/set_date_gregorian_old'
+    write(errunit,'(a,/)') ' ====================================================='
     call set_calendar_type(GREGORIAN)
+    call get_coded_date( coded_date, date_to_day ) !: assign coded_date and date_to_day used by the old greg calendar
     do year=1, 3200
       leap = mod(year,4) == 0
       leap = leap .and. .not.mod(year,100) == 0
@@ -624,48 +633,149 @@ logical :: test17=.true.,test18=.true.,test19=.true.,test20=.true.
         do dday=1,days_this_month
           !: test new set_date_gregorian
           Time  = set_date(year, month, dday, 0, 0, 0)
-          Time0 = set_date(year, month, dday, 0, 0, 0, old_method=.true.)
-          if( .not.(Time == Time0) ) call mpp_error(FATAl,'Error testing set_date_gregorian: Time != Time0')
-          call get_date(Time, yr, mo, day, hr, min, sec, old_method=.true.)
-          call get_date(Time0, yr0, mo0, day0, hr0, min0, sec0, old_method=.true.)
-          if( yr0.ne.yr .or. mo0.ne.mo .or. day0.ne.day ) then
-            write(outunit,"('expected year ',i5,'but got year ',i5)") yr0, yr
-            write(outunit,"('expected month',i5,'but got month',i5)") mo0, mo
-            write(outunit,"('expected day  ',i5,'but got day  ',i5)") day0, day
-            call mpp_error(FATAl,'Error testing set_date_gregorian')
+          Time0 = set_date_gregorian_old(year, month, dday, 0, 0, 0, 0, date_to_day)
+          if( .not. (Time==Time0) ) then
+             write(outunit,*) year, month, dday
+             call mpp_error(FATAL, 'failed set_date')
           end if
-          ! test new get_date_gregorian
+          !: test #1 get_date
           call get_date(Time0, yr, mo, day, hr, min, sec)
-          call get_date(Time0, yr0, mo0, day0, hr0, min0, sec0, old_method=.true.)
+          call get_date_gregorian_old(Time0, coded_date, yr0, mo0, day0, hr0, min0, sec0, ticks0)
           if( yr0.ne.yr .or. mo0.ne.mo .or. day0.ne.day ) then
             write(outunit,"('expected year ',i5,'but got year ',i5)") yr0, yr
             write(outunit,"('expected month',i5,'but got month',i5)") mo0, mo
             write(outunit,"('expected day  ',i5,'but got day  ',i5)") day0, day
             call mpp_error(FATAl,'Error testing get_date_gregorian 1')
           end if
+          !: test #2 get_date
           call get_date(Time, yr, mo, day, hr, min, sec)
-          call get_date(Time, yr0, mo0, day0, hr0, min0, sec0, old_method=.true.)
+          call get_date_gregorian_old(Time, coded_date, yr0, mo0, day0, hr0, min0, sec0, ticks0)
           if( yr0.ne.yr .or. mo0.ne.mo .or. day0.ne.day ) then
             write(outunit,"('expected year ',i5,'but got year ',i5)") yr0, yr
             write(outunit,"('expected month',i5,'but got month',i5)") mo0, mo
             write(outunit,"('expected day  ',i5,'but got day  ',i5)") day0, day
-            call mpp_error(FATAl,'Error testing set_date_gregorian 2')
+            call mpp_error(FATAl,'Error testing get_date_gregorian 1')
           end if
+          !: test #3 get_date
           call get_date(Time, yr, mo, day, hr, min, sec)
-          call get_date(Time0, yr0, mo0, day0, hr0, min0, sec0, old_method=.true.)
+          call get_date_gregorian_old(Time0, coded_date, yr0, mo0, day0, hr0, min0, sec0, ticks0)
           if( yr0.ne.yr .or. mo0.ne.mo .or. day0.ne.day ) then
             write(outunit,"('expected year ',i5,'but got year ',i5)") yr0, yr
             write(outunit,"('expected month',i5,'but got month',i5)") mo0, mo
             write(outunit,"('expected day  ',i5,'but got day  ',i5)") day0, day
-            call mpp_error(FATAl,'Error testing set_date_gregorian 2')
+            call mpp_error(FATAl,'Error testing get_date_gregorian 1')
+          end if
+          !: test #4 get_date
+          call get_date(Time0, yr, mo, day, hr, min, sec)
+          call get_date_gregorian_old(Time, coded_date, yr0, mo0, day0, hr0, min0, sec0, ticks0)
+          if( yr0.ne.yr .or. mo0.ne.mo .or. day0.ne.day ) then
+            write(outunit,"('expected year ',i5,'but got year ',i5)") yr0, yr
+            write(outunit,"('expected month',i5,'but got month',i5)") mo0, mo
+            write(outunit,"('expected day  ',i5,'but got day  ',i5)") day0, day
+            call mpp_error(FATAl,'Error testing get_date_gregorian 1')
           end if
         enddo
       enddo
     enddo
-    write(outunit,'(a)') 'test successful'
-  endif
+    write(outunit,'(a)') 'set_date_gregorian test successful'
+ endif
 
- call fms_io_exit
- call fms_end
+  call fms_io_exit
+  call fms_end
 
- end program test_time_manager
+contains
+
+  subroutine get_coded_date(coded_date_old, date_to_day_old)
+
+    implicit none
+
+    integer, parameter :: days_in_400_year_period = 146097
+    integer, intent(inout), dimension(days_in_400_year_period) :: coded_date_old
+    integer, intent(inout), dimension(400,12,31) :: date_to_day_old
+
+    integer :: iday, days_this_month, year, month, day
+    logical :: leap
+    character(len=256) :: err_msg_local
+
+    iday = 0
+    do year=1,400
+       leap = mod(year,4) == 0
+       leap = leap .and. .not.mod(year,100) == 0
+       leap = leap .or. mod(year,400) == 0
+       do month=1,12
+          days_this_month = days_per_month(month)
+          if(leap .and. month ==2) days_this_month = 29
+          do day=1,days_this_month
+             date_to_day_old(year,month,day) = iday
+             iday = iday+1
+             coded_date_old(iday) = day + 32*(month + 16*year)
+          enddo ! do day
+       enddo ! do month
+    enddo ! do year
+
+  end subroutine get_coded_date
+
+  subroutine get_date_gregorian_old(time, coded_date, year, month, day, hour, minute, second, tick)
+
+    ! Computes date corresponding to time for gregorian calendar
+    use time_manager_mod, only : set_time
+    use fms_mod, only : error_mesg
+
+    type(time_type), intent(in) :: time
+    integer, intent(in), dimension(146097) :: coded_date
+    integer, intent(out) :: year, month, day, hour, minute, second
+    integer, intent(out) :: tick
+
+    integer :: iday, isec, time_days, time_seconds, time_ticks
+
+    call get_time(Time, seconds=time_seconds, days=time_days, ticks=time_ticks)
+
+    iday = mod(time_days+1, days_in_400_year_period)
+    if(iday == 0) iday = days_in_400_year_period
+
+    year = coded_date(iday)/512
+    day = mod(coded_date(iday),32)
+    month = coded_date(iday)/32 - 16*year
+
+    year = year + 400*(time_days/days_in_400_year_period)
+
+    hour   = time_seconds / 3600
+    isec   = time_seconds - 3600*hour
+    minute = isec / 60
+    second = isec - 60*minute
+    tick   = time_ticks
+
+ end subroutine get_date_gregorian_old
+
+!> @brief Sets Time_out%days on a Gregorian calendar.  This is the original/old subroutine.
+!! Look up the total number of days between 1/1/0001 to the current month/day/year in the array date_to_day
+!! This function is kept in order to test the new set_date_gregorian
+ function set_date_gregorian_old(year, month, day, hour, minute, second, tick, date_to_day)
+
+! Computes time corresponding to date for gregorian calendar.
+
+ use time_manager_mod, only: set_time
+
+ type(time_type) :: set_date_gregorian_old
+
+ integer, intent(in)  :: year, month, day, hour, minute, second, tick
+ integer, intent(in),  dimension(400,12,31) :: date_to_day
+
+ integer, parameter :: days_in_400_year_period = 146097        ! Used only for gregorian
+ integer, dimension(days_in_400_year_period) :: coded_date     ! Used only for gregorian
+
+ integer :: yr1, day1, second1
+
+ second1 = second + 60*(minute + 60*hour)
+
+ yr1 = mod(year,400)
+ if(yr1 == 0) yr1 = 400
+ day1 = date_to_day(yr1,month,day)
+
+ day1 = day1 + days_in_400_year_period*((year-1)/400)
+ set_date_gregorian_old = set_time(seconds=second1, days=day1, ticks=tick)
+
+end function set_date_gregorian_old
+
+
+end program test_time_manager

--- a/test_fms/time_manager/test_time_manager.F90
+++ b/test_fms/time_manager/test_time_manager.F90
@@ -46,7 +46,7 @@ program test_time_manager
  character(len=256) :: err_msg, char_date
  character(len=8),  allocatable, dimension(:) :: test_time
  character(len=23), allocatable, dimension(:) :: test_date
- character(len=8)   :: test_name
+ character(len=8) :: test_name
  character(len=256) :: out_msg
 
  !: for testing set/get_date_gregorian

--- a/test_fms/time_manager/test_time_manager.F90
+++ b/test_fms/time_manager/test_time_manager.F90
@@ -623,6 +623,66 @@ program test_time_manager
     write(errunit,'(a,/)') ' ====================================================='
     call set_calendar_type(GREGORIAN)
     call get_coded_date( coded_date, date_to_day ) ! assign coded_date and date_to_day used by get/set_date_gregorian_old
+
+    ! Check that the get/set_date_gregorian_old here are the same as in time_manager
+    ! This part of the test will be deleted when the old methods are removed from time_manager
+    do year=1, 3200
+      leap = mod(year,4) == 0
+      leap = leap .and. .not.mod(year,100) == 0
+      leap = leap .or. mod(year,400) == 0
+      do month=1,12
+        days_this_month = days_per_month(month)
+        if(leap .and. month == 2) days_this_month = 29
+        do dday=1,days_this_month
+          ! test set_date_gregorian
+          Time  = set_date(year, month, dday, 0, 0, 0, old_method=.true.)
+          Time0 = set_date_gregorian_old(year, month, dday, 0, 0, 0, 0, date_to_day)
+          if( .not. (Time==Time0) ) then
+            write(outunit,'("ERROR with year",i5,"mo",i5,"dday",i5)') year, month, dday
+            call mpp_error(FATAL, 'ERROR testing set_date_gregorian_old:  Time!=Time0')
+          end if
+          ! test #1 get_date
+          call get_date(Time0, yr, mo, day, hr, min, sec, old_method=.true.)
+          call get_date_gregorian_old(Time0, coded_date, yr0, mo0, day0, hr0, min0, sec0, ticks0)
+          if( yr0.ne.yr .or. mo0.ne.mo .or. day0.ne.day ) then
+            write(outunit,"('expected year ',i5,'but got year ',i5)") yr0, yr
+            write(outunit,"('expected month',i5,'but got month',i5)") mo0, mo
+            write(outunit,"('expected day  ',i5,'but got day  ',i5)") day0, day
+            call mpp_error(FATAl,'Error testing get_date_gregorian_old 1')
+          end if
+          ! test #2 get_date
+          call get_date(Time, yr, mo, day, hr, min, sec, old_method=.true.)
+          call get_date_gregorian_old(Time, coded_date, yr0, mo0, day0, hr0, min0, sec0, ticks0)
+          if( yr0.ne.yr .or. mo0.ne.mo .or. day0.ne.day ) then
+            write(outunit,"('expected year ',i5,'but got year ',i5)") yr0, yr
+            write(outunit,"('expected month',i5,'but got month',i5)") mo0, mo
+            write(outunit,"('expected day  ',i5,'but got day  ',i5)") day0, day
+            call mpp_error(FATAl,'Error testing get_date_gregorian 2')
+          end if
+          ! test #3 get_date
+          call get_date(Time, yr, mo, day, hr, min, sec, old_method=.true.)
+          call get_date_gregorian_old(Time0, coded_date, yr0, mo0, day0, hr0, min0, sec0, ticks0)
+          if( yr0.ne.yr .or. mo0.ne.mo .or. day0.ne.day ) then
+            write(outunit,"('expected year ',i5,'but got year ',i5)") yr0, yr
+            write(outunit,"('expected month',i5,'but got month',i5)") mo0, mo
+            write(outunit,"('expected day  ',i5,'but got day  ',i5)") day0, day
+            call mpp_error(FATAl,'Error testing get_date_gregorian 3')
+          end if
+          ! test #4 get_date
+          call get_date(Time0, yr, mo, day, hr, min, sec, old_method=.true.)
+          call get_date_gregorian_old(Time, coded_date, yr0, mo0, day0, hr0, min0, sec0, ticks0)
+          if( yr0.ne.yr .or. mo0.ne.mo .or. day0.ne.day ) then
+            write(outunit,"('expected year ',i5,'but got year ',i5)") yr0, yr
+            write(outunit,"('expected month',i5,'but got month',i5)") mo0, mo
+            write(outunit,"('expected day  ',i5,'but got day  ',i5)") day0, day
+            call mpp_error(FATAl,'Error testing get_date_gregorian 4')
+          end if
+        enddo
+      enddo
+    enddo
+    write(outunit,'(a)') 'set_date_gregorian_old and get_date_gregorian_old tests successful'
+
+    ! test the new Gregorian methods and compare with the old methods
     do year=1, 3200
       leap = mod(year,4) == 0
       leap = leap .and. .not.mod(year,100) == 0
@@ -636,7 +696,7 @@ program test_time_manager
           Time0 = set_date_gregorian_old(year, month, dday, 0, 0, 0, 0, date_to_day)
           if( .not. (Time==Time0) ) then
              write(outunit,'("ERROR with year",i5,"mo",i5,"dday",i5)') year, month, dday
-             call mpp_error(FATAL, 'TEST 20 failed with set_date')
+             call mpp_error(FATAL, 'ERROR testing set_date_gregorian:  Time!=Time0')
           end if
           !: test #1 get_date
           call get_date(Time0, yr, mo, day, hr, min, sec)
@@ -685,11 +745,9 @@ program test_time_manager
 
 contains
 
+  ! get_coded_date:  copied from subroutine set_calendar_type in time_manager and slightly modified
+  ! to work in this test program.
   subroutine get_coded_date(coded_date_old, date_to_day_old)
-
-    ! copied from subroutine set_calendar_type in time_manager and slightly modified
-    ! to work in this test program.  This part in set_calendar_type
-    ! will be deleted in time_manager/time_manager.F90
 
     implicit none
 
@@ -698,46 +756,42 @@ contains
 
     integer :: iday, days_this_month, year, month, day
     logical :: leap
-    character(len=256) :: err_msg_local
 
     iday = 0
      date_to_day = -1 ! invalid_date = -1 in time_manager
      do year=1,400
-        leap = mod(year,4) == 0
-        leap = leap .and. .not.mod(year,100) == 0
-        leap = leap .or. mod(year,400) == 0
-        do month=1,12
-           days_this_month = days_per_month(month)
-           if(leap .and. month ==2) days_this_month = 29
-           do day=1,days_this_month
-              date_to_day_old(year,month,day) = iday
-              iday = iday+1
-              coded_date_old(iday) = day + 32*(month + 16*year)
-           enddo ! do day
-        enddo ! do month
+       leap = mod(year,4) == 0
+       leap = leap .and. .not.mod(year,100) == 0
+       leap = leap .or. mod(year,400) == 0
+       do month=1,12
+         days_this_month = days_per_month(month)
+         if(leap .and. month ==2) days_this_month = 29
+         do day=1,days_this_month
+           date_to_day_old(year,month,day) = iday
+           iday = iday+1
+           coded_date_old(iday) = day + 32*(month + 16*year)
+         enddo ! do day
+       enddo ! do month
      enddo ! do year
 
-   end subroutine get_coded_date
+  end subroutine get_coded_date
 
+  ! get_date_gregorian_old:  original get_date_gregorian subroutine in time_manager that has been slightly
+  ! modified to work in this test program
+  subroutine get_date_gregorian_old(time, coded_date, year, month, day, hour, minute, second, tick)
 
-   subroutine get_date_gregorian_old(time, coded_date, year, month, day, hour, minute, second, tick)
+    use time_manager_mod, only : set_time
 
-     ! Original get_date_gregorian subroutine in time_manager that has been slightly
-     ! modified to work in this test program
+    integer, parameter :: days_in_400_year_period = 146097
 
-     use time_manager_mod, only : set_time
-     use fms_mod, only : error_mesg
+    type(time_type), intent(in) :: time
+    integer, intent(in), dimension(days_in_400_year_period) :: coded_date
+    integer, intent(out) :: year, month, day, hour, minute, second
+    integer, intent(out) :: tick
 
-     integer, parameter :: days_in_400_year_period = 146097
+    integer :: iday, isec, time_days, time_seconds, time_ticks
 
-     type(time_type), intent(in) :: time
-     integer, intent(in), dimension(days_in_400_year_period) :: coded_date
-     integer, intent(out) :: year, month, day, hour, minute, second
-     integer, intent(out) :: tick
-
-     integer :: iday, isec, time_days, time_seconds, time_ticks
-
-     ! set time_days=Time%days and time_seconds=Time%seconds, time_ticks=Time%ticks
+    ! set time_days=Time%days and time_seconds=Time%seconds, time_ticks=Time%ticks
     call get_time(Time, seconds=time_seconds, days=time_days, ticks=time_ticks)
 
     iday = mod(time_days+1, days_in_400_year_period)
@@ -757,34 +811,31 @@ contains
 
   end subroutine get_date_gregorian_old
 
+  ! set_date_gregorian_old: original set_date_gregorian function in time_manager that has been slightly
+  ! modified to work in this test program
+  function set_date_gregorian_old(year, month, day, hour, minute, second, tick, date_to_day)
 
- function set_date_gregorian_old(year, month, day, hour, minute, second, tick, date_to_day)
+    use time_manager_mod, only: set_time
 
- ! Original set_date_gregorian subroutine in time_manager that has been slightly
- ! modified to work in this test program
+    type(time_type) :: set_date_gregorian_old
 
- use time_manager_mod, only: set_time
+    integer, parameter :: days_in_400_year_period = 146097
 
- type(time_type) :: set_date_gregorian_old
+    integer, intent(in)  :: year, month, day, hour, minute, second, tick
+    integer, intent(in),  dimension(400,12,31) :: date_to_day
 
- integer, parameter :: days_in_400_year_period = 146097        ! Used only for gregorian
+    integer :: yr1, day1, second1
 
- integer, intent(in)  :: year, month, day, hour, minute, second, tick
- integer, intent(in),  dimension(400,12,31) :: date_to_day
+    second1 = second + 60*(minute + 60*hour)
 
- integer :: yr1, day1, second1
+    yr1 = mod(year,400)
+    if(yr1 == 0) yr1 = 400
+    day1 = date_to_day(yr1,month,day)
 
- second1 = second + 60*(minute + 60*hour)
+    day1 = day1 + days_in_400_year_period*((year-1)/400)
 
- yr1 = mod(year,400)
- if(yr1 == 0) yr1 = 400
- day1 = date_to_day(yr1,month,day)
+    set_date_gregorian_old = set_time(seconds=second1, days=day1, ticks=tick)
 
- day1 = day1 + days_in_400_year_period*((year-1)/400)
-
- set_date_gregorian_old = set_time(seconds=second1, days=day1, ticks=tick)
-
- end function set_date_gregorian_old
-
+  end function set_date_gregorian_old
 
 end program test_time_manager

--- a/test_fms/time_manager/test_time_manager.F90
+++ b/test_fms/time_manager/test_time_manager.F90
@@ -46,7 +46,7 @@ program test_time_manager
  character(len=256) :: err_msg, char_date
  character(len=8),  allocatable, dimension(:) :: test_time
  character(len=23), allocatable, dimension(:) :: test_date
- character(len=8) :: test_name
+ character(len=8)   :: test_name
  character(len=256) :: out_msg
 
  !: for testing set/get_date_gregorian

--- a/test_fms/time_manager/test_time_manager.F90
+++ b/test_fms/time_manager/test_time_manager.F90
@@ -613,7 +613,7 @@ program test_time_manager
   write(outunit,'(a,i6)') ' ticks_per_second=',get_ticks_per_second()
 
  !==============================================================================================
- !  Tests the new set/get_date_gregorian by comparing against the old set/get_date_gregorian added to this test program
+ !  Tests the new set/get_date_gregorian by comparing against the old set/get_date_gregorian copied over to this test program
  !  This test loops through every day up to year 3200
 
   if(test20) then
@@ -691,14 +691,14 @@ program test_time_manager
         days_this_month = days_per_month(month)
         if(leap .and. month == 2) days_this_month = 29
         do dday=1,days_this_month
-          !: test new set_date_gregorian
+          ! test new set_date_gregorian
           Time  = set_date(year, month, dday, 0, 0, 0)
           Time0 = set_date_gregorian_old(year, month, dday, 0, 0, 0, 0, date_to_day)
           if( .not. (Time==Time0) ) then
              write(outunit,'("ERROR with year",i5,"mo",i5,"dday",i5)') year, month, dday
              call mpp_error(FATAL, 'ERROR testing set_date_gregorian:  Time!=Time0')
           end if
-          !: test #1 get_date
+          ! test #1 get_date
           call get_date(Time0, yr, mo, day, hr, min, sec)
           call get_date_gregorian_old(Time0, coded_date, yr0, mo0, day0, hr0, min0, sec0, ticks0)
           if( yr0.ne.yr .or. mo0.ne.mo .or. day0.ne.day ) then
@@ -707,7 +707,7 @@ program test_time_manager
             write(outunit,"('expected day  ',i5,'but got day  ',i5)") day0, day
             call mpp_error(FATAl,'Error testing get_date_gregorian 1')
           end if
-          !: test #2 get_date
+          ! test #2 get_date
           call get_date(Time, yr, mo, day, hr, min, sec)
           call get_date_gregorian_old(Time, coded_date, yr0, mo0, day0, hr0, min0, sec0, ticks0)
           if( yr0.ne.yr .or. mo0.ne.mo .or. day0.ne.day ) then
@@ -716,7 +716,7 @@ program test_time_manager
             write(outunit,"('expected day  ',i5,'but got day  ',i5)") day0, day
             call mpp_error(FATAl,'Error testing get_date_gregorian 2')
           end if
-          !: test #3 get_date
+          ! test #3 get_date
           call get_date(Time, yr, mo, day, hr, min, sec)
           call get_date_gregorian_old(Time0, coded_date, yr0, mo0, day0, hr0, min0, sec0, ticks0)
           if( yr0.ne.yr .or. mo0.ne.mo .or. day0.ne.day ) then
@@ -725,7 +725,7 @@ program test_time_manager
             write(outunit,"('expected day  ',i5,'but got day  ',i5)") day0, day
             call mpp_error(FATAl,'Error testing get_date_gregorian 3')
           end if
-          !: test #4 get_date
+          ! test #4 get_date
           call get_date(Time0, yr, mo, day, hr, min, sec)
           call get_date_gregorian_old(Time, coded_date, yr0, mo0, day0, hr0, min0, sec0, ticks0)
           if( yr0.ne.yr .or. mo0.ne.mo .or. day0.ne.day ) then

--- a/time_manager/time_manager.F90
+++ b/time_manager/time_manager.F90
@@ -157,11 +157,11 @@ integer, parameter :: max_type = 4
 integer, private :: days_per_month(12) = (/31,28,31,30,31,30,31,31,30,31,30,31/)
 integer, parameter :: seconds_per_day = rseconds_per_day  ! This should automatically cast real to integer
 integer, parameter :: days_in_400_year_period = 146097    ! Used only for gregorian
-integer, dimension(days_in_400_year_period) :: coded_date ! Used only for gregorian
-integer, dimension(400,12,31) :: date_to_day              ! Used only for gregorian
-integer, parameter :: invalid_date=-1                     ! Used only for gregorian
-integer,parameter :: do_floor = 0
-integer,parameter :: do_nearest = 1
+integer, dimension(days_in_400_year_period) :: coded_date ! Used only for gregorian, to be removed
+integer, dimension(400,12,31) :: date_to_day              ! Used only for gregorian, to be removed
+integer, parameter :: invalid_date=-1                     ! Used only for gregorian, to be removed
+integer, parameter :: do_floor = 0
+integer, parameter :: do_nearest = 1
 
 
 ! time_type is implemented as seconds and days to allow for larger intervals
@@ -1520,11 +1520,12 @@ end function repeat_alarm
 !     if(err_msg /= '') call error_mesg('my_routine','additional info: '//trim(err_msg),FATAL)
 !   </OUT>
 
-!> @brief Sets calendar_type. The arrays coded_date and days_this_month used for the Gregorian calendar
-!! are assigned in this subroutine.  The arrays and this component of the subroutine has been kept in order to be used by the original/old
-!! get_date_gregorian and set_date_gregorian which are now called get_date_gregorian_old and set_date_gregorian_old.  The
-!! get/set_date_gregorian_old subroutines have been kept in order to test the new get/set_date_gregorian. The new get/set_date_gregorian
-!! do not utilize the coded_date and days_this_month arrays.  As done in the get/set_date_gregorian_old, in the new routines,
+!> @brief Sets calendar_type. The coded_date and days_this_month arrays that were used for the Gregorian calendar
+!! are assigned in this subroutine.  The new get/set_date_gregorian do not thesearrays.  The arrays and the
+!! associated component of the subroutine have been kept in order to be used by the original/old get_date_gregorian
+!! and set_date_gregorian which are now called get_date_gregorian_old and set_date_gregorian_old.
+!! The get/set_date_gregorian_old subroutines have been kept for testing and will be removed by FMS 2021.04.
+!! As done in the get/set_date_gregorian_old, in the new routines,
 !! negative years and the proleptic Gregorian calendar are not used; and the discontinuity of days in October 1582
 !! (when the Gregorian calendar was adopted by select groups in Europe) is not taken into account.
 subroutine set_calendar_type(type, err_msg)
@@ -1555,6 +1556,7 @@ endif
 
 calendar_type = type
 
+! this section will be removed in the future
 if(type == GREGORIAN) then
   date_to_day = invalid_date
   iday = 0
@@ -1678,8 +1680,7 @@ end function get_ticks_per_second
 !   </OUT>
 
 !> @brief Gets the date for different calendar types.
-!! The added optional argument old_method allows user to choose either the new or old version
-!! of get_date_gregorian.  The variable old_method is only useful if the calendar type is Gregorian
+!! For calanedar_type = Gregorian, the new get_date_gregorian is called
  subroutine get_date(time, year, month, day, hour, minute, second, tick, err_msg)
 
 ! Given a time, computes the corresponding date given the selected calendar
@@ -1740,9 +1741,9 @@ end function get_ticks_per_second
  integer :: yearx, monthx, dayx, idayx !< temporary values for year, month, day
  integer :: i                          !< counter, dummy variable
 
- ! Computes date corresponding to time for gregorian calendar
+ ! Computes the date from time%days for the gregorian calendar
 
- !Carried over from the old subroutine
+ ! Carried over from the old subroutine
  if(Time%seconds >= 86400) then ! This check appears to be unecessary.
    call error_mesg('get_date','Time%seconds .ge. 86400 in subroutine get_date_gregorian',FATAL)
  endif
@@ -1807,7 +1808,7 @@ end function get_ticks_per_second
 
 !> @brief Gets the date on a Gregorian calendar.  This is the original/old subroutine.
 !! Looks up the year, month, day from the coded_date array
-!! This subroutine is kept in order to test the new get_date_gregorian
+!! This subroutine will be removed for 2021.04
  subroutine get_date_gregorian_old(time, year, month, day, hour, minute, second, tick)
 
 ! Computes date corresponding to time for gregorian calendar
@@ -2044,8 +2045,7 @@ end function get_ticks_per_second
 !   <OUT NAME="set_date" TYPE="time_type"> A time interval.</OUT>
 
 !> @brief Sets days for different calendar types.
-!! The added optional argument old_method allows user to choose either the new or old version
-!! of set_date_gregorian.  The variable old_method is only useful if the calendar type is Gregorian
+!! For calendar_type = Gregorian, the new set_date_gregorian is called
  function set_date_private(year, month, day, hour, minute, second, tick, Time_out, err_msg)
 
 ! Given a date, computes the corresponding time given the selected
@@ -2085,8 +2085,6 @@ end function get_ticks_per_second
 !------------------------------------------------------------------------
 
 !> @brief Calls set_date_private to set days for different calendar types.
-!! The added optional argument old_method allows user to choose either the new or old version
-!! of set_date_gregorian. The variable old_method is only useful if the calendar type is Gregorian
  function set_date_i(year, month, day, hour, minute, second, tick, err_msg)
  type(time_type) :: set_date_i
  integer, intent(in) :: day, month, year
@@ -2112,8 +2110,6 @@ end function get_ticks_per_second
 !------------------------------------------------------------------------
 
 !> @brief Calls set_date_private for different calendar types when given a string input.
-!! The added optional argument old_method allows user to choose either the new or old version
-!! of set_date_gregorian. The variable old_method is only useful if the calendar type is Gregorian
  function set_date_c(string, zero_year_warning, err_msg, allow_rounding)
 
  ! Examples of acceptable forms of string:
@@ -2324,7 +2320,7 @@ end function get_ticks_per_second
 
 !> @brief Sets Time_out%days on a Gregorian calendar.  This is the original/old subroutine.
 !! Look up the total number of days between 1/1/0001 to the current month/day/year in the array date_to_day
-!! This function is kept in order to test the new set_date_gregorian
+!! This function will be removed by 2021.04
  function set_date_gregorian_old(year, month, day, hour, minute, second, tick, Time_out, err_msg)
  logical :: set_date_gregorian_old
 

--- a/time_manager/time_manager.F90
+++ b/time_manager/time_manager.F90
@@ -156,10 +156,10 @@ integer, parameter :: max_type = 4
 ! Define number of days per month
 integer, private :: days_per_month(12) = (/31,28,31,30,31,30,31,31,30,31,30,31/)
 integer, parameter :: seconds_per_day = rseconds_per_day  ! This should automatically cast real to integer
-integer, parameter :: days_in_400_year_period = 146097    ! Used only for gregorian
-integer, dimension(days_in_400_year_period) :: coded_date ! Used only for gregorian, to be removed soon
-integer, dimension(400,12,31) :: date_to_day              ! Used only for gregorian, to be removed soon
-integer, parameter :: invalid_date=-1                     ! Used only for gregorian, to be removed soon
+integer, parameter :: days_in_400_year_period = 146097    !> Used only for gregorian
+integer, dimension(days_in_400_year_period) :: coded_date !> Used only for gregorian, to be removed soon
+integer, dimension(400,12,31) :: date_to_day              !> Used only for gregorian, to be removed soon
+integer, parameter :: invalid_date=-1                     !> Used only for gregorian, to be removed soon
 integer,parameter :: do_floor = 0
 integer,parameter :: do_nearest = 1
 

--- a/time_manager/time_manager.F90
+++ b/time_manager/time_manager.F90
@@ -157,20 +157,20 @@ integer, parameter :: max_type = 4
 integer, private :: days_per_month(12) = (/31,28,31,30,31,30,31,31,30,31,30,31/)
 integer, parameter :: seconds_per_day = rseconds_per_day  ! This should automatically cast real to integer
 integer, parameter :: days_in_400_year_period = 146097    ! Used only for gregorian
-integer, dimension(days_in_400_year_period) :: coded_date ! Used only for gregorian, to be removed
-integer, dimension(400,12,31) :: date_to_day              ! Used only for gregorian, to be removed
-integer, parameter :: invalid_date=-1                     ! Used only for gregorian, to be removed
-integer, parameter :: do_floor = 0
-integer, parameter :: do_nearest = 1
+integer, dimension(days_in_400_year_period) :: coded_date ! Used only for gregorian, to be removed soon
+integer, dimension(400,12,31) :: date_to_day              ! Used only for gregorian, to be removed soon
+integer, parameter :: invalid_date=-1                     ! Used only for gregorian, to be removed soon
+integer,parameter :: do_floor = 0
+integer,parameter :: do_nearest = 1
 
 
 ! time_type is implemented as seconds and days to allow for larger intervals
 type time_type
    private
-   integer :: seconds
-   integer :: days
-   integer :: ticks
-   integer :: dummy ! added as a workaround bug on IRIX64 (AP)
+   integer:: seconds
+   integer:: days
+   integer:: ticks
+   integer:: dummy ! added as a workaround bug on IRIX64 (AP)
 end type time_type
 
 !======================================================================
@@ -1520,12 +1520,11 @@ end function repeat_alarm
 !     if(err_msg /= '') call error_mesg('my_routine','additional info: '//trim(err_msg),FATAL)
 !   </OUT>
 
-!> @brief Sets calendar_type. The coded_date and days_this_month arrays that were used for the Gregorian calendar
-!! are assigned in this subroutine.  The new get/set_date_gregorian do not thesearrays.  The arrays and the
-!! associated component of the subroutine have been kept in order to be used by the original/old get_date_gregorian
-!! and set_date_gregorian which are now called get_date_gregorian_old and set_date_gregorian_old.
-!! The get/set_date_gregorian_old subroutines have been kept for testing and will be removed by FMS 2021.04.
-!! As done in the get/set_date_gregorian_old, in the new routines,
+!> @brief Sets calendar_type. The arrays coded_date and days_this_month used for the Gregorian calendar
+!! are assigned in this subroutine.  The arrays and this component of the subroutine has been kept in order to be used by the original/old
+!! get_date_gregorian and set_date_gregorian which are now called get_date_gregorian_old and set_date_gregorian_old.  The
+!! get/set_date_gregorian_old subroutines have been kept in order to test the new get/set_date_gregorian. The new get/set_date_gregorian
+!! do not utilize the coded_date and days_this_month arrays.  As done in the get/set_date_gregorian_old, in the new routines,
 !! negative years and the proleptic Gregorian calendar are not used; and the discontinuity of days in October 1582
 !! (when the Gregorian calendar was adopted by select groups in Europe) is not taken into account.
 subroutine set_calendar_type(type, err_msg)
@@ -1556,7 +1555,7 @@ endif
 
 calendar_type = type
 
-! this section will be removed in the future
+! this part is to be removed soon with set/get_date_gregorian
 if(type == GREGORIAN) then
   date_to_day = invalid_date
   iday = 0
@@ -1680,8 +1679,9 @@ end function get_ticks_per_second
 !   </OUT>
 
 !> @brief Gets the date for different calendar types.
-!! For calanedar_type = Gregorian, the new get_date_gregorian is called
- subroutine get_date(time, year, month, day, hour, minute, second, tick, err_msg)
+!! The added optional argument old_method allows user to choose either the new or old version
+!! of get_date_gregorian.  The variable old_method is only useful if the calendar type is Gregorian
+ subroutine get_date(time, year, month, day, hour, minute, second, tick, err_msg, old_method)
 
 ! Given a time, computes the corresponding date given the selected calendar
 
@@ -1689,9 +1689,13 @@ end function get_ticks_per_second
  integer, intent(out)           :: second, minute, hour, day, month, year
  integer, intent(out), optional :: tick
  character(len=*), intent(out), optional :: err_msg
-
+ logical, intent(in), optional  :: old_method !< option to choose betw the new and old ver of get_date_gregorian subroutine.
+                                              !! When .true., call get_date_gregorian_old to retrieve the date
+                                              !! from the array coded_date.  When .false., call get_date_gregorian to
+                                              !! compute the date on the fly.  Will be removed with set/get_date_gregorian_old
  character(len=128) :: err_msg_local
  integer :: tick1
+ logical :: old_method_local !< set as .false..  Takes on the value of old_method if old_method is present.  Will be removed
 
  if(.not.module_is_initialized) call time_manager_init
  if(present(err_msg)) err_msg = ''
@@ -1700,7 +1704,13 @@ end function get_ticks_per_second
  case(THIRTY_DAY_MONTHS)
    call get_date_thirty   (time, year, month, day, hour, minute, second, tick1)
  case(GREGORIAN)
-   call get_date_gregorian(time, year, month, day, hour, minute, second, tick1)
+   old_method_local=.false.
+   if(present(old_method)) old_method_local=old_method
+   if(old_method_local) then
+     call get_date_gregorian_old(time, year, month, day, hour, minute, second, tick1)
+   else
+     call get_date_gregorian(time, year, month, day, hour, minute, second, tick1)
+   end if
  case(JULIAN)
    call get_date_julian_private   (time, year, month, day, hour, minute, second, tick1)
  case(NOLEAP)
@@ -1741,9 +1751,9 @@ end function get_ticks_per_second
  integer :: yearx, monthx, dayx, idayx !< temporary values for year, month, day
  integer :: i                          !< counter, dummy variable
 
- ! Computes the date from time%days for the gregorian calendar
+ ! Computes date corresponding to time for gregorian calendar
 
- ! Carried over from the old subroutine
+ !Carried over from the old subroutine
  if(Time%seconds >= 86400) then ! This check appears to be unecessary.
    call error_mesg('get_date','Time%seconds .ge. 86400 in subroutine get_date_gregorian',FATAL)
  endif
@@ -1808,7 +1818,7 @@ end function get_ticks_per_second
 
 !> @brief Gets the date on a Gregorian calendar.  This is the original/old subroutine.
 !! Looks up the year, month, day from the coded_date array
-!! This subroutine will be removed for 2021.04
+!! This subroutine will be removed soon
  subroutine get_date_gregorian_old(time, year, month, day, hour, minute, second, tick)
 
 ! Computes date corresponding to time for gregorian calendar
@@ -2045,8 +2055,9 @@ end function get_ticks_per_second
 !   <OUT NAME="set_date" TYPE="time_type"> A time interval.</OUT>
 
 !> @brief Sets days for different calendar types.
-!! For calendar_type = Gregorian, the new set_date_gregorian is called
- function set_date_private(year, month, day, hour, minute, second, tick, Time_out, err_msg)
+!! The added optional argument old_method allows user to choose either the new or old version
+!! of set_date_gregorian.  The variable old_method is only useful if the calendar type is Gregorian
+ function set_date_private(year, month, day, hour, minute, second, tick, Time_out, err_msg, old_method)
 
 ! Given a date, computes the corresponding time given the selected
 ! date time mapping algorithm.  Note that it is possible to specify
@@ -2057,6 +2068,11 @@ end function get_ticks_per_second
  integer, intent(in) :: year, month, day, hour, minute, second, tick
  type(time_type) :: Time_out
  character(len=*), intent(out) :: err_msg
+ logical, intent(in), optional ::old_method !< option to choose betw the new and old ver of get_date_gregorian subroutine.
+                                            !! When .true., call set_date_gregorian_old to retrieve the time%days
+                                            !! from the array date_to_day.  When .false., call set_date_gregorian to
+                                            !! compute the time%days on the fly.  This option will be removed with get/set_date_gregorian_old
+ logical :: old_method_local !< set as .false..  Takes on the value of old_method if old_method is present.  Will be removed
 
  if(.not.module_is_initialized) call time_manager_init
 
@@ -2066,7 +2082,13 @@ end function get_ticks_per_second
  case(THIRTY_DAY_MONTHS)
    set_date_private = set_date_thirty   (year, month, day, hour, minute, second, tick, Time_out, err_msg)
  case(GREGORIAN)
-   set_date_private = set_date_gregorian(year, month, day, hour, minute, second, tick, Time_out, err_msg)
+   old_method_local = .false.
+   if( present(old_method) ) old_method_local=old_method
+   if( old_method_local ) then
+     set_date_private = set_date_gregorian_old(year, month, day, hour, minute, second, tick, Time_out, err_msg)
+   else
+     set_date_private = set_date_gregorian(year, month, day, hour, minute, second, tick, Time_out, err_msg)
+   end if
  case(JULIAN)
    set_date_private = set_date_julian_private   (year, month, day, hour, minute, second, tick, Time_out, err_msg)
  case(NOLEAP)
@@ -2085,13 +2107,20 @@ end function get_ticks_per_second
 !------------------------------------------------------------------------
 
 !> @brief Calls set_date_private to set days for different calendar types.
- function set_date_i(year, month, day, hour, minute, second, tick, err_msg)
+!! The added optional argument old_method allows user to choose either the new or old version
+!! of set_date_gregorian. The variable old_method is only useful if the calendar type is Gregorian
+ function set_date_i(year, month, day, hour, minute, second, tick, err_msg, old_method)
  type(time_type) :: set_date_i
  integer, intent(in) :: day, month, year
  integer, intent(in), optional :: second, minute, hour, tick
+ logical, intent(in), optional :: old_method !< option to choose betw the new and old ver of get_date_gregorian subroutine.
+                                             !! When .true., call set_date_gregorian_old to retrieve the time%days
+                                             !! from the array date_to_day.  When .false., call set_date_gregorian to
+                                             !! compute the time%days on the fly. This ption will be removed with get/set_date_gregorian_old
  character(len=*), intent(out), optional :: err_msg
  integer :: osecond, ominute, ohour, otick
  character(len=128) :: err_msg_local
+ logical :: old_method_local !< set as .false..  Takes on the value of old_method if old_method is present.  Will be removed
 
  if(.not.module_is_initialized) call time_manager_init
  if(present(err_msg)) err_msg = ''
@@ -2102,7 +2131,9 @@ end function get_ticks_per_second
  ohour   = 0; if(present(hour))   ohour   = hour
  otick   = 0; if(present(tick))   otick   = tick
 
- if(.not.set_date_private(year, month, day, ohour, ominute, osecond, otick, set_date_i, err_msg_local)) then
+ old_method_local = .false.
+ if( present(old_method) ) old_method_local=old_method
+ if(.not.set_date_private(year, month, day, ohour, ominute, osecond, otick, set_date_i, err_msg_local, old_method=old_method_local)) then
    if(error_handler('function set_date_i', err_msg_local, err_msg)) return
  end if
 
@@ -2110,7 +2141,9 @@ end function get_ticks_per_second
 !------------------------------------------------------------------------
 
 !> @brief Calls set_date_private for different calendar types when given a string input.
- function set_date_c(string, zero_year_warning, err_msg, allow_rounding)
+!! The added optional argument old_method allows user to choose either the new or old version
+!! of set_date_gregorian. The variable old_method is only useful if the calendar type is Gregorian
+ function set_date_c(string, zero_year_warning, err_msg, allow_rounding, old_method)
 
  ! Examples of acceptable forms of string:
 
@@ -2136,9 +2169,13 @@ end function get_ticks_per_second
  logical,          intent(in),  optional :: zero_year_warning
  character(len=*), intent(out), optional :: err_msg
  logical,          intent(in),  optional :: allow_rounding
-
+ logical,          intent(in),  optional :: old_method  !< option to choose betw the new and old ver of set_date_gregorian.
+                                                        !! When .true., call set_date_gregorian_old to retrieve the days
+                                                        !! from the array date_to_day.  When .false., call set_date_gregorian to
+                                                        !! compute the days on the fly.  Will be removed with set/get_date_gregorian_old
  character(len=4) :: formt='(i )'
  logical :: correct_form, zero_year_warning_local, allow_rounding_local
+ logical :: old_method_local !< set as .false..  Takes on the value of old_method if old_method is present.
  integer :: i1, i2, i3, i4, i5, i6, i7
  character(len=32) :: string_sifted_left
  integer :: year, month, day, hour, minute, second, tick
@@ -2225,7 +2262,9 @@ end function get_ticks_per_second
    endif
  endif
 
- if(.not.set_date_private(year, month, day, hour, minute, second, tick, set_date_c, err_msg_local)) then
+ old_method_local = .false.
+ if( present(old_method) ) old_method_local = old_method
+ if(.not.set_date_private(year, month, day, hour, minute, second, tick, set_date_c, err_msg_local,old_method=old_method_local)) then
    if(error_handler('function set_date_c', err_msg_local, err_msg)) return
  end if
 
@@ -2320,7 +2359,7 @@ end function get_ticks_per_second
 
 !> @brief Sets Time_out%days on a Gregorian calendar.  This is the original/old subroutine.
 !! Look up the total number of days between 1/1/0001 to the current month/day/year in the array date_to_day
-!! This function will be removed by 2021.04
+!! This function will be removed soon.
  function set_date_gregorian_old(year, month, day, hour, minute, second, tick, Time_out, err_msg)
  logical :: set_date_gregorian_old
 
@@ -3507,8 +3546,6 @@ subroutine time_list_error (T,Terr)
   write (terr,'(I0)') t%days
 end subroutine time_list_error
 
-
-!subroutine show_time_type(time, year, month, iday, dday)
 
 end module time_manager_mod
 

--- a/time_manager/time_manager.F90
+++ b/time_manager/time_manager.F90
@@ -167,10 +167,10 @@ integer,parameter :: do_nearest = 1
 ! time_type is implemented as seconds and days to allow for larger intervals
 type time_type
    private
-   integer:: seconds
-   integer:: days
-   integer:: ticks
-   integer:: dummy ! added as a workaround bug on IRIX64 (AP)
+   integer :: seconds
+   integer :: days
+   integer :: ticks
+   integer :: dummy ! added as a workaround bug on IRIX64 (AP)
 end type time_type
 
 !======================================================================
@@ -1680,7 +1680,7 @@ end function get_ticks_per_second
 !> @brief Gets the date for different calendar types.
 !! The added optional argument old_method allows user to choose either the new or old version
 !! of get_date_gregorian.  The variable old_method is only useful if the calendar type is Gregorian
- subroutine get_date(time, year, month, day, hour, minute, second, tick, err_msg, old_method)
+ subroutine get_date(time, year, month, day, hour, minute, second, tick, err_msg)
 
 ! Given a time, computes the corresponding date given the selected calendar
 
@@ -1688,13 +1688,9 @@ end function get_ticks_per_second
  integer, intent(out)           :: second, minute, hour, day, month, year
  integer, intent(out), optional :: tick
  character(len=*), intent(out), optional :: err_msg
- logical, intent(in), optional  :: old_method !< option to choose betw the new and old ver of get_date_gregorian subroutine.
-                                              !! When .true., call get_date_gregorian_old to retrieve the date
-                                              !! from the array coded_date.  When .false., call get_date_gregorian to
-                                              !! compute the date on the fly.
+
  character(len=128) :: err_msg_local
  integer :: tick1
- logical :: old_method_local !< set as .false..  Takes on the value of old_method if old_method is present.
 
  if(.not.module_is_initialized) call time_manager_init
  if(present(err_msg)) err_msg = ''
@@ -1703,13 +1699,7 @@ end function get_ticks_per_second
  case(THIRTY_DAY_MONTHS)
    call get_date_thirty   (time, year, month, day, hour, minute, second, tick1)
  case(GREGORIAN)
-   old_method_local=.false.
-   if(present(old_method)) old_method_local=old_method
-   if(old_method_local) then
-     call get_date_gregorian_old(time, year, month, day, hour, minute, second, tick1)
-   else
-     call get_date_gregorian(time, year, month, day, hour, minute, second, tick1)
-   end if
+   call get_date_gregorian(time, year, month, day, hour, minute, second, tick1)
  case(JULIAN)
    call get_date_julian_private   (time, year, month, day, hour, minute, second, tick1)
  case(NOLEAP)
@@ -2056,7 +2046,7 @@ end function get_ticks_per_second
 !> @brief Sets days for different calendar types.
 !! The added optional argument old_method allows user to choose either the new or old version
 !! of set_date_gregorian.  The variable old_method is only useful if the calendar type is Gregorian
- function set_date_private(year, month, day, hour, minute, second, tick, Time_out, err_msg, old_method)
+ function set_date_private(year, month, day, hour, minute, second, tick, Time_out, err_msg)
 
 ! Given a date, computes the corresponding time given the selected
 ! date time mapping algorithm.  Note that it is possible to specify
@@ -2067,11 +2057,6 @@ end function get_ticks_per_second
  integer, intent(in) :: year, month, day, hour, minute, second, tick
  type(time_type) :: Time_out
  character(len=*), intent(out) :: err_msg
- logical, intent(in), optional ::old_method !< option to choose betw the new and old ver of get_date_gregorian subroutine.
-                                            !! When .true., call set_date_gregorian_old to retrieve the time%days
-                                            !! from the array date_to_day.  When .false., call set_date_gregorian to
-                                            !! compute the time%days on the fly.
- logical :: old_method_local !< set as .false..  Takes on the value of old_method if old_method is present.
 
  if(.not.module_is_initialized) call time_manager_init
 
@@ -2081,13 +2066,7 @@ end function get_ticks_per_second
  case(THIRTY_DAY_MONTHS)
    set_date_private = set_date_thirty   (year, month, day, hour, minute, second, tick, Time_out, err_msg)
  case(GREGORIAN)
-   old_method_local = .false.
-   if( present(old_method) ) old_method_local=old_method
-   if( old_method_local ) then
-     set_date_private = set_date_gregorian_old(year, month, day, hour, minute, second, tick, Time_out, err_msg)
-   else
-     set_date_private = set_date_gregorian(year, month, day, hour, minute, second, tick, Time_out, err_msg)
-   end if
+   set_date_private = set_date_gregorian(year, month, day, hour, minute, second, tick, Time_out, err_msg)
  case(JULIAN)
    set_date_private = set_date_julian_private   (year, month, day, hour, minute, second, tick, Time_out, err_msg)
  case(NOLEAP)
@@ -2108,18 +2087,13 @@ end function get_ticks_per_second
 !> @brief Calls set_date_private to set days for different calendar types.
 !! The added optional argument old_method allows user to choose either the new or old version
 !! of set_date_gregorian. The variable old_method is only useful if the calendar type is Gregorian
- function set_date_i(year, month, day, hour, minute, second, tick, err_msg, old_method)
+ function set_date_i(year, month, day, hour, minute, second, tick, err_msg)
  type(time_type) :: set_date_i
  integer, intent(in) :: day, month, year
  integer, intent(in), optional :: second, minute, hour, tick
- logical, intent(in), optional :: old_method !< option to choose betw the new and old ver of get_date_gregorian subroutine.
-                                             !! When .true., call set_date_gregorian_old to retrieve the time%days
-                                             !! from the array date_to_day.  When .false., call set_date_gregorian to
-                                             !! compute the time%days on the fly.
  character(len=*), intent(out), optional :: err_msg
  integer :: osecond, ominute, ohour, otick
  character(len=128) :: err_msg_local
- logical :: old_method_local !< set as .false..  Takes on the value of old_method if old_method is present.
 
  if(.not.module_is_initialized) call time_manager_init
  if(present(err_msg)) err_msg = ''
@@ -2130,9 +2104,7 @@ end function get_ticks_per_second
  ohour   = 0; if(present(hour))   ohour   = hour
  otick   = 0; if(present(tick))   otick   = tick
 
- old_method_local = .false.
- if( present(old_method) ) old_method_local=old_method
- if(.not.set_date_private(year, month, day, ohour, ominute, osecond, otick, set_date_i, err_msg_local, old_method=old_method_local)) then
+ if(.not.set_date_private(year, month, day, ohour, ominute, osecond, otick, set_date_i, err_msg_local)) then
    if(error_handler('function set_date_i', err_msg_local, err_msg)) return
  end if
 
@@ -2142,7 +2114,7 @@ end function get_ticks_per_second
 !> @brief Calls set_date_private for different calendar types when given a string input.
 !! The added optional argument old_method allows user to choose either the new or old version
 !! of set_date_gregorian. The variable old_method is only useful if the calendar type is Gregorian
- function set_date_c(string, zero_year_warning, err_msg, allow_rounding, old_method)
+ function set_date_c(string, zero_year_warning, err_msg, allow_rounding)
 
  ! Examples of acceptable forms of string:
 
@@ -2168,13 +2140,9 @@ end function get_ticks_per_second
  logical,          intent(in),  optional :: zero_year_warning
  character(len=*), intent(out), optional :: err_msg
  logical,          intent(in),  optional :: allow_rounding
- logical,          intent(in),  optional :: old_method  !< option to choose betw the new and old ver of set_date_gregorian.
-                                                        !! When .true., call set_date_gregorian_old to retrieve the days
-                                                        !! from the array date_to_day.  When .false., call set_date_gregorian to
-                                                        !! compute the days on the fly.
+
  character(len=4) :: formt='(i )'
  logical :: correct_form, zero_year_warning_local, allow_rounding_local
- logical :: old_method_local !< set as .false..  Takes on the value of old_method if old_method is present.
  integer :: i1, i2, i3, i4, i5, i6, i7
  character(len=32) :: string_sifted_left
  integer :: year, month, day, hour, minute, second, tick
@@ -2261,9 +2229,7 @@ end function get_ticks_per_second
    endif
  endif
 
- old_method_local = .false.
- if( present(old_method) ) old_method_local = old_method
- if(.not.set_date_private(year, month, day, hour, minute, second, tick, set_date_c, err_msg_local,old_method=old_method_local)) then
+ if(.not.set_date_private(year, month, day, hour, minute, second, tick, set_date_c, err_msg_local)) then
    if(error_handler('function set_date_c', err_msg_local, err_msg)) return
  end if
 
@@ -3545,6 +3511,8 @@ subroutine time_list_error (T,Terr)
   write (terr,'(I0)') t%days
 end subroutine time_list_error
 
+
+!subroutine show_time_type(time, year, month, iday, dday)
 
 end module time_manager_mod
 

--- a/time_manager/time_manager.F90
+++ b/time_manager/time_manager.F90
@@ -156,10 +156,10 @@ integer, parameter :: max_type = 4
 ! Define number of days per month
 integer, private :: days_per_month(12) = (/31,28,31,30,31,30,31,31,30,31,30,31/)
 integer, parameter :: seconds_per_day = rseconds_per_day  ! This should automatically cast real to integer
-integer, parameter :: days_in_400_year_period = 146097    !> Used only for gregorian
-integer, dimension(days_in_400_year_period) :: coded_date !> Used only for gregorian, to be removed soon
-integer, dimension(400,12,31) :: date_to_day              !> Used only for gregorian, to be removed soon
-integer, parameter :: invalid_date=-1                     !> Used only for gregorian, to be removed soon
+integer, parameter :: days_in_400_year_period = 146097    !< Used only for gregorian
+integer, dimension(days_in_400_year_period) :: coded_date !< Used only for gregorian, to be removed soon
+integer, dimension(400,12,31) :: date_to_day              !< Used only for gregorian, to be removed soon
+integer, parameter :: invalid_date=-1                     !< Used only for gregorian, to be removed soon
 integer,parameter :: do_floor = 0
 integer,parameter :: do_nearest = 1
 


### PR DESCRIPTION
**Description**
In this PR,  tests for the new `get_date_gregorian` and `set_date_gregorian` have been revised  to `not` use the old methods in time_manager.  Instead, the old methods have been copied to the testing program and modified accordingly for testing.  

Fixes #740

**How Has This Been Tested?**
The time_manager unit test passes with Intel 19.1.0 and GCC 9.3.0 on Skylake

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

