### PR TITLE
Fixed num_lines in mpp_util.inc to have the proper number of lines

### DIFF
--- a/fms2_io/fms_io_utils.F90
+++ b/fms2_io/fms_io_utils.F90
@@ -505,7 +505,7 @@ end subroutine open_check
 
 !> @brief Read the ascii text from filename `ascii_filename`into string array
 !! `ascii_var`
-subroutine ascii_read(ascii_filename, ascii_var, out_dims)
+subroutine ascii_read(ascii_filename, ascii_var, num_lines, max_length)
   character(len=*), intent(in) :: ascii_filename !< The file name to be read
   character(len=:), dimension(:), allocatable, intent(out) :: ascii_var !< The
                                                                         !! string

--- a/fms2_io/fms_io_utils.F90
+++ b/fms2_io/fms_io_utils.F90
@@ -510,13 +510,15 @@ subroutine ascii_read(ascii_filename, ascii_var, out_dims)
   character(len=:), dimension(:), allocatable, intent(out) :: ascii_var !< The
                                                                         !! string
                                                                         !! array
-  integer, dimension(2), optional, intent(out) :: out_dims !< Optional argument to return number of lines and max_length of file
+  integer, optional, intent(out) :: num_lines !< Optional argument to return number of lines in file
+  integer, optional, intent(out) :: max_length !< Optional argument to return max_length of line in file
   integer, dimension(2) :: lines_and_length !< lines = 1, length = 2
   if(allocated(ascii_var)) deallocate(ascii_var)
   lines_and_length = get_ascii_file_num_lines_and_length(ascii_filename)
   allocate(character(len=lines_and_length(2))::ascii_var(lines_and_length(1)))
   call read_ascii_file(ascii_filename, lines_and_length(2), ascii_var)
-  if(present(out_dims)) out_dims = lines_and_length
+  if(present(num_lines)) num_lines = lines_and_length(1)
+  if(present(max_length)) max_length = lines_and_length(2)
 end subroutine ascii_read
 
 !> @brief Populate 2D maskmap from mask_table given a model

--- a/fms2_io/fms_io_utils.F90
+++ b/fms2_io/fms_io_utils.F90
@@ -510,8 +510,9 @@ subroutine ascii_read(ascii_filename, ascii_var, out_dims)
   character(len=:), dimension(:), allocatable, intent(out) :: ascii_var !< The
                                                                         !! string
                                                                         !! array
-  integer, dimension(2), optional, intent(out) :: out_dims
+  integer, dimension(2), optional, intent(out) :: out_dims !< Optional argument to return number of lines and max_length of file
   integer, dimension(2) :: lines_and_length !< lines = 1, length = 2
+  if(allocated(ascii_var)) deallocate(ascii_var)
   lines_and_length = get_ascii_file_num_lines_and_length(ascii_filename)
   allocate(character(len=lines_and_length(2))::ascii_var(lines_and_length(1)))
   call read_ascii_file(ascii_filename, lines_and_length(2), ascii_var)

--- a/fms2_io/fms_io_utils.F90
+++ b/fms2_io/fms_io_utils.F90
@@ -505,15 +505,17 @@ end subroutine open_check
 
 !> @brief Read the ascii text from filename `ascii_filename`into string array
 !! `ascii_var`
-subroutine ascii_read(ascii_filename, ascii_var)
+subroutine ascii_read(ascii_filename, ascii_var, out_dims)
   character(len=*), intent(in) :: ascii_filename !< The file name to be read
   character(len=:), dimension(:), allocatable, intent(out) :: ascii_var !< The
                                                                         !! string
                                                                         !! array
+  integer, dimension(2), optional, intent(out) :: out_dims
   integer, dimension(2) :: lines_and_length !< lines = 1, length = 2
   lines_and_length = get_ascii_file_num_lines_and_length(ascii_filename)
   allocate(character(len=lines_and_length(2))::ascii_var(lines_and_length(1)))
   call read_ascii_file(ascii_filename, lines_and_length(2), ascii_var)
+  if(present(out_dims)) out_dims = lines_and_length
 end subroutine ascii_read
 
 !> @brief Populate 2D maskmap from mask_table given a model

