### PR TITLE
Fixes for autotools build

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -65,6 +65,7 @@ SUBDIRS = \
   tracer_manager \
   sat_vapor_pres \
   random_numbers \
+  . \
   libFMS \
   test_fms \
   ${DOCS}

--- a/configure.ac
+++ b/configure.ac
@@ -50,7 +50,7 @@ LT_INIT()
 # is, then disable building shared libraries.  Note, the user can still override
 # this by using --enable-shared when running the configure script.
 AS_IF([test x${CRAYPE_VERSION:+yes} = "xyes"],[
-  AS_IF([test x${CRAYPE_LINK_TYP} = "xstatic"],
+  AS_IF([test x${CRAYPE_LINK_TYPE} = "xstatic"],
         [AC_DISABLE_SHARED])])
 
 

--- a/libFMS/Makefile.am
+++ b/libFMS/Makefile.am
@@ -60,6 +60,9 @@ libFMS_la_LIBADD += $(top_builddir)/exchange/libexchange.la
 libFMS_la_LIBADD += $(top_builddir)/topography/libtopography.la
 libFMS_la_LIBADD += $(top_builddir)/tracer_manager/libtracer_manager.la
 libFMS_la_LIBADD += $(top_builddir)/random_numbers/librandom_numbers.la
+libFMS_la_LIBADD += $(top_builddir)/diag_integral/libdiag_integral.la
+libFMS_la_LIBADD += $(top_builddir)/sat_vapor_pres/libsat_vapor_pres.la
+libFMS_la_LIBADD += $(top_builddir)/libFMS_mod.la
 
 # At least one source file must be included to please Automake.
 libFMS_la_SOURCES = $(top_builddir)/include/file_version.h


### PR DESCRIPTION
**Description**
Adds missing library files to the libFMS.la file. Also adjusts the root makefile to build libFMS.F90 before the libFMS directory.

Fixes a typo of one of the cray environment vars in the configure script

**How Has This Been Tested?**
tested on amd with gcc 9.3.0

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

