### PR TITLE
Test fixes for the testing tag

### DIFF
--- a/test_fms/fms2_io/test_atmosphere_io.sh
+++ b/test_fms/fms2_io/test_atmosphere_io.sh
@@ -24,7 +24,13 @@
 
 # Set common test settings.
 . ../test_common.sh
+
+[ -d atmosphere-output ] && rm -r atmosphere-output
+mkdir atmosphere-output
+cd atmosphere-output
+
 # make an input.nml for mpp_init to read
 printf "EOF\n&dummy\nEOF" | cat > input.nml
+
 # run the tests
-run_test test_atmosphere_io 6
+run_test ../test_atmosphere_io 6

--- a/test_fms/fms2_io/test_atmosphere_io.sh
+++ b/test_fms/fms2_io/test_atmosphere_io.sh
@@ -34,3 +34,5 @@ printf "EOF\n&dummy\nEOF" | cat > input.nml
 
 # run the tests
 run_test ../test_atmosphere_io 6
+
+cd .. && rm -r atmosphere-output

--- a/test_fms/time_interp/test_time_interp_external.F90
+++ b/test_fms/time_interp/test_time_interp_external.F90
@@ -93,7 +93,7 @@ if (mpp_pe() .eq. mpp_root_pe()) then
         call register_variable_attribute(fileobj, "lat", "cartesian_axis", "Y", str_len=1)
 
         call register_variable_attribute(fileobj, "time", "cartesian_axis", "T", str_len=1)
-        call register_variable_attribute(fileobj, "time", "units", "days since 1800-01-01 00:00:00", str_len=34)
+        call register_variable_attribute(fileobj, "time", "units", "days since 1800-01-01 00:00:00", str_len=30)
         call register_variable_attribute(fileobj, "time", "calendar", "julian", str_len=6)
 
         call write_data(fileobj, "lat", (/(-90+i*2.0,i=1,89)/))


### PR DESCRIPTION
**Description**
Fixes an incorrect string length in test_time_interp_external that caused it fail after the tag was released, and fixes the atmosphere test script so it won't fail after it's first run

**How Has This Been Tested?**
tested with intel and gcc on amd

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x]  I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