--- a/mpp/include/mpp_util.inc
+++ b/mpp/include/mpp_util.inc
@@ -1400,7 +1400,11 @@ end function rarray_to_char
              num_lines = 1
              do
                 read (UNIT=f_unit, FMT='(A)', IOSTAT=status) str_tmp
-                if ( status .lt. 0 ) exit
+                if ( status .lt. 0 ) then
+                   ! deprecate num_lines by 1 and ensure num_lines is at least 1
+                   num_lines = max (num_lines - 1, 1)
+                   exit
+                endif
                 if ( status .gt. 0 ) then
                    write (UNIT=text, FMT='(I5)') num_lines
                    call mpp_error(FATAL, 'get_ascii_file_num_lines: Error reading line '//trim(text)// &
@@ -1463,14 +1467,15 @@ end function rarray_to_char
              call mpp_error(FATAL, 'get_ascii_file_num_lines: Error opening file:' //trim(FILENAME)// &
                             '.  (IOSTAT = '//trim(text)//')')
           else
-             num_lines = 0
+             num_lines = 1
              max_length = 1
              do
                 read (UNIT=f_unit, FMT='(A)', IOSTAT=status) str_tmp
                 if ( status .lt. 0 ) then
-                  if ( num_lines .lt. 1 ) num_lines = 1
-                  exit
-                end if
+                   ! deprecate num_lines by 1 and ensure num_lines is at least 1
+                   num_lines = max (num_lines - 1, 1)
+                   exit
+                endif
                 if ( status .gt. 0 ) then
                    write (UNIT=text, FMT='(I5)') num_lines
                    call mpp_error(FATAL, 'get_ascii_file_num_lines: Error reading line '//trim(text)// &
@@ -1532,11 +1537,11 @@ end function rarray_to_char
 #include<file_version.h>
 
     character(len=5) :: text
-    character(len=len(Content(1))) :: this_line
     logical :: file_exist
     integer :: status, i, f_unit, log_unit
     integer :: from_pe
     integer :: pnum_lines, num_lines
+    character(len=LENGTH) :: str_tmp
 
     if( .NOT. read_ascii_file_on) then
        call mpp_error(FATAL,  &
@@ -1575,12 +1580,16 @@ end function rarray_to_char
                         //trim(text)//'.')
                 else
                    ! A second 'sanity' check on the file
-                   pnum_lines = 0
+                   pnum_lines = 1
 
                    do
-                      read (UNIT=f_unit, FMT='(A)', IOSTAT=status) this_line
+                      read (UNIT=f_unit, FMT='(A)', IOSTAT=status) str_tmp
 
-                      if ( status .lt. 0 ) exit
+                      if ( status .lt. 0 ) then
+                         ! deprecate pnum_lines by 1 and ensure pnum_lines is at least 1
+                         pnum_lines = max (pnum_lines - 1, 1)
+                         exit
+                      endif
                       if ( status .gt. 0 ) then
                          write (UNIT=text, FMT='(I5)') pnum_lines
                          call mpp_error(FATAL, 'READ_ASCII_FILE: Error reading line '//trim(text)//' in file '//trim(FILENAME)//'.')
@@ -1589,15 +1598,15 @@ end function rarray_to_char
                          call mpp_error(FATAL, 'READ_ASCII_FILE: number of lines in file '//trim(FILENAME)// &
                                 ' is greater than size(Content(:)). ')
                       end if
-                      if ( len_trim(this_line) == LENGTH ) then
+                      if ( len_trim(str_tmp) == LENGTH ) then
                          write(UNIT=text, FMT='(I5)') length
                          call mpp_error(FATAL, 'READ_ASCII_FILE: Length of output string ('//trim(text)//' is too small.&
                               & Increase the LENGTH value.')
                       end if
+                      Content(pnum_lines) = str_tmp
                       pnum_lines = pnum_lines + 1
-                      Content(pnum_lines) = this_line
                    end do
-                   if(num_lines .NE. pnum_lines .and. (num_lines .GT. 1 .or. (pnum_lines + 1) .NE. num_lines)) then
+                   if(num_lines .NE. pnum_lines) then
                       call mpp_error(FATAL, 'READ_ASCII_FILE: number of lines in file '//trim(FILENAME)// &
                           ' does not equal to size(Content(:)) ' )
                    end if

--- a/mpp/include/mpp_util.inc
+++ b/mpp/include/mpp_util.inc
@@ -1541,7 +1541,7 @@ end function rarray_to_char
     integer :: status, i, f_unit, log_unit
     integer :: from_pe
     integer :: pnum_lines, num_lines
-    character(len=LENGTH) :: str_tmp
+    character(len=LENGTH) :: str_tmp !< Temporary variable to store line from file
 
     if( .NOT. read_ascii_file_on) then
        call mpp_error(FATAL,  &

--- a/mpp/include/mpp_util.inc
+++ b/mpp/include/mpp_util.inc
@@ -1463,11 +1463,14 @@ end function rarray_to_char
              call mpp_error(FATAL, 'get_ascii_file_num_lines: Error opening file:' //trim(FILENAME)// &
                             '.  (IOSTAT = '//trim(text)//')')
           else
-             num_lines = 1
+             num_lines = 0
              max_length = 1
              do
                 read (UNIT=f_unit, FMT='(A)', IOSTAT=status) str_tmp
-                if ( status .lt. 0 ) exit
+                if ( status .lt. 0 ) then
+                  num_lines = num_lines + 1
+                  exit
+                end if
                 if ( status .gt. 0 ) then
                    write (UNIT=text, FMT='(I5)') num_lines
                    call mpp_error(FATAL, 'get_ascii_file_num_lines: Error reading line '//trim(text)// &

--- a/mpp/include/mpp_util.inc
+++ b/mpp/include/mpp_util.inc
@@ -1468,7 +1468,7 @@ end function rarray_to_char
              do
                 read (UNIT=f_unit, FMT='(A)', IOSTAT=status) str_tmp
                 if ( status .lt. 0 ) then
-                  num_lines = num_lines + 1
+                  if ( num_lines .lt. 1 ) num_lines = 1
                   exit
                 end if
                 if ( status .gt. 0 ) then
@@ -1532,6 +1532,7 @@ end function rarray_to_char
 #include<file_version.h>
 
     character(len=5) :: text
+    character(len=len(Content(1))) :: this_line
     logical :: file_exist
     integer :: status, i, f_unit, log_unit
     integer :: from_pe
@@ -1574,10 +1575,10 @@ end function rarray_to_char
                         //trim(text)//'.')
                 else
                    ! A second 'sanity' check on the file
-                   pnum_lines = 1
+                   pnum_lines = 0
 
                    do
-                      read (UNIT=f_unit, FMT='(A)', IOSTAT=status) Content(pnum_lines)
+                      read (UNIT=f_unit, FMT='(A)', IOSTAT=status) this_line
 
                       if ( status .lt. 0 ) exit
                       if ( status .gt. 0 ) then
@@ -1588,14 +1589,15 @@ end function rarray_to_char
                          call mpp_error(FATAL, 'READ_ASCII_FILE: number of lines in file '//trim(FILENAME)// &
                                 ' is greater than size(Content(:)). ')
                       end if
-                      if ( len_trim(Content(pnum_lines)) == LENGTH ) then
+                      if ( len_trim(this_line) == LENGTH ) then
                          write(UNIT=text, FMT='(I5)') length
                          call mpp_error(FATAL, 'READ_ASCII_FILE: Length of output string ('//trim(text)//' is too small.&
                               & Increase the LENGTH value.')
                       end if
                       pnum_lines = pnum_lines + 1
+                      Content(pnum_lines) = this_line
                    end do
-                   if(num_lines .NE. pnum_lines) then
+                   if(num_lines .NE. pnum_lines .and. (num_lines .GT. 1 .or. (pnum_lines + 1) .NE. num_lines)) then
                       call mpp_error(FATAL, 'READ_ASCII_FILE: number of lines in file '//trim(FILENAME)// &
                           ' does not equal to size(Content(:)) ' )
                    end if


### PR DESCRIPTION
**Description**
Makes changes to num_lines in mpp_util.inc so that it accurately reflects the number of lines in the file (except when the file has no content, in which case num_lines will be 1). Also adds an option in ascii_read to output the lines_and_length parameter (useful for testing purposes mostly).

Fixes #399 

**How Has This Been Tested?**
Ran with Intel19 on Skylake. Modified test_read_ascii_data in test_fms/fms2_io to test for files with varying line quantities (have since reverted those test changes to the standard test).

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

