### PR TITLE
Fix harcoded etc_unit and lack of newunit calls

### DIFF
--- a/column_diagnostics/column_diagnostics.F90
+++ b/column_diagnostics/column_diagnostics.F90
@@ -34,7 +34,7 @@ use fms_mod,                only:  fms_init, mpp_pe, mpp_root_pe, &
 use time_manager_mod,       only:  time_manager_init, month_name, &
                                    get_date, time_type
 use constants_mod,          only:  constants_init, PI, RADIAN
-use mpp_mod,                only:  input_nml_file, get_unit
+use mpp_mod,                only:  input_nml_file
 
 !-------------------------------------------------------------------
 
@@ -429,8 +429,7 @@ integer, dimension(:), intent(out)   :: diag_units            !< unit number for
               else
                  write( filename,'(a,i4.4)' )trim(filename)//'.', mpp_pe()-mpp_root_pe()
               endif
-              diag_units(nn) = get_unit()
-              open(diag_units(nn), file=trim(filename), action='WRITE', position='rewind', iostat=io)
+              open(newunit=diag_units(nn), file=trim(filename), action='WRITE', position='rewind', iostat=io)
               if(io/=0) call error_mesg ('column_diagnostics_mod', 'Error in opening file '//trim(filename), FATAL)
             endif  ! (open_file)
           endif

--- a/data_override/data_override.F90
+++ b/data_override/data_override.F90
@@ -42,7 +42,7 @@
 module data_override_mod
 use constants_mod, only: PI
 use mpp_mod, only : mpp_error, FATAL, WARNING, stdout, stdlog, mpp_max
-use mpp_mod, only : input_nml_file, get_unit
+use mpp_mod, only : input_nml_file
 use horiz_interp_mod, only : horiz_interp_init, horiz_interp_new, horiz_interp_type, &
                              assignment(=)
 use time_interp_external2_mod, only:time_interp_external_init, &
@@ -240,8 +240,7 @@ subroutine data_override_init(Atm_domain_in, Ocean_domain_in, Ice_domain_in, Lan
     enddo
 
 !  Read coupler_table
-    iunit = get_unit()
-    open(iunit, file='data_table', action='READ', iostat=io_status)
+    open(newunit=iunit, file='data_table', action='READ', iostat=io_status)
     if(io_status/=0) call mpp_error(FATAL, 'data_override_mod: Error in opening file data_table')
 
     ntable = 0

--- a/diag_integral/diag_integral.F90
+++ b/diag_integral/diag_integral.F90
@@ -69,7 +69,7 @@ use time_manager_mod, only:  time_type, get_time, set_time,  &
                              operator(+),  operator(-),      &
                              operator(==), operator(>=),     &
                              operator(/=)
-use mpp_mod,          only:  input_nml_file, get_unit
+use mpp_mod,          only:  input_nml_file
 use fms_mod,          only:  open_file, error_mesg, &
                              check_nml_error, &
                              fms_init, &

--- a/field_manager/field_manager.F90
+++ b/field_manager/field_manager.F90
@@ -189,8 +189,7 @@ use    mpp_mod, only : mpp_error,   &
                        mpp_pe,      &
                        mpp_root_pe, &
                        stdlog,      &
-                       stdout,      &
-                       get_unit
+                       stdout
 use    fms_mod, only : lowercase,   &
                        write_version_number
 use fms2_io_mod, only: file_exists
@@ -670,8 +669,7 @@ if(present(nfields)) nfields = 0
   return
 endif
 
-iunit = get_unit()
-open(iunit, file=trim(tbl_name), action='READ', iostat=io_status)
+open(newunit=iunit, file=trim(tbl_name), action='READ', iostat=io_status)
 if(io_status/=0) call mpp_error(FATAL, 'field_manager_mod: Error in opening file '//trim(tbl_name))
 !write_version_number should precede all writes to stdlog from field_manager
 call write_version_number("FIELD_MANAGER_MOD", version)

--- a/fms/fms.F90
+++ b/fms/fms.F90
@@ -137,7 +137,7 @@ use          mpp_mod, only:  mpp_error, NOTE, WARNING, FATAL,    &
                              stdin, stdout, stderr, stdlog,      &
                              mpp_error_state, lowercase,         &
                              uppercase, mpp_broadcast, input_nml_file, &
-                             get_unit, read_input_nml
+                             read_input_nml
 
 use  mpp_domains_mod, only:  domain2D, mpp_define_domains, &
                              mpp_update_domains, GLOBAL_DATA_DOMAIN, &
@@ -201,7 +201,7 @@ public :: mpp_error, NOTE, WARNING, FATAL, &
           mpp_error_state,                 &
           mpp_pe, mpp_npes, mpp_root_pe,   &
           stdin, stdout, stderr, stdlog,   &
-          mpp_chksum, get_unit, read_input_nml
+          mpp_chksum, read_input_nml
 public :: input_nml_file
 public :: mpp_clock_id, mpp_clock_begin, mpp_clock_end
 public :: MPP_CLOCK_SYNC, MPP_CLOCK_DETAILED

--- a/libFMS.F90
+++ b/libFMS.F90
@@ -267,7 +267,7 @@ module fms
                      mpp_pe, mpp_npes, mpp_root_pe, mpp_set_root_pe, mpp_declare_pelist, &
                      mpp_get_current_pelist, mpp_set_current_pelist, &
                      mpp_get_current_pelist_name, mpp_clock_id, mpp_clock_set_grain, &
-                     mpp_record_timing_data, get_unit, read_ascii_file, read_input_nml, &
+                     mpp_record_timing_data, read_ascii_file, read_input_nml, &
                      mpp_clock_begin, mpp_clock_end, get_ascii_file_num_lines, &
                      mpp_record_time_start, mpp_record_time_end, mpp_chksum, &
                      mpp_max, mpp_min, mpp_sum, mpp_transmit, mpp_send, mpp_recv, &

--- a/mpp/include/mpp_comm_mpi.inc
+++ b/mpp/include/mpp_comm_mpi.inc
@@ -134,18 +134,14 @@
   if(etc_unit_is_stderr) then
      etc_unit = stderr()
   else
-! 9 is reserved for etc_unit
-     etc_unit=9
-     inquire(unit=etc_unit,opened=opened)
-     if(opened) call mpp_error(FATAL,'Unit 9 is already in use (etc_unit) in mpp_comm_mpi')
      if (trim(etcfile) /= '/dev/null') then
         write( etcfile,'(a,i6.6)' )trim(etcfile)//'.', pe
      endif
      inquire(file=etcfile, exist=existed)
      if(existed) then
-        open( unit=etc_unit, file=trim(etcfile), status='REPLACE' )
+        open( newunit=etc_unit, file=trim(etcfile), status='REPLACE' )
      else
-        open( unit=etc_unit, file=trim(etcfile) )
+        open( newunit=etc_unit, file=trim(etcfile) )
      endif
   endif
 
@@ -308,7 +304,6 @@ subroutine mpp_exit()
 
   call FLUSH( out_unit )
 
-! close down etc_unit: 9
   inquire(unit=etc_unit, opened=opened)
   if (opened) then
    call FLUSH (etc_unit)

--- a/mpp/include/mpp_comm_nocomm.inc
+++ b/mpp/include/mpp_comm_nocomm.inc
@@ -100,18 +100,14 @@ subroutine mpp_init( flags,localcomm, alt_input_nml_path )
   endif
 
 ! non-root pe messages written to other location than stdout()
-! 9 is reserved for etc_unit
-  etc_unit=9
-  inquire(unit=etc_unit,opened=opened)
-  if(opened) call mpp_error(FATAL,'Unit 9 is already in use (etc_unit) in mpp_comm_nocomm')
   if (trim(etcfile) /= '/dev/null') then
     write( etcfile,'(a,i6.6)' )trim(etcfile)//'.', pe
   endif
   inquire(file=etcfile, exist=existed)
   if(existed) then
-     open( unit=etc_unit, file=trim(etcfile), status='REPLACE' )
+     open( newunit=etc_unit, file=trim(etcfile), status='REPLACE' )
   else
-     open( unit=etc_unit, file=trim(etcfile) )
+     open( newunit=etc_unit, file=trim(etcfile) )
   endif
   !if optional argument logunit=stdout, write messages to stdout instead.
   !if specifying non-defaults, you must specify units not yet in use.
@@ -237,7 +233,6 @@ subroutine mpp_exit()
      end do
   end if
 
-! close down etc_unit: 9
   inquire(unit=etc_unit, opened=opened)
   if (opened) then
    call FLUSH (etc_unit)

--- a/mpp/include/mpp_io_misc.inc
+++ b/mpp/include/mpp_io_misc.inc
@@ -71,9 +71,6 @@
           verbose = flags.EQ.MPP_VERBOSE .OR. debug
       end if
 
-!set range of allowed fortran unit numbers: could be compiler-dependent (should not overlap stdin/out/err)
-      call mpp_set_unit_range( 103, maxunits )
-
       !--- namelist
       read (input_nml_file, mpp_io_nml, iostat=io_status)
       if (io_status > 0) then

--- a/mpp/include/mpp_io_misc.inc
+++ b/mpp/include/mpp_io_misc.inc
@@ -71,9 +71,6 @@
           verbose = flags.EQ.MPP_VERBOSE .OR. debug
       end if
 
-      unit_begin = 103
-      unit_end = maxunits
-
       !--- namelist
       read (input_nml_file, mpp_io_nml, iostat=io_status)
       if (io_status > 0) then
@@ -85,7 +82,6 @@
       write(outunit, mpp_io_nml)
       write(logunit, mpp_io_nml)
 
-      print *, 'outunit', outunit
 !--- check the deflate level, set deflate = 1 if deflate_level is greater than equal to 0
       if(deflate_level .GE. 0) deflate = 1
       if(deflate .NE. 0) then
@@ -162,12 +158,12 @@
       mpp_file(NULLUNIT)%valid  = .TRUE.
       mpp_file(NULLUNIT)%initialized = .TRUE.
 !declare the stdunits to be open
-      if (outunit < NULLUNIT | outunit > 2*maxunits) mpp_file(outunit)%opened = .TRUE.
-      if (logunit < NULLUNIT | logunit > 2*maxunits) mpp_file(logunit)%opened = .TRUE.
+      if (outunit > NULLUNIT .AND. outunit < 2*maxunits) mpp_file(outunit)%opened = .TRUE.
+      if (logunit > NULLUNIT .AND. logunit < 2*maxunits) mpp_file(logunit)%opened = .TRUE.
       inunit  = stdin()
-      if (inunit < NULLUNIT | inunit > 2*maxunits) mpp_file(inunit)%opened  = .TRUE.
+      if (inunit > NULLUNIT .AND. inunit < 2*maxunits) mpp_file(inunit)%opened  = .TRUE.
       errunit = stderr()
-      if (errunit < NULLUNIT | errunit > 2*maxunits) mpp_file(errunit)%opened = .TRUE.
+      if (errunit > NULLUNIT .AND. errunit < 2*maxunits) mpp_file(errunit)%opened = .TRUE.
 
       if( pe.EQ.mpp_root_pe() )then
           iunit = stdlog()  ! PGI compiler does not like stdlog() doing I/O within write call

--- a/mpp/include/mpp_io_misc.inc
+++ b/mpp/include/mpp_io_misc.inc
@@ -162,11 +162,12 @@
       mpp_file(NULLUNIT)%valid  = .TRUE.
       mpp_file(NULLUNIT)%initialized = .TRUE.
 !declare the stdunits to be open
-      mpp_file(outunit)%opened = .TRUE.
-      mpp_file(logunit)%opened = .TRUE.
-      inunit  = stdin()  ; mpp_file(inunit)%opened  = .TRUE.
+      if (outunit < NULLUNIT | outunit > 2*maxunits) mpp_file(outunit)%opened = .TRUE.
+      if (logunit < NULLUNIT | logunit > 2*maxunits) mpp_file(logunit)%opened = .TRUE.
+      inunit  = stdin()
+      if (inunit < NULLUNIT | inunit > 2*maxunits) mpp_file(inunit)%opened  = .TRUE.
       errunit = stderr()
-      mpp_file(errunit)%opened = .TRUE.
+      if (errunit < NULLUNIT | errunit > 2*maxunits) mpp_file(errunit)%opened = .TRUE.
 
       if( pe.EQ.mpp_root_pe() )then
           iunit = stdlog()  ! PGI compiler does not like stdlog() doing I/O within write call

--- a/mpp/include/mpp_io_misc.inc
+++ b/mpp/include/mpp_io_misc.inc
@@ -71,6 +71,9 @@
           verbose = flags.EQ.MPP_VERBOSE .OR. debug
       end if
 
+      unit_begin = 103
+      unit_end = maxunits
+
       !--- namelist
       read (input_nml_file, mpp_io_nml, iostat=io_status)
       if (io_status > 0) then
@@ -82,6 +85,7 @@
       write(outunit, mpp_io_nml)
       write(logunit, mpp_io_nml)
 
+      print *, 'outunit', outunit
 !--- check the deflate level, set deflate = 1 if deflate_level is greater than equal to 0
       if(deflate_level .GE. 0) deflate = 1
       if(deflate .NE. 0) then
@@ -161,7 +165,8 @@
       mpp_file(outunit)%opened = .TRUE.
       mpp_file(logunit)%opened = .TRUE.
       inunit  = stdin()  ; mpp_file(inunit)%opened  = .TRUE.
-      errunit = stderr() ; mpp_file(errunit)%opened = .TRUE.
+      errunit = stderr()
+      mpp_file(errunit)%opened = .TRUE.
 
       if( pe.EQ.mpp_root_pe() )then
           iunit = stdlog()  ! PGI compiler does not like stdlog() doing I/O within write call

--- a/mpp/include/mpp_io_util.inc
+++ b/mpp/include/mpp_io_util.inc
@@ -557,25 +557,6 @@
     end function mpp_get_field_id
 
   !#####################################################################
-    subroutine mpp_get_unit_range( unit_begin_out, unit_end_out )
-      integer, intent(out) ::      unit_begin_out, unit_end_out
-
-      unit_begin_out = unit_begin; unit_end_out = unit_end
-      return
-    end subroutine mpp_get_unit_range
-
-  !#####################################################################
-    subroutine mpp_set_unit_range( unit_begin_in, unit_end_in )
-      integer, intent(in) ::       unit_begin_in, unit_end_in
-
-      if( unit_begin_in.GT.unit_end_in )call mpp_error( FATAL, 'MPP_SET_UNIT_RANGE: unit_begin_in.GT.unit_end_in.' )
-      if( unit_begin_in.LT.0           )call mpp_error( FATAL, 'MPP_SET_UNIT_RANGE: unit_begin_in.LT.0.' )
-      if( unit_end_in  .GT.maxunits    )call mpp_error( FATAL, 'MPP_SET_UNIT_RANGE: unit_end_in.GT.maxunits.' )
-      unit_begin = unit_begin_in; unit_end = unit_end_in
-      return
-    end subroutine mpp_set_unit_range
-
-  !#####################################################################
     !> @brief Set the mpp_io_stack variable to be at least n LONG words long
     subroutine mpp_io_set_stack_size(n)
       integer, intent(in) :: n

--- a/mpp/include/mpp_util.inc
+++ b/mpp/include/mpp_util.inc
@@ -133,16 +133,15 @@
        if( opened )then
           FLUSH(log_unit)
        else
-          log_unit=get_unit()
-          open( unit=log_unit, status='UNKNOWN', file=trim(configfile)//this_pe, position='APPEND', err=10 )
+          open(newunit=log_unit, status='UNKNOWN', file=trim(configfile)//this_pe, position='APPEND', err=10 )
        end if
        stdlog = log_unit
     else
-       inquire( unit=etc_unit, opened=opened )
+       inquire(unit=etc_unit, opened=opened )
        if( opened )then
           FLUSH(etc_unit)
        else
-          open( unit=etc_unit, status='UNKNOWN', file=trim(etcfile), position='APPEND', err=11 )
+          open(newunit=etc_unit, status='UNKNOWN', file=trim(etcfile), position='APPEND', err=11 )
        end if
        stdlog = etc_unit
     end if
@@ -157,12 +156,11 @@
   logical :: exist
   character(len=11) :: this_pe
   if( pe.EQ.root_pe )then
-     log_unit = get_unit()
      do p=0,npes-1
        write(this_pe,'(a,i6.6,a)') '.',p,'.out'
        inquire( file=trim(configfile)//this_pe, exist=exist )
        if(exist)then
-         open( unit=log_unit, file=trim(configfile)//this_pe, status='REPLACE' )
+         open(newunit=log_unit, file=trim(configfile)//this_pe, status='REPLACE' )
          close(log_unit)
        endif
      end do
@@ -988,8 +986,7 @@ end function rarray_to_char
     if( .NOT.ANY(clocks(1:clock_num)%detailed) )return
     write( filename,'(a,i6.6)' )'mpp_clock.out.', pe
 
-    SD_UNIT = get_unit()
-    open(SD_UNIT,file=trim(filename),form='formatted')
+    open(newunit=SD_UNIT,file=trim(filename),form='formatted')
 
     COMM_TYPE: do ct = 1,clock_num
 
@@ -1083,28 +1080,6 @@ end function rarray_to_char
 1005 format(a,f9.2,a)
     return
   end subroutine dump_clock_summary
-
-  !#####################################################################
-
-  integer function get_unit()
-
-    integer,save :: i
-    logical      :: l_open
-
-!  9 is reserved for etc_unit
-    do i=10,99
-       inquire(unit=i,opened=l_open)
-       if(.not.l_open)exit
-    end do
-
-    if(i==100)then
-       call mpp_error(FATAL,'Unable to get I/O unit')
-    else
-       get_unit = i
-    endif
-
-    return
-  end function get_unit
 
   !#####################################################################
 
@@ -1392,8 +1367,7 @@ end function rarray_to_char
        inquire(FILE=FILENAME, EXIST=file_exist)
 
        if ( file_exist ) then
-          f_unit = get_unit()
-          open(UNIT=f_unit, FILE=FILENAME, ACTION='READ', STATUS='OLD', IOSTAT=status)
+          open(newunit=f_unit, FILE=FILENAME, ACTION='READ', STATUS='OLD', IOSTAT=status)
 
           if ( status .ne. 0 ) then
              write (UNIT=text, FMT='(I5)') status
@@ -1462,8 +1436,7 @@ end function rarray_to_char
        inquire(FILE=FILENAME, EXIST=file_exist)
 
        if ( file_exist ) then
-          f_unit = get_unit()
-          open(UNIT=f_unit, FILE=FILENAME, ACTION='READ', STATUS='OLD', IOSTAT=status)
+          open(newunit=f_unit, FILE=FILENAME, ACTION='READ', STATUS='OLD', IOSTAT=status)
 
           if ( status .ne. 0 ) then
              write (UNIT=text, FMT='(I5)') status
@@ -1565,8 +1538,7 @@ end function rarray_to_char
        inquire(FILE=FILENAME, EXIST=file_exist)
 
        if ( file_exist ) then
-          f_unit = get_unit()
-          open(UNIT=f_unit, FILE=FILENAME, ACTION='READ', STATUS='OLD', IOSTAT=status)
+          open(newunit=f_unit, FILE=FILENAME, ACTION='READ', STATUS='OLD', IOSTAT=status)
 
           if ( status .ne. 0 ) then
              write (UNIT=text, FMT='(I5)') status

--- a/mpp/include/mpp_util.inc
+++ b/mpp/include/mpp_util.inc
@@ -140,13 +140,10 @@
        inquire(unit=etc_unit, opened=opened )
        if( opened )then
           FLUSH(etc_unit)
-          print *, 'non-root, opened', etc_unit
        else
           open(newunit=etc_unit, status='UNKNOWN', file=trim(etcfile), position='APPEND', err=11 )
-          print *, 'non-root, not opened', etc_unit
        end if
        stdlog = etc_unit
-       print *, 'non-root, stdlog', stdlog
     end if
     return
 10  call mpp_error( FATAL, 'STDLOG: unable to open '//trim(configfile)//this_pe//'.' )

--- a/mpp/include/mpp_util.inc
+++ b/mpp/include/mpp_util.inc
@@ -140,10 +140,13 @@
        inquire(unit=etc_unit, opened=opened )
        if( opened )then
           FLUSH(etc_unit)
+          print *, 'non-root, opened', etc_unit
        else
           open(newunit=etc_unit, status='UNKNOWN', file=trim(etcfile), position='APPEND', err=11 )
+          print *, 'non-root, not opened', etc_unit
        end if
        stdlog = etc_unit
+       print *, 'non-root, stdlog', stdlog
     end if
     return
 10  call mpp_error( FATAL, 'STDLOG: unable to open '//trim(configfile)//this_pe//'.' )

--- a/mpp/mpp.F90
+++ b/mpp/mpp.F90
@@ -210,7 +210,7 @@ private
   public :: mpp_set_warn_level, mpp_sync, mpp_sync_self, mpp_pe
   public :: mpp_npes, mpp_root_pe, mpp_set_root_pe, mpp_declare_pelist
   public :: mpp_get_current_pelist, mpp_set_current_pelist, mpp_get_current_pelist_name
-  public :: mpp_clock_id, mpp_clock_set_grain, mpp_record_timing_data, get_unit
+  public :: mpp_clock_id, mpp_clock_set_grain, mpp_record_timing_data
   public :: read_ascii_file, read_input_nml, mpp_clock_begin, mpp_clock_end
   public :: get_ascii_file_num_lines, get_ascii_file_num_lines_and_length
   public :: mpp_record_time_start, mpp_record_time_end

--- a/mpp/mpp_io.F90
+++ b/mpp/mpp_io.F90
@@ -371,8 +371,8 @@ private
   public :: default_field, default_axis, default_att
 
   !--- public interface from mpp_io_util.h ----------------------
-  public :: mpp_get_id, mpp_get_ncid, mpp_get_unit_range, mpp_is_valid
-  public :: mpp_set_unit_range, mpp_get_info, mpp_get_atts, mpp_get_fields
+  public :: mpp_get_id, mpp_get_ncid, mpp_is_valid
+  public :: mpp_get_info, mpp_get_atts, mpp_get_fields
   public :: mpp_get_times, mpp_get_axes, mpp_get_recdimid, mpp_get_axis_data, mpp_get_axis_by_name
   public :: mpp_io_set_stack_size, mpp_get_field_index, mpp_get_axis_index
   public :: mpp_get_field_name, mpp_get_att_value, mpp_get_att_length

--- a/mpp/mpp_memutils.F90
+++ b/mpp/mpp_memutils.F90
@@ -28,7 +28,7 @@
 module mpp_memutils_mod
 
   use mpp_mod, only: mpp_min, mpp_max, mpp_sum, mpp_pe, mpp_root_pe
-  use mpp_mod, only: mpp_error, FATAL, stderr, mpp_npes, get_unit
+  use mpp_mod, only: mpp_error, FATAL, stderr, mpp_npes
   use platform_mod
 
   implicit none

--- a/supported_interfaces.md
+++ b/supported_interfaces.md
@@ -392,7 +392,6 @@ Additional information for this module and others can be found in the Doxygen ge
 - mpp_clock_id
 - mpp_clock_set_grain
 - mpp_record_timing_data
-- get_unit
 - read_ascii_file
 - read_input_nml
 - mpp_clock_begin


### PR DESCRIPTION
**Description**
Removes hardcoded etc_unit, removes the obsolete get_unit function, and uses the Fortran intrinsic newunit when opening files with mpp.

Fixes #815 

**How Has This Been Tested?**
Tests pass on Skylake with Intel19.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

