### PR TITLE
Reintroduces the option to flush_nc_files with fms2_io

### DIFF
--- a/diag_manager/diag_util.F90
+++ b/diag_manager/diag_util.F90
@@ -58,7 +58,7 @@ use,intrinsic :: iso_c_binding, only: c_double,c_float,c_int64_t, &
        & get_axes_shift, get_diag_axis_name, get_diag_axis_domain_name, get_domainUG, &
        & get_axis_reqfld, axis_is_compressed, get_compressed_axes_ids
   USE diag_output_mod, ONLY: diag_output_init, write_axis_meta_data,&
-       & write_field_meta_data, done_meta_data
+       & write_field_meta_data, done_meta_data, diag_flush
   USE diag_output_mod, ONLY: diag_field_write, diag_write_time !<fms2_io use_mpp_io=.false.
   USE diag_grid_mod, ONLY: get_local_indexes
   USE fms_mod, ONLY: error_mesg, FATAL, WARNING, NOTE, mpp_pe, mpp_root_pe, lowercase, fms_error_handler,&
@@ -2299,6 +2299,7 @@ CONTAINS
        END IF
     ELSE
        IF ( time > files(file)%last_flush .AND. (flush_nc_files.OR.debug_diag_manager) ) THEN
+          call diag_flush(file, fileobjU, fileobj, fileobjND, fnum_for_domain(file))
           files(file)%last_flush = time
        END IF
     END IF

--- a/fms2_io/fms2_io.F90
+++ b/fms2_io/fms2_io.F90
@@ -104,6 +104,7 @@ public :: set_filename_appendix
 public :: get_instance_filename
 public :: nullify_filename_appendix
 public :: string2
+public :: flush_file
 !> @}
 
 !> @brief Opens a given netcdf or domain file.

--- a/fms2_io/netcdf_io.F90
+++ b/fms2_io/netcdf_io.F90
@@ -233,6 +233,7 @@ public :: check_if_open
 public :: set_fileobj_time_name
 public :: write_restart_bc
 public :: read_restart_bc
+public :: flush_file
 
 !> @ingroup netcdf_io_mod
 interface netcdf_add_restart_variable
@@ -2264,6 +2265,16 @@ subroutine write_restart_bc(fileobj, unlim_dim_level)
  enddo
 
 end subroutine write_restart_bc
+
+!> @brief flushes the netcdf file into disk
+subroutine flush_file(fileobj)
+  class(FmsNetcdfFile_t), intent(inout) :: fileobj !< FMS2_io fileobj
+
+  integer :: err !< Netcdf error code
+
+  err = nf90_sync(fileobj%ncid)
+  call check_netcdf_code(err, "Flush_file: File:"//trim(fileobj%path))
+end subroutine flush_file
 
 end module netcdf_io_mod
 !> @}


### PR DESCRIPTION
**Description**
Reintroduces the option to flush_nc_files with fms2_io

This works the same way it did in 2019.01.03 but with fms2_io. If `flush_nc_files is .true.`, it will call `diag_output:diag_flush` which will call `fms2_io:flush_file` which will call `nf90_sync`
Fixes # (issue)

**How Has This Been Tested?**
Passes a unit test that I created. 
Ran c96L33_am4p0_cmip6Diag with intel18, prod-openmp on gaea and everything still works.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

