### PR TITLE
Removes the hardcoded path for input.nml

### DIFF
--- a/diag_integral/diag_integral.F90
+++ b/diag_integral/diag_integral.F90
@@ -326,10 +326,8 @@ real,dimension(:,:), intent(in), optional :: area_in
 !-------------------------------------------------------------------------------
 !    read namelist.
 !-------------------------------------------------------------------------------
-    if ( file_exists('input.nml')) then
-        read (input_nml_file, nml=diag_integral_nml, iostat=io)
-        ierr = check_nml_error(io,'diag_integral_nml')
-    endif
+      read (input_nml_file, nml=diag_integral_nml, iostat=io)
+      ierr = check_nml_error(io,'diag_integral_nml')
 
 !-------------------------------------------------------------------------------
 !    write version number and namelist to logfile.

--- a/diag_manager/diag_manager.F90
+++ b/diag_manager/diag_manager.F90
@@ -198,11 +198,7 @@ use platform_mod
   USE mpp_io_mod, ONLY: mpp_open, mpp_close, mpp_get_maxunits
   USE mpp_mod, ONLY: mpp_get_current_pelist, mpp_pe, mpp_npes, mpp_root_pe, mpp_sum
 
-#ifdef INTERNAL_FILE_NML
   USE mpp_mod, ONLY: input_nml_file
-#else
-  USE fms_mod, ONLY: open_namelist_file, close_file
-#endif
 
   USE fms_mod, ONLY: error_mesg, FATAL, WARNING, NOTE, stdout, stdlog, write_version_number,&
        & file_exist, fms_error_handler, check_nml_error, get_mosaic_tile_file, lowercase
@@ -3531,9 +3527,6 @@ CONTAINS
     INTEGER, ALLOCATABLE, DIMENSION(:) :: pelist
     INTEGER :: stdlog_unit, stdout_unit
     integer :: j
-#ifndef INTERNAL_FILE_NML
-    INTEGER :: nml_unit
-#endif
     CHARACTER(len=256) :: err_msg_local
 
     NAMELIST /diag_manager_nml/ append_pelist_name, mix_snapshot_average_fields, max_output_fields, &
@@ -3582,23 +3575,12 @@ CONTAINS
        END IF
     END IF
 
-#ifdef INTERNAL_FILE_NML
     READ (input_nml_file, NML=diag_manager_nml, IOSTAT=mystat)
-#else
-    IF ( file_exist('input.nml') ) THEN
-       nml_unit = open_namelist_file()
-       READ (nml_unit, diag_manager_nml, iostat=mystat)
-       CALL close_file(nml_unit)
-    ELSE
-       ! Set mystat to an arbitrary positive number if input.nml does not exist.
-       mystat = 100
-    END IF
-#endif
     ! Check the status of reading the diag_manager_nml
 
     IF ( check_nml_error(IOSTAT=mystat, NML_NAME='DIAG_MANAGER_NML') < 0 ) THEN
        IF ( mpp_pe() == mpp_root_pe() ) THEN
