### PR TITLE
Resolve "make check hangs with intel"

### DIFF
--- a/mpp/include/mpp_util.inc
+++ b/mpp/include/mpp_util.inc
@@ -1447,6 +1447,7 @@ end function rarray_to_char
                             '.  (IOSTAT = '//trim(text)//')')
           else
              num_lines = 1
+             max_length = 1
              do
                 read (UNIT=f_unit, FMT='(A)', IOSTAT=status) str_tmp
                 if ( status .lt. 0 ) exit


### PR DESCRIPTION
**Description**
Inits the max_length to 1 to avoid make check to hang when using an empty namelist or when calling `ascii_read` on an empty file.

Fixes #765 

**How Has This Been Tested?**
`make check` passes with intel on skylake and and it still passes on gnu. 

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

