### PR TITLE
Fixes for test_mpp_global_field_ug and test_global_arrays

### DIFF
--- a/test_fms/mpp/test_global_arrays.F90
+++ b/test_fms/mpp/test_global_arrays.F90
@@ -285,6 +285,7 @@ function checkResultInt4(res)
     call mpp_recv(tres,2, root)
     checkResultInt4 = checkResultInt4 .and. res(1) .EQ. tres(1) .and. res(2) .eq. tres(2)
   end if
+  call mpp_sync()
   deallocate(tres)
 end function checkResultInt4
 
@@ -309,6 +310,7 @@ function checkResultInt8(res)
     call mpp_recv(tres,2, root)
     checkResultInt8 = checkResultInt8 .and. res(1) .EQ. tres(1) .and. res(2) .eq. tres(2)
   end if
+  call mpp_sync()
   deallocate(tres)
 end function checkResultInt8
 
@@ -334,6 +336,7 @@ function checkResultReal4(res)
     checkResultReal4 = checkResultReal4 .and. (abs((res(1)-tres(1))/res(1)) .lt. 1e-4) .and. &
                        (abs((res(2)-tres(2))/res(2)) .lt. 1e-4)
   end if
+  call mpp_sync()
   deallocate(tres)
 end function checkResultReal4
 
@@ -359,6 +362,7 @@ function checkResultReal8(res)
     checkResultReal8 = checkResultReal8 .and. (abs((res(1)-tres(1))/res(1)) .lt. 1e-7) .and. &
                        (abs((res(2)-tres(2))/res(2)) .lt. 1e-7)
   end if
+  call mpp_sync()
   deallocate(tres)
 end function checkResultReal8
 
@@ -392,6 +396,7 @@ function checkSumReal4(gsum)
     call mpp_send(recv, 2, root)
     checkSumReal4 = .true.
   endif
+  call mpp_sync()
   deallocate(recv)
 end function checkSumReal4
 
@@ -425,6 +430,7 @@ function checkSumReal8(gsum)
     call mpp_send(recv, 2, root)
     checkSumReal8 = .true.
   endif
+  call mpp_sync()
   deallocate(recv)
 end function checkSumReal8
 
@@ -458,6 +464,7 @@ function checkSumInt4(gsum)
     call mpp_send(recv, 2, root)
     checkSumInt4 = .true.
   endif
+  call mpp_sync()
   deallocate(recv)
 end function checkSumInt4
 
@@ -491,6 +498,7 @@ function checkSumInt8(gsum)
     call mpp_send(recv, 2, root)
     checkSumInt8 = .true.
   endif
+  call mpp_sync()
   deallocate(recv)
 end function checkSumInt8
 

--- a/test_fms/mpp/test_global_arrays.F90
+++ b/test_fms/mpp/test_global_arrays.F90
@@ -191,9 +191,8 @@ program test_global_arrays
   call mpp_error(NOTE, "----------Testing 32-bit real mpp_global_sum with 5 ranks and reordering----------")
   call mpp_update_domains(dataR4_5d, domain)
   sumR4_5d = mpp_global_sum(domain, dataR4_5d)
-
   ! check that shuffled array results are approximately the same as the original array
-  if(abs((sumR4-sumR4_5d)/sumR4) .gt. 1e-4) then
+  if(abs(sumR4-sumR4_5d) .gt. 1E-4 ) then
     strTmp1 = ""; strTmp2=""
     write(strTmp1,*) sumR4_5d
     write(strTmp2,*) sumR4
@@ -205,11 +204,10 @@ program test_global_arrays
   call mpp_update_domains(dataR8_5d, domain)
   sumR8_5d = mpp_global_sum(domain, dataR8_5d)
   ! check that shuffled array results are approximately the same as the original array
-  !> @note This test fails with gcc 9.3.0
-  if(abs((sumR8-sumR8_5d)/sumR8) .gt. 1e-7) then
+  if(abs(sumR8-sumR8_5d) .gt. 1E-7) then
     strTmp1 = ""; strTmp2=""
     write(strTmp1,*) sumR8_5d
-     write(strTmp2,*) sumR8
+    write(strTmp2,*) sumR8
     call mpp_error(FATAL,"test_global_arrays: invalid 64-bit real answer after reordering"// &
                    NEW_LINE('a')//"Sum: "// strTmp1// " ne "//strTmp2)
   endif

--- a/test_fms/mpp/test_global_arrays.sh
+++ b/test_fms/mpp/test_global_arrays.sh
@@ -52,5 +52,5 @@ then
     # Need to oversubscribe the MPI
     run_test test_global_arrays 8 $skip_test "true"
 fi
-
+touch input.nml
 run_test test_global_arrays 8 $skip_test

--- a/test_fms/mpp/test_mpp_global_field_ug.F90
+++ b/test_fms/mpp/test_mpp_global_field_ug.F90
@@ -61,7 +61,6 @@ program test_mpp_global_field_ug
 
   !> initialize mpp domain(s)
   call mpp_domains_init()
-  call mpp_domains_set_stack_size(stackmax)
 
   call setup_domains()
 


### PR DESCRIPTION
**Description**
Two small fixes for mpp tests to fix issues with make check/ci

- removes a call to set the domain stack size so that it uses the default size. This prevents a segfault during a subsequent call to `mpp_pass_SG_to_UG` when using impi and intel
- Changes real comparisons and adds syncs before deallocation in `test_global_arrays` to prevent occasional  failures within the CI and elsewhere

**How Has This Been Tested?**
Tested using intel and gcc (9.3.0) with impi +  using intel with mpich

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes
