### PR TITLE
Cmake build action

### DIFF
--- a/.github/workflows/build_cmake_gnu.yml
+++ b/.github/workflows/build_cmake_gnu.yml
@@ -8,14 +8,15 @@ jobs:
     strategy:
       matrix:
         omp-flags: [ -DOPENMP=on, -DOPENMP=off ]
+        libyaml-flag: [ "", -DWITH_YAML=on ]
     container:
       image: noaagfdl/ubuntu_libfms_gnu:cmake-3.22.0
       env:
-        CMAKE_FLAGS: "${{ matrix.omp-flags }} -D64BIT=on"
+        CMAKE_FLAGS: "${{ matrix.omp-flags }} ${{ matrix.libyaml-flag }} -D64BIT=on"
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Generate makefiles with CMake 
-      run: cmake $CMAKE_FLAGS
+      run: cmake $CMAKE_FLAGS .
     - name: Build the library
       run: make

--- a/.github/workflows/build_cmake_gnu.yml
+++ b/.github/workflows/build_cmake_gnu.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         omp-flags: [ -DOPENMP=on, -DOPENMP=off ]
     container:
-      image: ryanmulhall/ubuntu_libfms_cmake_gnu:latest
+      image: noaagfdl/ubuntu_libfms_gnu:cmake-3.22.0
       env:
         CMAKE_FLAGS: "${{ matrix.omp-flags }} -D64BIT=on"
     steps:

--- a/.github/workflows/build_cmake_gnu.yml
+++ b/.github/workflows/build_cmake_gnu.yml
@@ -1,0 +1,21 @@
+name: Build libFMS with cmake
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest 
+    strategy:
+      matrix:
+        omp-flags: [ -DOPENMP=on, -DOPENMP=off ]
+    container:
+      image: ryanmulhall/ubuntu_libfms_cmake_gnu:latest
+      env:
+        CMAKE_FLAGS: "${{ matrix.omp-flags }} -D64BIT=on"
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Generate makefiles with CMake 
+      run: cmake $CMAKE_FLAGS
+    - name: Build the library
+      run: make

--- a/.github/workflows/build_ubuntu_gnu.yml
+++ b/.github/workflows/build_ubuntu_gnu.yml
@@ -1,4 +1,4 @@
-name: Build libFMS test
+name: Build libFMS test with autotools
 
 on: [push, pull_request]
 


### PR DESCRIPTION
**Description**
Adds a github action to test the cmake build. Container is the same as the autotools action but with the newest versions of libyaml and cmake installed.

For build options I do both r4 and r8 builds each job with a matrix for the openmp and libyaml flags, if any other options should be tested let me know.

Fixes #644 

**How Has This Been Tested?**
I tested it [here](https://github.com/rem1776/FMS/actions/runs/1527432580) and then rolled back the merge with #863 

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes
