### PR TITLE
Adds str_copy to the yaml parser to better copy strings

### DIFF
--- a/parser/yaml_parser.F90
+++ b/parser/yaml_parser.F90
@@ -30,6 +30,7 @@ module yaml_parser_mod
 
 #ifdef use_yaml
 use fms_mod, only: fms_c2f_string
+use fms_io_utils_mod, only: string_copy
 use platform_mod
 use mpp_mod
 use iso_c_binding
@@ -281,7 +282,7 @@ subroutine get_value_from_key_0d(file_id, block_id, key_name, key_value, is_opti
           read(buffer,*, iostat=err_unit) key_value
           if (err_unit .ne. 0) call mpp_error(FATAL, "Key:"//trim(key_name)//" Error converting '"//trim(buffer)//"' to r8")
        type is (character(len=*))
-          key_value = buffer
+          call string_copy(key_value, buffer)
      class default
        call mpp_error(FATAL, "The type of your buffer in your get_value_from_key call for key "//trim(key_name)//&
                             &" is not supported. Only i4, i8, r4, r8 and strings are supported.")


### PR DESCRIPTION
**Description**
This uses `string_copy` to copy strings in the yaml parser. 

`string_copy` checks if the buffer copying into to has the correct length and crashes if it doesn't. 

Fixes # (issue)

**How Has This Been Tested?**
`make check` --wtih-yaml passes on intel

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

