### PR TITLE
Explict string length for buffer in axis_utils

### DIFF
--- a/axis_utils/axis_utils2.F90
+++ b/axis_utils/axis_utils2.F90
@@ -161,7 +161,8 @@ contains
   buffer = ""
   if (variable_att_exists(fileobj, name, "edges")) then
     !! If the reproduce_null_char_bug flag is turned on fms2io will not remove the null character
-    call get_variable_attribute(fileobj, name, "edges", buffer, reproduce_null_char_bug_flag=reproduce_null_char_bug)
+    call get_variable_attribute(fileobj, name, "edges", buffer(1:128), &
+        reproduce_null_char_bug_flag=reproduce_null_char_bug)
 
     !! Check for a null character here, if it exists *_bnds will be calculated instead of read in
     if (reproduce_null_char_bug) then
@@ -171,7 +172,8 @@ contains
     endif
   elseif (variable_att_exists(fileobj, name, "bounds")) then
     !! If the reproduce_null_char_bug flag is turned on fms2io will not remove the null character
-    call get_variable_attribute(fileobj, name, "bounds", buffer, reproduce_null_char_bug_flag=reproduce_null_char_bug)
+    call get_variable_attribute(fileobj, name, "bounds", buffer(1:128), &
+        reproduce_null_char_bug_flag=reproduce_null_char_bug)
 
     !! Check for a null character here, if it exists *_bnds will be calculated instead of read in
     if (reproduce_null_char_bug) then


### PR DESCRIPTION
The `buffer` character array in `axis_edges` was incorrectly sorted in the
`select type` blocks in PGI due to an inability to match the
assumed-length character type.  This behavior differs from Intel and
GNU.

This patch uses the same fix to the char array by passing a slice of the
whole array (`buffer(1:128)`).  I can only assume this signals to the
compiler that it is assumed-length.

This resolves observed issues in the OM_1deg MOM6 regression test.

Fixes #763

**How Has This Been Tested?**
Tested on Gaea in the MOM6-examples regression suite.

**Checklist:**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] `make distcheck` passes

