### PR TITLE
Removes any repeated visibility's from typedefs for intel

### DIFF
--- a/block_control/block_control.F90
+++ b/block_control/block_control.F90
@@ -34,20 +34,20 @@ public block_control_type
 
 !> Private type to dereference packed index from global index.
 !> @ingroup block_control_mod
-type, private :: ix_type
+type :: ix_type
   integer, dimension(:,:), allocatable :: ix
 end type ix_type
 
 !> Private type to dereference packed index from global indices.
 !> @ingroup block_control_mod
-type, private :: pk_type
+type :: pk_type
   integer, dimension(:), allocatable :: ii
   integer, dimension(:), allocatable :: jj
 end type pk_type
 
 !> @brief Block data and extents for OpenMP threading of column-based calculations
 !> @ingroup block_control_mod
-type, public :: block_control_type
+type :: block_control_type
   integer :: nx_block, ny_block  !< blocking factor using mpp-style decomposition
   integer :: nblks               !< number of blocks cover MPI domain
   integer :: isc, iec, jsc, jec  !< MPI domain global extents

--- a/block_control/block_control.F90
+++ b/block_control/block_control.F90
@@ -32,13 +32,13 @@ implicit none
 
 public block_control_type
 
-!> Private type to dereference packed index from global index.
+!> Type to dereference packed index from global index.
 !> @ingroup block_control_mod
 type :: ix_type
   integer, dimension(:,:), allocatable :: ix
 end type ix_type
 
-!> Private type to dereference packed index from global indices.
+!> Type to dereference packed index from global indices.
 !> @ingroup block_control_mod
 type :: pk_type
   integer, dimension(:), allocatable :: ii

--- a/drifters/drifters_comm.F90
+++ b/drifters/drifters_comm.F90
@@ -59,7 +59,7 @@ module drifters_comm_mod
 
   !> Type for drifter communication between PE's
   !> @ingroup drifters_comm_mod
-  type, public :: drifters_comm_type
+  type :: drifters_comm_type
      real           :: xcmin !< compute domain
      real           :: xcmax !< compute domain
      real           :: ycmin !< compute domain

--- a/fms2_io/fms_io_utils.F90
+++ b/fms2_io/fms_io_utils.F90
@@ -72,7 +72,7 @@ public :: nullify_filename_appendix
 
 !> @brief A linked list of strings
 !> @ingroup fms_io_utils_mod
-type, public :: char_linked_list
+type :: char_linked_list
   character(len=128) :: string
   type(char_linked_list), pointer :: head => null()
 endtype char_linked_list

--- a/mpp/mpp.F90
+++ b/mpp/mpp.F90
@@ -231,7 +231,7 @@ private
   !!
   !> peset hold communicators as SHMEM-compatible triads (start, log2(stride), num)
   !> @ingroup mpp_mod
-  type, public :: communicator
+  type :: communicator
      private
      character(len=32) :: name
      integer, pointer  :: list(:) =>NULL()
@@ -242,7 +242,7 @@ private
 
   !> Communication event profile
   !> @ingroup mpp_mod
-  type, public :: event
+  type :: event
      private
      character(len=16)                         :: name
      integer(i8_kind), dimension(MAX_EVENTS)   :: ticks, bytes
@@ -251,7 +251,7 @@ private
 
   !> a clock contains an array of event profiles for a region
   !> @ingroup mpp_mod
-  type, public :: clock
+  type :: clock
      private
      character(len=32)    :: name
      integer(i8_kind)     :: hits
@@ -267,7 +267,7 @@ private
 
   !> Summary of information from a clock run
   !> @ingroup mpp_mod
-  type, public :: Clock_Data_Summary
+  type :: Clock_Data_Summary
      private
      character(len=16)  :: name
      real(r8_kind)      :: msg_size_sums(MAX_BINS)
@@ -280,7 +280,7 @@ private
 
   !> holds name and clock data for use in @ref mpp_util.h
   !> @ingroup mpp_mod
-  type, public :: Summary_Struct
+  type :: Summary_Struct
      private
      character(len=16)         :: name
      type (Clock_Data_Summary) :: event(MAX_EVENT_TYPES)
@@ -288,7 +288,7 @@ private
 
   !> Data types for generalized data transfer (e.g. MPI_Type)
   !> @ingroup mpp_mod
-  type, public :: mpp_type
+  type :: mpp_type
      private
      integer :: counter !> Number of instances of this type
      integer :: ndims
@@ -304,7 +304,7 @@ private
 
   !> Persisent elements for linked list interaction
   !> @ingroup mpp_mod
