### PR TITLE
Updates fms_c2f_string to convert C-string and C-pointers to a Fortran string

### DIFF
--- a/fms/fms.F90
+++ b/fms/fms.F90
@@ -825,7 +825,7 @@ end function monotonic_array
   end function string_from_real
 
 !> \brief Converts a C-string to a pointer and then to a Fortran string
-pure function cstring_fortran_conversion (cstring) result(fstring)
+function cstring_fortran_conversion (cstring) result(fstring)
  character (kind=c_char), intent(in) :: cstring (*) !< Input C-string
  character(len=:), allocatable :: fstring    !< The fortran string returned
  fstring = cpointer_fortran_conversion(fms_cstring2cpointer(cstring))
@@ -833,7 +833,7 @@ end function cstring_fortran_conversion
 
 !> \brief Converts a C-string returned from a TYPE(C_PTR) function to
 !! a fortran string with type character.
-pure function cpointer_fortran_conversion (cstring) result(fstring)
+function cpointer_fortran_conversion (cstring) result(fstring)
  type (c_ptr), intent(in) :: cstring !< Input C-pointer
  character(len=:), allocatable :: fstring    !< The fortran string returned
  character(len=:,kind=c_char), pointer :: string_buffer !< A temporary pointer to between C and Fortran

--- a/fms/fms.F90
+++ b/fms/fms.F90
@@ -300,6 +300,8 @@ interface string
    module procedure string_from_integer
    module procedure string_from_real
 end interface
+!> Converts a C string to a Fortran string
+!> @ingroup fms_mod
 interface fms_c2f_string
    module procedure cstring_fortran_conversion
    module procedure cpointer_fortran_conversion
@@ -850,7 +852,7 @@ function cpointer_fortran_conversion (cstring) result(fstring)
 
  allocate(character(len=length) :: fstring) !> Set the length of fstring
 fstring = string_buffer
-
+ deallocate(string_buffer)
 end function cpointer_fortran_conversion
 !#######################################################################
 !> @brief Prints to the log file (or a specified unit) the version id string and

--- a/fms/fms.F90
+++ b/fms/fms.F90
@@ -300,6 +300,10 @@ interface string
    module procedure string_from_integer
    module procedure string_from_real
 end interface
+interface fms_c2f_string
+   module procedure cstring_fortran_conversion
+   module procedure cpointer_fortran_conversion
+end interface
 !> C functions
   interface
     !> @brief converts a kind=c_char to type c_ptr
@@ -820,10 +824,17 @@ end function monotonic_array
 
   end function string_from_real
 
+!> \brief Converts a C-string to a pointer and then to a Fortran string
+pure function cstring_fortran_conversion (cstring) result(fstring)
+ character (kind=c_char), intent(in) :: cstring (*) !< Input C-string
+ character(len=:), allocatable :: fstring    !< The fortran string returned
+ fstring = cpointer_fortran_conversion(fms_cstring2cpointer(cstring))
+end function cstring_fortran_conversion
+
 !> \brief Converts a C-string returned from a TYPE(C_PTR) function to
 !! a fortran string with type character.
-function fms_c2f_string (cstring) result(fstring)
- type (c_ptr) :: cstring
+pure function cpointer_fortran_conversion (cstring) result(fstring)
+ type (c_ptr), intent(in) :: cstring !< Input C-pointer
  character(len=:), allocatable :: fstring    !< The fortran string returned
  character(len=:,kind=c_char), pointer :: string_buffer !< A temporary pointer to between C and Fortran
  integer(c_size_t) :: length !< The string length
@@ -840,7 +851,7 @@ function fms_c2f_string (cstring) result(fstring)
  allocate(character(len=length) :: fstring) !> Set the length of fstring
 fstring = string_buffer
 
-end function fms_c2f_string
+end function cpointer_fortran_conversion
 !#######################################################################
 !> @brief Prints to the log file (or a specified unit) the version id string and
 !!  tag name.

--- a/test_fms/fms/test_fms.F90
+++ b/test_fms/fms/test_fms.F90
@@ -62,7 +62,7 @@ program test_fms
  Cstring(17) = c_null_char
  call mpp_error(NOTE,"Testing fms_cstring2cpointer and fms_c2f_string")
 ! test = fms_c2f_string(fms_cstring2cpointer(c_char_"100             "//c_null_char))
- test = fms_c2f_string(fms_cstring2cpointer(Cstring))
+ test = fms_c2f_string(Cstring)
  if (trim(answer) .eq. trim(test)) then
          call mpp_error(NOTE, trim(test)//" matches "//trim(answer))
  else


### PR DESCRIPTION
**Description**
The `fms_c2f_string` routine will now convert a c-string or a c-pointer string to a Fortran string.

Fixes #861

**How Has This Been Tested?**
test_fms.F90 updated and run with intel 2020

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [ ] `make distcheck` passes

