### PR TITLE
Fixes typo in mpp/Makefile.am

### DIFF
--- a/mpp/Makefile.am
+++ b/mpp/Makefile.am
@@ -244,6 +244,6 @@ BUILT_SOURCES = \
   mpp_efp_mod.$(FC_MODEXT) \
   mpp_domains_mod.$(FC_MODEXT) \
   mpp_io_mod.$(FC_MODEXT)
-nodist_include_HEADERS = $(BUILD_SOURCES)
+nodist_include_HEADERS = $(BUILT_SOURCES)
 
 include $(top_srcdir)/mkmods.mk


### PR DESCRIPTION
**Description**
Fixes typo in mpp/Makefile.am

Fixes #757 

**How Has This Been Tested?**
tried `make install` on skylake and it is now working correctly

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

