### PR TITLE
Add gcc 11.1 check to configure script

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -272,16 +272,6 @@ if test -n "$fc_version_info"; then
   FC_VERSION="$FC_VERSION ( $fc_version_info )"
 fi
 
-# Check if gcc is 11.1 for class(*) select type bug
-AC_MSG_CHECKING([if gcc 11.1 is loaded])
-if [ test -n "`$FC --version | grep GNU | grep 11.1`" ]; then
-  AC_MSG_RESULT([yes])
-  AC_MSG_RESULT([Warning: Compilation with GNU compilers version 11.1 is unsupported by this version\
- of FMS. Please use another compiler version])
-else
-  AC_MSG_RESULT([no])
-fi
-
 # Check if netcdf is version 4.7.4 to skip failing fms2_io tests
 AC_MSG_CHECKING([if netCDF 4.7.4 is loaded])
 if [ test "`nc-config --version`" == "netCDF 4.7.4" ]; then
@@ -375,4 +365,10 @@ AC_OUTPUT()
 ## if tests are being skipped, output warning at end of output
 if [ test "`nc-config --version`" == "netCDF 4.7.4" ]; then
   AC_MSG_RESULT([Warning: netCDF v4.7.4 is loaded. Incompatible fms2_io tests will be skipped and there may be netCDF issues with model runs.])
+fi
+
+# Check if gcc is 11.1 for class(*) select type bug
+if [ test -n "`$FC --version | grep GNU | grep 11.1`" ]; then
+  AC_MSG_RESULT([Warning: Compilation with GNU compilers version 11.1 is unsupported by this version\
+ of FMS. Please use another compiler version])
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -376,4 +376,3 @@ AC_OUTPUT()
 if [ test "`nc-config --version`" == "netCDF 4.7.4" ]; then
   AC_MSG_RESULT([Warning: netCDF v4.7.4 is loaded. Incompatible fms2_io tests will be skipped and there may be netCDF issues with model runs.])
 fi
-

--- a/configure.ac
+++ b/configure.ac
@@ -272,6 +272,16 @@ if test -n "$fc_version_info"; then
   FC_VERSION="$FC_VERSION ( $fc_version_info )"
 fi
 
+# Check if gcc is 11.1 for class(*) select type bug
+AC_MSG_CHECKING([if gcc 11 is loaded])
+if [ test -n "`$FC --version | grep GNU | grep 11\..\..`" ]; then
+  AC_MSG_RESULT([yes])
+  AC_MSG_ERROR([Compilation with gcc and gfortran 11 is unsupported by this version\
+ of FMS. Please use another compiler version])
+else
+  AC_MSG_RESULT([no])
+fi
+
 # Check if netcdf is version 4.7.4 to skip failing fms2_io tests
 AC_MSG_CHECKING([if netCDF 4.7.4 is loaded])
 if [ test "`nc-config --version`" == "netCDF 4.7.4" ]; then
@@ -367,8 +377,3 @@ if [ test "`nc-config --version`" == "netCDF 4.7.4" ]; then
   AC_MSG_RESULT([Warning: netCDF v4.7.4 is loaded. Incompatible fms2_io tests will be skipped and there may be netCDF issues with model runs.])
 fi
 
-# Check if gcc is 11.1 for class(*) select type bug
-if [ test -n "`$FC --version | grep GNU | grep 11\..\..`" ]; then
-  AC_MSG_RESULT([Warning: Compilation with gcc and gfortran 11 is unsupported by this version\
- of FMS. Please use another compiler version])
-fi

--- a/configure.ac
+++ b/configure.ac
@@ -368,7 +368,7 @@ if [ test "`nc-config --version`" == "netCDF 4.7.4" ]; then
 fi
 
 # Check if gcc is 11.1 for class(*) select type bug
-if [ test -n "`$FC --version | grep GNU | grep 11.1`" ]; then
-  AC_MSG_RESULT([Warning: Compilation with GNU compilers version 11.1 is unsupported by this version\
+if [ test -n "`$FC --version | grep GNU | grep 11\..\..`" ]; then
+  AC_MSG_RESULT([Warning: Compilation with gcc and gfortran 11 is unsupported by this version\
  of FMS. Please use another compiler version])
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -272,6 +272,16 @@ if test -n "$fc_version_info"; then
   FC_VERSION="$FC_VERSION ( $fc_version_info )"
 fi
 
+# Check if gcc is 11.1 for class(*) select type bug
+AC_MSG_CHECKING([if gcc 11.1 is loaded])
+if [ test -n "`$FC --version | grep GNU | grep 11.1`" ]; then
+  AC_MSG_RESULT([yes])
+  AC_MSG_RESULT([Warning: Compilation with GNU compilers version 11.1 is unsupported by this version\
+ of FMS. Please use another compiler version])
+else
+  AC_MSG_RESULT([no])
+fi
+
 # Check if netcdf is version 4.7.4 to skip failing fms2_io tests
 AC_MSG_CHECKING([if netCDF 4.7.4 is loaded])
 if [ test "`nc-config --version`" == "netCDF 4.7.4" ]; then


### PR DESCRIPTION
**Description**
Adds check in the configure script for GCC 11.1 and outputs a warning stating it is unsupported if found. This can be switched to a error if preferable but i figured since it still compiles it should just state that it is unsupported.

Fixes #756 

**How Has This Been Tested?**
Tested with intel and gnu 9.3.0 and 11.1.0 on amd

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