-  type, public :: mpp_type_list
+  type :: mpp_type_list
       private
       type(mpp_type), pointer :: head => null()
       type(mpp_type), pointer :: tail => null()

--- a/mpp/mpp_domains.F90
+++ b/mpp/mpp_domains.F90
@@ -227,7 +227,7 @@ module mpp_domains_mod
 
   !> @brief Private type for axis specification data for an unstructured grid
   !> @ingroup mpp_domains_mod
-  type, private :: unstruct_axis_spec
+  type :: unstruct_axis_spec
      private
      integer :: begin, end, size, max_size
      integer :: begin_index, end_index
@@ -235,7 +235,7 @@ module mpp_domains_mod
 
   !> Private type for axis specification data for an unstructured domain
   !> @ingroup mpp_domains_mod
-  type, private :: unstruct_domain_spec
+  type :: unstruct_domain_spec
      private
      type(unstruct_axis_spec) :: compute
      integer :: pe
@@ -245,7 +245,7 @@ module mpp_domains_mod
 
   !> Private type
   !> @ingroup mpp_domains_mod
-  type, private :: unstruct_overlap_type
+  type :: unstruct_overlap_type
      private
      integer :: count = 0
      integer :: pe
@@ -255,7 +255,7 @@ module mpp_domains_mod
 
   !> Private type
   !> @ingroup mpp_domains_mod
-  type, private :: unstruct_pass_type
+  type :: unstruct_pass_type
      private
      integer :: nsend, nrecv
      type(unstruct_overlap_type), pointer :: recv(:)=>NULL()
@@ -264,7 +264,7 @@ module mpp_domains_mod
 
   !> Domain information for managing data on unstructured grids
   !> @ingroup mpp_domains_mod
-  type, public :: domainUG
+  type :: domainUG
      private
      type(unstruct_axis_spec) :: compute, global !< axis specifications
      type(unstruct_domain_spec), pointer :: list(:)=>NULL() !<
@@ -285,7 +285,7 @@ module mpp_domains_mod
 
   !> Used to specify index limits along an axis of a domain
   !> @ingroup mpp_domains_mod
-  type, public :: domain_axis_spec
+  type :: domain_axis_spec
      private
      integer :: begin !< start of domain axis
      integer :: end !< end of domain axis
@@ -296,7 +296,7 @@ module mpp_domains_mod
 
   !> One dimensional domain used to manage shared data access between pes
   !> @ingroup mpp_domains_mod
-  type, public :: domain1D
+  type :: domain1D
      private
      type(domain_axis_spec) :: compute, data, global, memory !> index limits for different domains
      logical :: cyclic
@@ -308,7 +308,7 @@ module mpp_domains_mod
 
   !> Private type used to specify index limits for a domain decomposition
   !> @ingroup mpp_domains_mod
-  type, private :: domain1D_spec
+  type :: domain1D_spec
      private
      type(domain_axis_spec) :: compute
      type(domain_axis_spec) :: global
@@ -317,7 +317,7 @@ module mpp_domains_mod
 
   !> @brief Private type to specify multiple index limits and pe information for a 2D domain
   !> @ingroup mpp_domains_mod
-  type, private :: domain2D_spec
+  type :: domain2D_spec
      private
      type(domain1D_spec), pointer :: x(:)       => NULL() !< x-direction domain decomposition
      type(domain1D_spec), pointer :: y(:)       => NULL() !< y-direction domain decomposition
@@ -350,7 +350,7 @@ module mpp_domains_mod
 
   !> Private type for overlap specifications
   !> @ingroup mpp_domains_mod
-  type, private :: overlapSpec
+  type :: overlapSpec
      private
      integer                     :: whalo, ehalo, shalo, nhalo !< halo size
      integer                     :: xbegin, xend, ybegin, yend
@@ -363,7 +363,7 @@ module mpp_domains_mod
 
   !> @brief Upper and lower x and y bounds for a tile
   !> @ingroup mpp_domains_mod
-  type, private :: tile_type
+  type :: tile_type
      integer :: xbegin, xend, ybegin, yend
   end type tile_type
 
@@ -376,7 +376,7 @@ module mpp_domains_mod
   !! typically we only need 1 and 2D, but could need higher (e.g 3D LES)
   !! some elements are repeated below if they are needed once per domain, not once per axis
   !> @ingroup mpp_domains_mod
-  TYPE, PUBLIC :: domain2D
+  TYPE :: domain2D
      private
      character(len=NAME_LENGTH)  :: name='unnamed' !< name of the domain, default is "unspecified"
      integer(i8_kind)            :: id
@@ -431,14 +431,14 @@ module mpp_domains_mod
 
   !> index bounds for use in @ref nestSpec
   !> @ingroup mpp_domains_mod
-  type, private :: index_type
+  type :: index_type
      integer :: is_me, ie_me, js_me, je_me
      integer :: is_you, ie_you, js_you, je_you
   end type index_type
 
   !> Used to specify bounds and index information for nested tiles as a linked list
   !> @ingroup mpp_domains_mod
-  type, private :: nestSpec
+  type :: nestSpec
      private
      integer                     :: xbegin, xend, ybegin, yend
      integer                     :: xbegin_c, xend_c, ybegin_c, yend_c
@@ -455,7 +455,7 @@ module mpp_domains_mod
 
   !> @brief domain with nested fine and course tiles
   !> @ingroup mpp_domains_mod
-  type, public :: nest_domain_type
+  type :: nest_domain_type
      character(len=NAME_LENGTH)     :: name
      integer                        :: num_level
      type(nest_level_type), pointer :: nest(:) => NULL()
@@ -467,7 +467,7 @@ module mpp_domains_mod
 
   !> Private type to hold data for each level of nesting
   !> @ingroup mpp_domains_mod
-  type, private :: nest_level_type
+  type :: nest_level_type
      private
      logical                    :: on_level
      logical                    :: is_fine, is_coarse
@@ -497,7 +497,7 @@ module mpp_domains_mod
 
   !> Used for sending domain data between pe's
   !> @ingroup mpp_domains_mod
-  type, public :: domaincommunicator2D
+  type :: domaincommunicator2D
      private
      logical            :: initialized=.false.
      integer(i8_kind) :: id=-9999
@@ -547,7 +547,7 @@ module mpp_domains_mod
 
   !> Used for nonblocking data transfer
   !> @ingroup mpp_domains_mod
-  type, private :: nonblock_type
+  type :: nonblock_type
      integer                         :: recv_pos
      integer                         :: send_pos
      integer                         :: recv_msgsize
@@ -574,7 +574,7 @@ module mpp_domains_mod
 
   !> used for updates on a group
   !> @ingroup mpp_domains_mod
-  type, public :: mpp_group_update_type
+  type :: mpp_group_update_type
      private
      logical            :: initialized = .FALSE.
      logical            :: k_loop_inside = .TRUE.

--- a/mpp/mpp_io.F90
+++ b/mpp/mpp_io.F90
@@ -402,7 +402,7 @@ integer FILE_TYPE_USED
 integer, parameter :: MAX_ATT_LENGTH = 1280
 !> @}
 !> @ingroup mpp_io_mod
-type, public :: atttype
+type :: atttype
      private
      integer             :: type, len
      character(len=128)  :: name
@@ -411,7 +411,7 @@ type, public :: atttype
   end type atttype
 
   !> @ingroup mpp_io_mod
-  type, public :: axistype
+  type :: axistype
      private
      character(len=128) :: name
      character(len=128) :: name_bounds
@@ -432,14 +432,14 @@ type, public :: atttype
   end type axistype
 
   !> @ingroup mpp_io_mod
-  type, public :: validtype
+  type :: validtype
      private
      logical :: is_range ! if true, then the data represent the valid range
      real    :: min,max  ! boundaries of the valid range or missing value
   end type validtype
 
   !> @ingroup mpp_io_mod
-  type, public :: fieldtype
+  type :: fieldtype
      private
      character(len=128)      :: name
      character(len=128)      :: units
@@ -459,7 +459,7 @@ type, public :: atttype
   end type fieldtype
 
   !> @ingroup mpp_io_mod
-  type, public :: filetype
+  type :: filetype
      private
      character(len=256) :: name
      integer            :: action, format, access, threading, fileset, record, ncid

--- a/time_manager/time_manager.F90
+++ b/time_manager/time_manager.F90
@@ -166,7 +166,7 @@ integer,parameter :: do_nearest = 1
 !> @brief Type to represent amounts of time.
 !> Implemented as seconds and days to allow for larger intervals.
 !> @ingroup time_manager_mod
-type, public :: time_type
+type :: time_type
    private
    integer:: seconds
    integer:: days


### PR DESCRIPTION
**Description**
Some type definitions were changed to include `::` and it's visibility as part of #762 to be consistent for parsing. Intel(only) compilers complain if the visibility is specified twice so this PR just removes added `public` or `private` in typedefs.

**How Has This Been Tested?**
Tested on amd with intel and gnu

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

