### PR TITLE
Fixes filename in CMakeLists.txt 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@
 
 # Copyright (c) GFDL, @underwoo
 
-cmake_minimum_required(VERSION 3.7...3.15 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
 
 # Define the CMake project
 project(FMS
@@ -96,8 +96,7 @@ list(APPEND fms_fortran_src_files
   coupler/atmos_ocean_fluxes.F90
   coupler/coupler_types.F90
   coupler/ensemble_manager.F90
-  data_override/get_grid_version_fms2io.F90
-  data_override/get_grid_version_mpp.F90
+  data_override/get_grid_version.F90
   data_override/data_override.F90
   diag_integral/diag_integral.F90
   diag_manager/diag_axis.F90

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,7 @@ list(APPEND fms_fortran_src_files
   block_control/block_control.F90
   column_diagnostics/column_diagnostics.F90
   constants/constants.F90
+  constants/fmsconstants.F90
   coupler/atmos_ocean_fluxes.F90
   coupler/coupler_types.F90
   coupler/ensemble_manager.F90


### PR DESCRIPTION
**Description**
This PR removes the non-existing `data_override/get_grid_version_*.F90` files from  fms_fortran_src_files and replaces them with `data_override/get_grid_version.F90`.  This PR also updates the minimum required version of CMake to 3.12. 

Fixes #790 

**How Has This Been Tested?**
CMake 3.20.1 was used to build libFMS on Gaea with Intel 

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

