### PR TITLE
Moving Nest Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,6 @@ and this project uses `yyyy.rr[.pp]`, where `yyyy` is the year a patch is releas
 `rr` is a sequential release number (starting from `01`), and an optional two-digit
 sequential patch number (starting from `01`).
 
-## [2021.03.01] - 2021-09-07
-### Fixed
-- TIME_INTERP: Fixes issue in load_record when reading 3d variables with fms2_io and elimates redundant loads and validity checks for on-grid interpolations
-### Changed
-- Changes configure script to only check for gcc 11.1.0, not any gcc 11 version
-
 ## [2021.03] - 2021-08-16
 ### Known Issues
 - DIAG_MANAGER: 3D diurnal diagnostic variables are not supported in this version of FMS

--- a/mpp/include/mpp_define_nest_domains.inc
+++ b/mpp/include/mpp_define_nest_domains.inc
@@ -184,7 +184,7 @@ subroutine mpp_define_nest_domains(nest_domain, domain, num_nest, nest_level, ti
   allocate(nest_domain%istart_coarse(num_nest), nest_domain%iend_coarse(num_nest) )
   allocate(nest_domain%jstart_coarse(num_nest), nest_domain%jend_coarse(num_nest) )
 
-  ! WDR Added to enable moving nests
+  !---Added to enable moving nests
   allocate(nest_domain%nest_level(num_nest))
 
   nest_domain%tile_fine = tile_fine(1:num_nest)
@@ -198,7 +198,7 @@ subroutine mpp_define_nest_domains(nest_domain, domain, num_nest, nest_level, ti
   nest_domain%jstart_coarse = jstart_coarse(1:num_nest)
   nest_domain%jend_coarse = jend_coarse(1:num_nest)
 
-  ! WDR Added to enable moving nests; need this information when shifting the nest position.
+  !---Added to enable moving nests; need this information when shifting the nest position.
   nest_domain%nest_level = nest_level(1:num_nest)
 
   !--- make sure the tile_id of top level of grid is continuous and starting from 1
@@ -364,15 +364,17 @@ subroutine mpp_define_nest_domains(nest_domain, domain, num_nest, nest_level, ti
 
 end subroutine mpp_define_nest_domains
 
-!  Ramstrom/HRD Moving Nest
-!  Based on mpp_define_nest_domains, but just resets positioning of nest 
-!    Modifies the parent/coarse start and end indices of the nest location
-!    Computes new overlaps of nest PEs on parent PEs
+!>  Based on mpp_define_nest_domains, but just resets positioning of nest 
+!>    Modifies the parent/coarse start and end indices of the nest location
+!!    Computes new overlaps of nest PEs on parent PEs
+!!    Ramstrom/HRD Moving Nest
 subroutine mpp_shift_nest_domains(nest_domain, domain, delta_i_coarse, delta_j_coarse, extra_halo)
-  type(nest_domain_type),     intent(inout) :: nest_domain
-  type(domain2D), target,     intent(in   ) :: domain
-  integer,                    intent(in   ) :: delta_i_coarse(:), delta_j_coarse(:)
-  integer,          optional, intent(in   ) :: extra_halo
+  type(nest_domain_type),     intent(inout) :: nest_domain !< holds the information to pass data
+                                                           !! between nest and parent grids.
+  type(domain2D), target,     intent(in   ) :: domain !< domain for the grid defined in the current pelist
+  integer,                    intent(in   ) :: delta_i_coarse(:) !< Array of deltas of coarse grid in y direction
+  integer,                    intent(in   ) :: delta_j_coarse(:) !< Array of deltas of coarse grid in y direction
+  integer,          optional, intent(in   ) :: extra_halo  !< Extra halo size
 
   integer                                   :: n, l, m, my_tile_coarse
   integer                                   :: num_nest

--- a/mpp/mpp_domains.F90
+++ b/mpp/mpp_domains.F90
@@ -459,7 +459,7 @@ module mpp_domains_mod
   type :: nest_domain_type
      character(len=NAME_LENGTH)     :: name
      integer                        :: num_level
-     integer,               pointer :: nest_level(:)    !  Ramstrom -- Added for moving nest functionality
+     integer,               pointer :: nest_level(:)    !< Added for moving nest functionality
      type(nest_level_type), pointer :: nest(:) => NULL()
      integer                        :: num_nest
      integer,               pointer :: tile_fine(:), tile_coarse(:)


### PR DESCRIPTION
**Description**

Added new subroutine [mpp_shift_nest_domains()] and new variable [nest_level] to enable moving nests, by modifying the domain data structures.
Fixes # 838
https://github.com/NOAA-GFDL/FMS/issues/838

**How Has This Been Tested?**
Tests of C96 and C768 global configurations with 3X moving nest on tile 6 have been performed on Orion and Hera.

**Checklist:**
- [YES] My code follows the style guidelines of this project
- [YES] I have performed a self-review of my own code
- [YES] I have commented my code, particularly in hard-to-understand areas
- [YES ] I have made corresponding changes to the documentation
- [YES] My changes generate no new warnings
- [YES] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] `make distcheck` passes

