### PR TITLE
Create parallelWorks_intel_pr.yml

### DIFF
--- a/.github/workflows/parallelWorks_intel_pr.yml
+++ b/.github/workflows/parallelWorks_intel_pr.yml
@@ -1,4 +1,4 @@
-name: Pull Request CI libFMS with intel21
+name: Pull Request CI libFMS with intel18 and intel21
   
 on: pull_request 
 jobs:
@@ -10,8 +10,8 @@ jobs:
       matrix:
         include:
 # Turn this back on when fixed 
-#                - runname: FMS with intel 18
-#                  runscript: python3 /home/Thomas.Robinson/pw/storage/pw_api_python/FMStestStartClusters.py azcluster_noaa
+                - runname: FMS with intel 18
+                  runscript: python3 /home/Thomas.Robinson/pw/storage/pw_api_python/PRFMSintel18StartClusters.py $GITHUB_REF
 # Runs on FMS_CONTAINER_CI cluster
                 - runname: FMS with intel 2021 container
                   runscript: python3 /home/Thomas.Robinson/pw/storage/pw_api_python/PRFMSintel21StartClusters.py $GITHUB_REF
@@ -29,7 +29,7 @@ jobs:
       matrix:
         include:
                 - cluster: FMS_CONTAINER_CI
-#                - cluster: azcluster_noaa_two
+                - cluster: fms_intel18_ci
     steps:
                 - name: Turn off cluster
                   env:


### PR DESCRIPTION
**Description**
Updated parallelWorks_intel_pr.yml to run PRFMSintel18StartClusters.py during pull requests. It will now run both intel21 and intel18. 



**How Has This Been Tested?**
This has been tested on a Parallel.Works cluster. 

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

