### PR TITLE
replace hardwired input.nml with optional user specified path to input.nml

### DIFF
--- a/diag_integral/diag_integral.F90
+++ b/diag_integral/diag_integral.F90
@@ -69,7 +69,7 @@ use time_manager_mod, only:  time_type, get_time, set_time,  &
                              operator(+),  operator(-),      &
                              operator(==), operator(>=),     &
                              operator(/=)
-use mpp_mod,          only:  input_nml_file, get_unit
+use mpp_mod,          only:  input_nml_file, input_nml_filename, get_unit
 use fms_mod,          only:  open_file, error_mesg, &
                              check_nml_error, &
                              fms_init, &
@@ -326,7 +326,7 @@ real,dimension(:,:), intent(in), optional :: area_in
 !-------------------------------------------------------------------------------
 !    read namelist.
 !-------------------------------------------------------------------------------
-    if ( file_exists('input.nml')) then
+    if ( file_exists(input_nml_filename)) then
         read (input_nml_file, nml=diag_integral_nml, iostat=io)
         ierr = check_nml_error(io,'diag_integral_nml')
     endif

--- a/diag_manager/diag_manager.F90
+++ b/diag_manager/diag_manager.F90
@@ -197,6 +197,7 @@ use platform_mod
        & get_ticks_per_second
   USE mpp_io_mod, ONLY: mpp_open, mpp_close, mpp_get_maxunits
   USE mpp_mod, ONLY: mpp_get_current_pelist, mpp_pe, mpp_npes, mpp_root_pe, mpp_sum
+  USE mpp_mod, ONLY: input_nml_filename
 
 #ifdef INTERNAL_FILE_NML
   USE mpp_mod, ONLY: input_nml_file
@@ -3585,7 +3586,7 @@ CONTAINS
 #ifdef INTERNAL_FILE_NML
     READ (input_nml_file, NML=diag_manager_nml, IOSTAT=mystat)
 #else
-    IF ( file_exist('input.nml') ) THEN
+    IF ( file_exist(input_nml_filename) ) THEN
        nml_unit = open_namelist_file()
        READ (nml_unit, diag_manager_nml, iostat=mystat)
        CALL close_file(nml_unit)

--- a/fms/fms.F90
+++ b/fms/fms.F90
@@ -331,7 +331,7 @@ subroutine fms_init (localcomm, nml_filename )
  use mpp_mod,       only: input_nml_filename
 
  integer, intent(in), optional :: localcomm
- character(len=128), intent(in), optional :: nml_filename
+ character(len=1024), intent(in), optional :: nml_filename
  integer :: unit, ierr, io
  integer :: logunitnum
 

--- a/fms/fms.F90
+++ b/fms/fms.F90
@@ -338,7 +338,7 @@ subroutine fms_init (localcomm, nml_filename )
     if (module_is_initialized) return    ! return silently if already called
     module_is_initialized = .true.
 !---- initialize mpp routines ----
-    if(present(namelist_filename)) input_nml_filename = nml_filename
+    if(present(nml_filename)) input_nml_filename = nml_filename
     if(present(localcomm)) then
        call mpp_init(localcomm=localcomm)
     else

--- a/fms/fms_io.F90
+++ b/fms/fms_io.F90
@@ -111,7 +111,8 @@ use mpp_domains_mod, only: mpp_get_pelist, mpp_get_io_domain, mpp_get_domain_npe
 use mpp_domains_mod, only: domainUG, mpp_pass_SG_to_UG, mpp_get_UG_domain_ntiles, mpp_get_UG_domain_tile_id
 use mpp_mod,         only: mpp_error, FATAL, NOTE, WARNING, mpp_pe, mpp_root_pe, mpp_npes, stdlog, stdout
 use mpp_mod,         only: mpp_broadcast, ALL_PES, mpp_chksum, mpp_get_current_pelist, mpp_npes, lowercase
-use mpp_mod,         only: input_nml_file, mpp_get_current_pelist_name, uppercase
+use mpp_mod,         only: input_nml_file, input_nml_filename
+use mpp_mod,         only: mpp_get_current_pelist_name, uppercase
 use mpp_mod,         only: mpp_gather, mpp_scatter, mpp_send, mpp_recv, mpp_sync_self, COMM_TAG_1, EVENT_RECV
 use mpp_mod,         only: MPP_FILL_DOUBLE,MPP_FILL_INT
 
@@ -689,7 +690,7 @@ subroutine fms_io_init()
      call mpp_error(FATAL,'=>fms_io_init: Error reading input.nml')
   endif
 #else
