### PR TITLE
Add Intel -real-size option

### DIFF
--- a/m4/gx_fortran_options.m4
+++ b/m4/gx_fortran_options.m4
@@ -70,6 +70,7 @@
 #
 # The known flags are:
 # -fdefault-real-8: gfortran
+#    -real-size 64: Intel compiler
 #    -real_size 64: Intel compiler
 #        -s real64: Cray
 #              -r8: Portland Group compiler
@@ -81,6 +82,7 @@ gx_cv_fc_default_real_kind8_flag=unknown
 gx_fc_default_real_kind8_flag_FCFLAGS_save=$FCFLAGS
 for ac_flag in none \
                '-fdefault-real-8' \
+               '-real-size 64' \
                '-real_size 64' \
                '-s real64' \
                '-r8' \
@@ -126,6 +128,7 @@ AC_SUBST([FC_DEFAULT_REAL_KIND8_FLAG])
 # The known flags are:
 #             none: gfortran (gfortran does not have an option to set the
 #                   default REAL kind to KIND=4)
+#    -real-size 32: Intel compiler
 #    -real_size 32: Intel compiler
 #        -s real32: Cray
 #              -r4: Portland Group compiler
@@ -137,6 +140,7 @@ gx_cv_fc_default_real_kind4_flag=unknown
 gx_fc_default_real_kind4_flag_FCFLAGS_save=$FCFLAGS
 for ac_flag in none \
                '-fdefault-real-4' \
+               '-real-size 32' \
                '-real_size 32' \
                '-s real32' \
                '-r4' \


### PR DESCRIPTION
Newer Intel compilers use the -real-size option to change the default Fortran real kind when building.  Using the older -real_size option would cause compiler warnings to be printed.


Fixes #817

**How Has This Been Tested?**
Built on GFDL workstation with newer version of Intel.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

