### PR TITLE
C string to C pointer

### DIFF
--- a/fms/Makefile.am
+++ b/fms/Makefile.am
@@ -31,6 +31,8 @@ noinst_LTLIBRARIES = libfms.la
 
 # Each convenience library depends on its source.
 libfms_la_SOURCES = \
+  fms_c.c \
+  fms_c.h \
   fms.F90 \
   fms_io.F90 \
   fms_io_unstructured_field_exist.inc \

--- a/fms/fms.F90
+++ b/fms/fms.F90
@@ -209,7 +209,7 @@ public :: MPP_CLOCK_SYNC, MPP_CLOCK_DETAILED
 public :: CLOCK_COMPONENT, CLOCK_SUBCOMPONENT, &
           CLOCK_MODULE_DRIVER, CLOCK_MODULE,   &
           CLOCK_ROUTINE, CLOCK_LOOP, CLOCK_INFRA
-public :: fms_c2f_string
+public :: fms_c2f_string, fms_cstring2cpointer
 !public from the old fms_io but not exists here
 public :: string
 
@@ -302,11 +302,19 @@ interface string
 end interface
 !> C functions
   interface
+    !> @brief converts a kind=c_char to type c_ptr
+    pure function fms_cstring2cpointer (cs) result (cp) bind(c, name="cstring2cpointer")
+      import c_char, c_ptr
+        character(kind=c_char), intent(in) :: cs(*) !< C string input
+        type (c_ptr) :: cp !< C pointer
+    end function fms_cstring2cpointer
+
     !> @brief Finds the length of a C-string
     integer(c_size_t) pure function c_strlen(s) bind(c,name="strlen")
       import c_size_t, c_ptr
       type(c_ptr), intent(in), value :: s !< A C-string whose size is desired
     end function
+
     !> @brief Frees a C pointer
     subroutine c_free(ptr) bind(c,name="free")
       import c_ptr

--- a/fms/fms_c.c
+++ b/fms/fms_c.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+char * cstring2cpointer (char * cs)
+{
+	return cs;
+}

--- a/fms/fms_c.h
+++ b/fms/fms_c.h
@@ -1,0 +1,4 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+char * cstring2cpointer (char * cs);

--- a/test_fms/fms/test_fms.F90
+++ b/test_fms/fms/test_fms.F90
@@ -55,7 +55,11 @@ program test_fms
 ! Test the c string to c pointer conversion
  test = "                "
  answer = '100'
- Cstring =  "100             "//c_null_char
+ Cstring =  "                "
+ Cstring(1) = "1"
+ Cstring(2) = "0"
+ Cstring(3) = "0"
+ Cstring(17) = c_null_char
  call mpp_error(NOTE,"Testing fms_cstring2cpointer and fms_c2f_string")
 ! test = fms_c2f_string(fms_cstring2cpointer(c_char_"100             "//c_null_char))
  test = fms_c2f_string(fms_cstring2cpointer(Cstring))

--- a/test_fms/fms/test_fms.F90
+++ b/test_fms/fms/test_fms.F90
@@ -14,13 +14,14 @@ program test_fms
  use mpp_mod, only : mpp_error, fatal, note, mpp_init
  use fms_mod, only : fms_init, string, fms_end
  use fms_mod, only : fms_c2f_string
+ use fms_mod, only : fms_cstring2cpointer
  use test_fms_mod
  use, intrinsic :: iso_c_binding
 
  integer :: i !< Integer
  character(len=16) :: answer !< expected answer
  character(len=16) :: test !< Test string
- character(len=:,kind=c_char), pointer :: Cstring !< C string to convert
+ character(kind=c_char) :: Cstring (17)!< C string to convert
  type(c_ptr), pointer :: Cptr !< C pointer to string
 
  call mpp_init()
@@ -50,6 +51,22 @@ program test_fms
  else
          call mpp_error(FATAL, trim(test)//" does not match "//trim(answer))
  endif
+!!!!!!!!!!!!!!!!!!!!
+! Test the c string to c pointer conversion
+ test = "                "
+ answer = '100'
+ Cstring =  "100             "//c_null_char
+ call mpp_error(NOTE,"Testing fms_cstring2cpointer and fms_c2f_string")
+! test = fms_c2f_string(fms_cstring2cpointer(c_char_"100             "//c_null_char))
+ test = fms_c2f_string(fms_cstring2cpointer(Cstring))
+ if (trim(answer) .eq. trim(test)) then
+         call mpp_error(NOTE, trim(test)//" matches "//trim(answer))
+ else
+         call mpp_error(FATAL, trim(test)//" does not match "//trim(answer))
+ endif
+
+
+ 
 
  call fms_end()
  


### PR DESCRIPTION
**Description**
There is a function that converts a C-pointer to a Fortran string.  This function converts a C-string to a C-pointer to be used with that function.  This is the way.

Fixes #855 

**How Has This Been Tested?**
I added a test to test_fms.F90 that tests to make sure it works.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