-  call mpp_open(unit, 'input.nml',form=MPP_ASCII,action=MPP_RDONLY)
+  call mpp_open(unit, input_nml_filename,form=MPP_ASCII,action=MPP_RDONLY)
   read(unit,fms_io_nml,iostat=io_status)
   if (io_status > 0) then
      call mpp_error(FATAL,'=>fms_io_init: Error reading input.nml')
@@ -7279,7 +7280,7 @@ function open_namelist_file (file) result (unit)
      if ( file_exist('input_'//trim(pelist_name)//'.nml', no_domain=.true.) ) then
         filename='input_'//trim(pelist_name)//'.nml'
      else
-        filename='input.nml'
+        filename=input_nml_filename
      endif
      call mpp_open ( unit, trim(filename), form=MPP_ASCII, action=MPP_RDONLY, &
           access=MPP_SEQUENTIAL, threading=MPP_SINGLE )

--- a/interpolator/interpolator.F90
+++ b/interpolator/interpolator.F90
@@ -34,7 +34,7 @@ use mpp_mod,           only : mpp_error, &
                               mpp_npes,  &
                               WARNING,   &
                               NOTE,      &
-                              input_nml_file
+                              input_nml_file, input_nml_filename
 use mpp_io_mod,        only : mpp_open,          &
                               mpp_close,         &
                               mpp_get_times,     &
@@ -468,7 +468,7 @@ if (.not. module_is_initialized) then
 ! namelist input
 !--------------------------------------------------------------------
 
-the_file_exists = fms2_io_file_exist('input.nml')
+the_file_exists = fms2_io_file_exist(input_nml_filename)
 
 if (the_file_exists) then
     read (input_nml_file, nml=interpolator_nml, iostat=io)

--- a/mpp/include/mpp_comm_mpi.inc
+++ b/mpp/include/mpp_comm_mpi.inc
@@ -125,7 +125,7 @@
      if( .NOT.opened )exit
   end do
 
-  open(unit_nml,file='input.nml', iostat=io_status)
+  open(unit_nml,file=input_nml_filename, iostat=io_status)
   read(unit_nml,mpp_nml,iostat=io_status)
   close(unit_nml)
 #endif

--- a/mpp/include/mpp_comm_nocomm.inc
+++ b/mpp/include/mpp_comm_nocomm.inc
@@ -99,7 +99,7 @@ subroutine mpp_init( flags,localcomm )
      if( .NOT.opened )exit
   end do
 
-  open(unit_nml,file='input.nml', iostat=io_status)
+  open(unit_nml,file=input_nml_filename, iostat=io_status)
   read(unit_nml,mpp_nml,iostat=io_status)
   close(unit_nml)
 #endif

--- a/mpp/include/mpp_domains_misc.inc
+++ b/mpp/include/mpp_domains_misc.inc
@@ -80,7 +80,7 @@
          if( .NOT.opened )exit
       end do
 
-      open(unit_nml,file='input.nml', iostat=io_status)
+      open(unit_nml,file=input_nml_filename, iostat=io_status)
       read(unit_nml,mpp_domains_nml,iostat=io_status)
       close(unit_nml)
 #endif

--- a/mpp/include/mpp_io_misc.inc
+++ b/mpp/include/mpp_io_misc.inc
@@ -82,7 +82,7 @@
          inquire( unit_nml,OPENED=opened )
          if( .NOT.opened )exit
       end do
-      open(unit_nml,file='input.nml')
+      open(unit_nml,file=input_nml_filename)
       read(unit_nml,mpp_io_nml,iostat=io_status)
       close(unit_nml)
 #endif

--- a/mpp/include/mpp_util.inc
+++ b/mpp/include/mpp_util.inc
@@ -1344,7 +1344,7 @@ end function rarray_to_char
     filename='input_'//trim(pelist_name)//'.nml'
     inquire(FILE=filename, EXIST=file_exist)
     if (.not. file_exist ) then
-       filename='input.nml'
+       filename=input_nml_filename
     endif
     lines_and_length = get_ascii_file_num_lines_and_length(filename)
     allocate(character(len=lines_and_length(2))::input_nml_file(lines_and_length(1)))

--- a/mpp/mpp.F90
+++ b/mpp/mpp.F90
@@ -1284,7 +1284,7 @@ private
 ! public variable needed for reading input.nml from an internal file
   character(len=:), dimension(:), allocatable, target, public :: input_nml_file
 ! public variable defining the default name of the input.nml filename
-  character(len=128) :: input_nml_filename='./input.nml'
+  character(len=1024) :: input_nml_filename='./input.nml'
   logical :: read_ascii_file_on = .FALSE.
 !***********************************************************************
 

--- a/mpp/mpp.F90
+++ b/mpp/mpp.F90
@@ -201,6 +201,7 @@ private
   public :: mpp_init_test_full_init, mpp_init_test_init_true_only, mpp_init_test_peset_allocated
   public :: mpp_init_test_clocks_init, mpp_init_test_datatype_list_init, mpp_init_test_logfile_init
   public :: mpp_init_test_read_namelist, mpp_init_test_etc_unit, mpp_init_test_requests_allocated
+  public :: input_nml_filename
 
   !--- public data from mpp_data_mod ------------------------------
 !  public :: request
@@ -1282,6 +1283,8 @@ private
   integer, parameter :: INPUT_STR_LENGTH = 256
 ! public variable needed for reading input.nml from an internal file
   character(len=:), dimension(:), allocatable, target, public :: input_nml_file
+! public variable defining the default name of the input.nml filename
+  character(len=128) :: input_nml_filename='./input.nml'
   logical :: read_ascii_file_on = .FALSE.
 !***********************************************************************
 

--- a/mpp/mpp_domains.F90
+++ b/mpp/mpp_domains.F90
@@ -120,7 +120,7 @@ module mpp_domains_mod
   use mpp_mod,                only : mpp_max, mpp_min, mpp_sum, mpp_get_current_pelist, mpp_broadcast
   use mpp_mod,                only : mpp_sum_ad
   use mpp_mod,                only : mpp_sync, mpp_init, lowercase
-  use mpp_mod,                only : input_nml_file, mpp_alltoall
+  use mpp_mod,                only : input_nml_file, input_nml_filename, mpp_alltoall
   use mpp_mod,                only : mpp_type, mpp_byte
   use mpp_mod,                only : mpp_type_create, mpp_type_free
   use mpp_mod,                only : COMM_TAG_1, COMM_TAG_2, COMM_TAG_3, COMM_TAG_4

--- a/mpp/mpp_io.F90
+++ b/mpp/mpp_io.F90
@@ -329,7 +329,7 @@ use mpp_mod,            only : mpp_error, FATAL, WARNING, NOTE, stdin, stdout, s
 use mpp_mod,            only : mpp_pe, mpp_root_pe, mpp_npes, lowercase, mpp_transmit, mpp_sync_self
 use mpp_mod,            only : mpp_init, mpp_sync, mpp_clock_id, mpp_clock_begin, mpp_clock_end
 use mpp_mod,            only : MPP_CLOCK_SYNC, MPP_CLOCK_DETAILED, CLOCK_ROUTINE
-use mpp_mod,            only : input_nml_file, mpp_gather, mpp_broadcast
+use mpp_mod,            only : input_nml_file, input_nml_filename, mpp_gather, mpp_broadcast
 use mpp_mod,            only : mpp_send, mpp_recv, mpp_sync_self, EVENT_RECV, COMM_TAG_1
 use mpp_domains_mod,    only : domain1d, domain2d, NULL_DOMAIN1D, mpp_domains_init
 use mpp_domains_mod,    only : mpp_get_global_domain, mpp_get_compute_domain


### PR DESCRIPTION
**Description**

**THIS IS A DRAFT PR TO FACILITATE DISCUSSION**

Fixes #779 

`input.nml` is hard-wired and expected to exist in `CWD`.
For applications in DA with outer loops, this poses a limitation when there is a need to read a unique `input.nml` for that outer loop.

What is the solution being proposed in this PR:
We added a variable `input_nml_filename` in `mpp.F90`. Its default value is `input.nml`.
We added an optional argument `nml_filename` for the `subroutine fms_init()` in `fms.F90` 

During the initialization of FMS via `fms_init`, one can pass a path to their custom `input.nml`.  Absence of which is the current state of work.

We replaced all hard-wired instances of `input.nml` with the variable `input_nml_filename`.

This was tested in the CI.

**THE SECTION BELOW WILL BE UPDATED IF THIS DRAFT IS READY FOR A PR**

Include a summary of the change and which issue is fixed. Please also include
relevant motivation and context. List any dependencies that are required for
this change.

Fixes # 779

**How Has This Been Tested?**
Tested in the CI only (for now).
Please describe the tests that you ran to verify your changes. Please also note
any relevant details for your test configuration (e.g. compiler, OS).  Include
enough information so someone can reproduce your tests.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] `make distcheck` passes

