### PR TITLE
Bugfix: topography namelist variable declaration

### DIFF
--- a/topography/topography.F90
+++ b/topography/topography.F90
@@ -101,13 +101,13 @@ end interface
 
    character(len=128) :: topog_file = 'DATA/navy_topography.data', &
                          water_file = 'DATA/navy_pctwater.data'
+   logical :: use_mpp_io = .false.  !>@var Namelist flag to enable usage of mpp_io subroutines if true
    namelist /topography_nml/ topog_file, water_file, use_mpp_io
 ! </NAMELIST>
    integer, parameter    :: TOPOG_INDEX = 1
    integer, parameter    :: WATER_INDEX = 2
    logical :: file_is_opened(2) = .false.
    type(FmsNetcdfFile_t) :: fileobj(2) !< needed for fms2_io
-   logical :: use_mpp_io=.false.!>@var Namelist flag to enable usage of mpp_io subroutines if true
 !-----------------------------------------------------------------------
 ! --- resolution of the topography data set ---
 ! <DATASET NAME="">


### PR DESCRIPTION
**Description**
The use_mpp_io variable in the topography_nml namelist was declared
after the namelist reference to this variable.

While this doesn't seem to have been an issue in older compilers, it
does not build under GCC 11.

This patch moves the declaration to precede the namelist statement.

Fixes #753

**How Has This Been Tested?**
I have run the FMS autoconf build on my local environment and it completes.

**Checklist:**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules

