### PR TITLE
Makes MAX_FIELDS_PER_FILE a namelist variable and allocates 

### DIFF
--- a/diag_manager/diag_data.F90
+++ b/diag_manager/diag_data.F90
@@ -183,7 +183,7 @@ use platform_mod
   TYPE file_type
      CHARACTER(len=128) :: name !< Name of the output file.
      CHARACTER(len=128) :: long_name
-     INTEGER, DIMENSION(max_fields_per_file) :: fields
+     INTEGER, allocatable, DIMENSION(:) :: fields
      INTEGER :: num_fields
      INTEGER :: output_freq
      INTEGER :: output_units
@@ -410,6 +410,7 @@ use platform_mod
   !   Will determine which value to use when checking a regional output if the region is the full axis or a sub-axis.
   !   The values are defined as <TT>GLO_REG_VAL</TT> (-999) and <TT>GLO_REG_VAL_ALT</TT> (-1) in <TT>diag_data_mod</TT>.
   ! </DATA>
+  !> MAX_FIELDS_PER_FILE default = 300 Maximum number of fields per file.
   LOGICAL :: append_pelist_name = .FALSE.
   LOGICAL :: mix_snapshot_average_fields =.FALSE.
   INTEGER :: max_files = 31 !< Maximum number of output files allowed.  Increase via diag_manager_nml.
@@ -442,7 +443,7 @@ use platform_mod
   INTEGER :: max_axis_attributes = 4 !< Maximum number of user definable attributes per axis.
   LOGICAL :: prepend_date = .TRUE. !< Should the history file have the start date prepended to the file name
   LOGICAL :: use_mpp_io = .false. !< false is fms2_io (default); true is mpp_io
-
+  INTEGER :: MAX_FIELDS_PER_FILE = 300 !< Maximum number of fields per file.
   ! <!-- netCDF variable -->
   ! <DATA NAME="FILL_VALUE" TYPE="REAL" DEFAULT="NF90_FILL_REAL">
   !   Fill value used.  Value will be <TT>NF90_FILL_REAL</TT> if using the

--- a/diag_manager/diag_data.F90
+++ b/diag_manager/diag_data.F90
@@ -93,9 +93,6 @@ use platform_mod
 
 
   ! <!-- PARAMETERS for diag_data.F90 -->
-  ! <DATA NAME="MAX_FIELDS_PER_FILE" TYPE="INTEGER, PARAMETER" DEFAULT="300">
-  !   Maximum number of fields per file.
-  ! </DATA>
   ! <DATA NAME="DIAG_OTHER" TYPE="INTEGER, PARAMETER" DEFAULT="0" />
   ! <DATA NAME="DIAG_OCEAN" TYPE="INTEGER, PARAMETER" DEFAULT="1" />
   ! <DATA NAME="DIAG_ALL" TYPE="INTEGER, PARAMETER" DEFAULT="2" />
@@ -121,7 +118,6 @@ use platform_mod
   !   Return value for a diag_field that isn't found in the diag_table
   ! </DATA>
   ! Specify storage limits for fixed size tables used for pointers, etc.
-  INTEGER, PARAMETER :: MAX_FIELDS_PER_FILE = 300 !< Maximum number of fields per file.
   INTEGER, PARAMETER :: DIAG_OTHER = 0
   INTEGER, PARAMETER :: DIAG_OCEAN = 1
   INTEGER, PARAMETER :: DIAG_ALL   = 2

--- a/diag_manager/diag_util.F90
+++ b/diag_manager/diag_util.F90
@@ -1355,6 +1355,8 @@ CONTAINS
        ! </ERROR>
        CALL error_mesg('diag_util_mod::init_output_field',&
             & 'MAX_FIELDS_PER_FILE = '//TRIM(error_msg)//' exceeded.  Increase MAX_FIELDS_PER_FILE in diag_data.F90.', FATAL)
+    ELSEIF (.not. allocated(files(file_num)%fields(num_fields)) then
+       allocate(files(file_num)%fields(MAX_FIELDS_PER_FILE)) 
     END IF
     num_fields = files(file_num)%num_fields
     files(file_num)%fields(num_fields) = out_num

--- a/diag_manager/diag_util.F90
+++ b/diag_manager/diag_util.F90
@@ -1355,7 +1355,7 @@ CONTAINS
        ! </ERROR>
        CALL error_mesg('diag_util_mod::init_output_field',&
             & 'MAX_FIELDS_PER_FILE = '//TRIM(error_msg)//' exceeded.  Increase MAX_FIELDS_PER_FILE in diag_data.F90.', FATAL)
-    ELSEIF (.not. allocated(files(file_num)%fields(num_fields))) THEN
+    ELSEIF (.not. allocated(files(file_num)%fields)) THEN
        allocate(files(file_num)%fields(MAX_FIELDS_PER_FILE)) 
     END IF
     num_fields = files(file_num)%num_fields

--- a/diag_manager/diag_util.F90
+++ b/diag_manager/diag_util.F90
@@ -1355,7 +1355,7 @@ CONTAINS
        ! </ERROR>
        CALL error_mesg('diag_util_mod::init_output_field',&
             & 'MAX_FIELDS_PER_FILE = '//TRIM(error_msg)//' exceeded.  Increase MAX_FIELDS_PER_FILE in diag_data.F90.', FATAL)
-    ELSEIF (.not. allocated(files(file_num)%fields(num_fields)) then
+    ELSEIF (.not. allocated(files(file_num)%fields(num_fields))) THEN
        allocate(files(file_num)%fields(MAX_FIELDS_PER_FILE)) 
     END IF
     num_fields = files(file_num)%num_fields


### PR DESCRIPTION
**Description**
Changes the `max_fields_per_file` to a namelist variable, and allocated the `fields` with this value.

Fixes #747 

**How Has This Been Tested?**
`make` run with intel

**Checklist:**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] `make distcheck` passes