-          CALL error_mesg('diag_manager_mod::diag_manager_init', 'DIAG_MANAGER_NML not found in input.nml.  Using defaults.',&
+          CALL error_mesg('diag_manager_mod::diag_manager_init', 'DIAG_MANAGER_NML not found in input nml file.  Using defaults.',&
                & WARNING)
        END IF
     END IF

--- a/fms/fms.F90
+++ b/fms/fms.F90
@@ -321,14 +321,15 @@ contains
 !! The namelist variable clock_grain must be one of the following values:
 !! 'NONE', 'COMPONENT', 'SUBCOMPONENT', 'MODULE_DRIVER', 'MODULE', 'ROUTINE',
 !! 'LOOP', or 'INFRA' (case-insensitive).
-subroutine fms_init (localcomm )
+subroutine fms_init (localcomm, alt_input_nml_path)
 
 !--- needed to output the version number of constants_mod to the logfile ---
  use constants_mod, only: constants_version=>version !pjp: PI not computed
  use fms_io_mod,    only: fms_io_version
 
  integer, intent(in), optional :: localcomm
- integer :: ierr, io
+ character(len=*), intent(in), optional :: alt_input_nml_path
+ integer :: unit, ierr, io
  integer :: logunitnum
  integer :: stdout_unit !< Unit number for the stdout file
 
@@ -336,9 +337,17 @@ subroutine fms_init (localcomm )
     module_is_initialized = .true.
 !---- initialize mpp routines ----
     if(present(localcomm)) then
-       call mpp_init(localcomm=localcomm)
+       if(present(alt_input_nml_path)) then
+          call mpp_init(localcomm=localcomm, alt_input_nml_path=alt_input_nml_path)
+       else
+          call mpp_init(localcomm=localcomm)
+       endif
     else
-       call mpp_init()
+       if(present(alt_input_nml_path)) then
+          call mpp_init(alt_input_nml_path=alt_input_nml_path)
+       else
+          call mpp_init()
+       endif
     endif
     call mpp_domains_init()
     call fms_io_init()

--- a/fms/fms.F90
+++ b/fms/fms.F90
@@ -540,17 +540,10 @@ end subroutine fms_end
   !!       routine check_nml_error will return zero and the while loop will exit.
   !!       This code segment should be used to read namelist files.
   !!       @code{.F90}
-  !!         integer :: unit, ierr, io
+  !!         integer :: ierr, io
   !!
-  !!         if ( file_exist('input.nml') ) then
-  !!             unit = open_namelist_file ( )
-  !!             ierr=1
-  !!             do while (ierr > 0)
-  !!               read  (unit, nml=moist_processes_nml, iostat=io)
-  !!               ierr = check_nml_error(io,'moist_processes_nml')
-  !!             enddo
-  !!             call close_file (unit)
-  !!         endif
+  !!         read (input_nml_file, fms_nml, iostat=io)
+  !!         ierr = check_nml_error(io,'fms_nml')
   !!       @endcode
   !! @throws FATAL, Unknown error while reading namelist ...., (IOSTAT = ####)
   !! There was an error reading the namelist specified. Carefully examine all namelist and variables

--- a/fms/fms_io.F90
+++ b/fms/fms_io.F90
@@ -683,19 +683,10 @@ subroutine fms_io_init()
   if (module_is_initialized) return
   call mpp_io_init()
 
-#ifdef INTERNAL_FILE_NML
   read (input_nml_file, fms_io_nml, iostat=io_status)
   if (io_status > 0) then
-     call mpp_error(FATAL,'=>fms_io_init: Error reading input.nml')
+     call mpp_error(FATAL,'=>fms_io_init: Error reading input nml file')
   endif
-#else
-  call mpp_open(unit, 'input.nml',form=MPP_ASCII,action=MPP_RDONLY)
-  read(unit,fms_io_nml,iostat=io_status)
-  if (io_status > 0) then
-     call mpp_error(FATAL,'=>fms_io_init: Error reading input.nml')
-  endif
-  call mpp_close (unit)
-#endif
 
 ! take namelist options if present
 

--- a/interpolator/interpolator.F90
+++ b/interpolator/interpolator.F90
@@ -436,12 +436,8 @@ if (.not. module_is_initialized) then
 ! namelist input
 !--------------------------------------------------------------------
 
-the_file_exists = fms2_io_file_exist('input.nml')
-
-if (the_file_exists) then
-    read (input_nml_file, nml=interpolator_nml, iostat=io)
-    ierr = check_nml_error(io,'interpolator_nml')
-end if
+  read (input_nml_file, nml=interpolator_nml, iostat=io)
+  ierr = check_nml_error(io,'interpolator_nml')
 
 !---------------------------------------------------------------------
 !    write version number and namelist to logfile.

--- a/libFMS.F90
+++ b/libFMS.F90
@@ -273,7 +273,7 @@ module fms
                      mpp_max, mpp_min, mpp_sum, mpp_transmit, mpp_send, mpp_recv, &
                      mpp_sum_ad, mpp_broadcast, mpp_init, mpp_exit, mpp_gather, &
                      mpp_scatter, mpp_alltoall, mpp_type, mpp_byte, mpp_type_create, &
-                     mpp_type_free, input_nml_file, INPUT_STR_LENGTH
+                     mpp_type_free, input_nml_file
   use mpp_parameter_mod,only:MAXPES, MPP_VERBOSE, MPP_DEBUG, ALL_PES, ANY_PE, NULL_PE, &
                      NOTE, WARNING, FATAL, MPP_WAIT, MPP_READY, MAX_CLOCKS, &
                      MAX_EVENT_TYPES, MAX_EVENTS, MPP_CLOCK_SYNC, MPP_CLOCK_DETAILED, &

--- a/mpp/include/mpp_comm_mpi.inc
+++ b/mpp/include/mpp_comm_mpi.inc
@@ -37,7 +37,7 @@
   character(len=*), optional, intent(in) :: alt_input_nml_path
   integer                       :: my_pe, num_pes, len, i, iunit
   logical                       :: opened, existed
-  integer                       :: unit_begin, unit_end, unit_nml, io_status
+  integer                       :: io_status
   integer                       :: t_level
   character(len=5) :: this_pe
   type(mpp_type), pointer :: dtype
@@ -120,23 +120,9 @@
   if (t_level == 4) return
 
   !--- read namelist
-#ifdef INTERNAL_FILE_NML
   read (input_nml_file, mpp_nml, iostat=io_status)
-#else
-  unit_begin = 103
-  unit_end   = 512
-  do unit_nml = unit_begin, unit_end
-     inquire( unit_nml,OPENED=opened )
-     if( .NOT.opened )exit
-  end do
-
-  open(unit_nml,file='input.nml', iostat=io_status)
-  read(unit_nml,mpp_nml,iostat=io_status)
-  close(unit_nml)
-#endif
-
   if (io_status > 0) then
-     call mpp_error(FATAL,'=>mpp_init: Error reading input.nml')
+     call mpp_error(FATAL,'=>mpp_init: Error reading mpp_nml')
   endif
   if (t_level == 5) return
 

--- a/mpp/include/mpp_comm_mpi.inc
+++ b/mpp/include/mpp_comm_mpi.inc
@@ -113,7 +113,7 @@
 
   call mpp_init_logfile()
   if (present(alt_input_nml_path)) then
-     call read_input_nml(alt_input_nml_path)
+     call read_input_nml(alt_input_nml_path=alt_input_nml_path)
   else
      call read_input_nml
   end if

--- a/mpp/include/mpp_comm_mpi.inc
+++ b/mpp/include/mpp_comm_mpi.inc
@@ -30,10 +30,11 @@
   !    subroutine mpp_init( flags, in, out, err, log )
   !      integer, optional, intent(in) :: flags, in, out, err, log
   !> @brief Initialize the @ref mpp_mod module
-  subroutine mpp_init( flags, localcomm, test_level )
+  subroutine mpp_init( flags, localcomm, test_level, alt_input_nml_path )
   integer, optional, intent(in) :: flags
   integer, optional, intent(in) :: localcomm
   integer, optional, intent(in) :: test_level
+  character(len=*), optional, intent(in) :: alt_input_nml_path
   integer                       :: my_pe, num_pes, len, i, iunit
   logical                       :: opened, existed
   integer                       :: unit_begin, unit_end, unit_nml, io_status
@@ -111,7 +112,11 @@
   if (t_level == 3) return
 
   call mpp_init_logfile()
-  call read_input_nml
+  if (present(alt_input_nml_path)) then
+     call read_input_nml(alt_input_nml_path)
+  else
+     call read_input_nml
+  end if
   if (t_level == 4) return
 
   !--- read namelist

--- a/mpp/include/mpp_comm_nocomm.inc
+++ b/mpp/include/mpp_comm_nocomm.inc
@@ -88,7 +88,7 @@ subroutine mpp_init( flags,localcomm, alt_input_nml_path )
 
   call mpp_init_logfile()
   if (present(alt_input_nml_path)) then
-     call read_input_nml(alt_input_nml_path)
+     call read_input_nml(alt_input_nml_path=alt_input_nml_path)
   else
      call read_input_nml
   end if

--- a/mpp/include/mpp_comm_nocomm.inc
+++ b/mpp/include/mpp_comm_nocomm.inc
@@ -31,9 +31,10 @@
   !    subroutine mpp_init( flags, in, out, err, log )
   !      integer, optional, intent(in) :: flags, in, out, err, log
 !> @brief Initialize the @ref mpp_mod module
-subroutine mpp_init( flags,localcomm )
+subroutine mpp_init( flags,localcomm, alt_input_nml_path )
   integer, optional, intent(in) :: flags
   integer, optional, intent(in) :: localcomm ! dummy here, used only in MPI
+  character(len=*), optional, intent(in) :: alt_input_nml_path
   integer                       :: my_pe, num_pes, len, i, logunit
   logical                       :: opened, existed
   integer                       :: unit_begin, unit_end, unit_nml, io_status
@@ -86,7 +87,11 @@ subroutine mpp_init( flags,localcomm )
   end if
 
   call mpp_init_logfile()
-  call read_input_nml
+  if (present(alt_input_nml_path)) then
+     call read_input_nml(alt_input_nml_path)
+  else
+     call read_input_nml
+  end if
 
   !--- read namelist
 #ifdef INTERNAL_FILE_NML

--- a/mpp/include/mpp_comm_nocomm.inc
+++ b/mpp/include/mpp_comm_nocomm.inc
@@ -37,7 +37,7 @@ subroutine mpp_init( flags,localcomm, alt_input_nml_path )
   character(len=*), optional, intent(in) :: alt_input_nml_path
   integer                       :: my_pe, num_pes, len, i, logunit
   logical                       :: opened, existed
-  integer                       :: unit_begin, unit_end, unit_nml, io_status
+  integer                       :: io_status
 
   if( module_is_initialized )return
 
@@ -94,23 +94,9 @@ subroutine mpp_init( flags,localcomm, alt_input_nml_path )
   end if
 
   !--- read namelist
-#ifdef INTERNAL_FILE_NML
   read (input_nml_file, mpp_nml, iostat=io_status)
-#else
-  unit_begin = 103
-  unit_end   = 512
-  do unit_nml = unit_begin, unit_end
-     inquire( unit_nml,OPENED=opened )
-     if( .NOT.opened )exit
-  end do
-
-  open(unit_nml,file='input.nml', iostat=io_status)
-  read(unit_nml,mpp_nml,iostat=io_status)
-  close(unit_nml)
-#endif
-
   if (io_status > 0) then
-     call mpp_error(FATAL,'=>mpp_init: Error reading input.nml')
+     call mpp_error(FATAL,'=>mpp_init: Error reading mpp_nml')
   endif
 
 ! non-root pe messages written to other location than stdout()

--- a/mpp/include/mpp_domains_misc.inc
+++ b/mpp/include/mpp_domains_misc.inc
@@ -53,7 +53,7 @@
     subroutine mpp_domains_init(flags)
       integer, intent(in), optional :: flags
       integer                       :: n
-      integer                       :: unit_begin, unit_end, unit_nml, io_status, unit
+      integer                       :: io_status, unit
       logical                       :: opened
 
       if( module_is_initialized )return
@@ -70,23 +70,9 @@
       end if
 
       !--- namelist
-#ifdef INTERNAL_FILE_NML
       read (input_nml_file, mpp_domains_nml, iostat=io_status)
-#else
-      unit_begin = 103
-      unit_end   = 512
-      do unit_nml = unit_begin, unit_end
-         inquire( unit_nml,OPENED=opened )
-         if( .NOT.opened )exit
-      end do
-
-      open(unit_nml,file='input.nml', iostat=io_status)
-      read(unit_nml,mpp_domains_nml,iostat=io_status)
-      close(unit_nml)
-#endif
-
       if (io_status > 0) then
-         call mpp_error(FATAL,'=>mpp_domains_init: Error reading input.nml')
+         call mpp_error(FATAL,'=>mpp_domains_init: Error reading mpp_domains_nml')
       endif
 
 

--- a/mpp/include/mpp_io_misc.inc
+++ b/mpp/include/mpp_io_misc.inc
@@ -49,7 +49,7 @@
 
     subroutine mpp_io_init( flags, maxunit )
       integer, intent(in), optional :: flags, maxunit
-      integer                       :: unit_nml, io_status, iunit
+      integer                       :: io_status, iunit
       integer                       :: logunit, outunit, inunit, errunit
       logical                       :: opened
       real(r8_kind)             :: doubledata = 0
@@ -75,20 +75,9 @@
       call mpp_set_unit_range( 103, maxunits )
 
       !--- namelist
-#ifdef INTERNAL_FILE_NML
       read (input_nml_file, mpp_io_nml, iostat=io_status)
-#else
-      do unit_nml = unit_begin, unit_end
-         inquire( unit_nml,OPENED=opened )
-         if( .NOT.opened )exit
-      end do
-      open(unit_nml,file='input.nml')
-      read(unit_nml,mpp_io_nml,iostat=io_status)
-      close(unit_nml)
-#endif
-
       if (io_status > 0) then
-         call mpp_error(FATAL,'=>mpp_io_init: Error reading input.nml')
+         call mpp_error(FATAL,'=>mpp_io_init: Error reading mpp_io_nml')
       endif
 
 

--- a/mpp/include/mpp_util.inc
+++ b/mpp/include/mpp_util.inc
@@ -1295,7 +1295,7 @@ end function rarray_to_char
 !
 ! ! parameter defining length of character variables
 !   integer, parameter :: INPUT_STR_LENGTH = 256
-! ! public variable needed for reading input.nml from an internal file
+! ! public variable needed for reading an input nml file from an internal file
 !   character(len=INPUT_STR_LENGTH), dimension(:), allocatable, public :: input_nml_file
 !
 
@@ -1303,7 +1303,7 @@ end function rarray_to_char
 ! subroutine READ_INPUT_NML
 !
 !
-! Reads an existing input.nml into a character array and broadcasts
+! Reads an existing input nml file into a character array and broadcasts
 ! it to the non-root mpi-tasks. This allows the use of reads from an
 ! internal file for namelist settings (requires 2003 compliant compiler)
 !

--- a/mpp/include/mpp_util.inc
+++ b/mpp/include/mpp_util.inc
@@ -1293,10 +1293,8 @@ end function rarray_to_char
 !
 ! THESE LINES MUST BE PRESENT IN MPP.F90
 !
-! ! parameter defining length of character variables
-!   integer, parameter :: INPUT_STR_LENGTH = 256
 ! ! public variable needed for reading an input nml file from an internal file
-!   character(len=INPUT_STR_LENGTH), dimension(:), allocatable, public :: input_nml_file
+!   character(len=:), dimension(:), allocatable, public :: input_nml_file
 !
 
 !-----------------------------------------------------------------------

--- a/mpp/include/mpp_util.inc
+++ b/mpp/include/mpp_util.inc
@@ -1310,12 +1310,13 @@ end function rarray_to_char
 ! read(input_nml_file, nml=<name_nml>, iostat=status)
 !
 !
-  subroutine read_input_nml(pelist_name_in)
+  subroutine read_input_nml(pelist_name_in, alt_input_nml_path)
 
 ! Include variable "version" to be written to log file.
 #include<file_version.h>
 
     character(len=*), intent(in), optional :: pelist_name_in
+    character(len=*), intent(in), optional :: alt_input_nml_path
 ! private variables
     integer :: log_unit
     integer :: i
@@ -1344,7 +1345,11 @@ end function rarray_to_char
     filename='input_'//trim(pelist_name)//'.nml'
     inquire(FILE=filename, EXIST=file_exist)
     if (.not. file_exist ) then
-       filename='input.nml'
+       if (present(alt_input_nml_path)) then
+          filename = alt_input_nml_path
+       else
+          filename = 'input.nml'
+       end if
     endif
     lines_and_length = get_ascii_file_num_lines_and_length(filename)
     allocate(character(len=lines_and_length(2))::input_nml_file(lines_and_length(1)))

--- a/mpp/mpp.F90
+++ b/mpp/mpp.F90
@@ -1280,7 +1280,7 @@ private
 !
 ! parameter defining length of character variables
   integer, parameter :: INPUT_STR_LENGTH = 256
-! public variable needed for reading input.nml from an internal file
+! public variable needed for reading input nml file from an internal file
   character(len=:), dimension(:), allocatable, target, public :: input_nml_file
   logical :: read_ascii_file_on = .FALSE.
 !***********************************************************************

--- a/mpp/mpp.F90
+++ b/mpp/mpp.F90
@@ -191,7 +191,7 @@ private
   public :: MPP_VERBOSE, MPP_DEBUG, ALL_PES, ANY_PE, NULL_PE, NOTE, WARNING, FATAL
   public :: MPP_CLOCK_SYNC, MPP_CLOCK_DETAILED, CLOCK_COMPONENT, CLOCK_SUBCOMPONENT
   public :: CLOCK_MODULE_DRIVER, CLOCK_MODULE, CLOCK_ROUTINE, CLOCK_LOOP, CLOCK_INFRA
-  public :: MAXPES, EVENT_RECV, EVENT_SEND, INPUT_STR_LENGTH
+  public :: MAXPES, EVENT_RECV, EVENT_SEND
   public :: COMM_TAG_1,  COMM_TAG_2,  COMM_TAG_3,  COMM_TAG_4
   public :: COMM_TAG_5,  COMM_TAG_6,  COMM_TAG_7,  COMM_TAG_8
   public :: COMM_TAG_9,  COMM_TAG_10, COMM_TAG_11, COMM_TAG_12
@@ -1278,8 +1278,6 @@ private
 !***********************************************************************
 !  variables needed for subroutine read_input_nml (include/mpp_util.inc)
 !
-! parameter defining length of character variables
-  integer, parameter :: INPUT_STR_LENGTH = 256
 ! public variable needed for reading input nml file from an internal file
   character(len=:), dimension(:), allocatable, target, public :: input_nml_file
   logical :: read_ascii_file_on = .FALSE.

--- a/test_fms/mpp/test_mpp_get_ascii_lines.F90
+++ b/test_fms/mpp/test_mpp_get_ascii_lines.F90
@@ -18,7 +18,7 @@
 !***********************************************************************
 
 program test_get_ascii_lines
-  use mpp_mod, only: mpp_init, mpp_init_test_logfile_init, get_ascii_file_num_lines, read_ascii_file, INPUT_STR_LENGTH
+  use mpp_mod, only: mpp_init, mpp_init_test_logfile_init, get_ascii_file_num_lines, read_ascii_file
   use mpp_mod, only: input_nml_file
   use, intrinsic ::  iso_fortran_env, only: INT8
 
@@ -28,6 +28,7 @@ program test_get_ascii_lines
      procedure assertEquals_int_int
   end interface assertEquals
 
+  integer, parameter :: str_length = 256
   integer, parameter :: num_tests = 5
   integer(KIND=INT8) :: test_number
   integer, dimension(num_tests) :: my_num_lines=(/5,25,0,5,5/)
@@ -43,7 +44,7 @@ program test_get_ascii_lines
                                                          "0 line test    ",&
                                                          "blank line test",&
                                                          "long line test "/)
-  character(len=INPUT_STR_LENGTH), allocatable :: file_contents(:)
+  character(len=str_length), allocatable :: file_contents(:)
   namelist /test_mpp_get_ascii_lines_nml/ test_number
 
   open(30, file="test_numb2.nml", form="formatted", status="old")
@@ -52,7 +53,7 @@ program test_get_ascii_lines
 
   call mpp_init(test_level=mpp_init_test_logfile_init)
   my_num_lines(test_number) = my_num_lines(test_number)+1 !!!!! Please See Note At End of File
-  f_num_lines = get_ascii_file_num_lines(trim(file_name(test_number)), INPUT_STR_LENGTH)
+  f_num_lines = get_ascii_file_num_lines(trim(file_name(test_number)), str_length)
   call assertEquals(f_num_lines, my_num_lines(test_number), trim(test_name(test_number)))
   call MPI_FINALIZE(ierr)
 

--- a/test_fms/mpp/test_read_ascii_file.F90
+++ b/test_fms/mpp/test_read_ascii_file.F90
@@ -26,9 +26,10 @@ program test_read_ascii_file
 
   use mpp_mod, only : mpp_init, mpp_init_test_peset_allocated
   use mpp_mod, only : mpp_error, FATAL, NOTE
-  use mpp_mod, only : read_ascii_file, INPUT_STR_LENGTH, get_ascii_file_num_lines
+  use mpp_mod, only : read_ascii_file, get_ascii_file_num_lines
   use mpp_mod, only : mpp_get_current_pelist, mpp_npes
 
+  integer, parameter :: str_length
   character(len=256), dimension(:), allocatable :: test_array !< Content array
   character(len=256) :: filename !< Name of ascii file to be read
   character(len=256) :: filename2 !< Name of alternative ascii file to be read
@@ -49,21 +50,21 @@ program test_read_ascii_file
   if (test_numb == 1 .or. test_numb == 7 .or. test_numb == 8) then
     if (test_numb == 1) then
       filename = "input.nml"
-      num_lines = get_ascii_file_num_lines(filename, INPUT_STR_LENGTH)
+      num_lines = get_ascii_file_num_lines(filename, str_length)
       allocate(test_array(num_lines))
-      call read_ascii_file(filename, INPUT_STR_LENGTH, test_array)
+      call read_ascii_file(filename, str_length, test_array)
     else if (test_numb == 7) then
       filename = "input.nml"
-      num_lines = get_ascii_file_num_lines(filename, INPUT_STR_LENGTH)
+      num_lines = get_ascii_file_num_lines(filename, str_length)
       allocate(test_array(num_lines))
       allocate(cur_pelist(0:mpp_npes()-1))
       call mpp_get_current_pelist(cur_pelist)
-      call read_ascii_file(filename, INPUT_STR_LENGTH, test_array, PELIST=cur_pelist)
+      call read_ascii_file(filename, str_length, test_array, PELIST=cur_pelist)
     else if (test_numb == 8) then
       filename = "empty.nml"
-      num_lines = get_ascii_file_num_lines(filename, INPUT_STR_LENGTH)
+      num_lines = get_ascii_file_num_lines(filename, str_length)
       allocate(test_array(num_lines))
-      call read_ascii_file(filename, INPUT_STR_LENGTH, test_array)
+      call read_ascii_file(filename, str_length, test_array)
     end if
     ! Content check
     open(2, file=filename, iostat=stat)
@@ -82,31 +83,31 @@ program test_read_ascii_file
     if (test_numb == 2) then
       filename = "input.nml"
       allocate(test_array(20))
-      call read_ascii_file(filename, INPUT_STR_LENGTH, test_array)
+      call read_ascii_file(filename, str_length, test_array)
     else if (test_numb == 3) then
       filename = "doesnotexist.txt"
       ! Need to pass in an exist file name below to avoid raising error on
       ! get_ascii_file_num_lines call in order to get to the error in read_ascii_file
       filename2 = "input.nml"
-      num_lines = get_ascii_file_num_lines(filename2, INPUT_STR_LENGTH)
+      num_lines = get_ascii_file_num_lines(filename2, str_length)
       allocate(test_array(num_lines))
-      call read_ascii_file(filename, INPUT_STR_LENGTH, test_array)
+      call read_ascii_file(filename, str_length, test_array)
     else if (test_numb == 4) then
       filename = "input.nml"
       filename2 = "empty.nml"
-      num_lines = get_ascii_file_num_lines(filename2, INPUT_STR_LENGTH)
+      num_lines = get_ascii_file_num_lines(filename2, str_length)
       allocate(test_array(num_lines))
-      call read_ascii_file(filename, INPUT_STR_LENGTH, test_array)
+      call read_ascii_file(filename, str_length, test_array)
     else if (test_numb == 5) then
       filename = "input.nml"
-      num_lines = get_ascii_file_num_lines(filename, INPUT_STR_LENGTH)
+      num_lines = get_ascii_file_num_lines(filename, str_length)
       allocate(test_array(num_lines))
       call read_ascii_file(filename, 0, test_array)
     else if (test_numb == 6) then
       filename = "input.nml"
-      num_lines = get_ascii_file_num_lines(filename, INPUT_STR_LENGTH)
+      num_lines = get_ascii_file_num_lines(filename, str_length)
       allocate(test_array(num_lines-1))
-      call read_ascii_file(filename, INPUT_STR_LENGTH, test_array)
+      call read_ascii_file(filename, str_length, test_array)
     end if
   end if
   call MPI_FINALIZE(ierr)

--- a/test_fms/mpp/test_read_ascii_file.F90
+++ b/test_fms/mpp/test_read_ascii_file.F90
@@ -29,7 +29,7 @@ program test_read_ascii_file
   use mpp_mod, only : read_ascii_file, get_ascii_file_num_lines
   use mpp_mod, only : mpp_get_current_pelist, mpp_npes
 
-  integer, parameter :: str_length
+  integer, parameter :: str_length = 256
   character(len=256), dimension(:), allocatable :: test_array !< Content array
   character(len=256) :: filename !< Name of ascii file to be read
   character(len=256) :: filename2 !< Name of alternative ascii file to be read

--- a/test_fms/mpp/test_read_input_nml.F90
+++ b/test_fms/mpp/test_read_input_nml.F90
@@ -27,7 +27,7 @@ program test_read_input_nml
   use mpp_mod, only : mpp_init, mpp_init_test_peset_allocated
   use mpp_mod, only : mpp_error, FATAL, NOTE
   use mpp_mod, only : read_input_nml, mpp_get_current_pelist_name
-  use mpp_mod, only : input_nml_file, INPUT_STR_LENGTH
+  use mpp_mod, only : input_nml_file
 #include<file_version.h>
 
 character(len=200) :: line !< Storage location of lines read from the input nml

--- a/topography/topography.F90
+++ b/topography/topography.F90
@@ -880,7 +880,7 @@ end module topography_mod
 !   <TESTPROGRAM NAME="">
 !
 !  To run this program you will need the topography and percent water
-!  data sets and use the following namelist (in file input.nml).
+!  data sets and use the following namelist (in the input nml file).
 !
 !   &amp;gaussian_topog_nml
 !     height = 5000., 3000., 3000., 3000.,


### PR DESCRIPTION
**Description**
The path for the input namelist can now be specified in the fms_init call. All references to input.nml have been replaced by a reference to either the path (in the case of ingesting the file contents) or the input_nml_file variable which contains the namelist information. References using '#ifdef INTERNAL_FILE_NML' have been removed since this is now always defined.

Fixes #779 

**How Has This Been Tested?**
Compiles with Intel19 on Skylake.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

