### PR TITLE
mpp_type_free cleanup

### DIFF
--- a/mpp/include/mpp_comm_mpi.inc
+++ b/mpp/include/mpp_comm_mpi.inc
@@ -227,7 +227,7 @@ subroutine mpp_exit()
   real    :: t, tmin, tmax, tavg, tstd
   real    :: m, mmin, mmax, mavg, mstd, t_total
   logical :: opened
-  type(mpp_type), pointer :: dtype
+  type(mpp_type), pointer :: dtype, next_dtype
 
   if( .NOT.module_is_initialized )return
   call mpp_set_current_pelist()
@@ -315,12 +315,12 @@ subroutine mpp_exit()
    close(etc_unit)
   endif
 
-  ! Clear derived data types (skipping list head, mpp_byte)
+  ! Clear derived data types
   dtype => datatypes%head
-  do while (.not. associated(dtype))
-      dtype => dtype%next
-      dtype%counter = 1         ! Force deallocation
+  do while (associated(dtype))
+      next_dtype => dtype%next
       call mpp_type_free(dtype)
+      dtype => next_dtype
   end do
 
   call mpp_set_current_pelist()
@@ -1419,19 +1419,20 @@ subroutine mpp_type_free(dtype)
     dtype%counter = dtype%counter - 1
 
     if (dtype%counter < 1) then
-        ! De-register the datatype in MPI runtime
-        call MPI_Type_free(dtype%id, error)
-
         ! Remove from list
         dtype%prev => dtype%next
-
-        ! Remove from memory
-        if (allocated(dtype%sizes)) deallocate(dtype%sizes)
-        if (allocated(dtype%subsizes)) deallocate(dtype%subsizes)
-        if (allocated(dtype%starts)) deallocate(dtype%starts)
-        deallocate(dtype)
-
         datatypes%length = datatypes%length - 1
+
+        ! Free resources
+        deallocate(dtype%sizes)
+        deallocate(dtype%subsizes)
+        deallocate(dtype%starts)
+
+        ! User-defined datatype cleanup
+        if (dtype%id /= MPI_BYTE) then
+            call MPI_Type_free(dtype%id, error)
+            deallocate(dtype)
+        endif
     end if
 
     if (current_clock .NE. 0) &


### PR DESCRIPTION
**Description**

This patch fixes some issues and errors in the `mpp_type_free` funcrion,
mostly related to the handling of the default `mpp_byte` type.

MPI datatypes are handled through the `mpp_type` wrapper for
non-contiguous data transfers within collectives.  User-defined types
are stored in a linked list, with a minimal wrapper to `MPI_BYTE` stored
at the head.  Because this type is intrinsic, it is handled separately.

The cleanup function `mpp_type_free` had some errors where it was not
cleaning up these types, and (had it been working) would have
incorrectly tried to de-register `MPI_BYTE`, which causes a SIGSEGV.

This patch resolves the linked list iteration and also excepts the
de-register and deallocation associated with `MPI_BYTE`.

This also has the very small benefit of fixing up some minor memory
leaks associated with `mpp_byte`.

Include a summary of the change and which issue is fixed. Please also include
relevant motivation and context. List any dependencies that are required for
this change.

Fixes #821

**How Has This Been Tested?**
Tested in the MOM6 verification suite (`.testing`).

**Checklist:**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] `make distcheck` passes

