### PR TITLE
Domain nest fix

### DIFF
--- a/mpp/include/mpp_define_nest_domains.inc
+++ b/mpp/include/mpp_define_nest_domains.inc
@@ -2214,18 +2214,34 @@ function search_C2F_nest_overlap(nest_domain, nest_level, extra_halo, position)
           iy = iy + 1
        else if ( rank_x < rank_y ) then
           n = n+1
-          ind_x (nrecv) = ix
-          ind_y (nrecv) = -1
-          cur_pos = cur_pos + update_x%recv(ix)%totsize
-          pelist(nrecv) = update_x%recv(ix)%pe
-          ix = ix + 1
+          if (nrecv > nrecv_x) then
+             ind_x (nrecv) = -1
+             ind_y (nrecv) = iy
+             cur_pos = cur_pos + update_y%recv(iy)%totsize
+             pelist(nrecv) = update_y%recv(iy)%pe
+             iy = iy+1
+          else
+             ind_x (nrecv) = ix
+             ind_y (nrecv) = -1
+             cur_pos = cur_pos + update_x%recv(ix)%totsize
+             pelist(nrecv) = update_x%recv(ix)%pe
+             ix = ix + 1
+          endif
        else if ( rank_y < rank_x ) then
           n = n+1
-          ind_x (nrecv) = -1
-          ind_y (nrecv) = iy
-          cur_pos = cur_pos + update_y%recv(iy)%totsize
-          pelist(nrecv) = update_y%recv(iy)%pe
-          iy = iy+1
+          if (nrecv > nrecv_y) then
+             ind_x (nrecv) = ix
+             ind_y (nrecv) = -1
+             cur_pos = cur_pos + update_x%recv(ix)%totsize
+             pelist(nrecv) = update_x%recv(ix)%pe
+             ix = ix + 1
+          else
+             ind_x (nrecv) = -1
+             ind_y (nrecv) = iy
+             cur_pos = cur_pos + update_y%recv(iy)%totsize
+             pelist(nrecv) = update_y%recv(iy)%pe
+             iy = iy+1
+          endif
        endif
     end do
 
@@ -2284,18 +2300,33 @@ function search_C2F_nest_overlap(nest_domain, nest_level, extra_halo, position)
           iy = iy + 1
        else if ( rank_x < rank_y ) then
           n = n+1
-          ind_x (nsend) = ix
-          ind_y (nsend) = -1
-          cur_pos = cur_pos + update_x%send(ix)%totsize
-          pelist(nsend) = update_x%send(ix)%pe
-          ix = ix + 1
+          if (nsend > nsend_x) then
+             ind_x (nsend) = -1
+             ind_y (nsend) = iy
+             cur_pos = cur_pos + update_y%send(iy)%totsize
+             pelist(nsend) = update_y%send(iy)%pe
+          else
+             ind_x (nsend) = ix
+             ind_y (nsend) = -1
+             cur_pos = cur_pos + update_x%send(ix)%totsize
+             pelist(nsend) = update_x%send(ix)%pe
+             ix = ix + 1
+          endif
        else if ( rank_y < rank_x ) then
           n = n+1
-          ind_x (nsend) = -1
-          ind_y (nsend) = iy
-          cur_pos = cur_pos + update_y%send(iy)%totsize
-          pelist(nsend) = update_y%send(iy)%pe
-          iy = iy+1
+          if (nsend > nsend_y) then
+             ind_x (nsend) = ix
+             ind_y (nsend) = -1
+             cur_pos = cur_pos + update_x%send(ix)%totsize
+             pelist(nsend) = update_x%send(ix)%pe
+             ix = ix + 1
+          else
+             ind_x (nsend) = -1
+             ind_y (nsend) = iy
+             cur_pos = cur_pos + update_y%send(iy)%totsize
+             pelist(nsend) = update_y%send(iy)%pe
+             iy = iy+1
+          endif
        endif
     end do
 

--- a/mpp/include/mpp_define_nest_domains.inc
+++ b/mpp/include/mpp_define_nest_domains.inc
@@ -2190,21 +2190,19 @@ function search_C2F_nest_overlap(nest_domain, nest_level, extra_halo, position)
     nrecv = 0
     cur_pos = 0
     do while (n<=ntot)
