### PR TITLE
Update gcc 11 check in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -276,8 +276,8 @@ fi
 AC_MSG_CHECKING([if gcc 11.1.0 is loaded])
 if [ test -n "`$FC --version | grep GNU | grep 11\.1\..`" ]; then
   AC_MSG_RESULT([yes])
-  AC_MSG_ERROR([Compilation with gcc and gfortran 11.1.0 is unsupported by this version\
- of FMS. Please use gcc/gfortran 11.2.0 or an older version.])
+  AC_MSG_ERROR([Compilation with gcc and gfortran 11.1.0 is unsupported \
+by this version of FMS due to a bug in the compiler. Please use a different version of gcc/gfortran.])
 else
   AC_MSG_RESULT([no])
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -276,8 +276,8 @@ fi
 AC_MSG_CHECKING([if gcc 11.1.0 is loaded])
 if [ test -n "`$FC --version | grep GNU | grep 11\.1\..`" ]; then
   AC_MSG_RESULT([yes])
-  AC_MSG_ERROR([Compilation with gcc and gfortran 11 is unsupported by this version\
- of FMS. Please use another compiler version])
+  AC_MSG_ERROR([Compilation with gcc and gfortran 11.1.0 is unsupported by this version\
+ of FMS. Please use gcc/gfortran 11.2.0 or an older version.])
 else
   AC_MSG_RESULT([no])
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -273,8 +273,8 @@ if test -n "$fc_version_info"; then
 fi
 
 # Check if gcc is 11.1 for class(*) select type bug
-AC_MSG_CHECKING([if gcc 11 is loaded])
-if [ test -n "`$FC --version | grep GNU | grep 11\..\..`" ]; then
+AC_MSG_CHECKING([if gcc 11.1.0 is loaded])
+if [ test -n "`$FC --version | grep GNU | grep 11\.1\..`" ]; then
   AC_MSG_RESULT([yes])
   AC_MSG_ERROR([Compilation with gcc and gfortran 11 is unsupported by this version\
  of FMS. Please use another compiler version])


### PR DESCRIPTION
**Description**
A check was added for gcc 11 due to issues with class(*) in select type, this PR changes the check to allow for versions after 11.1.0 to pass configure since it was fixed in 11.2.0

Fixes #756

**How Has This Been Tested?**
no code changes

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

