### PR TITLE
Non-blocking domain updates bug fix

### DIFF
--- a/mpp/include/mpp_do_updateV_nonblock.h
+++ b/mpp/include/mpp_do_updateV_nonblock.h
@@ -567,6 +567,7 @@ subroutine MPP_COMPLETE_DO_UPDATE_3D_V_(id_update, f_addrsx, f_addrsy, domain, u
   integer :: tMe, dir
 
   update_edge_only = BTEST(flags, EDGEONLY)
+  recv = .false.
   recv(1) = BTEST(flags,EAST)
   recv(3) = BTEST(flags,SOUTH)
   recv(5) = BTEST(flags,WEST)

--- a/mpp/include/mpp_do_update_nonblock.h
+++ b/mpp/include/mpp_do_update_nonblock.h
@@ -277,6 +277,7 @@ subroutine MPP_COMPLETE_DO_UPDATE_3D_(id_update, f_addrs, domain, update, d_type
   pointer(ptr_field, field)
 
   update_edge_only = BTEST(flags, EDGEONLY)
+  recv = .false.
   recv(1) = BTEST(flags,EAST)
   recv(3) = BTEST(flags,SOUTH)
   recv(5) = BTEST(flags,WEST)


### PR DESCRIPTION
**Description**
Initializes a logical array to false in the two non-blocking domain update routines. This fixes crashes and incorrect values from `mpp_complete_update_domains` by preventing unintentional updates from the undefined logical values.

Fixes #484

**How Has This Been Tested?**
Tested on amd with intel and gcc + impi, and with the domains tests enabled in #800 

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