-       if(ix <= nrecv_x ) then
-          rank_x = update_x%recv(ix)%pe-mpp_pe()
-          if(rank_x .LE. 0) rank_x = rank_x + nlist
+       if ( ix <= nrecv_x ) then
+          rank_x = update_x%recv(ix)%pe
        else
-          rank_x = nlist+1
+          rank_x = -1
        endif
-       if(iy <= nrecv_y ) then
-          rank_y = update_y%recv(iy)%pe-mpp_pe()
-          if(rank_y .LE. 0) rank_y = rank_y + nlist
+       if ( iy <= nrecv_y ) then
+          rank_y = update_y%recv(iy)%pe
        else
-          rank_y = nlist+1
+          rank_y = -1
        endif
        nrecv = nrecv + 1
        start_pos(nrecv) = cur_pos
-       if( rank_x == rank_y ) then
+       if ( (rank_x == rank_y) .and. ( (rank_x >= 0) .and. (rank_y >= 0) ) ) then
           n = n+2
           ind_x (nrecv) = ix
           ind_y (nrecv) = iy
@@ -2214,12 +2212,12 @@ function search_C2F_nest_overlap(nest_domain, nest_level, extra_halo, position)
           iy = iy + 1
        else if ( rank_x < rank_y ) then
           n = n+1
-          if (nrecv > nrecv_x) then
+          if ( rank_x < 0 ) then
              ind_x (nrecv) = -1
              ind_y (nrecv) = iy
              cur_pos = cur_pos + update_y%recv(iy)%totsize
              pelist(nrecv) = update_y%recv(iy)%pe
-             iy = iy+1
+             iy = iy + 1
           else
              ind_x (nrecv) = ix
              ind_y (nrecv) = -1
@@ -2229,7 +2227,7 @@ function search_C2F_nest_overlap(nest_domain, nest_level, extra_halo, position)
           endif
        else if ( rank_y < rank_x ) then
           n = n+1
-          if (nrecv > nrecv_y) then
+          if ( rank_y < 0 ) then
              ind_x (nrecv) = ix
              ind_y (nrecv) = -1
              cur_pos = cur_pos + update_x%recv(ix)%totsize
@@ -2240,7 +2238,7 @@ function search_C2F_nest_overlap(nest_domain, nest_level, extra_halo, position)
              ind_y (nrecv) = iy
              cur_pos = cur_pos + update_y%recv(iy)%totsize
              pelist(nrecv) = update_y%recv(iy)%pe
-             iy = iy+1
+             iy = iy + 1
           endif
        endif
     end do
@@ -2276,21 +2274,19 @@ function search_C2F_nest_overlap(nest_domain, nest_level, extra_halo, position)
     nsend = 0
     cur_pos = 0
     do while (n<=ntot)
-       if(ix <= nsend_x ) then
-          rank_x = update_x%send(ix)%pe-mpp_pe()
-          if(rank_x .LE. 0) rank_x = rank_x + nlist
+       if ( ix <= nsend_x ) then
+          rank_x = update_x%send(ix)%pe
        else
-          rank_x = nlist+1
+          rank_x = -1
        endif
-       if(iy <= nsend_y ) then
-          rank_y = update_y%send(iy)%pe-mpp_pe()
-          if(rank_y .LE. 0) rank_y = rank_y + nlist
+       if ( iy <= nsend_y ) then
+          rank_y = update_y%send(iy)%pe
        else
-          rank_y = nlist+1
+          rank_y = -1
        endif
        nsend = nsend + 1
        start_pos(nsend) = cur_pos
-       if( rank_x == rank_y ) then
+       if ( (rank_x == rank_y) .and. ( (rank_x >= 0) .and. (rank_y >= 0) ) ) then
           n = n+2
           ind_x (nsend) = ix
           ind_y (nsend) = iy
@@ -2300,11 +2296,12 @@ function search_C2F_nest_overlap(nest_domain, nest_level, extra_halo, position)
           iy = iy + 1
        else if ( rank_x < rank_y ) then
           n = n+1
-          if (nsend > nsend_x) then
+          if ( rank_x < 0 ) then
              ind_x (nsend) = -1
              ind_y (nsend) = iy
              cur_pos = cur_pos + update_y%send(iy)%totsize
              pelist(nsend) = update_y%send(iy)%pe
+             iy = iy + 1
           else
              ind_x (nsend) = ix
              ind_y (nsend) = -1
@@ -2314,7 +2311,7 @@ function search_C2F_nest_overlap(nest_domain, nest_level, extra_halo, position)
           endif
        else if ( rank_y < rank_x ) then
           n = n+1
-          if (nsend > nsend_y) then
+          if ( rank_y < 0 ) then
              ind_x (nsend) = ix
              ind_y (nsend) = -1
              cur_pos = cur_pos + update_x%send(ix)%totsize
@@ -2325,7 +2322,7 @@ function search_C2F_nest_overlap(nest_domain, nest_level, extra_halo, position)
              ind_y (nsend) = iy
              cur_pos = cur_pos + update_y%send(iy)%totsize
              pelist(nsend) = update_y%send(iy)%pe
-             iy = iy+1
+             iy = iy + 1
           endif
        endif
     end do

--- a/test_fms/mpp/test_mpp_domains.F90
+++ b/test_fms/mpp/test_mpp_domains.F90
@@ -137,7 +137,11 @@ program test_mpp_domains
 
 
   call mpp_init()
-  call mpp_domains_init(MPP_DEBUG)
+  if (debug) then
+    call mpp_domains_init(MPP_DEBUG)
+  else
+    call mpp_domains_init()
+  endif
   call mpp_domains_set_stack_size(stackmax)
 
   outunit = stdout()

--- a/test_fms/mpp/test_mpp_domains.F90
+++ b/test_fms/mpp/test_mpp_domains.F90
@@ -19,12 +19,11 @@
 program test_mpp_domains
   use mpp_mod,         only : FATAL, WARNING, MPP_DEBUG, NOTE, MPP_CLOCK_SYNC,MPP_CLOCK_DETAILED
   use mpp_mod,         only : mpp_pe, mpp_npes, mpp_root_pe, mpp_error, mpp_set_warn_level
-  use mpp_mod,         only : mpp_declare_pelist, mpp_set_current_pelist, mpp_sync, mpp_sync_self
+  use mpp_mod,         only : mpp_declare_pelist, mpp_set_current_pelist, mpp_sync
   use mpp_mod,         only : mpp_clock_begin, mpp_clock_end, mpp_clock_id
   use mpp_mod,         only : mpp_init, mpp_exit, mpp_chksum, stdout, stderr
   use mpp_mod,         only : input_nml_file
   use mpp_mod,         only : mpp_get_current_pelist, mpp_broadcast
-  use mpp_mod,         only : mpp_init_test_requests_allocated
 
   use mpp_domains_mod, only : GLOBAL_DATA_DOMAIN, BITWISE_EXACT_SUM, BGRID_NE, CGRID_NE, DGRID_NE, AGRID
   use mpp_domains_mod, only : FOLD_SOUTH_EDGE, FOLD_NORTH_EDGE, FOLD_WEST_EDGE, FOLD_EAST_EDGE
@@ -54,6 +53,7 @@ program test_mpp_domains
   use mpp_domains_mod, only : WUPDATE, SUPDATE, mpp_get_compute_domains, NONSYMEDGEUPDATE, mpp_get_tile_id
   use mpp_memutils_mod, only : mpp_memuse_begin, mpp_memuse_end
   use fms_affinity_mod, only : fms_affinity_set
+
   use compare_data_checksums
   use test_domains_utility_mod
   use platform_mod
@@ -73,6 +73,7 @@ program test_mpp_domains
   integer :: wide_halo_x = 0, wide_halo_y = 0
   integer :: nx_cubic = 0, ny_cubic = 0
   logical :: test_nest = .false.
+  logical :: test_nest_regional = .false.
   logical :: test_performance = .false.
   logical :: test_interface = .true.
   logical :: test_edge_update = .false.
@@ -112,6 +113,7 @@ program test_mpp_domains
   integer :: istart_coarse(MAX_NNEST) = 0, icount_coarse(MAX_NNEST) = 0
   integer :: jstart_coarse(MAX_NNEST) = 0, jcount_coarse(MAX_NNEST) = 0
   integer :: extra_halo = 0
+  integer :: layout_nest(2,MAX_NNEST) = 0
   character :: cyclic_nest(MAX_NCONTACT) = 'N'
 
   namelist / test_mpp_domains_nml / nx, ny, nz, stackmax, debug, mpes, check_parallel, &
@@ -122,18 +124,19 @@ program test_mpp_domains
                                refine_ratio, istart_coarse, icount_coarse, jstart_coarse, jcount_coarse, &
                                extra_halo, npes_nest_tile, cyclic_nest, mix_2D_3D, test_get_nbr, &
                                test_edge_update, test_cubic_grid_redistribute, ensemble_size, &
-                               layout_cubic, layout_ensemble, nthreads, test_boundary, &
+                               layout_cubic, layout_ensemble, layout_nest, nthreads, test_boundary, &
                                layout_tripolar, test_group, test_global_sum, test_subset, &
-                               test_nonsym_edge, test_halosize_performance, test_adjoint, wide_halo
+                               test_nonsym_edge, test_halosize_performance, test_adjoint, wide_halo, &
+                               test_nest_regional
   integer :: i, j, k, n
   integer :: layout(2)
   integer :: id
   integer :: outunit, errunit, io_status
   integer :: omp_get_num_threads, omp_get_thread_num
-  integer                         :: ierr
+  integer :: ierr
 
 
-  call mpp_init(test_level=mpp_init_test_requests_allocated)
+  call mpp_init()
   call mpp_domains_init(MPP_DEBUG)
   call mpp_domains_set_stack_size(stackmax)
 
@@ -147,6 +150,7 @@ program test_mpp_domains
 
   pe = mpp_pe()
   npes = mpp_npes()
+
 
   if( pe.EQ.mpp_root_pe() ) then
      print '(a,9i6)', 'npes, mpes, nx, ny, nz, whalo, ehalo, shalo, nhalo =', &
@@ -165,7 +169,7 @@ program test_mpp_domains
      "test_mpp_domain: nx_cubic and ny_cubic should be both zero or both positive")
 
   if( test_nest .and. (num_nest>0) ) then
-    if (mpp_pe() == mpp_root_pe())  print *, '--------------------> Calling test_update_nest_domain <-------------------'
+    if (mpp_pe() == mpp_root_pe())  print *, '-----------------> Calling test_update_nest_domain Cubic <----------------'
      do n = 1, num_nest
         if( istart_coarse(n) == 0 .OR. jstart_coarse(n) == 0 ) call mpp_error(FATAL, &
         "test_mpp_domain: check the setting of namelist variable istart_coarse, jstart_coarse")
@@ -176,9 +180,32 @@ program test_mpp_domains
      enddo
      if(ANY(refine_ratio(:).LT.1)) call  mpp_error(FATAL, &
         "test_mpp_domain: check the setting of namelist variable refine_ratio")
+    if (mpp_pe() == mpp_root_pe())  print *, '-----------------> Starting test_update_nest_domain_r8 Cubic <----------------'
      call test_update_nest_domain_r8('Cubic-Grid')
+    if (mpp_pe() == mpp_root_pe())  print *, '-----------------> Finished test_update_nest_domain_r8 Cubic <----------------'
+    if (mpp_pe() == mpp_root_pe())  print *, '-----------------> Starting test_update_nest_domain_r4 Cubic <----------------'
      call test_update_nest_domain_r4('Cubic-Grid')
-    if (mpp_pe() == mpp_root_pe())  print *, '--------------------> Finished test_update_nest_domain <-------------------'
+    if (mpp_pe() == mpp_root_pe())  print *, '-----------------> Finished test_update_nest_domain_r4 Cubic <----------------'
+  endif
+
+  if( test_nest_regional .and. (num_nest>0) ) then
+    if (mpp_pe() == mpp_root_pe())  print *, '---------------> Calling test_update_nest_domain Regional <--------------'
+     do n = 1, num_nest
+        if( istart_coarse(n) == 0 .OR. jstart_coarse(n) == 0 ) call mpp_error(FATAL, &
+        "test_mpp_domain: check the setting of namelist variable istart_coarse, jstart_coarse")
+        if( icount_coarse(n) == 0 .OR. jcount_coarse(n) == 0 ) call mpp_error(FATAL, &
+        "test_mpp_domain: check the setting of namelist variable icount_coarse, jcount_coarse")
+        if( tile_coarse(n) .LE. 0) call mpp_error(FATAL, &
+            "test_mpp_domain: check the setting of namelist variable tile_coarse")
+     enddo
+     if(ANY(refine_ratio(:).LT.1)) call  mpp_error(FATAL, &
+        "test_mpp_domain: check the setting of namelist variable refine_ratio")
+    if (mpp_pe() == mpp_root_pe())  print *, '---------------> Starting test_update_nest_domain_r8 Regional <--------------'
+     call test_update_nest_domain_r8('Regional')
+    if (mpp_pe() == mpp_root_pe())  print *, '---------------> Finished test_update_nest_domain_r8 Regional <--------------'
+    if (mpp_pe() == mpp_root_pe())  print *, '---------------> Starting test_update_nest_domain_r4 Regional <--------------'
+     call test_update_nest_domain_r4('Regional')
+    if (mpp_pe() == mpp_root_pe())  print *, '---------------> Finished test_update_nest_domain_r4 Regional <--------------'
   endif
 
   if( test_halosize_performance ) then
@@ -303,7 +330,7 @@ program test_mpp_domains
       if (mpp_pe() == mpp_root_pe())  print *, '--------------------> Finish test_get_nbr <-------------------'
   endif
 
-  call MPI_finalize(ierr)
+  call mpp_exit()
 
 contains
   subroutine test_openmp()
@@ -6074,6 +6101,21 @@ end subroutine test_halosize_update
        ny = ny_cubic
        ntiles_nest_top = 6
        cubic_grid = .true.
+    case ( 'Regional' )
+       if( nx_cubic == 0 ) then
+          call mpp_error(NOTE,'test_update_nest_domain: for Regional grid mosaic, nx_cubic is zero, '//&
+                  'No test is done for Cubic-Grid mosaic. ' )
+          return
+       endif
+       if( nx_cubic .NE. ny_cubic ) then
+          call mpp_error(NOTE,'test_update_nest_domain: for Regional grid mosaic, nx_cubic does not equal ny_cubic, '//&
+                  'No test is done for Cubic-Grid mosaic. ' )
+          return
+       endif
+       nx = nx_cubic
+       ny = ny_cubic
+       ntiles_nest_top = 1
+       cubic_grid = .false.
     case default
        call mpp_error(FATAL, 'test_update_nest_domain: no such test: '//type)
     end select
@@ -6138,10 +6180,15 @@ end subroutine test_halosize_update
        allocate(layout2D(2,ntiles_nest_top), global_indices(4,ntiles_nest_top), pe_start(ntiles_nest_top), pe_end(ntiles_nest_top) )
        npes_per_tile = npes_nest_tile(1)
 
+
        call mpp_define_layout( (/1,nx,1,ny/), npes_per_tile, layout )
        do n = 1, ntiles_nest_top
           global_indices(:,n) = (/1,nx,1,ny/)
-          layout2D(:,n)         = layout
+          if (ANY(layout_cubic == 0)) then
+             layout2D(:,n)         = layout
+          else
+             layout2D(:,n)         = layout_cubic(:)
+           endif
        end do
        do n = 1, ntiles_nest_top
           pe_start(n) = (n-1)*npes_per_tile
@@ -6151,6 +6198,10 @@ end subroutine test_halosize_update
        if( cubic_grid ) then
           call define_cubic_mosaic(type, domain, (/nx,nx,nx,nx,nx,nx/), (/ny,ny,ny,ny,ny,ny/), &
                                    global_indices, layout2D, pe_start, pe_end )
+       else
+          call mpp_define_domains(global_indices(:,ntiles_nest_top), layout2D(:,ntiles_nest_top), domain, &
+                          whalo=whalo, ehalo=ehalo, shalo=shalo, nhalo=nhalo, &
+                          symmetry=.true., name=trim(type)//' top level grid', tile_id=1  )
        endif
        call mpp_get_compute_domain(domain, isc_coarse, iec_coarse, jsc_coarse, jec_coarse)
        call mpp_get_data_domain(domain, isd_coarse, ied_coarse, jsd_coarse, jed_coarse)
@@ -6170,7 +6221,11 @@ end subroutine test_halosize_update
           call mpp_set_current_pelist(my_pelist)
           nx_fine = iend_fine(n) - istart_fine(n) + 1
           ny_fine = jend_fine(n) - jstart_fine(n) + 1
-          call mpp_define_layout( (/1,nx_fine,1,ny_fine/), my_npes, layout )
+          if (ANY(layout_nest(:,n) == 0)) then
+             call mpp_define_layout( (/1,nx_fine,1,ny_fine/), my_npes, layout )
+          else
+             layout(:)         = layout_nest(:,n)
+          endif
           call mpp_define_domains((/1,nx_fine,1,ny_fine/), layout, domain, &
                           whalo=whalo, ehalo=ehalo, shalo=shalo, nhalo=nhalo, &
                           symmetry=.true., name=trim(type)//' fine grid', tile_id = tile_fine(n) )
@@ -6300,6 +6355,7 @@ end subroutine test_halosize_update
           if(allocated(x))       deallocate(x)
           if(allocated(x1))      deallocate(x1)
           if(allocated(x2))      deallocate(x2)
+
        !---------------------------------------------------------------------------
        !
        !                    fine to coarse CGRID scalar pair update
@@ -6581,13 +6637,11 @@ end subroutine test_halosize_update
        if(allocated(y1))      deallocate(y1)
        if(allocated(y2))      deallocate(y2)
 
-
        !---------------------------------------------------------------------------
        !
        !                 Coarse to Fine scalar field, position = CENTER
        !
        !---------------------------------------------------------------------------
-
        !--- first check the index is correct or not
        !--- The index from nest domain
        call mpp_get_C2F_index(nest_domain, isw_f, iew_f, jsw_f, jew_f, isw_c, iew_c, jsw_c, jew_c, WEST, l)
@@ -7081,7 +7135,6 @@ end subroutine test_halosize_update
        !                 Coarse to Fine scalar field, position = CORNER
        !
        !---------------------------------------------------------------------------
-
        if(is_coarse_pe) then
           call mpp_get_compute_domain(domain_coarse, isc_coarse, iec_coarse, jsc_coarse, jec_coarse)
           call mpp_get_data_domain(domain_coarse, isd_coarse, ied_coarse, jsd_coarse, jed_coarse)
@@ -7190,7 +7243,6 @@ end subroutine test_halosize_update
        endif
        deallocate(x)
 
-
        !---------------------------------------------------------------------------
        !
        !                    coarse to fine CGRID scalar pair update
@@ -7246,7 +7298,7 @@ end subroutine test_halosize_update
              isw_cy2 = istart_coarse(my_fine_id)-whalo
              iew_cy2 = istart_coarse(my_fine_id)
              jsw_cy2 = jstart_coarse(my_fine_id) + (jsc_fine - jstart_fine(my_fine_id))/y_refine(my_fine_id) - shalo
-             jew_cy2 = jstart_coarse(my_fine_id) + (jec_fine + shift - jstart_fine(my_fine_id))/y_refine(my_fine_id) + nhalo
+             jew_cy2 = jstart_coarse(my_fine_id) + (jec_fine - jstart_fine(my_fine_id))/y_refine(my_fine_id) + nhalo + shift
           endif
           !--- east
           if( iec_fine == nx_fine ) then
@@ -7492,7 +7544,6 @@ end subroutine test_halosize_update
        !                    coarse to fine CGRID vector update
        !
        !---------------------------------------------------------------------------
-
        if(is_coarse_pe) then
           call mpp_get_compute_domain(domain_coarse, isc_coarse, iec_coarse, jsc_coarse, jec_coarse)
           call mpp_get_data_domain(domain_coarse, isd_coarse, ied_coarse, jsd_coarse, jed_coarse)
@@ -7599,7 +7650,6 @@ end subroutine test_halosize_update
           deallocate(wbuffery, ebuffery, sbuffery, nbuffery)
           deallocate(wbuffery2, ebuffery2, sbuffery2, nbuffery2)
        endif
-
 
        !---------------------------------------------------------------------------
        !
@@ -7777,7 +7827,8 @@ end subroutine test_halosize_update
        call mpp_set_current_pelist()
     enddo
 
-    call mpp_set_current_pelist()
+    call mpp_set_current_pelist(pelist)
+    call mpp_sync(pelist)
     deallocate(pelist)
 
   end subroutine test_update_nest_domain_r8
@@ -7906,6 +7957,21 @@ end subroutine test_halosize_update
        ny = ny_cubic
        ntiles_nest_top = 6
        cubic_grid = .true.
+    case ( 'Regional' )
+       if( nx_cubic == 0 ) then
+          call mpp_error(NOTE,'test_update_nest_domain: for Regional grid mosaic, nx_cubic is zero, '//&
+                  'No test is done for Cubic-Grid mosaic. ' )
+          return
+       endif
+       if( nx_cubic .NE. ny_cubic ) then
+          call mpp_error(NOTE,'test_update_nest_domain: for Regional grid mosaic, nx_cubic does not equal ny_cubic, '//&
+                  'No test is done for Cubic-Grid mosaic. ' )
+          return
+       endif
+       nx = nx_cubic
+       ny = ny_cubic
+       ntiles_nest_top = 1
+       cubic_grid = .false.
     case default
        call mpp_error(FATAL, 'test_update_nest_domain: no such test: '//type)
     end select
@@ -7973,7 +8039,11 @@ end subroutine test_halosize_update
        call mpp_define_layout( (/1,nx,1,ny/), npes_per_tile, layout )
        do n = 1, ntiles_nest_top
           global_indices(:,n) = (/1,nx,1,ny/)
-          layout2D(:,n)         = layout
+          if (ANY(layout_cubic == 0)) then
+             layout2D(:,n)         = layout
+          else
+             layout2D(:,n)         = layout_cubic(:)
+           endif
        end do
        do n = 1, ntiles_nest_top
           pe_start(n) = (n-1)*npes_per_tile
@@ -7983,6 +8053,10 @@ end subroutine test_halosize_update
        if( cubic_grid ) then
           call define_cubic_mosaic(type, domain, (/nx,nx,nx,nx,nx,nx/), (/ny,ny,ny,ny,ny,ny/), &
                                    global_indices, layout2D, pe_start, pe_end )
+       else
+          call mpp_define_domains(global_indices(:,ntiles_nest_top), layout2D(:,ntiles_nest_top), domain, &
+                          whalo=whalo, ehalo=ehalo, shalo=shalo, nhalo=nhalo, &
+                          symmetry=.true., name=trim(type)//' top level grid', tile_id=1  )
        endif
        call mpp_get_compute_domain(domain, isc_coarse, iec_coarse, jsc_coarse, jec_coarse)
        call mpp_get_data_domain(domain, isd_coarse, ied_coarse, jsd_coarse, jed_coarse)
@@ -8002,7 +8076,11 @@ end subroutine test_halosize_update
           call mpp_set_current_pelist(my_pelist)
           nx_fine = iend_fine(n) - istart_fine(n) + 1
           ny_fine = jend_fine(n) - jstart_fine(n) + 1
-          call mpp_define_layout( (/1,nx_fine,1,ny_fine/), my_npes, layout )
+          if (ANY(layout_nest(:,n) == 0)) then
+             call mpp_define_layout( (/1,nx_fine,1,ny_fine/), my_npes, layout )
+          else
+             layout(:)         = layout_nest(:,n)
+          endif
           call mpp_define_domains((/1,nx_fine,1,ny_fine/), layout, domain, &
                           whalo=whalo, ehalo=ehalo, shalo=shalo, nhalo=nhalo, &
                           symmetry=.true., name=trim(type)//' fine grid', tile_id = tile_fine(n) )
@@ -8132,6 +8210,7 @@ end subroutine test_halosize_update
           if(allocated(x))       deallocate(x)
           if(allocated(x1))      deallocate(x1)
           if(allocated(x2))      deallocate(x2)
+
        !---------------------------------------------------------------------------
        !
        !                    fine to coarse CGRID scalar pair update
@@ -8413,13 +8492,11 @@ end subroutine test_halosize_update
        if(allocated(y1))      deallocate(y1)
        if(allocated(y2))      deallocate(y2)
 
-
        !---------------------------------------------------------------------------
        !
        !                 Coarse to Fine scalar field, position = CENTER
        !
        !---------------------------------------------------------------------------
-
        !--- first check the index is correct or not
        !--- The index from nest domain
        call mpp_get_C2F_index(nest_domain, isw_f, iew_f, jsw_f, jew_f, isw_c, iew_c, jsw_c, jew_c, WEST, l)
@@ -8913,7 +8990,6 @@ end subroutine test_halosize_update
        !                 Coarse to Fine scalar field, position = CORNER
        !
        !---------------------------------------------------------------------------
-
        if(is_coarse_pe) then
           call mpp_get_compute_domain(domain_coarse, isc_coarse, iec_coarse, jsc_coarse, jec_coarse)
           call mpp_get_data_domain(domain_coarse, isd_coarse, ied_coarse, jsd_coarse, jed_coarse)
@@ -9022,7 +9098,6 @@ end subroutine test_halosize_update
        endif
        deallocate(x)
 
-
        !---------------------------------------------------------------------------
        !
        !                    coarse to fine CGRID scalar pair update
@@ -9078,7 +9153,7 @@ end subroutine test_halosize_update
              isw_cy2 = istart_coarse(my_fine_id)-whalo
              iew_cy2 = istart_coarse(my_fine_id)
              jsw_cy2 = jstart_coarse(my_fine_id) + (jsc_fine - jstart_fine(my_fine_id))/y_refine(my_fine_id) - shalo
-             jew_cy2 = jstart_coarse(my_fine_id) + (jec_fine + shift - jstart_fine(my_fine_id))/y_refine(my_fine_id) + nhalo
+             jew_cy2 = jstart_coarse(my_fine_id) + (jec_fine - jstart_fine(my_fine_id))/y_refine(my_fine_id) + nhalo + shift
           endif
           !--- east
           if( iec_fine == nx_fine ) then
@@ -9324,7 +9399,6 @@ end subroutine test_halosize_update
        !                    coarse to fine CGRID vector update
        !
        !---------------------------------------------------------------------------
-
        if(is_coarse_pe) then
           call mpp_get_compute_domain(domain_coarse, isc_coarse, iec_coarse, jsc_coarse, jec_coarse)
           call mpp_get_data_domain(domain_coarse, isd_coarse, ied_coarse, jsd_coarse, jed_coarse)
@@ -9431,7 +9505,6 @@ end subroutine test_halosize_update
           deallocate(wbuffery, ebuffery, sbuffery, nbuffery)
           deallocate(wbuffery2, ebuffery2, sbuffery2, nbuffery2)
        endif
-
 
        !---------------------------------------------------------------------------
        !
@@ -9609,7 +9682,8 @@ end subroutine test_halosize_update
        call mpp_set_current_pelist()
     enddo
 
-    call mpp_set_current_pelist()
+    call mpp_set_current_pelist(pelist)
+    call mpp_sync(pelist)
     deallocate(pelist)
 
   end subroutine test_update_nest_domain_r4


### PR DESCRIPTION
**Description**
Fixes an algorithm used with nested grid updates to properly coalesce pelist strings for vector quantities.

Also updates the mpp domains CI test to add a regional top-level domain for the nested tests.  Additional namelist options are added to expand the capability of the test to be used when prototyping and debugging.

Fixes # (issue)

**How Has This Been Tested?**
The algorithm was tested extensively in the domains CI test and SHiELD model.  FMS CI was also manually run to ensure the updates are good.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

