### PR TITLE
Xgrid and gradient_mod r8 precision

### DIFF
--- a/diag_manager/diag_manager.F90
+++ b/diag_manager/diag_manager.F90
@@ -1460,7 +1460,7 @@ CONTAINS
   LOGICAL FUNCTION send_data_3d_r8(diag_field_id, field, time, is_in, js_in, ks_in, &
              & mask, rmask, ie_in, je_in, ke_in, weight, err_msg)
     INTEGER, INTENT(in) :: diag_field_id
-    REAL(kind=8), INTENT(in), DIMENSION(:,:,:) :: field
+    REAL(r8_kind), INTENT(in), DIMENSION(:,:,:) :: field
     REAL, INTENT(in), OPTIONAL :: weight
     TYPE (time_type), INTENT(in), OPTIONAL :: time
     INTEGER, INTENT(in), OPTIONAL :: is_in, js_in, ks_in,ie_in,je_in, ke_in

--- a/exchange/xgrid.F90
+++ b/exchange/xgrid.F90
@@ -96,8 +96,6 @@
 module xgrid_mod
 
 
-#include <fms_platform.h>
-
 use       fms_mod,   only: check_nml_error,  &
                            error_mesg, FATAL, NOTE, stdlog,      &
                            WARNING, &
@@ -135,6 +133,7 @@ use gradient_mod,        only: gradient_cubic
 use fms2_io_mod,         only: FmsNetcdfFile_t, open_file, variable_exists, close_file
 use fms2_io_mod,         only: FmsNetcdfDomainFile_t, read_data, get_dimension_size
 use fms2_io_mod,         only: get_variable_units, dimension_exists
+use platform_mod
 
 implicit none
 private
@@ -185,9 +184,9 @@ logical :: init = .true.
 integer :: remapping_method
 
 !> Area elements used inside each model
-real, allocatable, dimension(:,:) :: AREA_ATM_MODEL, AREA_LND_MODEL, AREA_OCN_MODEL
+real(r8_kind), allocatable, dimension(:,:) :: AREA_ATM_MODEL, AREA_LND_MODEL, AREA_OCN_MODEL
 !> Area elements based on a the spherical model used by the ICE layer
-real, allocatable, dimension(:,:) :: AREA_ATM_SPHERE, AREA_LND_SPHERE, AREA_OCN_SPHERE
+real(r8_kind), allocatable, dimension(:,:) :: AREA_ATM_SPHERE, AREA_LND_SPHERE, AREA_OCN_SPHERE
 
 !> @}
 
@@ -247,7 +246,7 @@ end interface
 !!     side grid(s), and (3) after re_interpolation back onto its home side grid(s).
 !!     Conservation_check must be called by all PEs to work properly.
 !!
-!! @param d real data
+!! @param d real(r8_kind) data
 !! @param grid_id 3 character grid ID
 !! @param[inout] xmap exchange grid
 !! @param[out] global sum of a variable on home model grid, after side grid interpolation and after
@@ -284,28 +283,28 @@ type xcell_type
   integer :: recv_pos       !< position in the receive buffer.
   integer :: pe             !< other side pe that has this cell
   integer :: tile           !< tile index of side 1 mosaic.
-  real    :: area           !< geographic area of exchange cell
-!  real    :: area1_ratio     !(= x_area/grid1_area), will be added in the future to improve efficiency
-!  real    :: area2_ratio     !(= x_area/grid2_area), will be added in the future to improve efficiency
-  real    :: di !< Weight for the gradient of flux
-  real    :: dj !< Weight for the gradient of flux
-  real    :: scale
+  real(r8_kind)    :: area           !< geographic area of exchange cell
+!  real(r8_kind)    :: area1_ratio     !(= x_area/grid1_area), will be added in the future to improve efficiency
+!  real(r8_kind)    :: area2_ratio     !(= x_area/grid2_area), will be added in the future to improve efficiency
+  real(r8_kind)    :: di !< Weight for the gradient of flux
+  real(r8_kind)    :: dj !< Weight for the gradient of flux
+  real(r8_kind)    :: scale
 end type xcell_type
 
 !> Type to hold pointers for grid boxes
 !> @ingroup xgrid_mod
 type grid_box_type
-   real, dimension(:,:),   pointer :: dx     => NULL()
-   real, dimension(:,:),   pointer :: dy     => NULL()
-   real, dimension(:,:),   pointer :: area   => NULL()
-   real, dimension(:),     pointer :: edge_w => NULL()
-   real, dimension(:),     pointer :: edge_e => NULL()
-   real, dimension(:),     pointer :: edge_s => NULL()
-   real, dimension(:),     pointer :: edge_n => NULL()
-   real, dimension(:,:,:), pointer :: en1    => NULL()
-   real, dimension(:,:,:), pointer :: en2    => NULL()
-   real, dimension(:,:,:), pointer :: vlon   => NULL()
-   real, dimension(:,:,:), pointer :: vlat   => NULL()
+   real(r8_kind), dimension(:,:),   pointer :: dx     => NULL()
+   real(r8_kind), dimension(:,:),   pointer :: dy     => NULL()
+   real(r8_kind), dimension(:,:),   pointer :: area   => NULL()
+   real(r8_kind), dimension(:),     pointer :: edge_w => NULL()
+   real(r8_kind), dimension(:),     pointer :: edge_e => NULL()
+   real(r8_kind), dimension(:),     pointer :: edge_s => NULL()
+   real(r8_kind), dimension(:),     pointer :: edge_n => NULL()
+   real(r8_kind), dimension(:,:,:), pointer :: en1    => NULL()
+   real(r8_kind), dimension(:,:,:), pointer :: en2    => NULL()
+   real(r8_kind), dimension(:,:,:), pointer :: vlon   => NULL()
+   real(r8_kind), dimension(:,:,:), pointer :: vlat   => NULL()
 end type grid_box_type
 
 !> Private type to hold all data needed from given grid for an exchange grid
@@ -340,13 +339,13 @@ type grid_type
   integer                         :: im                     !< global domain range
   integer                         :: jm                     !< global domain range
   integer                         :: km                     !< global domain range
-  real, pointer, dimension(:)     :: lon =>NULL()       !< center of global grids
-  real, pointer, dimension(:)     :: lat =>NULL()       !< center of global grids
-  real, pointer, dimension(:,:)   :: geolon=>NULL()   !< geographical grid center
-  real, pointer, dimension(:,:)   :: geolat=>NULL()   !< geographical grid center
-  real, pointer, dimension(:,:,:) :: frac_area =>NULL()               !< partition fractions
-  real, pointer, dimension(:,:)   :: area =>NULL()                    !< cell area
-  real, pointer, dimension(:,:)   :: area_inv =>NULL()                !< 1 / area for normalization
+  real(r8_kind), pointer, dimension(:)     :: lon =>NULL()       !< center of global grids
+  real(r8_kind), pointer, dimension(:)     :: lat =>NULL()       !< center of global grids
+  real(r8_kind), pointer, dimension(:,:)   :: geolon=>NULL()   !< geographical grid center
+  real(r8_kind), pointer, dimension(:,:)   :: geolat=>NULL()   !< geographical grid center
+  real(r8_kind), pointer, dimension(:,:,:) :: frac_area =>NULL()               !< partition fractions
+  real(r8_kind), pointer, dimension(:,:)   :: area =>NULL()                    !< cell area
+  real(r8_kind), pointer, dimension(:,:)   :: area_inv =>NULL()                !< 1 / area for normalization
   integer                         :: first                      !< xgrid index range
   integer                         :: last                       !< xgrid index range
   integer                         :: first_get              !< xgrid index range for get_2_from_xgrid
@@ -376,10 +375,10 @@ end type grid_type
 !> @ingroup xgrid_mod
 type x1_type
   integer :: i, j
-  real    :: area   !< (= geographic area * frac_area)
-!  real    :: area_ratio !(= x1_area/grid1_area) ! will be added in the future to improve efficiency
-  real    :: di !< weight for the gradient of flux
-  real    :: dj !< weight for the gradient of flux
+  real(r8_kind)    :: area   !< (= geographic area * frac_area)
+!  real(r8_kind)    :: area_ratio !(= x1_area/grid1_area) ! will be added in the future to improve efficiency
+  real(r8_kind)    :: di !< weight for the gradient of flux
+  real(r8_kind)    :: dj !< weight for the gradient of flux
   integer :: tile           !< tile index of side 1 mosaic.
   integer :: pos
 end type x1_type
@@ -388,8 +387,8 @@ end type x1_type
 !> @ingroup xgrid_mod
 type x2_type
   integer :: i, j, l, k, pos
-  real    :: area   !< geographic area of exchange cell
-!  real    :: area_ratio !(=x2_area/grid2_area )  ! will be added in the future to improve efficiency
+  real(r8_kind)    :: area   !< geographic area of exchange cell
+!  real(r8_kind)    :: area_ratio !(=x2_area/grid2_area )  ! will be added in the future to improve efficiency
 end type x2_type
 
 !> Private type for overlap exchange grid data
@@ -403,8 +402,8 @@ type overlap_type
    integer, allocatable :: g(:)
    integer, allocatable :: xLoc(:)
    integer, allocatable :: tile(:)
-   real,    allocatable :: di(:)
-   real,    allocatable :: dj(:)
+   real(r8_kind),    allocatable :: di(:)
+   real(r8_kind),    allocatable :: dj(:)
 end type overlap_type
 
 !> Private type used for exchange grid communication
@@ -465,8 +464,8 @@ end type xmap_type
 ! Include variable "version" to be written to log file.
 #include<file_version.h>
 
- real, parameter                              :: EPS = 1.0e-10
- real, parameter                              :: LARGE_NUMBER = 1.e20
+ real(r8_kind), parameter                              :: EPS = 1.0e-10
+ real(r8_kind), parameter                              :: LARGE_NUMBER = 1.e20
  logical :: module_is_initialized = .FALSE.
  integer :: id_put_1_to_xgrid_order_1 = 0
  integer :: id_put_1_to_xgrid_order_2 = 0
@@ -609,27 +608,27 @@ logical,        intent(in)             :: use_higher_order
 
   integer, pointer,       dimension(:)   :: i1=>NULL(), j1=>NULL()
   integer, pointer,       dimension(:)   :: i2=>NULL(), j2=>NULL()
-  real,    pointer,       dimension(:)   :: di=>NULL(), dj=>NULL()
-  real,    pointer,       dimension(:)   :: area =>NULL()
+  real(r8_kind),    pointer,       dimension(:)   :: di=>NULL(), dj=>NULL()
+  real(r8_kind),    pointer,       dimension(:)   :: area =>NULL()
   integer, pointer,       dimension(:)   :: i1_tmp=>NULL(), j1_tmp=>NULL()
   integer, pointer,       dimension(:)   :: i2_tmp=>NULL(), j2_tmp=>NULL()
-  real,    pointer,       dimension(:)   :: di_tmp=>NULL(), dj_tmp=>NULL()
-  real,    pointer,       dimension(:)   :: area_tmp =>NULL()
+  real(r8_kind),    pointer,       dimension(:)   :: di_tmp=>NULL(), dj_tmp=>NULL()
+  real(r8_kind),    pointer,       dimension(:)   :: area_tmp =>NULL()
   integer, pointer,       dimension(:)   :: i1_side1=>NULL(), j1_side1=>NULL()
   integer, pointer,       dimension(:)   :: i2_side1=>NULL(), j2_side1=>NULL()
-  real,    pointer,       dimension(:)   :: di_side1=>NULL(), dj_side1=>NULL()
-  real,    pointer,       dimension(:)   :: area_side1 =>NULL()
+  real(r8_kind),    pointer,       dimension(:)   :: di_side1=>NULL(), dj_side1=>NULL()
+  real(r8_kind),    pointer,       dimension(:)   :: area_side1 =>NULL()
 
-  real,    allocatable, dimension(:,:) :: tmp
-  real,    allocatable, dimension(:)   :: send_buffer, recv_buffer
+  real(r8_kind),    allocatable, dimension(:,:) :: tmp
+  real(r8_kind),    allocatable, dimension(:)   :: send_buffer, recv_buffer
   type (grid_type),   pointer, save    :: grid1 =>NULL()
   integer                              :: l, ll, ll_repro, p, siz(4), nxgrid, size_prev
   type(xcell_type),   allocatable      :: x_local(:)
   integer                              :: size_repro, out_unit
   logical                              :: scale_exist = .false.
   logical                              :: is_distribute = .false.
-  real,    allocatable,   dimension(:) :: scale
-  real                                 :: garea
+  real(r8_kind),    allocatable,   dimension(:) :: scale
+  real(r8_kind)                                 :: garea
   integer                              :: npes, isc, iec, nxgrid_local, pe, nxgrid_local_orig
   integer                              :: nxgrid1, nxgrid2, nset1, nset2, ndivs, cur_ind
   integer                              :: pos, nsend, nrecv, l1, l2, n, mypos, m
@@ -1312,10 +1311,10 @@ subroutine get_grid_version1(grid, grid_id, grid_file)
   character(len=3), intent(in)            :: grid_id
   character(len=*), intent(in)            :: grid_file
 
-  real, dimension(grid%im) :: lonb
-  real, dimension(grid%jm) :: latb
-  real, allocatable        :: tmpx(:,:), tmpy(:,:)
-  real                     :: d2r
+  real(r8_kind), dimension(grid%im) :: lonb
+  real(r8_kind), dimension(grid%jm) :: latb
+  real(r8_kind), allocatable        :: tmpx(:,:), tmpy(:,:)
+  real(r8_kind)                     :: d2r
   integer                  :: is, ie, js, je, nlon, nlat, i, j
   integer                  :: start(4), nread(4), isc2, iec2, jsc2, jec2
   type(FmsNetcdfDomainFile_t) :: fileobj
@@ -1381,13 +1380,15 @@ subroutine get_grid_version2(grid, grid_id, grid_file)
   character(len=3), intent(in)            :: grid_id
   character(len=*), intent(in)            :: grid_file
 
-  real, dimension(grid%im) :: lonb
-  real, dimension(grid%jm) :: latb
-  real, allocatable        :: tmpx(:,:), tmpy(:,:)
-  real                     :: d2r
+  real(r8_kind), dimension(grid%im) :: lonb
+  real(r8_kind), dimension(grid%jm) :: latb
+  real(r8_kind), allocatable        :: tmpx(:,:), tmpy(:,:)
+  real(r8_kind)                     :: d2r
   integer                  :: is, ie, js, je, nlon, nlat, i, j
   integer                  :: start(4), nread(4), isc2, iec2, jsc2, jec2
   type(FmsNetcdfFile_t) :: fileobj
+  real(r8_kind), allocatable, target :: geolon(:,:), geolat(:,:)
+  integer           :: isd, ied, jsd, jed
 
   if(.not. open_file(fileobj, grid_file, 'read') ) then
      call error_mesg('xgrid_mod(get_grid_version2)', 'Error in opening file '//trim(grid_file), FATAL)
@@ -1436,10 +1437,31 @@ subroutine get_grid_version2(grid, grid_id, grid_file)
         end do
         grid%is_latlon = .true.
      else
-        allocate(grid%geolon(grid%isd_me:grid%ied_me, grid%jsd_me:grid%jed_me))
-        allocate(grid%geolat(grid%isd_me:grid%ied_me, grid%jsd_me:grid%jed_me))
+        isd = grid%isd_me; ied = grid%ied_me
+        jsd = grid%jsd_me; jed = grid%jed_me
+        print *, mpp_pe(), isd, ied, jsd, jed
+        print *, mpp_pe(), grid%is_me, grid%ie_me, grid%js_me, grid%je_me
+
+        ! TODO these allocations fail, grid%geolon/lat are real(r8_kind)(:,:) pointers
+        !! try different ways of allocating/pointing
+        ! original allocations
+        !!allocate(grid%geolon(grid%isd_me:grid%ied_me, grid%jsd_me:grid%jed_me))
+        !!allocate(grid%geolat(grid%isd_me:grid%ied_me, grid%jsd_me:grid%jed_me))
+
+        !allocate(geolon(isd:ied,jsd:jed))
+        allocate(geolon(0:49,0:49))
+        allocate(geolat(0:49,0:49))
+        !allocate(geolat(isd:ied,jsd:jed))
+
+        !!print *, mpp_pe(), "allocated"
+
+        grid%geolon => geolon!(isd:ied,jsd:jed)
+        grid%geolat => geolat!(isd:ied,jsd:jed)
+
         grid%geolon = 1e10
+
         grid%geolat = 1e10
+
         !--- area_ocn_sphere, area_lnd_sphere, area_atm_sphere is not been defined.
         do j = grid%js_me,grid%je_me
            do i = grid%is_me,grid%ie_me
@@ -1451,6 +1473,7 @@ subroutine get_grid_version2(grid, grid_id, grid_file)
         call mpp_update_domains(grid%geolat, grid%domain)
         grid%is_latlon = .false.
      end if
+     call mpp_sync()
      deallocate(tmpx, tmpy)
   end if
 
@@ -1465,7 +1488,7 @@ end subroutine get_grid_version2
 subroutine get_area_elements_fms2_io(fileobj, name, data)
   type(FmsNetcdfDomainFile_t), intent(in) :: fileobj
   character(len=*), intent(in) :: name
-  real, intent(out)            :: data(:,:)
+  real(r8_kind), intent(out)            :: data(:,:)
 
   if(variable_exists(fileobj, name)) then
      call read_data(fileobj, name, data)
@@ -1530,10 +1553,10 @@ subroutine setup_xmap(xmap, grid_ids, grid_domains, grid_file, atm_grid, lnd_ug_
   integer :: unit, nxgrid_file, i1, i2, i3, tile1, tile2, j
   integer :: nxc, nyc, out_unit
   type (grid_type), pointer, save :: grid =>NULL(), grid1 =>NULL()
-  real, dimension(3) :: xxx
-  real, dimension(:,:), allocatable   :: check_data
-  real, dimension(:,:,:), allocatable :: check_data_3D
-  real,                 allocatable   :: tmp_2d(:,:), tmp_3d(:,:,:)
+  real(r8_kind), dimension(3) :: xxx
+  real(r8_kind), dimension(:,:), allocatable   :: check_data
+  real(r8_kind), dimension(:,:,:), allocatable :: check_data_3D
+  real(r8_kind),                 allocatable   :: tmp_2d(:,:), tmp_3d(:,:,:)
   character(len=256)                  :: xgrid_file, xgrid_name, xgrid_dimname
   character(len=256)                  :: tile_file, mosaic_file
   character(len=256)                  :: mosaic1, mosaic2, contact
@@ -2274,8 +2297,8 @@ subroutine set_comm_get1(xmap)
   integer              :: i1, j1, tile1, p, n, pos, buffer_pos, mypos
   integer              :: nsend, nrecv, rbuf_size, sbuf_size, msgsize
   logical              :: found
-  real,    allocatable :: recv_buf(:), send_buf(:)
-  real,    allocatable :: diarray(:), djarray(:)
+  real(r8_kind),    allocatable :: recv_buf(:), send_buf(:)
+  real(r8_kind),    allocatable :: diarray(:), djarray(:)
   integer, allocatable :: iarray(:), jarray(:), tarray(:)
   integer, allocatable :: pos_x(:), pelist(:), size_pe(:), pe_side1(:)
   integer              :: recv_buffer_pos(0:xmap%npes)
@@ -2573,8 +2596,8 @@ subroutine set_comm_put1(xmap)
   integer              :: i1, j1, tile1, p, n, pos, buffer_pos
   integer              :: nsend, nrecv, msgsize, nset, rbuf_size, sbuf_size
   logical              :: found
-  real,    allocatable :: recv_buf(:), send_buf(:)
-  real,    allocatable :: diarray(:), djarray(:)
+  real(r8_kind),    allocatable :: recv_buf(:), send_buf(:)
+  real(r8_kind),    allocatable :: diarray(:), djarray(:)
   integer, allocatable :: iarray(:), jarray(:), tarray(:)
   integer, allocatable :: pos_x(:), pelist(:), size_pe(:), pe_put1(:)
   integer              :: root_pe, recvsize, sendsize
@@ -3064,7 +3087,7 @@ end subroutine regen
 
 !> @brief Changes sub-grid portion areas and/or number.
 subroutine set_frac_area_sg(f, grid_id, xmap)
-real, dimension(:,:,:), intent(in   ) :: f !< fraction area to be set
+real(r8_kind), dimension(:,:,:), intent(in   ) :: f !< fraction area to be set
 character(len=3),       intent(in   ) :: grid_id !< 3 character grid ID
 type (xmap_type),       intent(inout) :: xmap !< exchange grid with given grid ID
 
@@ -3096,7 +3119,7 @@ end subroutine  set_frac_area_sg
 
 !> @brief Changes sub-grid portion areas and/or number.
 subroutine set_frac_area_ug(f, grid_id, xmap)
-real, dimension(:,:),   intent(in   ) :: f !< fractional area to set
+real(r8_kind), dimension(:,:),   intent(in   ) :: f !< fractional area to set
 character(len=3),       intent(in   ) :: grid_id !< 3 character grid ID
 type (xmap_type),       intent(inout) :: xmap !< exchange grid with given grid ID
 
@@ -3139,9 +3162,9 @@ end function xgrid_count
 
 !> Scatters data to exchange grid
 subroutine put_side1_to_xgrid(d, grid_id, x, xmap, remap_method, complete)
-  real, dimension(:,:), intent(in   )    :: d !< data to send
+  real(r8_kind), dimension(:,:), intent(in   )    :: d !< data to send
   character(len=3),     intent(in   )    :: grid_id !< 3 character grid ID
-  real, dimension(:),   intent(inout)    :: x !< xgrid data
+  real(r8_kind), dimension(:),   intent(inout)    :: x !< xgrid data
   type (xmap_type),     intent(inout)    :: xmap !< exchange grid
   integer, intent(in), optional          :: remap_method !< exchange grid interpolation method can
                                                          !! be FIRST_ORDER(=1) or SECOND_ORDER(=2)
@@ -3156,8 +3179,8 @@ subroutine put_side1_to_xgrid(d, grid_id, x, xmap, remap_method, complete)
   integer,                                   save :: xsize=0
   integer,                                   save :: method_saved=0
   character(len=3),                          save :: grid_id_saved=""
-  integer(LONG_KIND), dimension(MAX_FIELDS), save :: d_addrs=-9999
-  integer(LONG_KIND), dimension(MAX_FIELDS), save :: x_addrs=-9999
+  integer(i8_kind), dimension(MAX_FIELDS), save :: d_addrs=-9999
+  integer(i8_kind), dimension(MAX_FIELDS), save :: x_addrs=-9999
 
   if (grid_id==xmap%grids(1)%id) then
      method = FIRST_ORDER      ! default
@@ -3230,9 +3253,9 @@ end subroutine put_side1_to_xgrid
 
 !> Scatters data to exchange grid
 subroutine put_side2_to_xgrid(d, grid_id, x, xmap)
-real, dimension(:,:,:), intent(in   ) :: d !< data to send
+real(r8_kind), dimension(:,:,:), intent(in   ) :: d !< data to send
 character(len=3),       intent(in   ) :: grid_id !< 3 character grid ID
-real, dimension(:),     intent(inout) :: x !< xgrid data
+real(r8_kind), dimension(:),     intent(inout) :: x !< xgrid data
 type (xmap_type),       intent(inout) :: xmap !< exchange grid
 
   integer :: g
@@ -3255,9 +3278,9 @@ end subroutine put_side2_to_xgrid
 !#######################################################################
 
 subroutine get_side1_from_xgrid(d, grid_id, x, xmap, complete)
-  real, dimension(:,:), intent(  out) :: d !< recieved xgrid data
+  real(r8_kind), dimension(:,:), intent(  out) :: d !< recieved xgrid data
   character(len=3),     intent(in   ) :: grid_id !< 3 character grid ID
-  real, dimension(:),   intent(in   ) :: x !< xgrid data
+  real(r8_kind), dimension(:),   intent(in   ) :: x !< xgrid data
   type (xmap_type),     intent(inout) :: xmap !< exchange grid
   logical, intent(in), optional     :: complete
 
@@ -3269,8 +3292,8 @@ subroutine get_side1_from_xgrid(d, grid_id, x, xmap, complete)
   integer,                                   save :: lsize=0
   integer,                                   save :: xsize=0
   character(len=3),                          save :: grid_id_saved=""
-  integer(LONG_KIND), dimension(MAX_FIELDS), save :: d_addrs=-9999
-  integer(LONG_KIND), dimension(MAX_FIELDS), save :: x_addrs=-9999
+  integer(i8_kind), dimension(MAX_FIELDS), save :: d_addrs=-9999
+  integer(i8_kind), dimension(MAX_FIELDS), save :: x_addrs=-9999
 
   if (grid_id==xmap%grids(1)%id) then
      is_complete = .true.
@@ -3330,9 +3353,9 @@ end subroutine get_side1_from_xgrid
 !#######################################################################
 
 subroutine get_side2_from_xgrid(d, grid_id, x, xmap)
-real, dimension(:,:,:), intent(  out) :: d !< received xgrid data
+real(r8_kind), dimension(:,:,:), intent(  out) :: d !< received xgrid data
 character(len=3),       intent(in   ) :: grid_id !< 3 character grid ID
-real, dimension(:),     intent(in   ) :: x !< xgrid data
+real(r8_kind), dimension(:),     intent(in   ) :: x !< xgrid data
 type (xmap_type),       intent(in   ) :: xmap !< exchange grid
 
   integer :: g
@@ -3391,9 +3414,9 @@ end subroutine some
 
 subroutine put_2_to_xgrid(d, grid, x, xmap)
 type (grid_type),                                intent(in) :: grid
-real, dimension(grid%is_me:grid%ie_me, &
+real(r8_kind), dimension(grid%is_me:grid%ie_me, &
                 grid%js_me:grid%je_me, grid%km), intent(in) :: d
-real, dimension(:    ), intent(inout) :: x
+real(r8_kind), dimension(:    ), intent(inout) :: x
 type (xmap_type),       intent(in   ) :: xmap
 
   integer                 ::   l
@@ -3410,9 +3433,9 @@ end subroutine put_2_to_xgrid
 
 subroutine get_2_from_xgrid(d, grid, x, xmap)
 type (grid_type),                                intent(in ) :: grid
-real, dimension(grid%is_me:grid%ie_me, &
+real(r8_kind), dimension(grid%is_me:grid%ie_me, &
                 grid%js_me:grid%je_me, grid%km), intent(out) :: d
-real, dimension(:),     intent(in   ) :: x
+real(r8_kind), dimension(:),     intent(in   ) :: x
 type (xmap_type),       intent(in   ) :: xmap
 
   integer                 :: l, k
@@ -3438,8 +3461,8 @@ end subroutine get_2_from_xgrid
 !#######################################################################
 
 subroutine put_1_to_xgrid_order_1(d_addrs, x_addrs, xmap, isize, jsize, xsize, lsize)
-  integer(LONG_KIND), dimension(:), intent(in) :: d_addrs
-  integer(LONG_KIND), dimension(:), intent(in) :: x_addrs
+  integer(i8_kind), dimension(:), intent(in) :: d_addrs
+  integer(i8_kind), dimension(:), intent(in) :: x_addrs
   type (xmap_type),              intent(inout) :: xmap
   integer,                          intent(in) :: isize, jsize, xsize, lsize
 
@@ -3447,12 +3470,12 @@ subroutine put_1_to_xgrid_order_1(d_addrs, x_addrs, xmap, isize, jsize, xsize, l
   integer                         :: from_pe, to_pe, pos, n, l, count
   integer                         :: ibegin, istart, iend, start_pos
   type (comm_type), pointer, save :: comm =>NULL()
-  real                            :: recv_buffer(xmap%put1%recvsize*lsize)
-  real                            :: send_buffer(xmap%put1%sendsize*lsize)
-  real                            :: unpack_buffer(xmap%put1%recvsize)
+  real(r8_kind)                            :: recv_buffer(xmap%put1%recvsize*lsize)
+  real(r8_kind)                            :: send_buffer(xmap%put1%sendsize*lsize)
+  real(r8_kind)                            :: unpack_buffer(xmap%put1%recvsize)
 
-  real, dimension(isize, jsize)   :: d
-  real, dimension(xsize)          :: x
+  real(r8_kind), dimension(isize, jsize)   :: d
+  real(r8_kind), dimension(xsize)          :: x
   pointer(ptr_d, d)
   pointer(ptr_x, x)
 
@@ -3527,29 +3550,29 @@ end subroutine put_1_to_xgrid_order_1
 
 
 subroutine put_1_to_xgrid_order_2(d_addrs, x_addrs, xmap, isize, jsize, xsize, lsize)
-  integer(LONG_KIND), dimension(:), intent(in) :: d_addrs
-  integer(LONG_KIND), dimension(:), intent(in) :: x_addrs
+  integer(i8_kind), dimension(:), intent(in) :: d_addrs
+  integer(i8_kind), dimension(:), intent(in) :: x_addrs
   type (xmap_type),              intent(inout) :: xmap
   integer,                          intent(in) :: isize, jsize, xsize, lsize
 
   !: NOTE: halo size is assumed to be 1 in setup_xmap
-  real, dimension(0:isize+1, 0:jsize+1, lsize) :: tmp
-  real, dimension(isize,     jsize,     lsize) :: tmpx, tmpy
-  real, dimension(isize,     jsize,     lsize) :: d_bar_max, d_bar_min
-  real, dimension(isize,     jsize,     lsize) :: d_max, d_min
-  real                            :: d_bar
+  real(r8_kind), dimension(0:isize+1, 0:jsize+1, lsize) :: tmp
+  real(r8_kind), dimension(isize,     jsize,     lsize) :: tmpx, tmpy
+  real(r8_kind), dimension(isize,     jsize,     lsize) :: d_bar_max, d_bar_min
+  real(r8_kind), dimension(isize,     jsize,     lsize) :: d_max, d_min
+  real(r8_kind)                            :: d_bar
   integer                         :: i, is, ie, im, j, js, je, jm, ii, jj
   integer                         :: p, l, ioff, joff, isd, jsd
   type (grid_type), pointer, save :: grid1 =>NULL()
   type (comm_type), pointer, save :: comm  =>NULL()
   integer                         :: buffer_pos, msgsize, from_pe, to_pe, pos, n
   integer                         :: ibegin, count, istart, iend
-  real                            :: recv_buffer(xmap%put1%recvsize*lsize*3)
-  real                            :: send_buffer(xmap%put1%sendsize*lsize*3)
-  real                            :: unpack_buffer(xmap%put1%recvsize*3)
+  real(r8_kind)                            :: recv_buffer(xmap%put1%recvsize*lsize*3)
+  real(r8_kind)                            :: send_buffer(xmap%put1%sendsize*lsize*3)
+  real(r8_kind)                            :: unpack_buffer(xmap%put1%recvsize*3)
   logical                         :: on_west_edge, on_east_edge, on_south_edge, on_north_edge
-  real, dimension(isize, jsize)   :: d
-  real, dimension(xsize)          :: x
+  real(r8_kind), dimension(isize, jsize)   :: d
+  real(r8_kind), dimension(xsize)          :: x
   pointer(ptr_d, d)
   pointer(ptr_x, x)
 
@@ -3764,25 +3787,25 @@ end subroutine put_1_to_xgrid_order_2
 !#######################################################################
 
 subroutine get_1_from_xgrid(d_addrs, x_addrs, xmap, isize, jsize, xsize, lsize)
-  integer(LONG_KIND), dimension(:), intent(in) :: d_addrs
-  integer(LONG_KIND), dimension(:), intent(in) :: x_addrs
+  integer(i8_kind), dimension(:), intent(in) :: d_addrs
+  integer(i8_kind), dimension(:), intent(in) :: x_addrs
   type (xmap_type),              intent(inout) :: xmap
   integer,                          intent(in) :: isize, jsize, xsize, lsize
 
-  real, dimension(xmap%size), target :: dg(xmap%size, lsize)
+  real(r8_kind), dimension(xmap%size), target :: dg(xmap%size, lsize)
   integer                            :: i, j, l, p, n, m
   integer                            :: msgsize, buffer_pos, pos
   integer                            :: istart, iend, count
-  real              , pointer, save  :: dgp =>NULL()
+  real(r8_kind)              , pointer, save  :: dgp =>NULL()
   type  (grid_type) , pointer, save  :: grid1 =>NULL()
   type  (comm_type) , pointer, save  :: comm  =>NULL()
   type(overlap_type), pointer, save  :: send => NULL()
   type(overlap_type), pointer, save  :: recv => NULL()
-  real                               :: recv_buffer(xmap%get1%recvsize*lsize*3)
-  real                               :: send_buffer(xmap%get1%sendsize*lsize*3)
-  real                               :: unpack_buffer(xmap%get1%recvsize*3)
-  real                               :: d(isize,jsize)
-  real, dimension(xsize)             :: x
+  real(r8_kind)                               :: recv_buffer(xmap%get1%recvsize*lsize*3)
+  real(r8_kind)                               :: send_buffer(xmap%get1%sendsize*lsize*3)
+  real(r8_kind)                               :: unpack_buffer(xmap%get1%recvsize*3)
+  real(r8_kind)                               :: d(isize,jsize)
+  real(r8_kind), dimension(xsize)             :: x
   pointer(ptr_d, d)
   pointer(ptr_x, x)
 
@@ -3897,8 +3920,8 @@ end subroutine get_1_from_xgrid
 !#######################################################################
 
 subroutine get_1_from_xgrid_repro(d_addrs, x_addrs, xmap, xsize, lsize)
-  integer(LONG_KIND), dimension(:), intent(in) :: d_addrs
-  integer(LONG_KIND), dimension(:), intent(in) :: x_addrs
+  integer(i8_kind), dimension(:), intent(in) :: d_addrs
+  integer(i8_kind), dimension(:), intent(in) :: x_addrs
   type (xmap_type),              intent(inout) :: xmap
   integer,                          intent(in) :: xsize, lsize
 
@@ -3909,11 +3932,11 @@ subroutine get_1_from_xgrid_repro(d_addrs, x_addrs, xmap, xsize, lsize)
   type(overlap_type), pointer, save  :: send => NULL()
   type(overlap_type), pointer, save  :: recv => NULL()
     integer,  dimension(0:xmap%npes-1) :: pl, ml
-  real                               :: recv_buffer(xmap%recv_count_repro_tot*lsize)
-  real                               :: send_buffer(xmap%send_count_repro_tot*lsize)
-  real                               :: d(xmap%grids(1)%is_me:xmap%grids(1)%ie_me, &
+  real(r8_kind)                               :: recv_buffer(xmap%recv_count_repro_tot*lsize)
+  real(r8_kind)                               :: send_buffer(xmap%send_count_repro_tot*lsize)
+  real(r8_kind)                               :: d(xmap%grids(1)%is_me:xmap%grids(1)%ie_me, &
                                           xmap%grids(1)%js_me:xmap%grids(1)%je_me)
-  real, dimension(xsize)             :: x
+  real(r8_kind), dimension(xsize)             :: x
   pointer(ptr_d, d)
   pointer(ptr_x, x)
 
@@ -3997,18 +4020,18 @@ end subroutine get_1_from_xgrid_repro
 !> @brief conservation_check - returns three numbers which are the global sum of a
 !!   variable (1) on its home model grid, (2) after interpolation to the other
 !!   side grid(s), and (3) after re_interpolation back onto its home side grid(s).
-!! @return real conservation_check_side1
+!! @return real(r8_kind) conservation_check_side1
 function conservation_check_side1(d, grid_id, xmap,remap_method) ! this one for 1->2->1
-real, dimension(:,:),    intent(in   ) :: d !< model data to check
+real(r8_kind), dimension(:,:),    intent(in   ) :: d !< model data to check
 character(len=3),        intent(in   ) :: grid_id !< 3 character grid id
 type (xmap_type),        intent(inout) :: xmap !< exchange grid
-real, dimension(3)                     :: conservation_check_side1
+real(r8_kind), dimension(3)                     :: conservation_check_side1
 integer, intent(in), optional :: remap_method
 
 
-  real, dimension(xmap%size) :: x_over, x_back
-  real, dimension(size(d,1),size(d,2)) :: d1
-  real, dimension(:,:,:), allocatable  :: d2
+  real(r8_kind), dimension(xmap%size) :: x_over, x_back
+  real(r8_kind), dimension(size(d,1),size(d,2)) :: d1
+  real(r8_kind), dimension(:,:,:), allocatable  :: d2
   integer                              :: g
   type (grid_type), pointer, save      :: grid1 =>NULL(), grid2 =>NULL()
 
@@ -4044,18 +4067,18 @@ end function conservation_check_side1
 !> @brief conservation_check - returns three numbers which are the global sum of a
 !!   variable (1) on its home model grid, (2) after interpolation to the other
 !!   side grid(s), and (3) after re_interpolation back onto its home side grid(s).
-!! @return real conservation_check_side2
+!! @return real(r8_kind) conservation_check_side2
 function conservation_check_side2(d, grid_id, xmap,remap_method) ! this one for 2->1->2
-real, dimension(:,:,:), intent(in   )  :: d !< model data to check
+real(r8_kind), dimension(:,:,:), intent(in   )  :: d !< model data to check
 character(len=3),       intent(in   )  :: grid_id !< 3 character grid ID
 type (xmap_type),       intent(inout)  :: xmap !< exchange grid
-real, dimension(3)                     :: conservation_check_side2
+real(r8_kind), dimension(3)                     :: conservation_check_side2
 integer, intent(in), optional :: remap_method
 
 
-  real, dimension(xmap%size) :: x_over, x_back
-  real, dimension(:,:  ), allocatable :: d1
-  real, dimension(:,:,:), allocatable :: d2
+  real(r8_kind), dimension(xmap%size) :: x_over, x_back
+  real(r8_kind), dimension(:,:  ), allocatable :: d1
+  real(r8_kind), dimension(:,:,:), allocatable :: d2
   integer                             :: g
   type (grid_type), pointer, save     :: grid1 =>NULL(), grid2 =>NULL()
 
@@ -4100,19 +4123,19 @@ end function conservation_check_side2
 !> @brief conservation_check_ug - returns three numbers which are the global sum of a
 !!   variable (1) on its home model grid, (2) after interpolation to the other
 !!   side grid(s), and (3) after re_interpolation back onto its home side grid(s).
-!! @return real conservation_check_ug_side1
+!! @return real(r8_kind) conservation_check_ug_side1
 function conservation_check_ug_side1(d, grid_id, xmap,remap_method) ! this one for 1->2->1
-real, dimension(:,:),    intent(in   ) :: d !< model data to check
+real(r8_kind), dimension(:,:),    intent(in   ) :: d !< model data to check
 character(len=3),        intent(in   ) :: grid_id !< 3 character grid ID
 type (xmap_type),        intent(inout) :: xmap !< exchange grid
-real, dimension(3)                     :: conservation_check_ug_side1
+real(r8_kind), dimension(3)                     :: conservation_check_ug_side1
 integer, intent(in), optional :: remap_method
 
-  real, dimension(xmap%size) :: x_over, x_back
-  real, dimension(size(d,1),size(d,2)) :: d1
-  real, dimension(:,:,:), allocatable  :: d2
-  real, dimension(:    ), allocatable  :: d_ug
-  real, dimension(:,:),   allocatable  :: d2_ug
+  real(r8_kind), dimension(xmap%size) :: x_over, x_back
+  real(r8_kind), dimension(size(d,1),size(d,2)) :: d1
+  real(r8_kind), dimension(:,:,:), allocatable  :: d2
+  real(r8_kind), dimension(:    ), allocatable  :: d_ug
+  real(r8_kind), dimension(:,:),   allocatable  :: d2_ug
   integer                              :: g
   type (grid_type), pointer, save      :: grid1 =>NULL(), grid2 =>NULL()
 
@@ -4172,18 +4195,18 @@ end function conservation_check_ug_side1
 !> @brief conservation_check_ug - returns three numbers which are the global sum of a
 !!   variable (1) on its home model grid, (2) after interpolation to the other
 !!   side grid(s), and (3) after re_interpolation back onto its home side grid(s).
-!! @return real conservation_check_ug_side2
+!! @return real(r8_kind) conservation_check_ug_side2
 function conservation_check_ug_side2(d, grid_id, xmap,remap_method) ! this one for 2->1->2
-real, dimension(:,:,:), intent(in   )  :: d !< model data to check
+real(r8_kind), dimension(:,:,:), intent(in   )  :: d !< model data to check
 character(len=3),       intent(in   )  :: grid_id !< 3 character grid ID
 type (xmap_type),       intent(inout)  :: xmap !< exchange grid
-real, dimension(3)                     :: conservation_check_ug_side2
+real(r8_kind), dimension(3)                     :: conservation_check_ug_side2
 integer, intent(in),   optional :: remap_method
 
 
-  real, dimension(xmap%size) :: x_over, x_back
-  real, dimension(:,:  ), allocatable :: d1, d_ug
-  real, dimension(:,:,:), allocatable :: d2
+  real(r8_kind), dimension(xmap%size) :: x_over, x_back
+  real(r8_kind), dimension(:,:  ), allocatable :: d1, d_ug
+  real(r8_kind), dimension(:,:,:), allocatable :: d2
   integer                             :: g
   type (grid_type), pointer, save     :: grid1 =>NULL(), grid2 =>NULL()
 
@@ -4256,7 +4279,7 @@ end function conservation_check_ug_side2
 subroutine get_xmap_grid_area(id, xmap, area)
   character(len=3),     intent(in   ) :: id
   type (xmap_type),     intent(inout) :: xmap
-  real, dimension(:,:), intent(out  ) :: area
+  real(r8_kind), dimension(:,:), intent(out  ) :: area
   integer                             :: g
   logical                             :: found
 
@@ -4280,16 +4303,16 @@ end subroutine get_xmap_grid_area
 !> @brief This function is used to calculate the gradient along zonal direction.
 !!   Maybe need to setup a limit for the gradient. The grid is assumeed
 !!   to be regular lat-lon grid
-!! @return real grad_zonal_latlon
+!! @return real(r8_kind) grad_zonal_latlon
 function grad_zonal_latlon(d, lon, lat, is, ie, js, je, isd, jsd)
 
   integer,                    intent(in) :: isd, jsd
-  real, dimension(isd:,jsd:), intent(in) :: d
-  real, dimension(:),         intent(in) :: lon
-  real, dimension(:),         intent(in) :: lat
+  real(r8_kind), dimension(isd:,jsd:), intent(in) :: d
+  real(r8_kind), dimension(:),         intent(in) :: lon
+  real(r8_kind), dimension(:),         intent(in) :: lat
   integer,                    intent(in) :: is, ie, js, je
-  real, dimension(is:ie,js:je)           :: grad_zonal_latlon
-  real                                   :: dx, costheta
+  real(r8_kind), dimension(is:ie,js:je)           :: grad_zonal_latlon
+  real(r8_kind)                                   :: dx, costheta
   integer                                :: i, j, ip1, im1
 
   !  calculate the gradient of the data on each grid
@@ -4323,11 +4346,11 @@ end function grad_zonal_latlon
 !! @return grad_merid_latlon
 function grad_merid_latlon(d, lat, is, ie, js, je, isd, jsd)
   integer,                    intent(in) :: isd, jsd
-  real, dimension(isd:,jsd:), intent(in) :: d
-  real, dimension(:),         intent(in) :: lat
+  real(r8_kind), dimension(isd:,jsd:), intent(in) :: d
+  real(r8_kind), dimension(:),         intent(in) :: lat
   integer,                    intent(in) :: is, ie, js, je
-  real, dimension(is:ie,js:je)           :: grad_merid_latlon
-  real                                   :: dy
+  real(r8_kind), dimension(is:ie,js:je)           :: grad_merid_latlon
+  real(r8_kind)                                   :: dy
   integer                                :: i, j, jp1, jm1
 
   !  calculate the gradient of the data on each grid
@@ -4383,16 +4406,16 @@ subroutine stock_move_3d(from, to, grid_index, data, xmap, &
 
   type(stock_type), intent(inout), optional :: from, to
   integer, intent(in)             :: grid_index        !< grid index
-  real, intent(in)                :: data(:,:,:)  !< data array is 3d
+  real(r8_kind), intent(in)                :: data(:,:,:)  !< data array is 3d
   type(xmap_type), intent(in)     :: xmap
-  real, intent(in)                :: delta_t
+  real(r8_kind), intent(in)                :: delta_t
   integer, intent(in)             :: from_side !< ISTOCK_TOP, ISTOCK_BOTTOM, or ISTOCK_SIDE
   integer, intent(in)             :: to_side !< ISTOCK_TOP, ISTOCK_BOTTOM, or ISTOCK_SIDE
-  real, intent(in)                :: radius       !< earth radius
+  real(r8_kind), intent(in)                :: radius       !< earth radius
   character(len=*), intent(in), optional      :: verbose
   integer, intent(out)            :: ier
 
-  real    :: from_dq, to_dq
+  real(r8_kind)    :: from_dq, to_dq
 
   ier = 0
   if(grid_index == 1) then
@@ -4442,16 +4465,16 @@ subroutine stock_move_2d(from, to, grid_index, data, xmap, &
 
   type(stock_type), intent(inout), optional :: from, to
   integer, optional, intent(in)   :: grid_index
-  real, intent(in)                :: data(:,:)    !< data array is 2d
+  real(r8_kind), intent(in)                :: data(:,:)    !< data array is 2d
   type(xmap_type), intent(in)     :: xmap
-  real, intent(in)                :: delta_t
+  real(r8_kind), intent(in)                :: delta_t
   integer, intent(in)             :: from_side !< ISTOCK_TOP, ISTOCK_BOTTOM, or ISTOCK_SIDE
   integer, intent(in)             :: to_side !< ISTOCK_TOP, ISTOCK_BOTTOM, or ISTOCK_SIDE
-  real, intent(in)                :: radius       !< earth radius
+  real(r8_kind), intent(in)                :: radius       !< earth radius
   character(len=*), intent(in)    :: verbose
   integer, intent(out)            :: ier
 
-  real    :: to_dq, from_dq
+  real(r8_kind)    :: to_dq, from_dq
 
   ier = 0
 
@@ -4507,17 +4530,17 @@ subroutine stock_move_ug_3d(from, to, grid_index, data, xmap, &
 
   type(stock_type), intent(inout), optional :: from, to
   integer, intent(in)             :: grid_index        !< grid index
-  real, intent(in)                :: data(:,:)  !< data array is 3d
+  real(r8_kind), intent(in)                :: data(:,:)  !< data array is 3d
   type(xmap_type), intent(in)     :: xmap
-  real, intent(in)                :: delta_t
+  real(r8_kind), intent(in)                :: delta_t
   integer, intent(in)             :: from_side !< ISTOCK_TOP, ISTOCK_BOTTOM, or ISTOCK_SIDE
   integer, intent(in)             :: to_side !< ISTOCK_TOP, ISTOCK_BOTTOM, or ISTOCK_SIDE
-  real, intent(in)                :: radius       !< earth radius
+  real(r8_kind), intent(in)                :: radius       !< earth radius
   character(len=*), intent(in), optional      :: verbose
   integer, intent(out)            :: ier
-  real, dimension(size(data,1),size(data,2)) :: tmp
+  real(r8_kind), dimension(size(data,1),size(data,2)) :: tmp
 
-  real    :: from_dq, to_dq
+  real(r8_kind)    :: from_dq, to_dq
 
   ier = 0
   if(grid_index == 1) then
@@ -4562,11 +4585,11 @@ subroutine stock_integrate_2d(data, xmap, delta_t, radius, res, ier)
 
   use mpp_mod, only : mpp_sum
 
-  real, intent(in)                :: data(:,:)    !< data array is 2d
+  real(r8_kind), intent(in)                :: data(:,:)    !< data array is 2d
   type(xmap_type), intent(in)     :: xmap
-  real, intent(in)                :: delta_t
-  real, intent(in)                :: radius       !< earth radius
-  real, intent(out)               :: res
+  real(r8_kind), intent(in)                :: delta_t
+  real(r8_kind), intent(in)                :: radius       !< earth radius
+  real(r8_kind), intent(out)               :: res
   integer, intent(out)            :: ier
 
   ier = 0
@@ -4596,15 +4619,15 @@ subroutine stock_print(stck, Time, comp_name, index, ref_value, radius, pelist)
   type(time_type), intent(in)   :: Time
   character(len=*)              :: comp_name
   integer, intent(in)           :: index     !< to map stock element (water, heat, ..) to a name
-  real, intent(in)              :: ref_value !< the stock value returned by the component per PE
-  real, intent(in)              :: radius
+  real(r8_kind), intent(in)              :: ref_value !< the stock value returned by the component per PE
+  real(r8_kind), intent(in)              :: radius
   integer, intent(in), optional :: pelist(:)
 
   integer, parameter :: initID = -2 !< initial value for diag IDs. Must not be equal to the value
   !! that register_diag_field returns when it can't register the filed -- otherwise the registration
   !! is attempted every time this subroutine is called
 
-  real :: f_value, c_value, planet_area
+  real(r8_kind) :: f_value, c_value, planet_area
   character(len=80) :: formatString
   integer :: iday, isec, hours
   integer :: diagID, compInd
@@ -4612,7 +4635,7 @@ subroutine stock_print(stck, Time, comp_name, index, ref_value, radius, pelist)
   integer, dimension(NELEMS,4), save :: c_valueDiagID = initID
   integer, dimension(NELEMS,4), save :: fmc_valueDiagID = initID
 
-  real :: diagField
+  real(r8_kind) :: diagField
   logical :: used
   character(len=30) :: field_name, units
 
@@ -4688,7 +4711,7 @@ end subroutine stock_print
 !###############################################################################
  !> @return logical is_lat_lon
  function is_lat_lon(lon, lat)
-    real, dimension(:,:), intent(in) :: lon, lat
+    real(r8_kind), dimension(:,:), intent(in) :: lon, lat
     logical                          :: is_lat_lon
     integer                          :: i, j, nlon, nlat, num
 
@@ -4730,15 +4753,15 @@ end subroutine stock_print
 !#######################################################################
 
 ! <SUBROUTINE NAME="get_side1_from_xgrid_ug" INTERFACE="get_from_xgrid_ug">
-!   <IN NAME="x"  TYPE="real" DIM="(:)" > </IN>
+!   <IN NAME="x"  TYPE="real(r8_kind)" DIM="(:)" > </IN>
 !   <IN NAME="grid_id"  TYPE=" character(len=3)"  > </IN>
-!   <OUT NAME="d"  TYPE="real" DIM="(:,:)" > </OUT>
+!   <OUT NAME="d"  TYPE="real(r8_kind)" DIM="(:,:)" > </OUT>
 !   <INOUT NAME="xmap"  TYPE="xmap_type"  > </INOUT>
 
 subroutine get_side1_from_xgrid_ug(d, grid_id, x, xmap, complete)
-  real, dimension(:),   intent(  out) :: d
+  real(r8_kind), dimension(:),   intent(  out) :: d
   character(len=3),     intent(in   ) :: grid_id
-  real, dimension(:),   intent(in   ) :: x
+  real(r8_kind), dimension(:),   intent(in   ) :: x
   type (xmap_type),     intent(inout) :: xmap
   logical, intent(in), optional     :: complete
 
@@ -4749,8 +4772,8 @@ subroutine get_side1_from_xgrid_ug(d, grid_id, x, xmap, complete)
   integer,                                   save :: lsize=0
   integer,                                   save :: xsize=0
   character(len=3),                          save :: grid_id_saved=""
-  integer(LONG_KIND), dimension(MAX_FIELDS), save :: d_addrs=-9999
-  integer(LONG_KIND), dimension(MAX_FIELDS), save :: x_addrs=-9999
+  integer(i8_kind), dimension(MAX_FIELDS), save :: d_addrs=-9999
+  integer(i8_kind), dimension(MAX_FIELDS), save :: x_addrs=-9999
 
   if (grid_id==xmap%grids(1)%id) then
      is_complete = .true.
@@ -4808,17 +4831,17 @@ end subroutine get_side1_from_xgrid_ug
 !#######################################################################
 
 ! <SUBROUTINE NAME="put_side1_to_xgrid_ug" INTERFACE="put_to_xgrid_ug">
-!   <IN NAME="d"  TYPE="real" DIM="(:,:)" > </IN>
+!   <IN NAME="d"  TYPE="real(r8_kind)" DIM="(:,:)" > </IN>
 !   <IN NAME="grid_id"  TYPE=" character(len=3)"  > </IN>
-!   <INOUT NAME="x"  TYPE="real" DIM="(:)" > </INOUT>
+!   <INOUT NAME="x"  TYPE="real(r8_kind)" DIM="(:)" > </INOUT>
 !   <INOUT NAME="xmap"  TYPE="xmap_type"  > </INOUT>
 !   <IN NAME="remap_method" TYPE="integer,optional"></IN>
 
 !> @brief Currently only support first order.
 subroutine put_side1_to_xgrid_ug(d, grid_id, x, xmap, complete)
-  real, dimension(:),   intent(in   )    :: d !<
+  real(r8_kind), dimension(:),   intent(in   )    :: d !<
   character(len=3),     intent(in   )    :: grid_id
-  real, dimension(:),   intent(inout)    :: x
+  real(r8_kind), dimension(:),   intent(inout)    :: x
   type (xmap_type),     intent(inout)    :: xmap
   logical, intent(in), optional          :: complete
 
@@ -4829,8 +4852,8 @@ subroutine put_side1_to_xgrid_ug(d, grid_id, x, xmap, complete)
   integer,                                   save :: lsize=0
   integer,                                   save :: xsize=0
   character(len=3),                          save :: grid_id_saved=""
-  integer(LONG_KIND), dimension(MAX_FIELDS), save :: d_addrs=-9999
-  integer(LONG_KIND), dimension(MAX_FIELDS), save :: x_addrs=-9999
+  integer(i8_kind), dimension(MAX_FIELDS), save :: d_addrs=-9999
+  integer(i8_kind), dimension(MAX_FIELDS), save :: x_addrs=-9999
 
   if (grid_id==xmap%grids(1)%id) then
      is_complete = .true.
@@ -4884,15 +4907,15 @@ end subroutine put_side1_to_xgrid_ug
 !#######################################################################
 
 ! <SUBROUTINE NAME="put_side2_to_xgrid_ug" INTERFACE="put_to_xgrid_ug">
-!   <IN NAME="d"  TYPE="real" DIM="(:,:)" > </IN>
+!   <IN NAME="d"  TYPE="real(r8_kind)" DIM="(:,:)" > </IN>
 !   <IN NAME="grid_id"  TYPE=" character(len=3)"  > </IN>
-!   <INOUT NAME="x"  TYPE="real" DIM="(:)" > </INOUT>
+!   <INOUT NAME="x"  TYPE="real(r8_kind)" DIM="(:)" > </INOUT>
 !   <INOUT NAME="xmap"  TYPE="xmap_type"  > </INOUT>
 
 subroutine put_side2_to_xgrid_ug(d, grid_id, x, xmap)
-  real, dimension(:,:), intent(in   ) :: d
+  real(r8_kind), dimension(:,:), intent(in   ) :: d
   character(len=3),     intent(in   ) :: grid_id
-  real, dimension(:),   intent(inout) :: x
+  real(r8_kind), dimension(:),   intent(inout) :: x
   type (xmap_type),     intent(inout) :: xmap
 
   integer :: g
@@ -4916,15 +4939,15 @@ end subroutine put_side2_to_xgrid_ug
 !#######################################################################
 
 ! <SUBROUTINE NAME="get_side2_from_xgrid_ug" INTERFACE="get_from_xgrid_ug">
-!   <IN NAME="x"  TYPE="real" DIM="(:)" > </IN>
+!   <IN NAME="x"  TYPE="real(r8_kind)" DIM="(:)" > </IN>
 !   <IN NAME="grid_id"  TYPE=" character(len=3)"  > </IN>
-!   <OUT NAME="d"  TYPE="real" DIM="(:,:)" > </OUT>
+!   <OUT NAME="d"  TYPE="real(r8_kind)" DIM="(:,:)" > </OUT>
 !   <INOUT NAME="xmap"  TYPE="xmap_type"  > </INOUT>
 
 subroutine get_side2_from_xgrid_ug(d, grid_id, x, xmap)
-  real, dimension(:,:), intent(  out) :: d
+  real(r8_kind), dimension(:,:), intent(  out) :: d
   character(len=3),     intent(in   ) :: grid_id
-  real, dimension(:),   intent(in   ) :: x
+  real(r8_kind), dimension(:),   intent(in   ) :: x
   type (xmap_type),     intent(in   ) :: xmap
 
   integer :: g
@@ -4949,8 +4972,8 @@ end subroutine get_side2_from_xgrid_ug
 !#######################################################################
 
 subroutine put_1_to_xgrid_ug_order_1(d_addrs, x_addrs, xmap, dsize, xsize, lsize)
-  integer(LONG_KIND), dimension(:), intent(in) :: d_addrs
-  integer(LONG_KIND), dimension(:), intent(in) :: x_addrs
+  integer(i8_kind), dimension(:), intent(in) :: d_addrs
+  integer(i8_kind), dimension(:), intent(in) :: x_addrs
   type (xmap_type),              intent(inout) :: xmap
   integer,                          intent(in) :: dsize, xsize, lsize
 
@@ -4958,12 +4981,12 @@ subroutine put_1_to_xgrid_ug_order_1(d_addrs, x_addrs, xmap, dsize, xsize, lsize
   integer                         :: from_pe, to_pe, pos, n, l, count
   integer                         :: ibegin, istart, iend, start_pos
   type (comm_type), pointer, save :: comm =>NULL()
-  real                            :: recv_buffer(xmap%put1%recvsize*lsize)
-  real                            :: send_buffer(xmap%put1%sendsize*lsize)
-  real                            :: unpack_buffer(xmap%put1%recvsize)
+  real(r8_kind)                            :: recv_buffer(xmap%put1%recvsize*lsize)
+  real(r8_kind)                            :: send_buffer(xmap%put1%sendsize*lsize)
+  real(r8_kind)                            :: unpack_buffer(xmap%put1%recvsize)
 
-  real, dimension(dsize)   :: d
-  real, dimension(xsize)   :: x
+  real(r8_kind), dimension(dsize)   :: d
+  real(r8_kind), dimension(xsize)   :: x
   pointer(ptr_d, d)
   pointer(ptr_x, x)
   integer :: lll
@@ -5038,8 +5061,8 @@ end subroutine put_1_to_xgrid_ug_order_1
 
 subroutine put_2_to_xgrid_ug(d, grid, x, xmap)
 type (grid_type),                                intent(in) :: grid
-real, dimension(grid%ls_me:grid%le_me, grid%km), intent(in) :: d
-real, dimension(:    ), intent(inout) :: x
+real(r8_kind), dimension(grid%ls_me:grid%le_me, grid%km), intent(in) :: d
+real(r8_kind), dimension(:    ), intent(inout) :: x
 type (xmap_type),       intent(in   ) :: xmap
 
   integer                 ::   l
@@ -5054,25 +5077,25 @@ end subroutine put_2_to_xgrid_ug
 
 
 subroutine get_1_from_xgrid_ug(d_addrs, x_addrs, xmap, isize, xsize, lsize)
-  integer(LONG_KIND), dimension(:), intent(in) :: d_addrs
-  integer(LONG_KIND), dimension(:), intent(in) :: x_addrs
+  integer(i8_kind), dimension(:), intent(in) :: d_addrs
+  integer(i8_kind), dimension(:), intent(in) :: x_addrs
   type (xmap_type),              intent(inout) :: xmap
   integer,                          intent(in) :: isize, xsize, lsize
 
-  real, dimension(xmap%size), target :: dg(xmap%size, lsize)
+  real(r8_kind), dimension(xmap%size), target :: dg(xmap%size, lsize)
   integer                            :: i, j, l, p, n, m
   integer                            :: msgsize, buffer_pos, pos
   integer                            :: istart, iend, count
-  real              , pointer, save  :: dgp =>NULL()
+  real(r8_kind)              , pointer, save  :: dgp =>NULL()
   type  (grid_type) , pointer, save  :: grid1 =>NULL()
   type  (comm_type) , pointer, save  :: comm  =>NULL()
   type(overlap_type), pointer, save  :: send => NULL()
   type(overlap_type), pointer, save  :: recv => NULL()
-  real                               :: recv_buffer(xmap%get1%recvsize*lsize*3)
-  real                               :: send_buffer(xmap%get1%sendsize*lsize*3)
-  real                               :: unpack_buffer(xmap%get1%recvsize*3)
-  real                               :: d(isize)
-  real, dimension(xsize)             :: x
+  real(r8_kind)                               :: recv_buffer(xmap%get1%recvsize*lsize*3)
+  real(r8_kind)                               :: send_buffer(xmap%get1%sendsize*lsize*3)
+  real(r8_kind)                               :: unpack_buffer(xmap%get1%recvsize*3)
+  real(r8_kind)                               :: d(isize)
+  real(r8_kind), dimension(xsize)             :: x
   pointer(ptr_d, d)
   pointer(ptr_x, x)
 
@@ -5185,8 +5208,8 @@ end subroutine get_1_from_xgrid_ug
 !#######################################################################
 
 subroutine get_1_from_xgrid_ug_repro(d_addrs, x_addrs, xmap, xsize, lsize)
-  integer(LONG_KIND), dimension(:), intent(in) :: d_addrs
-  integer(LONG_KIND), dimension(:), intent(in) :: x_addrs
+  integer(i8_kind), dimension(:), intent(in) :: d_addrs
+  integer(i8_kind), dimension(:), intent(in) :: x_addrs
   type (xmap_type),              intent(inout) :: xmap
   integer,                          intent(in) :: xsize, lsize
 
@@ -5197,10 +5220,10 @@ subroutine get_1_from_xgrid_ug_repro(d_addrs, x_addrs, xmap, xsize, lsize)
   type(overlap_type), pointer, save  :: send => NULL()
   type(overlap_type), pointer, save  :: recv => NULL()
     integer,  dimension(0:xmap%npes-1) :: pl, ml
-  real                               :: recv_buffer(xmap%recv_count_repro_tot*lsize)
-  real                               :: send_buffer(xmap%send_count_repro_tot*lsize)
-  real                               :: d(xmap%grids(1)%ls_me:xmap%grids(1)%le_me)
-  real, dimension(xsize)             :: x
+  real(r8_kind)                               :: recv_buffer(xmap%recv_count_repro_tot*lsize)
+  real(r8_kind)                               :: send_buffer(xmap%send_count_repro_tot*lsize)
+  real(r8_kind)                               :: d(xmap%grids(1)%ls_me:xmap%grids(1)%le_me)
+  real(r8_kind), dimension(xsize)             :: x
   pointer(ptr_d, d)
   pointer(ptr_x, x)
 
@@ -5282,8 +5305,8 @@ end subroutine get_1_from_xgrid_ug_repro
 
 subroutine get_2_from_xgrid_ug(d, grid, x, xmap)
 type (grid_type),                                intent(in ) :: grid
-real, dimension(grid%ls_me:grid%le_me, grid%km), intent(out) :: d
-real, dimension(:),     intent(in   ) :: x
+real(r8_kind), dimension(grid%ls_me:grid%le_me, grid%km), intent(out) :: d
+real(r8_kind), dimension(:),     intent(in   ) :: x
 type (xmap_type),       intent(in   ) :: xmap
 
   integer                 :: l, k

--- a/exchange/xgrid.F90
+++ b/exchange/xgrid.F90
@@ -1437,31 +1437,10 @@ subroutine get_grid_version2(grid, grid_id, grid_file)
         end do
         grid%is_latlon = .true.
      else
-        isd = grid%isd_me; ied = grid%ied_me
-        jsd = grid%jsd_me; jed = grid%jed_me
-        print *, mpp_pe(), isd, ied, jsd, jed
-        print *, mpp_pe(), grid%is_me, grid%ie_me, grid%js_me, grid%je_me
-
-        ! TODO these allocations fail, grid%geolon/lat are real(r8_kind)(:,:) pointers
-        !! try different ways of allocating/pointing
-        ! original allocations
-        !!allocate(grid%geolon(grid%isd_me:grid%ied_me, grid%jsd_me:grid%jed_me))
-        !!allocate(grid%geolat(grid%isd_me:grid%ied_me, grid%jsd_me:grid%jed_me))
-
-        !allocate(geolon(isd:ied,jsd:jed))
-        allocate(geolon(0:49,0:49))
-        allocate(geolat(0:49,0:49))
-        !allocate(geolat(isd:ied,jsd:jed))
-
-        !!print *, mpp_pe(), "allocated"
-
-        grid%geolon => geolon!(isd:ied,jsd:jed)
-        grid%geolat => geolat!(isd:ied,jsd:jed)
-
+        allocate(grid%geolon(grid%isd_me:grid%ied_me, grid%jsd_me:grid%jed_me))
+        allocate(grid%geolat(grid%isd_me:grid%ied_me, grid%jsd_me:grid%jed_me))
         grid%geolon = 1e10
-
         grid%geolat = 1e10
-
         !--- area_ocn_sphere, area_lnd_sphere, area_atm_sphere is not been defined.
         do j = grid%js_me,grid%je_me
            do i = grid%is_me,grid%ie_me
@@ -1473,7 +1452,6 @@ subroutine get_grid_version2(grid, grid_id, grid_file)
         call mpp_update_domains(grid%geolat, grid%domain)
         grid%is_latlon = .false.
      end if
-     call mpp_sync()
      deallocate(tmpx, tmpy)
   end if
 

--- a/mosaic/gradient.F90
+++ b/mosaic/gradient.F90
@@ -33,6 +33,7 @@ module gradient_mod
 
 use mpp_mod,       only : mpp_error, FATAL
 use constants_mod, only : RADIUS
+use platform_mod
 
 implicit none
 private
@@ -65,11 +66,11 @@ subroutine gradient_cubic(pin, dx, dy, area, edge_w, edge_e, edge_s, edge_n,    
                           en_n, en_e, vlon, vlat, grad_x, grad_y, on_west_edge, &
                           on_east_edge, on_south_edge, on_north_edge)
 
-  real,    dimension(:,:  ), intent(in ) :: pin, dx, dy, area
-  real,    dimension(:    ), intent(in ) :: edge_w, edge_e, edge_s, edge_n
-  real,    dimension(:,:,:), intent(in ) :: en_n, en_e
-  real,    dimension(:,:,:), intent(in ) :: vlon, vlat
-  real,    dimension(:,:  ), intent(out) :: grad_x, grad_y
+  real(r8_kind),    dimension(:,:  ), intent(in ) :: pin, dx, dy, area
+  real(r8_kind),    dimension(:    ), intent(in ) :: edge_w, edge_e, edge_s, edge_n
+  real(r8_kind),    dimension(:,:,:), intent(in ) :: en_n, en_e
+  real(r8_kind),    dimension(:,:,:), intent(in ) :: vlon, vlat
+  real(r8_kind),    dimension(:,:  ), intent(out) :: grad_x, grad_y
   logical,                   intent(in ) :: on_west_edge, on_east_edge, on_south_edge, on_north_edge
   integer :: nx, ny
 
@@ -104,11 +105,11 @@ end subroutine gradient_cubic
 
 subroutine calc_cubic_grid_info(xt, yt, xc, yc, dx, dy, area, edge_w, edge_e, edge_s, edge_n, &
                            en_n, en_e, vlon, vlat, on_west_edge, on_east_edge, on_south_edge, on_north_edge )
-  real,    dimension(:,:  ), intent(in ) :: xt, yt, xc, yc
-  real,    dimension(:,:  ), intent(out) :: dx, dy, area
-  real,    dimension(:    ), intent(out) :: edge_w, edge_e, edge_s, edge_n
-  real,    dimension(:,:,:), intent(out) :: en_n, en_e
-  real,    dimension(:,:,:), intent(out) :: vlon, vlat
+  real(r8_kind),    dimension(:,:  ), intent(in ) :: xt, yt, xc, yc
+  real(r8_kind),    dimension(:,:  ), intent(out) :: dx, dy, area
+  real(r8_kind),    dimension(:    ), intent(out) :: edge_w, edge_e, edge_s, edge_n
+  real(r8_kind),    dimension(:,:,:), intent(out) :: en_n, en_e
+  real(r8_kind),    dimension(:,:,:), intent(out) :: vlon, vlat
   logical,                   intent(in ) :: on_west_edge, on_east_edge, on_south_edge, on_north_edge
   integer :: nx, ny, nxp, nyp
 

--- a/mosaic2/grid2.F90
+++ b/mosaic2/grid2.F90
@@ -37,6 +37,7 @@ use mosaic2_mod, only : get_mosaic_ntiles, get_mosaic_xgrid_size, get_mosaic_gri
 use mpp_domains_mod, only : domain2d, mpp_define_mosaic, mpp_get_compute_domain, &
                             mpp_get_global_domain, domainUG, mpp_pass_SG_to_UG
 use mosaic2_mod, only : get_mosaic_ncontacts, get_mosaic_contact
+use platform_mod
 
 implicit none;private
 
@@ -72,6 +73,9 @@ interface get_grid_cell_vertices
    module procedure get_grid_cell_vertices_1D
    module procedure get_grid_cell_vertices_2D
    module procedure get_grid_cell_vertices_UG
+#ifdef OVERLOAD_R8
+   module procedure get_grid_cell_vertices_2D_r8
+#endif
 end interface
 
 !> Gets grid cell centers
@@ -87,6 +91,9 @@ end interface
 interface get_grid_cell_area
    module procedure get_grid_cell_area_SG
    module procedure get_grid_cell_area_UG
+#ifdef OVERLOAD_R8
+   module procedure get_grid_cell_area_SG_r8 !! r8 overload for exchange grid
+#endif
 end interface get_grid_cell_area
 
 !> Gets the area of a given component per grid cell
@@ -94,6 +101,9 @@ end interface get_grid_cell_area
 interface get_grid_comp_area
    module procedure get_grid_comp_area_SG
    module procedure get_grid_comp_area_UG
+#ifdef OVERLOAD_R8
+   module procedure get_grid_comp_area_SG_r8 !! r8 overload for exchange grid
+#endif
 end interface get_grid_comp_area
 
 !> @addtogroup grid2_mod
@@ -557,6 +567,384 @@ subroutine get_grid_comp_area_SG(component,tile,area,domain)
   ! convert area to m2
   area = area*4.*PI*radius**2
 end subroutine get_grid_comp_area_SG
+
+#ifdef OVERLOAD_R8
+
+!> @brief r8_kind override version of @ref get_Grid_cell_vertices_2D
+subroutine get_grid_cell_vertices_2D_r8(component, tile, lonb, latb, domain)
+  character(len=*),         intent(in) :: component !< Component model (atm, lnd, ocn)
+  integer,                  intent(in) :: tile !< Tile number
+  real(r8_kind),                  intent(inout) :: lonb(:,:),latb(:,:) !< Cell vertices
+  type(domain2d), optional, intent(in) :: domain !< Domain
+
+  ! local vars
+  integer :: nlon, nlat
+  integer :: i,j
+  real(r8_kind), allocatable :: buffer(:), tmp(:,:), x_vert_t(:,:,:), y_vert_t(:,:,:)
+  integer :: is,ie,js,je ! boundaries of our domain
+  integer :: i0,j0 ! offsets for coordinates
+  integer :: isg, jsg
+  integer :: start(4), nread(4)
+  character(len=MAX_FILE)      :: tilefile
+  type(FmsNetcdfFile_t)  :: tilefileobj
+
+  call get_grid_size_for_one_tile(component, tile, nlon, nlat)
+  if (present(domain)) then
+    call mpp_get_compute_domain(domain,is,ie,js,je)
+  else
+    is = 1 ; ie = nlon
+    js = 1 ; je = nlat
+    !--- domain normally should be present
+    call mpp_error (NOTE, module_name//'/get_grid_cell_vertices '//&
+       'domain is not present, global data will be read')
+  endif
+  i0 = -is+1; j0 = -js+1
+
+  ! verify that lonb and latb sizes are consistent with the size of domain
+  if (size(lonb,1)/=ie-is+2.or.size(lonb,2)/=je-js+2) &
+       call mpp_error (FATAL, module_name//'/get_grid_cell_vertices '//&
+       'Size of argument "lonb" is not consistent with the domain size')
+  if (size(latb,1)/=ie-is+2.or.size(latb,2)/=je-js+2) &
+       call mpp_error (FATAL, module_name//'/get_grid_cell_vertices '//&
+       'Size of argument "latb" is not consistent with the domain size')
+  if(trim(component) .NE. 'ATM' .AND. component .NE. 'LND' .AND. component .NE. 'OCN') then
+     call mpp_error(FATAL, module_name//'/get_grid_cell_vertices '//&
+          'Illegal component name "'//trim(component)//'": must be one of ATM, LND, or OCN')
+  endif
+
+  select case(grid_version)
+  case(VERSION_0)
+     if (.not. grid_spec_exists) then
+       call mpp_error(FATAL, 'grid2_mod(get_grid_cell_vertices_2D): grid_spec does not exist')
+     end if
+     select case(component)
+     case('ATM','LND')
+        allocate(buffer(max(nlon,nlat)+1))
+        ! read coordinates of grid cell vertices
+        call read_data(gridfileobj, 'xb'//lowercase(component(1:1)), buffer(1:nlon+1))
+        do j = js, je+1
+           do i = is, ie+1
+              lonb(i+i0,j+j0) = buffer(i)
+           enddo
+        enddo
+        call read_data(gridfileobj, 'yb'//lowercase(component(1:1)), buffer(1:nlat+1))
+        do j = js, je+1
+           do i = is, ie+1
+              latb(i+i0,j+j0) = buffer(j)
+           enddo
+        enddo
+        deallocate(buffer)
+     case('OCN')
+        if (present(domain)) then
+           start = 1; nread = 1
+           start(1) = is; start(2) = js
+           nread(1) = ie-is+2; nread(2) = je-js+2
+           call read_data(gridfileobj, "geolon_vert_t", lonb, corner=start, edge_lengths=nread)
+           call read_data(gridfileobj, "geolat_vert_t", latb, corner=start, edge_lengths=nread)
+         else
+           call read_data(gridfileobj, "geolon_vert_t", lonb)
+           call read_data(gridfileobj, "geolat_vert_t", latb)
+         endif
+     end select
+  case(VERSION_1)
+     if (.not. grid_spec_exists) then
+       call mpp_error(FATAL, 'grid2_mod(get_grid_cell_vertices_2D): grid_spec does not exist')
+     end if
+     select case(component)
+     case('ATM','LND')
+        allocate(buffer(max(nlon,nlat)+1))
+        ! read coordinates of grid cell vertices
+        call read_data(gridfileobj, 'xb'//lowercase(component(1:1)), buffer(1:nlon+1))
+        do j = js, je+1
+           do i = is, ie+1
+              lonb(i+i0,j+j0) = buffer(i)
+           enddo
+        enddo
+        call read_data(gridfileobj, 'yb'//lowercase(component(1:1)), buffer(1:nlat+1))
+        do j = js, je+1
+           do i = is, ie+1
+              latb(i+i0,j+j0) = buffer(j)
+           enddo
+        enddo
+        deallocate(buffer)
+     case('OCN')
+        nlon=ie-is+1; nlat=je-js+1
+        allocate (x_vert_t(nlon,nlat,4), y_vert_t(nlon,nlat,4) )
+        call read_data(gridfileobj, 'x_vert_T', x_vert_t)
+        call read_data(gridfileobj, 'y_vert_T', y_vert_t)
+        lonb(1:nlon,1:nlat) = x_vert_t(1:nlon,1:nlat,1)
+        lonb(nlon+1,1:nlat) = x_vert_t(nlon,1:nlat,2)
+        lonb(1:nlon,nlat+1) = x_vert_t(1:nlon,nlat,4)
+        lonb(nlon+1,nlat+1) = x_vert_t(nlon,nlat,3)
+        latb(1:nlon,1:nlat) = y_vert_t(1:nlon,1:nlat,1)
+        latb(nlon+1,1:nlat) = y_vert_t(nlon,1:nlat,2)
+        latb(1:nlon,nlat+1) = y_vert_t(1:nlon,nlat,4)
+        latb(nlon+1,nlat+1) = y_vert_t(nlon,nlat,3)
+        deallocate(x_vert_t, y_vert_t)
+     end select
+  case(VERSION_2, VERSION_3)
+     ! get the name of the grid file for the component and tile
+     tilefile = read_file_name(mosaic_fileobj(get_component_number(trim(component))), 'gridfiles',tile)
+     call open_grid_file(tilefileobj, grid_dir//tilefile)
+     if(PRESENT(domain)) then
+        call mpp_get_global_domain(domain, xbegin=isg, ybegin=jsg)
+        start = 1; nread = 1
+        start(1) = 2*(is-isg+1) - 1; nread(1) = 2*(ie-is)+3
+        start(2) = 2*(js-jsg+1) - 1; nread(2) = 2*(je-js)+3
+        allocate(tmp(nread(1), nread(2)) )
+        call read_data(tilefileobj, "x", tmp, corner=start, edge_lengths=nread)
+        do j = 1, je-js+2
+           do i = 1, ie-is+2
+              lonb(i,j) = tmp(2*i-1,2*j-1)
+           enddo
+        enddo
+        call read_data(tilefileobj, "y", tmp, corner=start, edge_lengths=nread)
+        do j = 1, je-js+2
+           do i = 1, ie-is+2
+              latb(i,j) = tmp(2*i-1,2*j-1)
+           enddo
+        enddo
+     else
+        allocate(tmp(2*nlon+1,2*nlat+1))
+        call read_data(tilefileobj, "x", tmp)
+        do j = js, je+1
+           do i = is, ie+1
+              lonb(i+i0,j+j0) = tmp(2*i-1,2*j-1)
+           end do
+        end do
+        call read_data(tilefileobj, "y", tmp)
+        do j = js, je+1
+           do i = is, ie+1
+              latb(i+i0,j+j0) = tmp(2*i-1,2*j-1)
+           end do
+        end do
+     endif
+     deallocate(tmp)
+     call close_file(tilefileobj)
+  end select
+end subroutine get_grid_cell_vertices_2D_r8
+
+!> @brief get the area of the component per grid cell
+subroutine get_grid_comp_area_SG_r8(component,tile,area,domain)
+  character(len=*) :: component !< Component model (atm, lnd, ocn)
+  integer, intent(in) :: tile !< Tile number
+  real(r8_kind), intent(inout) :: area(:,:) !< Area of grid cell
+  type(domain2d), intent(in), optional :: domain !< Domain
+  ! local vars
+  integer :: n_xgrid_files ! number of exchange grid files in the mosaic
+  integer :: siz(2), nxgrid
+  integer :: i,j,m,n
+  integer, allocatable :: i1(:), j1(:), i2(:), j2(:)
+  real(r8_kind), allocatable :: xgrid_area(:)
+  real(r8_kind), allocatable :: rmask(:,:)
+  character(len=MAX_NAME) :: &
+     xgrid_name, & ! name of the variable holding xgrid names
+     tile_name,  & ! name of the tile
+     xgrid_file, & ! name of the current xgrid file
+     mosaic_name,& ! name of the mosaic
+     tilefile
+  character(len=4096)     :: attvalue
+  character(len=MAX_NAME), allocatable :: nest_tile_name(:)
+  character(len=MAX_NAME) :: varname1, varname2
+  integer :: is,ie,js,je ! boundaries of our domain
+  integer :: i0, j0 ! offsets for x and y, respectively
+  integer :: num_nest_tile, ntiles
+  logical :: is_nest
+  integer :: found_xgrid_files ! how many xgrid files we actually found in the grid spec
+  integer :: ibegin, iend, bsize, l
+  type(FmsNetcdfFile_t) :: tilefileobj, xgrid_fileobj
+
+  select case (grid_version)
+  case(VERSION_0,VERSION_1)
+     if (.not. grid_spec_exists) then
+       call mpp_error(FATAL, 'grid2_mod(get_grid_comp_area_SG): grid_spec does not exist')
+     end if
+     select case(component)
+     case('ATM')
+        call read_data(gridfileobj,'AREA_ATM',area)
+     case('OCN')
+        allocate(rmask(size(area,1),size(area,2)))
+        call read_data(gridfileobj,'AREA_OCN',area)
+        call read_data(gridfileobj,'wet',     rmask)
+        area = area*rmask
+        deallocate(rmask)
+     case('LND')
+        call read_data(gridfileobj,'AREA_LND',area)
+     case default
+        call mpp_error(FATAL, module_name//'/get_grid_comp_area'//&
+             'Illegal component name "'//trim(component)//'": must be one of ATM, LND, or OCN')
+     end select
+  case(VERSION_2, VERSION_3) ! mosaic gridspec
+     select case (component)
+     case ('ATM')
+        ! just read the grid cell area and return
+        call get_grid_cell_area(component,tile,area)
+        return
+     case ('LND')
+        xgrid_name = 'aXl_file'
+        if (.not. grid_spec_exists) then
+          call mpp_error(FATAL, 'grid2_mod(get_grid_comp_area_SG): grid_spec does not exist')
+        end if
+        call read_data(gridfileobj, 'lnd_mosaic', mosaic_name)
+        tile_name  = trim(mosaic_name)//'_tile'//char(tile+ichar('0'))
+     case ('OCN')
+        xgrid_name = 'aXo_file'
+        if (.not. grid_spec_exists) then
+          call mpp_error(FATAL, 'grid2_mod(get_grid_comp_area_SG): grid_spec does not exist')
+        end if
+        call read_data(gridfileobj, 'ocn_mosaic', mosaic_name)
+        tile_name  = trim(mosaic_name)//'_tile'//char(tile+ichar('0'))
+     case default
+        call mpp_error(FATAL, module_name//'/get_grid_comp_area'//&
+             'Illegal component name "'//trim(component)//'": must be one of ATM, LND, or OCN')
+     end select
+     ! get the boundaries of the requested domain
+     if(present(domain)) then
+        call mpp_get_compute_domain(domain,is,ie,js,je)
+        i0 = 1-is ; j0=1-js
+     else
+        call get_grid_size(component,tile,ie,je)
+        is = 1 ; i0 = 0
+        js = 1 ; j0 = 0
+     endif
+     if (size(area,1)/=ie-is+1.or.size(area,2)/=je-js+1) &
+        call mpp_error(FATAL, module_name//'/get_grid_comp_area '//&
+        'size of the output argument "area" is not consistent with the domain')
+
+     ! find the nest tile
+     if (.not. grid_spec_exists) then
+       call mpp_error(FATAL, 'grid2_mod(get_grid_comp_area_SG): grid_spec does not exist')
+     end if
+     call read_data(gridfileobj, 'atm_mosaic', mosaic_name)
+     call get_grid_ntiles('atm', ntiles)
+     allocate(nest_tile_name(ntiles))
+     num_nest_tile = 0
+     do n = 1, ntiles
+        tilefile = read_file_name(mosaic_fileobj(1), 'gridfiles', n)
+        call open_grid_file(tilefileobj, grid_dir//tilefile)
+        if (global_att_exists(tilefileobj, "nest_grid")) then
+           call get_global_attribute(tilefileobj, "nest_grid", attvalue)
+           if(trim(attvalue) == "TRUE") then
+              num_nest_tile = num_nest_tile + 1
+              nest_tile_name(num_nest_tile) = trim(mosaic_name)//'_tile'//char(n+ichar('0'))
+           else if(trim(attvalue) .NE. "FALSE") then
+              call mpp_error(FATAL, module_name//'/get_grid_comp_area value of global attribute nest_grid in file'// &
+                   trim(tilefile)//' should be TRUE or FALSE')
+           endif
+        end if
+        call close_file(tilefileobj)
+     end do
+     area(:,:) = 0.
+     if (.not. grid_spec_exists) then
+       call mpp_error(FATAL, 'grid2_mod(get_grid_comp_area_SG): grid_spec does not exist')
+     end if
+     if(variable_exists(gridfileobj,xgrid_name)) then
+        ! get the number of the exchange-grid files
+        call get_variable_size(gridfileobj,xgrid_name,siz)
+        n_xgrid_files = siz(2)
+        found_xgrid_files = 0
+        ! loop through all exchange grid files
+        do n = 1, n_xgrid_files
+           ! get the name of the current exchange grid file
+           xgrid_file = read_file_name(gridfileobj,xgrid_name,n)
+           call open_grid_file(xgrid_fileobj, grid_dir//xgrid_file)
+           ! skip the rest of the loop if the name of the current tile isn't found
+           ! in the file name, but check this only if there is more than 1 tile
+           if(n_xgrid_files>1) then
+              if(index(xgrid_file,trim(tile_name))==0) cycle
+           endif
+           found_xgrid_files = found_xgrid_files + 1
+           !---make sure the atmosphere grid is not a nested grid
+           is_nest = .false.
+           do m = 1, num_nest_tile
+              if(index(xgrid_file, trim(nest_tile_name(m))) .NE. 0) then
+                 is_nest = .true.
+                 exit
+              end if
+           end do
+           if(is_nest) cycle
+
+           ! finally read the exchange grid
+           nxgrid = get_mosaic_xgrid_size(xgrid_fileobj)
+           if(nxgrid < BUFSIZE) then
+              allocate(i1(nxgrid), j1(nxgrid), i2(nxgrid), j2(nxgrid), xgrid_area(nxgrid))
+           else
+              allocate(i1(BUFSIZE), j1(BUFSIZE), i2(BUFSIZE), j2(BUFSIZE), xgrid_area(BUFSIZE))
+           endif
+           ibegin = 1
+           do l = 1,nxgrid,BUFSIZE
+              bsize = min(BUFSIZE, nxgrid-l+1)
+              iend = ibegin + bsize - 1
+              call get_mosaic_xgrid(xgrid_fileobj, i1(1:bsize), j1(1:bsize), i2(1:bsize), j2(1:bsize), &
+                                    xgrid_area(1:bsize), ibegin, iend)
+              ! and sum the exchange grid areas
+              do m = 1, bsize
+                 i = i2(m); j = j2(m)
+                 if (i<is.or.i>ie) cycle
+                 if (j<js.or.j>je) cycle
+                 area(i+i0,j+j0) = area(i+i0,j+j0) + xgrid_area(m)
+              end do
+              ibegin = iend + 1
+           enddo
+           deallocate(i1, j1, i2, j2, xgrid_area)
+           call close_file(xgrid_fileobj)
+        enddo
+        if (found_xgrid_files == 0) &
+           call mpp_error(FATAL, 'get_grid_comp_area no xgrid files were found for component '&
+                 //trim(component)//' (mosaic name is '//trim(mosaic_name)//')')
+
+     endif
+     deallocate(nest_tile_name)
+  end select ! version
+  ! convert area to m2
+  area = area*4.*PI*radius**2
+end subroutine get_grid_comp_area_SG_r8
+
+!> @brief return grid cell area for the specified model component and tile
+subroutine get_grid_cell_area_SG_r8(component, tile, cellarea, domain)
+  character(len=*), intent(in)    :: component !< Component model (atm, lnd, ocn)
+  integer         , intent(in)    :: tile !< Tile number
+  real(r8_kind)   , intent(inout) :: cellarea(:,:) !< Cell area
+  type(domain2d)  , intent(in), optional :: domain !< Domain
+
+  ! local vars
+  integer :: nlon, nlat
+  real(r8_kind), allocatable :: glonb(:,:), glatb(:,:)
+
+  select case(grid_version)
+  case(VERSION_0,VERSION_1)
+     if (.not. grid_spec_exists) then
+       call mpp_error(FATAL, 'grid2_mod(get_grid_cell_area_SG): grid_spec does not exist')
+     end if
+     select case(trim(component))
+     case('LND')
+        call read_data(gridfileobj, 'AREA_LND_CELL', cellarea)
+     case('ATM','OCN')
+        call read_data(gridfileobj, 'AREA_'//trim(uppercase(component)),cellarea)
+     case default
+        call mpp_error(FATAL, module_name//'/get_grid_cell_area'//&
+             'Illegal component name "'//trim(component)//'": must be one of ATM, LND, or OCN')
+     end select
+     ! convert area to m2
+     cellarea = cellarea*4.*PI*radius**2
+  case(VERSION_2, VERSION_3)
+     if (present(domain)) then
+        call mpp_get_compute_domain(domain,xsize=nlon,ysize=nlat)
+     else
+        call get_grid_size(component,tile,nlon,nlat)
+     endif
+     allocate(glonb(nlon+1,nlat+1),glatb(nlon+1,nlat+1))
+     call get_grid_cell_vertices(component, tile, glonb, glatb, domain)
+     if (great_circle_algorithm) then
+        call calc_mosaic_grid_great_circle_area(glonb*pi/180.0, glatb*pi/180.0, cellarea)
+     else
+        call calc_mosaic_grid_area(glonb*pi/180.0, glatb*pi/180.0, cellarea)
+     end if
+     deallocate(glonb,glatb)
+  end select
+
+end subroutine get_grid_cell_area_SG_r8
+#endif
 
 !> @brief return grid cell area for the specified model component and tile on an
 !! unstructured domain

--- a/mosaic2/mosaic2.F90
+++ b/mosaic2/mosaic2.F90
@@ -552,7 +552,7 @@ end function transfer_to_model_index
 
   end subroutine calc_mosaic_grid_area_r8
 
-  !> @brief r8_kind overload for @ref calc_mosaic_grid_area
+  !> @brief r8_kind overload for @ref calc_mosaic_grid_great_circle_area
   subroutine calc_mosaic_grid_great_circle_area_r8(lon, lat, area)
      real(r8_kind), dimension(:,:), intent(in)    :: lon
      real(r8_kind), dimension(:,:), intent(in)    :: lat

--- a/mosaic2/mosaic2.F90
+++ b/mosaic2/mosaic2.F90
@@ -41,9 +41,33 @@ use mpp_domains_mod, only : domain2D, mpp_get_current_ntile, mpp_get_tile_id
 use constants_mod, only : PI, RADIUS
 use fms2_io_mod,   only : FmsNetcdfFile_t, open_file, close_file, get_dimension_size
 use fms2_io_mod,   only : read_data, variable_exists
+use platform_mod
 
 implicit none
 private
+
+!! interfaces for r8 overloads(as needed by exchange/grid)
+!> Interface for @ref get_mosaic_xgrid if mixed mode is enabled
+interface get_mosaic_xgrid
+  module procedure get_mosaic_xgrid
+#ifdef OVERLOAD_R8
+  module procedure get_mosaic_xgrid_r8
+#endif
+end interface get_mosaic_xgrid
+
+interface calc_mosaic_grid_great_circle_area
+  module procedure calc_mosaic_grid_great_circle_area
+#ifdef OVERLOAD_R8
+  module procedure calc_mosaic_grid_great_circle_area_r8
+#endif
+end interface calc_mosaic_grid_great_circle_area
+
+interface calc_mosaic_grid_area
+  module procedure calc_mosaic_grid_area
+#ifdef OVERLOAD_R8
+  module procedure calc_mosaic_grid_area_r8
+#endif
+end interface calc_mosaic_grid_area
 
 character(len=*), parameter :: &
      grid_dir  = 'INPUT/'      !> root directory for all grid files
@@ -160,6 +184,62 @@ end subroutine mosaic_init
     return
 
   end subroutine get_mosaic_xgrid
+#ifdef OVERLOAD_R8
+!> @brief Get exchange grid information from mosaic xgrid file(for r8_kind in mixed mode).
+!> Example usage:
+!!
+!!           call get_mosaic_xgrid(fileobj, nxgrid, i1, j1, i2, j2, area)
+!!
+  subroutine get_mosaic_xgrid_r8(fileobj, i1, j1, i2, j2, area, ibegin, iend)
+    type(FmsNetcdfFile_t), intent(in) :: fileobj !> The file that contains exchange grid information.
+    integer,       intent(inout) :: i1(:), j1(:), i2(:), j2(:) !> i and j indices for grids 1 and 2
+    real(r8_kind),      intent(inout) :: area(:) !> area of the exchange grid. The area is scaled to
+                                            !! represent unit earth area
+    integer, optional, intent(in) :: ibegin, iend
+
+    integer                            :: start(4), nread(4), istart
+    real,    dimension(2, size(i1(:))) :: tile1_cell, tile2_cell
+    integer                            :: nxgrid, n
+    real                               :: garea
+    real                               :: get_global_area;
+
+    garea = get_global_area();
+
+    ! When start and nread present, make sure nread(1) is the same as the size of the data
+    if(present(ibegin) .and. present(iend)) then
+       istart = ibegin
+       nxgrid = iend - ibegin + 1
+       if(nxgrid .NE. size(i1(:))) call mpp_error(FATAL, "get_mosaic_xgrid: nxgrid .NE. size(i1(:))")
+       if(nxgrid .NE. size(j1(:))) call mpp_error(FATAL, "get_mosaic_xgrid: nxgrid .NE. size(j1(:))")
+       if(nxgrid .NE. size(i2(:))) call mpp_error(FATAL, "get_mosaic_xgrid: nxgrid .NE. size(i2(:))")
+       if(nxgrid .NE. size(j2(:))) call mpp_error(FATAL, "get_mosaic_xgrid: nxgrid .NE. size(j2(:))")
+       if(nxgrid .NE. size(area(:))) call mpp_error(FATAL, "get_mosaic_xgrid: nxgrid .NE. size(area(:))")
+    else
+       istart = 1
+       nxgrid = size(i1(:))
+    endif
+
+    start  = 1; nread = 1
+    start(1) = istart; nread(1) = nxgrid
+    call read_data(fileobj, 'xgrid_area', area, corner=start, edge_lengths=nread)
+    start = 1; nread = 1
+    nread(1) = 2
+    start(2) = istart; nread(2) = nxgrid
+    call read_data(fileobj, 'tile1_cell', tile1_cell, corner=start, edge_lengths=nread)
+    call read_data(fileobj, 'tile2_cell', tile2_cell, corner=start, edge_lengths=nread)
+
+     do n = 1, nxgrid
+       i1(n) = tile1_cell(1,n)
+       j1(n) = tile1_cell(2,n)
+       i2(n) = tile2_cell(1,n)
+       j2(n) = tile2_cell(2,n)
+       area(n) = area(n)/garea
+    end do
+
+    return
+
+  end subroutine get_mosaic_xgrid_r8
+#endif
 
   !###############################################################################
   !> Get number of tiles in the mosaic_file.
@@ -451,6 +531,46 @@ end function transfer_to_model_index
      call get_grid_great_circle_area( nlon, nlat, lon, lat, area)
 
   end subroutine calc_mosaic_grid_great_circle_area
+
+#ifdef OVERLOAD_R8
+  !> @brief r8_kind overload for @ref calc_mosaic_grid_area
+  subroutine calc_mosaic_grid_area_r8(lon, lat, area)
+     real(r8_kind), dimension(:,:), intent(in)    :: lon
+     real(r8_kind), dimension(:,:), intent(in)    :: lat
+     real(r8_kind), dimension(:,:), intent(inout) :: area
+     integer                             :: nlon, nlat
+
+     nlon = size(area,1)
+     nlat = size(area,2)
+     ! make sure size of lon, lat and area are consitency
+     if( size(lon,1) .NE. nlon+1 .OR. size(lat,1) .NE. nlon+1 ) &
+        call mpp_error(FATAL, "mosaic_mod: size(lon,1) and size(lat,1) should equal to size(area,1)+1")
+     if( size(lon,2) .NE. nlat+1 .OR. size(lat,2) .NE. nlat+1 ) &
+        call mpp_error(FATAL, "mosaic_mod: size(lon,2) and size(lat,2) should equal to size(area,2)+1")
+
+     call get_grid_area( nlon, nlat, lon, lat, area)
+
+  end subroutine calc_mosaic_grid_area_r8
+
+  !> @brief r8_kind overload for @ref calc_mosaic_grid_area
+  subroutine calc_mosaic_grid_great_circle_area_r8(lon, lat, area)
+     real(r8_kind), dimension(:,:), intent(in)    :: lon
+     real(r8_kind), dimension(:,:), intent(in)    :: lat
+     real(r8_kind), dimension(:,:), intent(inout) :: area
+     integer                             :: nlon, nlat
+
+     nlon = size(area,1)
+     nlat = size(area,2)
+     ! make sure size of lon, lat and area are consitency
+     if( size(lon,1) .NE. nlon+1 .OR. size(lat,1) .NE. nlon+1 ) &
+        call mpp_error(FATAL, "mosaic_mod: size(lon,1) and size(lat,1) should equal to size(area,1)+1")
+     if( size(lon,2) .NE. nlat+1 .OR. size(lat,2) .NE. nlat+1 ) &
+        call mpp_error(FATAL, "mosaic_mod: size(lon,2) and size(lat,2) should equal to size(area,2)+1")
+
+     call get_grid_great_circle_area( nlon, nlat, lon, lat, area)
+
+  end subroutine calc_mosaic_grid_great_circle_area_r8
+#endif
 
   !#####################################################################
   !> This function check if a point (lon1,lat1) is inside a polygon (lon2(:), lat2(:))


### PR DESCRIPTION
**Description**
Makes all reals in xgrid and gradient modules explictly r8_kind, and adds any other necessary r8_kind overloads/interfaces to mosaic2 and diag_manager. This fixes mixed precision runtime issues with gradient_mod and the exchange grid from the xgrid test enabled in #800 

**How Has This Been Tested?**
Tested on amd with intel 2020_up2 and gnu 9.3.0 and with #800  

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

