### PR TITLE
Adds an action to run `make check` on main branch 

### DIFF
--- a/.github/workflows/build_parallelWorks_intel_tag.yml
+++ b/.github/workflows/build_parallelWorks_intel_tag.yml
@@ -1,0 +1,15 @@
+name: Build testing libFMS with intel
+  
+on: 
+   push:
+        tags:
+             - '*alpha*'
+             - '*beta*'
+jobs:
+     intelBuild:
+           runs-on: [self-hosted, pw-platform]
+           steps:
+                - name: Spinning up cluster
+                  run: python3 /home/Thomas.Robinson/pw/storage/pw_api_python/FMStestStartClusters.py azcluster_noaa
+                - name: Turn off cluster
+                  run: python3 /home/Thomas.Robinson/pw/storage/pw_api_python/stopClusters.py azcluster_noaa


### PR DESCRIPTION
**Description**
Adds an action to compile FMS on the parallel works cloud instance when an alpha or beta tag is created.  

Fixes # 

**How Has This Been Tested?**
I tested this in a test repo and the build works and is triggered on tag creation in that repo.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

