### PR TITLE
fix: test_fms2_io.sh

### DIFF
--- a/test_fms/fms/test_fms.F90
+++ b/test_fms/fms/test_fms.F90
@@ -20,5 +20,7 @@ program test_fms
  else
          call mpp_error(FATAL, trim(test)//" does not match "//trim(answer))
  endif
+
+ call fms_end()
  
 end program test_fms

--- a/test_fms/fms/test_fms.F90
+++ b/test_fms/fms/test_fms.F90
@@ -1,6 +1,6 @@
 program test_fms
  use mpp_mod, only : mpp_error, fatal, note, mpp_init
- use fms_mod, only : fms_init, string
+ use fms_mod, only : fms_init, string, fms_end
 
  integer :: i !< Integer
  character(len=16) :: answer !< expected answer

--- a/test_fms/fms2_io/test_fms2_io.F90
+++ b/test_fms/fms2_io/test_fms2_io.F90
@@ -86,9 +86,9 @@ call parse_args(parser)
 
 !Set defaults.
 tests(:) = .true.
-nx = 96
-ny = 96
-nz = 30
+nx = 36
+ny = 36
+nz = 10
 io_layout(:) = 1
 ocn_io_layout(:) = 1
 npes_group = 1

--- a/test_fms/fms2_io/test_fms2_io.sh
+++ b/test_fms/fms2_io/test_fms2_io.sh
@@ -28,8 +28,7 @@
 # Set common test settings.
 . ../test_common.sh
 # Set the test variable
-skip_test="skip"
 # make a dummy file for mpp_init to read
 printf "EOF\n&dummy\nEOF" | cat > input.nml
 # run the tests
-run_test test_fms2_io 6 ${skip_test}
+run_test test_fms2_io 6

--- a/test_fms/fms2_io/test_fms2_io.sh
+++ b/test_fms/fms2_io/test_fms2_io.sh
@@ -27,7 +27,9 @@
 #
 # Set common test settings.
 . ../test_common.sh
+# Set the test variable
+skip_test="skip"
 # make a dummy file for mpp_init to read
 printf "EOF\n&dummy\nEOF" | cat > input.nml
 # run the tests
-run_test test_fms2_io 6
+run_test test_fms2_io 6 ${skip_test}


### PR DESCRIPTION
**Description**
test_fms2_io.sh crashes because it requires the stacksize to be set to unlimited which can't be done on all systems.  

Fixes #832

**How Has This Been Tested?**
`make check` passes and the test is skipped

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes