### PR TITLE
Fixes for linter action

### DIFF
--- a/.github/workflows/am4_regression_parallelWorks_intel_tag.yml
+++ b/.github/workflows/am4_regression_parallelWorks_intel_tag.yml
@@ -1,5 +1,5 @@
 name: Tag CI libFMS with AM4 regression
-  
+
 on:
    push:
         tags:
@@ -14,7 +14,7 @@ jobs:
       max-parallel: 3
       matrix:
         include:
-# Runs AM4 with intel18 on AM4_intel18 
+# Runs AM4 with intel18 on AM4_intel18
 #                - runname: AM4 build and run with intel 18
 #                  runscript: python3 /home/Thomas.Robinson/pw/storage/pw_api_python/AM4_intel18StartClusters.py am4_intel18
 # Runs AM4 using a container to build and run the model with intel 21

--- a/.github/workflows/build_cmake_gnu.yml
+++ b/.github/workflows/build_cmake_gnu.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest 
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         omp-flags: [ -DOPENMP=on, -DOPENMP=off ]
@@ -16,7 +16,7 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
-    - name: Generate makefiles with CMake 
+    - name: Generate makefiles with CMake
       run: cmake $CMAKE_FLAGS .
     - name: Build the library
       run: make

--- a/.github/workflows/lint_fms.yml
+++ b/.github/workflows/lint_fms.yml
@@ -9,4 +9,4 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Run Lint
-        uses: NOAA-GFDL/simple_lint@v2
+        uses: NOAA-GFDL/simple_lint@v3

--- a/.github/workflows/parallelWorks_intel_pr.yml
+++ b/.github/workflows/parallelWorks_intel_pr.yml
@@ -1,5 +1,5 @@
 name: Pull Request CI libFMS with intel18 and intel21
-  
+
 on: [pull_request,workflow_dispatch]
 jobs:
    parallelWorks:
@@ -9,7 +9,7 @@ jobs:
       max-parallel: 2
       matrix:
         include:
-# Turn this back on when fixed 
+# Turn this back on when fixed
                 - runname: FMS with intel 18
                   runscript: python3 /home/Thomas.Robinson/pw/storage/pw_api_python/PRFMSintel18StartClusters.py $GITHUB_REF
 # Runs on FMS_CONTAINER_CI cluster

--- a/.github/workflows/update_docs.yml
+++ b/.github/workflows/update_docs.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Setup repo 
+      - name: Setup repo
         run: | # do autotool's job for substitutes since we don't need a full build environement
           mkdir gen_docs
           sed 's/@abs_top_builddir@\/docs/gen_docs/' docs/Doxyfile.in > gen_docs/Doxyfile

--- a/CODE_STYLE.md
+++ b/CODE_STYLE.md
@@ -43,8 +43,8 @@
 * Inline doxygen descriptions for all member variables.
 
 ## Functions
-* Functions should include a result variable on its own line, that does not have
-  a specific intent.
+* If a function has a result variable, it should be declared on its own line, 
+  and the variable should not be declared with a specific intent.
 * Inline doxygen descriptions for all arguments, except the result variable.
 * Doxygen description on the line(s) before the function definition.  This must
   specify what the function is returning using the `@return` doxygen keyword.
@@ -120,9 +120,7 @@ module example_mod
 
   !> @brief Doxygen description
   !! @return Function return value.
-  function func1(arg1, &
-    & arg2) &
-    & result(res)
+  function func1(arg1, arg2) result(res)
     integer(kind=INT32),intent(in) :: arg1 !< Inline doxygen description
     integer(kind=INT32),intent(in) :: arg2 !< Inline doxygen description
     integer(kind=INT32) :: res

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,10 +35,10 @@ uphold this code. Please report unacceptable behavior to
 
 1. Create an issue that describes the change, or feature request
 2. Fork the project
-3. Create a feature branch off an up-do-date `master` branch
+3. Create a feature branch off an up-do-date `main` branch
 4. Update the tests and code
 5. Push the commits to your fork
-6. Submit a pull request to the `master` branch
+6. Submit a pull request to the `main` branch
 
 ## Support
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -83,9 +83,9 @@ AM_FCFLAGS = $(FC_MODINC). $(FC_MODOUT)$(MODDIR)
 noinst_LTLIBRARIES = libFMS_mod.la
 libFMS_mod_la_SOURCES = libFMS.F90
 
-fms.$(FC_MODEXT): .mods/*_mod.$(FC_MODEXT) 
+fms.$(FC_MODEXT): .mods/*_mod.$(FC_MODEXT)
 
-nodist_include_HEADERS = libFMS_mod.la 
+nodist_include_HEADERS = libFMS_mod.la
 
 include $(top_srcdir)/mkmods.mk
 

--- a/amip_interp/amip_interp.F90
+++ b/amip_interp/amip_interp.F90
@@ -28,7 +28,8 @@
 !!
 !! 1. AMIP @link http://www-pcmdi.llnl.gov/amip @endlink from Jan 1979 to Jan 1989 (2 deg x 2 deg)
 !! 2. Reynolds OI @link amip_interp.rey_oi.txt @endlink from Nov 1981 to Jan 1999 (1 deg x 1 deg)
-!! 3. Reynolds EOF @link ftp://podaac.jpl.nasa.gov/pub/sea_surface_temperature/reynolds/rsst/doc/rsst.html @endlink from Jan 1950 to Dec 1998 (2 deg x 2 deg)
+!! 3. Reynolds EOF @link ftp://podaac.jpl.nasa.gov/pub/sea_surface_temperature/reynolds/rsst/doc/rsst.html
+!! @endlink from Jan 1950 to Dec 1998 (2 deg x 2 deg)
 !!
 !! All original data are observed monthly means. This module
 !! interpolates linearly in time between pairs of monthly means.
@@ -501,7 +502,8 @@ if ( .not.use_daily ) then
     if (DEBUG) then
           call get_date(Amip_Time,jhctod(1),jhctod(2),jhctod(3),jhctod(4),jhctod(5),jhctod(6))
           if (mpp_pe() == 0) then
-             write (*,200) 'JHC: use_daily = F, AMIP_Time: ',jhctod(1),jhctod(2),jhctod(3),jhctod(4),jhctod(5),jhctod(6)
+             write (*,200) 'JHC: use_daily = F, AMIP_Time: ',jhctod(1),jhctod(2),jhctod(3),jhctod(4),jhctod(5), &
+                   & jhctod(6)
              write (*,300) 'JHC: use_daily = F, interped SST: ', sst(1,1),sst(5,5),sst(10,10)
           endif
     endif
@@ -512,7 +514,8 @@ if ( .not.use_daily ) then
 ! add by JHC
 else
     call get_date(Amip_Time,jhctod(1),jhctod(2),jhctod(3),jhctod(4),jhctod(5),jhctod(6))
-     if (mpp_pe() == mpp_root_pe()) write(*,200) 'amip_interp_mod: use_daily = T, Amip_Time = ',jhctod(1),jhctod(2),jhctod(3),jhctod(4),jhctod(5),jhctod(6)
+     if (mpp_pe() == mpp_root_pe()) write(*,200) 'amip_interp_mod: use_daily = T, Amip_Time = ',jhctod(1), &
+        & jhctod(2),jhctod(3),jhctod(4),jhctod(5),jhctod(6)
 
     yr = jhctod(1); mo = jhctod(2); dy = jhctod(3)
 

--- a/astronomy/astronomy.F90
+++ b/astronomy/astronomy.F90
@@ -1483,7 +1483,8 @@ end subroutine daily_mean_solar_1d
 !! @param [in] <lat> Latitudes of model grid points
 !! @param [in] <time_since_ae> Time of year; autumnal equinox = 0.0, one year = 2 * pi
 !! @param [out] <cosz> Cosine of solar zenith angle
-!! @param [out] <solar> Shortwave flux factor: cosine of zenith angle * daylight fraction / (earth-sun distance squared)
+!! @param [out] <solar> Shortwave flux factor: cosine of zenith angle * daylight fraction /
+!! (earth-sun distance squared)
 subroutine daily_mean_solar_2level (lat, time_since_ae, cosz, solar)
 
 !----------------------------------------------------------------------
@@ -1652,7 +1653,8 @@ end subroutine daily_mean_solar_cal_1d
 !! @param [in] <lat> Latitudes of model grid points
 !! @param [in] <time> Time of year (time_type)
 !! @param [out] <cosz> Cosine of solar zenith angle
-!! @param [out] <solar> Shortwave flux factor: cosine of zenith angle * daylight fraction / (earth-sun distance squared)
+!! @param [out] <solar> Shortwave flux factor: cosine of zenith angle * daylight fraction /
+!! (earth-sun distance squared)
 subroutine daily_mean_solar_cal_2level (lat, time, cosz, solar)
 
 real, dimension(:),  intent(in)   :: lat
@@ -1738,7 +1740,8 @@ end subroutine daily_mean_solar_cal_0d
 !! @param [in] <jnd> Ending index of latitude window
 !! @param [in] <lat> Latitudes of model grid points
 !! @param [out] <cosz> Cosine of solar zenith angle
-!! @param [out] <solar> Shortwave flux factor: cosine of zenith angle * daylight fraction / (earth-sun distance squared)
+!! @param [out] <solar> Shortwave flux factor: cosine of zenith angle * daylight fraction /
+!! (earth-sun distance squared)
 !! @param [out] <fracday> Daylight fraction of time interval
 !! @param [out] <rrsun> Earth-Sun distance (r) relative to semi-major axis of orbital ellipse (a):(a/r)**2
 subroutine annual_mean_solar_2d (js, je, lat, cosz, solar, fracday,  &
@@ -1845,7 +1848,8 @@ end subroutine annual_mean_solar_2d
 !! @param [in] <jnd> Ending index of latitude window
 !! @param [in] <lat> Latitudes of model grid points
 !! @param [out] <cosz> Cosine of solar zenith angle
-!! @param [out] <solar> Shortwave flux factor: cosine of zenith angle * daylight fraction / (earth-sun distance squared)
+!! @param [out] <solar> Shortwave flux factor: cosine of zenith angle * daylight fraction /
+!! (earth-sun distance squared)
 !! @param [out] <fracday> Daylight fraction of time interval
 !! @param [out] <rrsun_out> Earth-Sun distance (r) relative to semi-major axis of orbital ellipse (a):(a/r)**2
 subroutine annual_mean_solar_1d (jst, jnd, lat, cosz, solar,  &

--- a/astronomy/astronomy.F90
+++ b/astronomy/astronomy.F90
@@ -129,7 +129,8 @@ public       &
 !! @param [in] <time> Time at which astronomical values are desired (time_type variable) [seconds, days]
 !! @param [out] <cosz> Cosine of solar zenith angle, set to zero when entire period is in darkness [dimensionless]
 !! @param [out] <fracday> Daylight fraction of time interval [dimensionless]
-!! @param [out] <rrsun> Earth-Sun distance (r) relative to semi-major axis of orbital ellipse (a):(a/r)**2 [dimensionless]
+!! @param [out] <rrsun> Earth-Sun distance (r) relative to semi-major axis of orbital ellipse
+!! (a):(a/r)**2 [dimensionless]
 !! @param [in] <dt> OPTIONAL: Time interval after gmt over which the astronomical variables are to be
 !!                  averaged. this produces averaged output rather than instantaneous. [radians], (1 day = 2 * pi)
 !! @param [in] <dt_time> OPTIONAL: Time interval after gmt over which the astronomical variables are to be
@@ -190,8 +191,10 @@ end interface
 !! @param [in] <time> Time at which astronomical values are desired (time_type variable) [seconds, days]
 !! @param [out] <cosz> Cosine of solar zenith angle, set to zero when entire period is in darkness [dimensionless]
 !! @param [out] <fracday> Daylight fraction of time interval [dimensionless]
-!! @param [out] <rrsun> Earth-Sun distance (r) relative to semi-major axis of orbital ellipse (a):(a/r)**2 [dimensionless]
-!! @param [out] <solar> shortwave flux factor: cosine of zenith angle * daylight fraction / (earth-sun distance squared) [dimensionless]
+!! @param [out] <rrsun> Earth-Sun distance (r) relative to semi-major axis of orbital ellipse
+!! (a):(a/r)**2 [dimensionless]
+!! @param [out] <solar> shortwave flux factor: cosine of zenith angle * daylight fraction /
+!! (earth-sun distance squared) [dimensionless]
 !> @ingroup astronomy_mod
 interface daily_mean_solar
    module procedure daily_mean_solar_2d
@@ -2141,7 +2144,7 @@ real, dimension(size(latitude,1),size(latitude,2))   :: h
 !---------------------------------------------------------------------
       real, dimension (size(latitude,1),size(latitude,2)):: &
                                                   cos_half_day, & !< Cosine of half-day length [dimensionless]
-                                                                                                  lat !< Model latitude, adjusted so that it is never 0.5*pi or -0.5*pi
+                                                  lat !< Model latitude, adjusted so that it is never 0.5*pi or -0.5*pi
       real :: tan_dec !< tangent of solar declination [dimensionless]
       real :: eps = 1.0E-05 !< small increment
 

--- a/axis_utils/axis_utils.F90
+++ b/axis_utils/axis_utils.F90
@@ -415,8 +415,8 @@ contains
     do i=2,ia
        if (array(i) < array(i-1)) then
           unit = stdout()
-          write (unit,*) '=> Error: "frac_index" array must be monotonically increasing when searching for nearest value to ',&
-                              value
+          write (unit,*) &
+            '=> Error: "frac_index" array must be monotonically increasing when searching for nearest value to ', value
           write (unit,*) '          array(i) < array(i-1) for i=',i
           write (unit,*) '          array(i) for i=1..ia follows:'
           do ii=1,ia

--- a/axis_utils/axis_utils2.F90
+++ b/axis_utils/axis_utils2.F90
@@ -443,8 +443,8 @@ end subroutine axis_edges
     do i=2,ia
        if (array(i) < array(i-1)) then
           unit = stdout()
-          write (unit,*) '=> Error: "frac_index" array must be monotonically increasing when searching for nearest value to ',&
-                              value
+          write (unit,*) &
+            '=> Error: "frac_index" array must be monotonically increasing when searching for nearest value to ', value
           write (unit,*) '          array(i) < array(i-1) for i=',i
           write (unit,*) '          array(i) for i=1..ia follows:'
           do ii=1,ia

--- a/constants/constants.F90
+++ b/constants/constants.F90
@@ -81,11 +81,14 @@ real :: realnumber !< dummy variable to use in HUGE initializations
 #ifdef GFS_PHYS
 ! SJL: the following are from fv3_gfsphysics/gfs_physics/physics/physcons.f90
 real,               public, parameter :: RADIUS = 6.3712e+6_r8_kind * small_fac !< Radius of the Earth [m]
-real(kind=r8_kind), public, parameter :: PI_8   = 3.1415926535897931_r8_kind    !< Ratio of circle circumference to diameter [N/A]
-real,               public, parameter :: PI     = 3.1415926535897931_r8_kind    !< Ratio of circle circumference to diameter [N/A]
+real(kind=r8_kind), public, parameter :: PI_8   = 3.1415926535897931_r8_kind    !< Ratio of circle circumference
+                                                                                !! to diameter [N/A]
+real,               public, parameter :: PI     = 3.1415926535897931_r8_kind    !< Ratio of circle circumference
+                                                                                !! to diameter [N/A]
 real,               public, parameter :: OMEGA  = 7.2921e-5_r8_kind / small_fac !< Rotation rate of the Earth [1/s]
 real,               public, parameter :: GRAV   = 9.80665_r8_kind     !< Acceleration due to gravity [m/s^2]
-real(kind=r8_kind), public, parameter :: GRAV_8 = 9.80665_r8_kind     !< Acceleration due to gravity [m/s^2] (REAL(KIND=8))
+real(kind=r8_kind), public, parameter :: GRAV_8 = 9.80665_r8_kind     !< Acceleration due to gravity
+                                                                      !! [m/s^2] (REAL(KIND=8))
 real,               public, parameter :: RDGAS  = 287.05_r8_kind      !< Gas constant for dry air [J/kg/deg]
 real,               public, parameter :: RVGAS  = 461.50_r8_kind      !< Gas constant for water vapor [J/kg/deg]
 ! Extra:
@@ -93,15 +96,18 @@ real,               public, parameter :: HLV      = 2.5e6_r8_kind     !< Latent 
 real,               public, parameter :: HLF      = 3.3358e5_r8_kind  !< Latent heat of fusion [J/kg]
 real,               public, parameter :: con_cliq = 4.1855e+3_r8_kind !< spec heat H2O liq [J/kg/K]
 real,               public, parameter :: con_csol = 2.1060e+3_r8_kind !< spec heat H2O ice [J/kg/K]
-real,               public, parameter :: CP_AIR = 1004.6_r8_kind      !< Specific heat capacity of dry air at constant pressure [J/kg/deg]
+real,               public, parameter :: CP_AIR = 1004.6_r8_kind      !< Specific heat capacity of dry
+                                                                      !! air at constant pressure [J/kg/deg]
 real,               public, parameter :: KAPPA  = RDGAS/CP_AIR        !< RDGAS / CP_AIR [dimensionless]
 real,               public, parameter :: TFREEZE = 273.15_r8_kind     !< Freezing temperature of fresh water [K]
 
 #else
 
 real,         public, parameter :: RADIUS = 6371.0e+3_r8_kind * small_fac   !< Radius of the Earth [m]
-real(kind=8), public, parameter :: PI_8   = 3.14159265358979323846_r8_kind  !< Ratio of circle circumference to diameter [N/A]
-real,         public, parameter :: PI     = 3.14159265358979323846_r8_kind  !< Ratio of circle circumference to diameter [N/A]
+real(kind=8), public, parameter :: PI_8   = 3.14159265358979323846_r8_kind  !< Ratio of circle circumference
+                                                                            !! to diameter [N/A]
+real,         public, parameter :: PI     = 3.14159265358979323846_r8_kind  !< Ratio of circle circumference
+                                                                            !! to diameter [N/A]
 real,         public, parameter :: OMEGA  = 7.292e-5_r8_kind / small_fac    !< Rotation rate of the Earth [1/s]
 real,         public, parameter :: GRAV   = 9.80_r8_kind             !< Acceleration due to gravity [m/s^2]
 real,         public, parameter :: RDGAS  = 287.04_r8_kind           !< Gas constant for dry air [J/kg/deg]
@@ -110,21 +116,26 @@ real,         public, parameter :: RVGAS  = 461.50_r8_kind           !< Gas cons
 real,         public, parameter :: HLV = 2.500e6_r8_kind             !< Latent heat of evaporation [J/kg]
 real,         public, parameter :: HLF = 3.34e5_r8_kind              !< Latent heat of fusion [J/kg]
 real,         public, parameter :: KAPPA  = 2.0_r8_kind/7.0_r8_kind  !< RDGAS / CP_AIR [dimensionless]
-real,         public, parameter :: CP_AIR = RDGAS/KAPPA              !< Specific heat capacity of dry air at constant pressure [J/kg/deg]
+real,         public, parameter :: CP_AIR = RDGAS/KAPPA              !< Specific heat capacity of dry
+                                                                     !! air at constant pressure [J/kg/deg]
 real,         public, parameter :: TFREEZE = 273.16_r8_kind          !< Freezing temperature of fresh water [K]
 #endif
 
 real, public, parameter :: STEFAN  = 5.6734e-8_r8_kind !< Stefan-Boltzmann constant [W/m^2/deg^4]
 
-real, public, parameter :: CP_VAPOR = 4.0_r8_kind*RVGAS      !< Specific heat capacity of water vapor at constant pressure [J/kg/deg]
+real, public, parameter :: CP_VAPOR = 4.0_r8_kind*RVGAS      !< Specific heat capacity of water vapor
+                                                             !! at constant pressure [J/kg/deg]
 real, public, parameter :: CP_OCEAN = 3989.24495292815_r8_kind !< Specific heat capacity taken from McDougall (2002)
                                                                !! "Potential Enthalpy ..." [J/kg/deg]
 real, public, parameter :: RHO0    = 1.035e3_r8_kind  !< Average density of sea water [kg/m^3]
 real, public, parameter :: RHO0R   = 1.0_r8_kind/RHO0 !< Reciprocal of average density of sea water [m^3/kg]
-real, public, parameter :: RHO_CP  = RHO0*CP_OCEAN    !< (kg/m^3)*(cal/kg/deg C)(joules/cal) = (joules/m^3/deg C) [J/m^3/deg]
+real, public, parameter :: RHO_CP  = RHO0*CP_OCEAN    !< (kg/m^3)*(cal/kg/deg C)(joules/cal) = (joules/m^3/deg
+                                                      !! C) [J/m^3/deg]
 
-real, public, parameter :: ES0 = 1.0_r8_kind        !< Humidity factor. Controls the humidity content of the atmosphere through
-                                                    !! the Saturation Vapour Pressure expression when using DO_SIMPLE. [dimensionless]
+real, public, parameter :: ES0 = 1.0_r8_kind        !< Humidity factor. Controls the humidity content
+                                                    !! of the atmosphere through
+                                                    !! the Saturation Vapour Pressure expression
+                                                    !! when using DO_SIMPLE. [dimensionless]
 real, public, parameter :: DENS_H2O = 1000._r8_kind !< Density of liquid water [kg/m^3]
 real, public, parameter :: HLS = HLV + HLF          !< Latent heat of sublimation [J/kg]
 
@@ -148,18 +159,25 @@ real, public, parameter :: SECONDS_PER_HOUR   = 3600._r8_kind        !< Seconds 
 real, public, parameter :: SECONDS_PER_MINUTE = 60._r8_kind          !< Seconds in a minute [s]
 real, public, parameter :: RAD_TO_DEG         = 180._r8_kind/PI      !< Degrees per radian [deg/rad]
 real, public, parameter :: DEG_TO_RAD         = PI/180._r8_kind      !< Radians per degree [rad/deg]
-real, public, parameter :: RADIAN             = RAD_TO_DEG           !< Equal to RAD_TO_DEG for backward compatability. [rad/deg]
-real, public, parameter :: ALOGMIN            = -50.0_r8_kind        !< Minimum value allowed as argument to log function [N/A]
-real, public, parameter :: EPSLN              = 1.0e-40_r8_kind      !< A small number to prevent divide by zero exceptions [N/A]
+real, public, parameter :: RADIAN             = RAD_TO_DEG           !< Equal to RAD_TO_DEG for backward
+                                                                     !! compatability. [rad/deg]
+real, public, parameter :: ALOGMIN            = -50.0_r8_kind        !< Minimum value allowed as argument
+                                                                     !! to log function [N/A]
+real, public, parameter :: EPSLN              = 1.0e-40_r8_kind      !< A small number to prevent divide
+                                                                     !! by zero exceptions [N/A]
 
-real, public, parameter :: RADCON = ((1.0E+02*GRAV)/(1.0E+04*CP_AIR))*SECONDS_PER_DAY !< Factor used to convert flux divergence to
-                                                                                      !! heating rate in degrees per day [deg sec/(cm day)]
+real, public, parameter :: RADCON = ((1.0E+02*GRAV)/(1.0E+04*CP_AIR))*SECONDS_PER_DAY !< Factor used
+                                                                                      !! to convert flux divergence to
+                                                                                      !! heating rate in degrees
+                                                                                      !! per day [deg sec/(m day)]
 real, public, parameter :: RADCON_MKS  = (GRAV/CP_AIR)*SECONDS_PER_DAY !< Factor used to convert flux divergence to
-                                                                       !! heating rate in degrees per day [deg sec/(m day)]
+                                                                       !! heating rate in degrees
+                                                                       !! per day [deg sec/(m day)]
 real, public, parameter :: O2MIXRAT    = 2.0953E-01_r8_kind !< Mixing ratio of molecular oxygen in air [dimensionless]
 real, public, parameter :: RHOAIR      = 1.292269_r8_kind   !< Reference atmospheric density [kg/m^3]
 real, public, parameter :: VONKARM     = 0.40_r8_kind       !< Von Karman constant [dimensionless]
-real, public, parameter :: C2DBARS     = 1.e-4_r8_kind      !< Converts rho*g*z (in mks) to dbars: 1dbar = 10^4 (kg/m^3)(m/s^2)m [dbars]
+real, public, parameter :: C2DBARS     = 1.e-4_r8_kind      !< Converts rho*g*z (in mks) to dbars: 1dbar
+                                                            !! = 10^4 (kg/m^3)(m/s^2)m [dbars]
 real, public, parameter :: KELVIN      = 273.15_r8_kind     !< Degrees Kelvin at zero Celsius [K]
 
 public :: constants_init

--- a/coupler/atmos_ocean_fluxes.F90
+++ b/coupler/atmos_ocean_fluxes.F90
@@ -415,7 +415,7 @@ contains
   !! @throw FATAL, "Flux index, [ind] does not match array index, [n] for [name]"
   !! @throw FATAL, "Problem changing to [name]"
   !! @throw FATAL, "Undefined flux_type given for [name]: [gas_fluxes%bc(n)%flux_type]"
-  !! @throw FATAL, "Undefined implementation given for [name]: 
+  !! @throw FATAL, "Undefined implementation given for [name]:
   !!                [gas_fluxes%bc(n)%flux_type]/implementation/[gas_fluxes%bc(n)%implementation]"
   !! @throw FATAL, "No param for [name]: need [num_parameters]"
   !! @throw FATAL, "Wrong number of param for [name]: [size(gas_fluxes%bc(n)%param(:))] given, need [num_parameters]"

--- a/coupler/atmos_ocean_fluxes.F90
+++ b/coupler/atmos_ocean_fluxes.F90
@@ -660,7 +660,8 @@ contains
           call mpp_error(FATAL, trim(error_header) // ' No param for ' // trim(name) // trim(error_string))
         elseif (size(gas_fluxes%bc(n)%param(:)) .ne. num_parameters) then
           write (error_string,'(a,i2,a,i2)') ': ', size(gas_fluxes%bc(n)%param(:)), ' given, need ', num_parameters
-          call mpp_error(FATAL, trim(error_header) // ' Wrong number of param for ' // trim(name) // trim(error_string))
+          call mpp_error(FATAL, trim(error_header) // &
+                         &  ' Wrong number of param for ' // trim(name) // trim(error_string))
         endif
       elseif (num_parameters .eq. 0) then
         if (associated(gas_fluxes%bc(n)%param)) then

--- a/coupler/atmos_ocean_fluxes.F90
+++ b/coupler/atmos_ocean_fluxes.F90
@@ -262,7 +262,8 @@ contains
         ! Check that the flux_type/implementation that we will use
         ! (both possibly given from the field_table) is defined
         implementation_test = fm_util_get_string('implementation', scalar = .true.)
-        if (.not. fm_exists('/coupler_mod/types/' // trim(flux_type_test) //  '/implementation/' // trim(implementation_test))) then
+        if (.not. fm_exists('/coupler_mod/types/' // trim(flux_type_test) //  '/implementation/' // &
+        &  trim(implementation_test))) then
           if (flux_type .eq. flux_type_test) then
             if (implementation .eq. implementation_test) then
               call mpp_error(FATAL, trim(error_header) // ' Should not get here, as it is tested for above')
@@ -414,7 +415,8 @@ contains
   !! @throw FATAL, "Flux index, [ind] does not match array index, [n] for [name]"
   !! @throw FATAL, "Problem changing to [name]"
   !! @throw FATAL, "Undefined flux_type given for [name]: [gas_fluxes%bc(n)%flux_type]"
-  !! @throw FATAL, "Undefined implementation given for [name]: [gas_fluxes%bc(n)%flux_type]/implementation/[gas_fluxes%bc(n)%implementation]"
+  !! @throw FATAL, "Undefined implementation given for [name]: 
+  !!                [gas_fluxes%bc(n)%flux_type]/implementation/[gas_fluxes%bc(n)%implementation]"
   !! @throw FATAL, "No param for [name]: need [num_parameters]"
   !! @throw FATAL, "Wrong number of param for [name]: [size(gas_fluxes%bc(n)%param(:))] given, need [num_parameters]"
   !! @throw FATAL, "No params needed for [name] but has size of [size(gas_fluxes%bc(n)%param(:))]"
@@ -586,7 +588,8 @@ contains
 
       gas_fields_ice%bc(n)%name = name
       do m = 1, fm_util_get_length(trim(flux_list) // 'ice/name')
-        gas_fields_ice%bc(n)%field(m)%name = trim(name) // "_" // fm_util_get_string(trim(flux_list) // 'ice/name', index = m)
+        gas_fields_ice%bc(n)%field(m)%name = trim(name) // "_" // fm_util_get_string(trim(flux_list) // &
+                                        &  'ice/name', index = m)
         gas_fields_ice%bc(n)%field(m)%override = .false.
         gas_fields_ice%bc(n)%field(m)%mean     = .false.
       enddo
@@ -594,7 +597,8 @@ contains
       ! Save the units.
       do m = 1, fm_util_get_length(trim(flux_list) // 'flux/name')
         gas_fluxes%bc(n)%field(m)%units =&
-            & fm_util_get_string(trim(fm_util_get_string(trim(flux_list) // 'flux/name', index = m)) // '-units', scalar = .true.)
+            & fm_util_get_string(trim(fm_util_get_string(trim(flux_list) // 'flux/name', index = m)) // &
+            &  '-units', scalar = .true.)
       enddo
       do m = 1, fm_util_get_length(trim(flux_list) // 'atm/name')
         gas_fields_atm%bc(n)%field(m)%units =&
@@ -608,7 +612,8 @@ contains
       ! Save the long names.
       do m = 1, fm_util_get_length(trim(flux_list) // 'flux/name')
         gas_fluxes%bc(n)%field(m)%long_name =&
-            & fm_util_get_string(trim(fm_util_get_string(trim(flux_list) // 'flux/name', index = m)) // '-long_name', scalar = .true.)
+            & fm_util_get_string(trim(fm_util_get_string(trim(flux_list) // 'flux/name', index = m)) // &
+            &  '-long_name', scalar = .true.)
         gas_fluxes%bc(n)%field(m)%long_name = trim(gas_fluxes%bc(n)%field(m)%long_name) // ' for ' // name
       enddo
       do m = 1, fm_util_get_length(trim(flux_list) // 'atm/name')
@@ -664,7 +669,8 @@ contains
         endif
       else
         write (error_string,'(a,i2)') ': ', num_parameters
-        call mpp_error(FATAL, trim(error_header) // 'Num_parameters is negative for ' // trim(name) // trim(error_string))
+        call mpp_error(FATAL, trim(error_header) // &
+                       &  'Num_parameters is negative for ' // trim(name) // trim(error_string))
       endif
       num_flags = fm_util_get_integer(trim(flux_list) // '/num_flags', scalar = .true.)
       if (num_flags .gt. 0) then
@@ -963,7 +969,8 @@ contains
     call fm_util_set_value('air_sea_gas_flux_generic/implementation/duce/num_parameters', 1)
 
     if (fm_new_list('air_sea_gas_flux_generic/implementation/johnson') .le. 0) then
-      call mpp_error(FATAL, trim(error_header) // ' Could not set the "air_sea_gas_flux_generic/implementation/johnson" list')
+      call mpp_error(FATAL, trim(error_header) // &
+                     &  ' Could not set the "air_sea_gas_flux_generic/implementation/johnson" list')
     endif
     call fm_util_set_value('air_sea_gas_flux_generic/implementation/johnson/num_parameters', 2)
 
@@ -1044,7 +1051,8 @@ contains
     endif
     call fm_util_set_value('air_sea_gas_flux/implementation/ocmip2/num_parameters', 2)
     if (fm_new_list('air_sea_gas_flux/implementation/ocmip2_data') .le. 0) then
-      call mpp_error(FATAL, trim(error_header) // ' Could not set the "air_sea_gas_flux/implementation/ocmip2_data" list')
+      call mpp_error(FATAL, trim(error_header) // &
+                     &  ' Could not set the "air_sea_gas_flux/implementation/ocmip2_data" list')
     endif
     call fm_util_set_value('air_sea_gas_flux/implementation/ocmip2_data/num_parameters', 2)
     if (fm_new_list('air_sea_gas_flux/implementation/linear') .le. 0) then
@@ -1080,13 +1088,15 @@ contains
       call mpp_error(FATAL, trim(error_header) // ' Could not set the "air_sea_gas_flux/ice" list')
     endif
 
-    call fm_util_set_value('air_sea_gas_flux/ice/name',      'alpha',                                                index = ind_alpha)
-    call fm_util_set_value('air_sea_gas_flux/ice/long_name', 'Solubility from atmosphere times Schmidt number term', index = ind_alpha)
-    call fm_util_set_value('air_sea_gas_flux/ice/units',     'mol/m^3/atm',                                          index = ind_alpha)
+    call fm_util_set_value('air_sea_gas_flux/ice/name', 'alpha', index = ind_alpha)
+    call fm_util_set_value('air_sea_gas_flux/ice/long_name', &
+                          &  'Solubility from atmosphere times Schmidt number term', index = ind_alpha)
+    call fm_util_set_value('air_sea_gas_flux/ice/units', 'mol/m^3/atm', index = ind_alpha)
 
-    call fm_util_set_value('air_sea_gas_flux/ice/name',      'csurf',                                         index = ind_csurf)
-    call fm_util_set_value('air_sea_gas_flux/ice/long_name', 'Ocean concentration times Schmidt number term', index = ind_csurf)
-    call fm_util_set_value('air_sea_gas_flux/ice/units',     'mol/m^3',                                       index = ind_csurf)
+    call fm_util_set_value('air_sea_gas_flux/ice/name', 'csurf', index = ind_csurf)
+    call fm_util_set_value('air_sea_gas_flux/ice/long_name', 'Ocean concentration times Schmidt number term', &
+                          &  index = ind_csurf)
+    call fm_util_set_value('air_sea_gas_flux/ice/units', 'mol/m^3', index = ind_csurf)
 
     ! Add the flux output field(s).
     if (fm_new_list('air_sea_gas_flux/flux') .le. 0) then

--- a/coupler/coupler_types.F90
+++ b/coupler/coupler_types.F90
@@ -3209,9 +3209,8 @@ contains
 
     !< Open the files
     do n = 1, num_rest_files
-        file_is_open(n) = open_file(bc_rest_files(n), trim(dir)// &
-                                                             & rest_file_names(n), io_type, mpp_domain, &
-                                                                              &  is_restart=.true.)
+        file_is_open(n) = open_file(bc_rest_files(n), trim(dir)//rest_file_names(n), io_type, mpp_domain, &
+                                  & is_restart=.true.)
         if (file_is_open(n)) then
              call register_axis_wrapper(bc_rest_files(n), to_read=to_read)
         endif
@@ -3503,9 +3502,8 @@ contains
 
     !< Open the files
     do n = 1, num_rest_files
-        file_is_open(n) = open_file(bc_rest_files(n), trim(dir)// &
-                                                             & rest_file_names(n), io_type, mpp_domain, &
-                                                                              &  is_restart=.true.)
+        file_is_open(n) = open_file(bc_rest_files(n), trim(dir)//rest_file_names(n), io_type, mpp_domain, &
+                                  & is_restart=.true.)
         if (file_is_open(n)) then
 
              if (to_read) then

--- a/coupler/coupler_types.F90
+++ b/coupler/coupler_types.F90
@@ -111,7 +111,8 @@ module coupler_types_mod
   !> @ingroup coupler_types_mod
   type, public :: coupler_3d_bc_type
     integer                                            :: num_bcs = 0  !< The number of boundary condition fields
-    type(coupler_3d_field_type), dimension(:), pointer :: bc => NULL() !< A pointer to the array of boundary condition fields
+    type(coupler_3d_field_type), dimension(:), pointer :: bc => NULL() !< A pointer to the array of boundary
+                                                                       !! condition fields
     logical    :: set = .false.       !< If true, this type has been initialized
     integer    :: isd, isc, iec, ied  !< The i-direction data and computational domain index ranges for this type
     integer    :: jsd, jsc, jec, jed  !< The j-direction data and computational domain index ranges for this type
@@ -164,7 +165,8 @@ module coupler_types_mod
   !> @ingroup coupler_types_mod
   type, public    :: coupler_2d_bc_type
     integer                                            :: num_bcs = 0  !< The number of boundary condition fields
-    type(coupler_2d_field_type), dimension(:), pointer :: bc => NULL() !< A pointer to the array of boundary condition fields
+    type(coupler_2d_field_type), dimension(:), pointer :: bc => NULL() !< A pointer to the array of boundary
+                                                                       !! condition fields
     logical    :: set = .false.       !< If true, this type has been initialized
     integer    :: isd, isc, iec, ied  !< The i-direction data and computational domain index ranges for this type
     integer    :: jsd, jsc, jec, jed  !< The j-direction data and computational domain index ranges for this type
@@ -208,7 +210,8 @@ module coupler_types_mod
   !> @ingroup coupler_types_mod
   type, public    :: coupler_1d_bc_type
     integer                                            :: num_bcs = 0  !< The number of boundary condition fields
-    type(coupler_1d_field_type), dimension(:), pointer :: bc => NULL() !< A pointer to the array of boundary condition fields
+    type(coupler_1d_field_type), dimension(:), pointer :: bc => NULL() !< A pointer to the array of boundary
+                                                                       !! condition fields
     logical    :: set = .false.       !< If true, this type has been initialized
   end type coupler_1d_bc_type
 
@@ -379,7 +382,8 @@ contains
     integer, intent(in)                     :: ie !< upper bound of first dimension
     integer, intent(in)                     :: js !< lower bound of second dimension
     integer, intent(in)                     :: je !< upper bound of second dimension
-    character(len=*), intent(in)            :: diag_name !< name for diagnostic file--if blank, then don't register the fields
+    character(len=*), intent(in)            :: diag_name !< name for diagnostic file--if blank, then
+                                                         !! don't register the fields
     integer, dimension(:), intent(in)       :: axes !< array of axes identifiers for diagnostic variable registration
     type(time_type), intent(in)             :: time !< model time variable for registering diagnostic field
     character(len=*), intent(in), optional  :: suffix !< optional suffix to make the name identifier unique
@@ -415,7 +419,8 @@ contains
     integer, intent(in)                     :: js !< lower bound of second dimension
     integer, intent(in)                     :: je !< upper bound of second dimension
     integer, intent(in)                     :: kd !< third dimension
-    character(len=*), intent(in)            :: diag_name !< name for diagnostic file--if blank, then don't register the fields
+    character(len=*), intent(in)            :: diag_name !< name for diagnostic file--if blank, then
+                                                         !! don't register the fields
     integer, dimension(:), intent(in)       :: axes !< array of axes identifiers for diagnostic variable registration
     type(time_type), intent(in)             :: time !< model time variable for registering diagnostic field
     character(len=*), intent(in), optional  :: suffix !< optional suffix to make the name identifier unique
@@ -449,7 +454,8 @@ contains
     integer, intent(in)                     :: ie !< upper bound of first dimension
     integer, intent(in)                     :: js !< lower bound of second dimension
     integer, intent(in)                     :: je !< upper bound of second dimension
-    character(len=*), intent(in)            :: diag_name !< name for diagnostic file--if blank, then don't register the fields
+    character(len=*), intent(in)            :: diag_name !< name for diagnostic file--if blank, then
+                                                         !! don't register the fields
     integer, dimension(:), intent(in)       :: axes !< array of axes identifiers for diagnostic variable registration
     type(time_type), intent(in)             :: time !< model time variable for registering diagnostic field
     character(len=*), intent(in), optional  :: suffix !< optional suffix to make the name identifier unique
@@ -484,7 +490,8 @@ contains
     integer, intent(in)                     :: js !< lower bound of second dimension
     integer, intent(in)                     :: je !< upper bound of second dimension
     integer, intent(in)                     :: kd !< third dimension
-    character(len=*), intent(in)            :: diag_name !< name for diagnostic file--if blank, then don't register the fields
+    character(len=*), intent(in)            :: diag_name !< name for diagnostic file--if blank, then
+                                                         !! don't register the fields
     integer, dimension(:), intent(in)       :: axes !< array of axes identifiers for diagnostic variable registration
     type(time_type), intent(in)             :: time !< model time variable for registering diagnostic field
     character(len=*), intent(in), optional  :: suffix !< optional suffix to make the name identifier unique
@@ -518,7 +525,8 @@ contains
     integer, intent(in)                     :: ie !< upper bound of first dimension
     integer, intent(in)                     :: js !< lower bound of second dimension
     integer, intent(in)                     :: je !< upper bound of second dimension
-    character(len=*), intent(in)            :: diag_name !< name for diagnostic file--if blank, then don't register the fields
+    character(len=*), intent(in)            :: diag_name !< name for diagnostic file--if blank, then
+                                                         !! don't register the fields
     integer, dimension(:), intent(in)       :: axes !< array of axes identifiers for diagnostic variable registration
     type(time_type), intent(in)             :: time !< model time variable for registering diagnostic field
     character(len=*), intent(in), optional  :: suffix !< optional suffix to make the name identifier unique
@@ -553,7 +561,8 @@ contains
     integer, intent(in)                     :: js !< lower bound of second dimension
     integer, intent(in)                     :: je !< upper bound of second dimension
     integer, intent(in)                     :: kd !< third dimension
-    character(len=*), intent(in)            :: diag_name !< name for diagnostic file--if blank, then don't register the fields
+    character(len=*), intent(in)            :: diag_name !< name for diagnostic file--if blank, then
+                                                         !! don't register the fields
     integer, dimension(:), intent(in)       :: axes !< array of axes identifiers for diagnostic variable registration
     type(time_type), intent(in)             :: time !< model time variable for registering diagnostic field
     character(len=*), intent(in), optional  :: suffix !< optional suffix to make the name identifier unique
@@ -1191,8 +1200,10 @@ contains
                                                            !! that is being copied
     integer,          optional, intent(in)    :: field_index !< The index of the field in the
                                                            !! boundary condition that is being copied
-    character(len=*), optional, intent(in)    :: exclude_flux_type !< A string describing which types of fluxes to exclude from this copy.
-    character(len=*), optional, intent(in)    :: only_flux_type    !< A string describing which types of fluxes to include from this copy.
+    character(len=*), optional, intent(in)    :: exclude_flux_type !< A string describing which types
+                                                                   !! of fluxes to exclude from this copy.
+    character(len=*), optional, intent(in)    :: only_flux_type    !< A string describing which types
+                                                                   !! of fluxes to include from this copy.
     logical,          optional, intent(in)    :: pass_through_ice !< If true, only copy BCs whose
                                                            !! value of pass_through ice matches this
     logical :: copy_bc
@@ -1388,8 +1399,10 @@ contains
                                                          !! that is being copied
     integer,          optional, intent(in)    :: field_index !< The index of the field in the
                                                          !! boundary condition that is being copied
-    character(len=*), optional, intent(in)    :: exclude_flux_type !< A string describing which types of fluxes to exclude from this copy.
-    character(len=*), optional, intent(in)    :: only_flux_type    !< A string describing which types of fluxes to include from this copy.
+    character(len=*), optional, intent(in)    :: exclude_flux_type !< A string describing which types
+                                                                   !! of fluxes to exclude from this copy.
+    character(len=*), optional, intent(in)    :: only_flux_type    !< A string describing which types
+                                                                   !! of fluxes to include from this copy.
     logical,          optional, intent(in)    :: pass_through_ice !< If true, only copy BCs whose
                                                          !! value of pass_through ice matches this
     integer,          optional, intent(in)    :: ind3_start  !< The starting value of the 3rd
@@ -2133,11 +2146,13 @@ contains
     if (n2 >= n1) then
       ! A more consciencious implementation would include a more descriptive error messages.
       if ((var_in%iec-var_in%isc) /= (var%iec-var%isc))&
-          & call mpp_error(FATAL, "CT_increment_data_2d_3d: There is an i-direction computational domain size mismatch.")
+          & call mpp_error(FATAL, &
+                           &  "CT_increment_data_2d_3d: There is an i-direction computational domain size mismatch.")
       if ((var_in%jec-var_in%jsc) /= (var%jec-var%jsc))&
           & call mpp_error(FATAL, "CT_increment_data_2d_3d: There is a j-direction computational domain size mismatch.")
       if ((1+var_in%ke-var_in%ks) /= size(weights,3))&
-          & call mpp_error(FATAL, "CT_increment_data_2d_3d: There is a k-direction size mismatch with the weights array.")
+          & call mpp_error(FATAL, &
+                           &  "CT_increment_data_2d_3d: There is a k-direction size mismatch with the weights array.")
       if ((var_in%isc-var_in%isd < halo) .or. (var_in%ied-var_in%iec < halo))&
           & call mpp_error(FATAL, "CT_increment_data_2d_3d: Excessive i-direction halo size for the input structure.")
       if ((var_in%jsc-var_in%jsd < halo) .or. (var_in%jed-var_in%jec < halo))&
@@ -2154,7 +2169,8 @@ contains
       elseif ((1+var_in%ied-var_in%isd) == size(weights,1)) then
         iow = 1 + (var_in%isc - var_in%isd) - var%isc
       else
-        call mpp_error(FATAL, "CT_increment_data_2d_3d: weights array must be the i-size of a computational or data domain.")
+        call mpp_error(FATAL, &
+                       &  "CT_increment_data_2d_3d: weights array must be the i-size of a computational or data domain.")
       endif
       if ((1+var%jec-var%jsc) == size(weights,2)) then
         jow = 1 - var%jsc
@@ -2163,7 +2179,8 @@ contains
       elseif ((1+var_in%jed-var_in%jsd) == size(weights,2)) then
         jow = 1 + (var_in%jsc - var_in%jsd) - var%jsc
       else
-        call mpp_error(FATAL, "CT_increment_data_2d_3d: weights array must be the j-size of a computational or data domain.")
+        call mpp_error(FATAL, &
+                       &  "CT_increment_data_2d_3d: weights array must be the j-size of a computational or data domain.")
       endif
 
       io1 = var_in%isc - var%isc
@@ -3049,7 +3066,8 @@ contains
   !! @throw FATAL, "axes has less than 2 elements"
   subroutine CT_set_diags_2d(var, diag_name, axes, time)
     type(coupler_2d_bc_type), intent(inout) :: var  !< BC_type structure for which to register diagnostics
-    character(len=*),         intent(in)    :: diag_name !< name for diagnostic file--if blank, then don't register the fields
+    character(len=*),         intent(in)    :: diag_name !< name for diagnostic file--if blank, then
+                                                         !! don't register the fields
     integer, dimension(:),    intent(in)    :: axes !< array of axes identifiers for diagnostic variable registration
     type(time_type),          intent(in)    :: time !< model time variable for registering diagnostic field
 
@@ -3076,7 +3094,8 @@ contains
   !! @throw FATAL, "axes has less than 3 elements"
   subroutine CT_set_diags_3d(var, diag_name, axes, time)
     type(coupler_3d_bc_type), intent(inout) :: var  !< BC_type structure for which to register diagnostics
-    character(len=*),         intent(in)    :: diag_name !< name for diagnostic file--if blank, then don't register the fields
+    character(len=*),         intent(in)    :: diag_name !< name for diagnostic file--if blank, then
+                                                         !! don't register the fields
     integer, dimension(:),    intent(in)    :: axes !< array of axes identifiers for diagnostic variable registration
     type(time_type),          intent(in)    :: time !< model time variable for registering diagnostic field
 
@@ -3189,7 +3208,8 @@ contains
 
     !< Open the files
     do n = 1, num_rest_files
-        file_is_open(n) = open_file(bc_rest_files(n), trim(dir)//rest_file_names(n), io_type, mpp_domain, is_restart=.true.)
+        file_is_open(n) = open_file(bc_rest_files(n), trim(dir)// &
+                                                             & rest_file_names(n), io_type, mpp_domain, is_restart=.true.)
         if (file_is_open(n)) then
              call register_axis_wrapper(bc_rest_files(n), to_read=to_read)
         endif
@@ -3396,7 +3416,8 @@ contains
   subroutine mpp_io_CT_register_restarts_to_file_2d(var, file_name, rest_file, mpp_domain, varname_prefix)
     type(coupler_2d_bc_type), intent(inout) :: var  !< BC_type structure to be registered for restarts
     character(len=*),         intent(in)    :: file_name !< The name of the restart file
-    type(restart_file_type),  pointer       :: rest_file !< A (possibly associated) structure describing the restart file
+    type(restart_file_type),  pointer       :: rest_file !< A (possibly associated) structure describing
+                                                         !! the restart file
     type(domain2D),           intent(in)    :: mpp_domain !< The FMS domain to use for this registration call
     character(len=*), optional, intent(in)  :: varname_prefix !< A prefix for the variable name
                                                          !! in the restart file, intended to allow
@@ -3480,7 +3501,8 @@ contains
 
     !< Open the files
     do n = 1, num_rest_files
-        file_is_open(n) = open_file(bc_rest_files(n), trim(dir)//rest_file_names(n), io_type, mpp_domain, is_restart=.true.)
+        file_is_open(n) = open_file(bc_rest_files(n), trim(dir)// &
+                                                             & rest_file_names(n), io_type, mpp_domain, is_restart=.true.)
         if (file_is_open(n)) then
 
              if (to_read) then

--- a/coupler/coupler_types.F90
+++ b/coupler/coupler_types.F90
@@ -2149,7 +2149,8 @@ contains
           & call mpp_error(FATAL, &
                            &  "CT_increment_data_2d_3d: There is an i-direction computational domain size mismatch.")
       if ((var_in%jec-var_in%jsc) /= (var%jec-var%jsc))&
-          & call mpp_error(FATAL, "CT_increment_data_2d_3d: There is a j-direction computational domain size mismatch.")
+          & call mpp_error(FATAL, &
+                           &  "CT_increment_data_2d_3d: There is a j-direction computational domain size mismatch.")
       if ((1+var_in%ke-var_in%ks) /= size(weights,3))&
           & call mpp_error(FATAL, &
                            &  "CT_increment_data_2d_3d: There is a k-direction size mismatch with the weights array.")
@@ -2170,7 +2171,7 @@ contains
         iow = 1 + (var_in%isc - var_in%isd) - var%isc
       else
         call mpp_error(FATAL, &
-                       &  "CT_increment_data_2d_3d: weights array must be the i-size of a computational or data domain.")
+                   &  "CT_increment_data_2d_3d: weights array must be the i-size of a computational or data domain.")
       endif
       if ((1+var%jec-var%jsc) == size(weights,2)) then
         jow = 1 - var%jsc
@@ -2180,7 +2181,7 @@ contains
         jow = 1 + (var_in%jsc - var_in%jsd) - var%jsc
       else
         call mpp_error(FATAL, &
-                       &  "CT_increment_data_2d_3d: weights array must be the j-size of a computational or data domain.")
+                   &  "CT_increment_data_2d_3d: weights array must be the j-size of a computational or data domain.")
       endif
 
       io1 = var_in%isc - var%isc
@@ -3209,7 +3210,8 @@ contains
     !< Open the files
     do n = 1, num_rest_files
         file_is_open(n) = open_file(bc_rest_files(n), trim(dir)// &
-                                                             & rest_file_names(n), io_type, mpp_domain, is_restart=.true.)
+                                                             & rest_file_names(n), io_type, mpp_domain, &
+                                                                              &  is_restart=.true.)
         if (file_is_open(n)) then
              call register_axis_wrapper(bc_rest_files(n), to_read=to_read)
         endif
@@ -3502,7 +3504,8 @@ contains
     !< Open the files
     do n = 1, num_rest_files
         file_is_open(n) = open_file(bc_rest_files(n), trim(dir)// &
-                                                             & rest_file_names(n), io_type, mpp_domain, is_restart=.true.)
+                                                             & rest_file_names(n), io_type, mpp_domain, &
+                                                                              &  is_restart=.true.)
         if (file_is_open(n)) then
 
              if (to_read) then

--- a/coupler/ensemble_manager.F90
+++ b/coupler/ensemble_manager.F90
@@ -65,7 +65,8 @@ contains
 !> @brief Initializes @ref ensemble_manager_mod
 !!
 !> @throw FATAL, "ensemble_manager_mod: ensemble_nml variable ensemble_size must be a positive integer"
-!! @throw FATAL, "ensemble_manager_mod: ensemble_nml variable ensemble_size should be no larger than MAX_ENSEMBLE_SIZE, change ensemble_size or increase MAX_ENSEMBLE_SIZE"
+!! @throw FATAL, "ensemble_manager_mod: ensemble_nml variable ensemble_size should be no larger
+!! than MAX_ENSEMBLE_SIZE, change ensemble_size or increase MAX_ENSEMBLE_SIZE"
 !! @throw FATAL, "ensemble_size must be divis by npes"
 !! @throw FATAL, "get_ensemble_pelist: size of pelist 1st index < ensemble_size"
 !! @throw FATAL, "get_ensemble_pelist: size of pelist 2nd index < ocean_npes_pm"

--- a/data_override/data_override.F90
+++ b/data_override/data_override.F90
@@ -277,11 +277,12 @@ subroutine data_override_init(Atm_domain_in, Ocean_domain_in, Ice_domain_in, Lan
  else if(variable_exists(fileobj, "ocn_mosaic_file" ) .OR. variable_exists(fileobj, "gridfiles" ) ) then
    use_get_grid_version = 2
    if(variable_exists(fileobj, "gridfiles" ) ) then
-     if(count_ne_1((ocn_on .OR. ice_on), lnd_on, atm_on)) call mpp_error(FATAL, 'data_override_mod: the grid file ' // &
+     if(count_ne_1((ocn_on .OR. ice_on), lnd_on, atm_on)) call mpp_error(FATAL, 'data_override_mod: the grid file ' //&
           'is a solo mosaic, one and only one of atm_on, lnd_on or ice_on/ocn_on should be true')
    end if
  else
-   call mpp_error(FATAL, 'data_override_mod: none of x_T, geolon_t, ocn_mosaic_file or gridfiles exist in '//trim(grid_file))
+   call mpp_error(FATAL, 'data_override_mod: none of x_T, geolon_t, ocn_mosaic_file or gridfiles exist in '// &
+                  & trim(grid_file))
  endif
 
  if(use_get_grid_version .EQ. 1) then
@@ -377,7 +378,8 @@ subroutine read_table(data_table)
        if (record(1:1) == '#') cycle
        if (record(1:10) == '          ') cycle
        ntable=ntable+1
-       if (index(lowercase(record), "inside_region") .ne. 0 .or. index(lowercase(record), "outside_region") .ne. 0) then
+       if (index(lowercase(record), "inside_region") .ne. 0 .or. index(lowercase(record), &
+          &  "outside_region") .ne. 0) then
           if(index(lowercase(record), ".false.") .ne. 0 .or. index(lowercase(record), ".true.") .ne. 0 ) then
              ntable_lima = ntable_lima + 1
              read(record,*,err=99) data_entry%gridname, data_entry%fieldname_code, data_entry%fieldname_file, &
@@ -390,7 +392,8 @@ subroutine read_table(data_table)
           else
              ntable_new=ntable_new+1
              read(record,*,err=99) data_entry%gridname, data_entry%fieldname_code, data_entry%fieldname_file, &
-                                   data_entry%file_name, data_entry%interpol_method, data_entry%factor, region, region_type
+                                   data_entry%file_name, data_entry%interpol_method, data_entry%factor, region, &
+                                           &  region_type
              if (data_entry%interpol_method == 'default') then
                 data_entry%interpol_method = default_table%interpol_method
              endif
@@ -428,7 +431,8 @@ subroutine read_table(data_table)
              "data_override: lon_end should be greater than lon_start")
           if(data_entry%lat_end .LE. data_entry%lat_start) call mpp_error(FATAL, &
              "data_override: lat_end should be greater than lat_start")
-       else if (index(lowercase(record), ".false.") .ne. 0 .or. index(lowercase(record), ".true.") .ne. 0 ) then ! old format
+       else if (index(lowercase(record), ".false.") .ne. 0 .or. index(lowercase(record), ".true.") .ne. 0 ) then ! old
+                                                                                                              !! format
           ntable_lima = ntable_lima + 1
           read(record,*,err=99) data_entry%gridname, data_entry%fieldname_code, data_entry%fieldname_file, &
                                    data_entry%file_name, ongrid, data_entry%factor
@@ -781,7 +785,8 @@ subroutine data_override_3d(gridname,fieldname_code,data,time,override,data_inde
         use_comp_domain = .true.
         nwindows = (nxc/size(data,1))*(nyc/size(data,2))
      else
-        call mpp_error(FATAL, "data_override: data is not on data domain and compute domain is not divisible by size(data)")
+        call mpp_error(FATAL, &
+                     & "data_override: data is not on data domain and compute domain is not divisible by size(data)")
      endif
      override_array(curr_position)%window_size(1) = size(data,1)
      override_array(curr_position)%window_size(2) = size(data,2)
@@ -897,11 +902,11 @@ subroutine data_override_3d(gridname,fieldname_code,data,time,override,data_inde
            call read_data(fileobj, axis_names(2), lat_tmp)
            ! limit lon_start, lon_end are inside lon_in
            !       lat_start, lat_end are inside lat_in
-           if( data_table(index1)%lon_start < lon_tmp(1) .OR. data_table(index1)%lon_start .GT. lon_tmp(axis_sizes(1))) &
+           if(data_table(index1)%lon_start < lon_tmp(1) .OR. data_table(index1)%lon_start .GT. lon_tmp(axis_sizes(1)))&
               call mpp_error(FATAL, "data_override: lon_start is outside lon_T")
            if( data_table(index1)%lon_end < lon_tmp(1) .OR. data_table(index1)%lon_end .GT. lon_tmp(axis_sizes(1))) &
               call mpp_error(FATAL, "data_override: lon_end is outside lon_T")
-           if( data_table(index1)%lat_start < lat_tmp(1) .OR. data_table(index1)%lat_start .GT. lat_tmp(axis_sizes(2))) &
+           if(data_table(index1)%lat_start < lat_tmp(1) .OR. data_table(index1)%lat_start .GT. lat_tmp(axis_sizes(2)))&
               call mpp_error(FATAL, "data_override: lat_start is outside lat_T")
            if( data_table(index1)%lat_end < lat_tmp(1) .OR. data_table(index1)%lat_end .GT. lat_tmp(axis_sizes(2))) &
               call mpp_error(FATAL, "data_override: lat_end is outside lat_T")

--- a/data_override/data_override.F90
+++ b/data_override/data_override.F90
@@ -378,8 +378,7 @@ subroutine read_table(data_table)
        if (record(1:1) == '#') cycle
        if (record(1:10) == '          ') cycle
        ntable=ntable+1
-       if (index(lowercase(record), "inside_region") .ne. 0 .or. index(lowercase(record), &
-          &  "outside_region") .ne. 0) then
+       if(index(lowercase(record), "inside_region") .ne. 0 .or. index(lowercase(record), "outside_region") .ne. 0) then
           if(index(lowercase(record), ".false.") .ne. 0 .or. index(lowercase(record), ".true.") .ne. 0 ) then
              ntable_lima = ntable_lima + 1
              read(record,*,err=99) data_entry%gridname, data_entry%fieldname_code, data_entry%fieldname_file, &
@@ -393,7 +392,7 @@ subroutine read_table(data_table)
              ntable_new=ntable_new+1
              read(record,*,err=99) data_entry%gridname, data_entry%fieldname_code, data_entry%fieldname_file, &
                                    data_entry%file_name, data_entry%interpol_method, data_entry%factor, region, &
-                                           &  region_type
+                                 & region_type
              if (data_entry%interpol_method == 'default') then
                 data_entry%interpol_method = default_table%interpol_method
              endif
@@ -431,8 +430,8 @@ subroutine read_table(data_table)
              "data_override: lon_end should be greater than lon_start")
           if(data_entry%lat_end .LE. data_entry%lat_start) call mpp_error(FATAL, &
              "data_override: lat_end should be greater than lat_start")
-       else if (index(lowercase(record), ".false.") .ne. 0 .or. index(lowercase(record), ".true.") .ne. 0 ) then ! old
-                                                                                                              !! format
+       ! old format
+       else if (index(lowercase(record), ".false.") .ne. 0 .or. index(lowercase(record), ".true.") .ne. 0 ) then
           ntable_lima = ntable_lima + 1
           read(record,*,err=99) data_entry%gridname, data_entry%fieldname_code, data_entry%fieldname_file, &
                                    data_entry%file_name, ongrid, data_entry%factor

--- a/data_override/get_grid_version.F90
+++ b/data_override/get_grid_version.F90
@@ -64,7 +64,8 @@ endif
 end subroutine check_grid_sizes
 
 !> Get global lon and lat of three model (target) grids, with a given file name
-subroutine get_grid_version_1(grid_file, mod_name, domain, isc, iec, jsc, jec, lon, lat, min_lon, max_lon, grid_center_bug)
+subroutine get_grid_version_1(grid_file, mod_name, domain, isc, iec, jsc, jec, lon, lat, min_lon, max_lon, &
+                             &  grid_center_bug)
   character(len=*),            intent(in) :: grid_file !< name of grid file
   character(len=*),            intent(in) :: mod_name !< module name
   type(domain2d),              intent(in) :: domain !< 2D domain
@@ -244,7 +245,8 @@ subroutine get_grid_version_2(fileobj, mod_name, domain, isc, iec, jsc, jec, lon
 
      solo_mosaic_file = 'INPUT/'//trim(solo_mosaic_file)
      if(.not. open_file(mosaicfileobj, solo_mosaic_file, 'read')) then
-        call mpp_error(FATAL, 'data_override_mod(get_grid_version_2: Error in opening solo mosaic file '//trim(solo_mosaic_file))
+        call mpp_error(FATAL, 'data_override_mod(get_grid_version_2: Error in opening solo mosaic file '// &
+                       & trim(solo_mosaic_file))
      endif
      open_solo_mosaic=.true.
   else

--- a/diag_manager/diag_axis.F90
+++ b/diag_manager/diag_axis.F90
@@ -518,7 +518,8 @@ CONTAINS
              IF ( allocated(Axes(id)%attributes(i)%fatt) ) THEN
                 ALLOCATE(attributes(i)%fatt(SIZE(Axes(id)%attributes(i)%fatt(:))), STAT=istat)
                 IF ( istat .NE. 0 ) THEN
-                   CALL error_mesg('diag_axis_mod::get_diag_axis', 'Unable to allocate memory for attribute%fatt', FATAL)
+                   CALL error_mesg('diag_axis_mod::get_diag_axis', &
+                                  &  'Unable to allocate memory for attribute%fatt', FATAL)
                 END IF
                 DO j=1, SIZE(attributes(i)%fatt(:))
                    attributes(i)%fatt(j) = Axes(id)%attributes(i)%fatt(j)
@@ -528,7 +529,8 @@ CONTAINS
              IF ( allocated(Axes(id)%attributes(i)%iatt) ) THEN
                 ALLOCATE(attributes(i)%iatt(SIZE(Axes(id)%attributes(i)%iatt(:))), STAT=istat)
                 IF ( istat .NE. 0 ) THEN
-                   CALL error_mesg('diag_axis_mod::get_diag_axis', 'Unable to allocate memory for attribute%iatt', FATAL)
+                   CALL error_mesg('diag_axis_mod::get_diag_axis', &
+                                  &  'Unable to allocate memory for attribute%iatt', FATAL)
                 END IF
                 DO j=1, SIZE(attributes(i)%iatt(:))
                    attributes(i)%iatt(j) = Axes(id)%attributes(i)%iatt(j)
@@ -1083,7 +1085,8 @@ CONTAINS
           ! <ERROR STATUS="FATAL">
           !   Unable to allocate memory for diag axis attributes
           ! </ERROR>
-          IF ( fms_error_handler('diag_util_mod::attribute_init_axis', 'Unable to allocate memory for diag axis attributes', err_msg) ) THEN
+          IF ( fms_error_handler('diag_util_mod::attribute_init_axis', &
+             &  'Unable to allocate memory for diag axis attributes', err_msg) ) THEN
              RETURN
           END IF
        ELSE
@@ -1218,7 +1221,8 @@ CONTAINS
 
     associate (axis=>Axes(id))
     if (.not.allocated(axis%attributes)) call error_mesg(tag, &
-       'attempt to get compression dimensions from axis "'//trim(axis%name)//'" which is not compressed (does not have any attributes)', FATAL)
+       'attempt to get compression dimensions from axis "'//trim(axis%name)// &
+        & '" which is not compressed (does not have any attributes)', FATAL)
 
     iatt = 0
     do k = 1,axis%num_attributes

--- a/diag_manager/diag_data.F90
+++ b/diag_manager/diag_data.F90
@@ -215,8 +215,7 @@ use platform_mod
      ! coordinates of the buffer and counter are (x, y, z, time-of-day)
      REAL, allocatable, DIMENSION(:,:,:,:) :: buffer !< coordinates of the buffer and counter are (x,
                                                      !! y, z, time-of-day)
-     REAL, allocatable, DIMENSION(:,:,:,:) :: counter !< coordinates of the buffer and counter are (x,
-                                                      !! y, z, time-of-day)
+     REAL, allocatable, DIMENSION(:,:,:,:) :: counter !< coordinates of the buffer and counter are (x,y,z,time-of-day)
      ! the following two counters are used in time-averaging for some
      ! combination of the field options. Their size is the length of the
      ! diurnal axis; the counters must be tracked separately for each of
@@ -230,8 +229,7 @@ use platform_mod
      !! in each can be different, depending on time step and the number of
      !! diurnal samples.
      INTEGER, allocatable, dimension(:) :: num_elements !< the following two counters are used in time-averaging
-                                                        !! for some
-     !! combination of the field options. Their size is the length of the
+     !! for some combination of the field options. Their size is the length of the
      !! diurnal axis; the counters must be tracked separately for each of
      !! the diurnal interval, because the number of time slices accumulated
      !! in each can be different, depending on time step and the number of

--- a/diag_manager/diag_data.F90
+++ b/diag_manager/diag_data.F90
@@ -214,7 +214,8 @@ use platform_mod
      CHARACTER(len=50) :: time_method !< time method field from the input file
      ! coordinates of the buffer and counter are (x, y, z, time-of-day)
      REAL, allocatable, DIMENSION(:,:,:,:) :: buffer !< coordinates of the buffer and counter are (x, y, z, time-of-day)
-     REAL, allocatable, DIMENSION(:,:,:,:) :: counter !< coordinates of the buffer and counter are (x, y, z, time-of-day)
+     REAL, allocatable, DIMENSION(:,:,:,:) :: counter !< coordinates of the buffer and counter are (x,
+                                                      !! y, z, time-of-day)
      ! the following two counters are used in time-averaging for some
      ! combination of the field options. Their size is the length of the
      ! diurnal axis; the counters must be tracked separately for each of
@@ -227,7 +228,8 @@ use platform_mod
      !! the diurnal interval, because the number of time slices accumulated
      !! in each can be different, depending on time step and the number of
      !! diurnal samples.
-     INTEGER, allocatable, dimension(:) :: num_elements !< the following two counters are used in time-averaging for some
+     INTEGER, allocatable, dimension(:) :: num_elements !< the following two counters are used in time-averaging
+                                                        !! for some
      !! combination of the field options. Their size is the length of the
      !! diurnal axis; the counters must be tracked separately for each of
      !! the diurnal interval, because the number of time slices accumulated
@@ -298,7 +300,8 @@ use platform_mod
   INTEGER :: max_files = 31 !< Maximum number of output files allowed.  Increase via diag_manager_nml.
   INTEGER :: max_output_fields = 300 !< Maximum number of output fields.  Increase via diag_manager_nml.
   INTEGER :: max_input_fields = 600 !< Maximum number of input fields.  Increase via diag_manager_nml.
-  INTEGER :: max_out_per_in_field = 150 !< Maximum number of output_fields per input_field.  Increase via diag_manager_nml.
+  INTEGER :: max_out_per_in_field = 150 !< Maximum number of output_fields per input_field.  Increase
+                                        !! via diag_manager_nml.
   INTEGER :: max_axes = 60 !< Maximum number of independent axes.
   LOGICAL :: do_diag_field_log = .FALSE.
   LOGICAL :: write_bytes_in_file = .FALSE.
@@ -320,7 +323,8 @@ use platform_mod
                                                !! The values are defined as <TT>GLO_REG_VAL</TT>
                                                !! (-999) and <TT>GLO_REG_VAL_ALT</TT> (-1) in <TT>diag_data_mod</TT>.
 
-  INTEGER :: max_field_attributes = 4 !< Maximum number of user definable attributes per field. Liptak: Changed from 2 to 4 20170718
+  INTEGER :: max_field_attributes = 4 !< Maximum number of user definable attributes per field. Liptak:
+                                      !! Changed from 2 to 4 20170718
   INTEGER :: max_file_attributes = 2 !< Maximum number of user definable global attributes per file.
   INTEGER :: max_axis_attributes = 4 !< Maximum number of user definable attributes per axis.
   LOGICAL :: prepend_date = .TRUE. !< Should the history file have the start date prepended to the file name.
@@ -359,7 +363,8 @@ use platform_mod
   type(FmsNetcdfUnstructuredDomainFile_t),allocatable, target :: fileobjU(:)
   type(FmsNetcdfDomainFile_t),allocatable, target :: fileobj(:)
   type(FmsNetcdfFile_t),allocatable, target :: fileobjND(:)
-  character(len=2),allocatable :: fnum_for_domain(:) !< If this file number in the array is for the "unstructured" or "2d" domain
+  character(len=2),allocatable :: fnum_for_domain(:) !< If this file number in the array is for the "unstructured"
+                                                     !! or "2d" domain
 
   ! <!-- Even More Variables -->
   TYPE(time_type) :: time_zero

--- a/diag_manager/diag_data.F90
+++ b/diag_manager/diag_data.F90
@@ -213,7 +213,8 @@ use platform_mod
      INTEGER :: pow_value !< Power value to use for mean_pow(n) calculations
      CHARACTER(len=50) :: time_method !< time method field from the input file
      ! coordinates of the buffer and counter are (x, y, z, time-of-day)
-     REAL, allocatable, DIMENSION(:,:,:,:) :: buffer !< coordinates of the buffer and counter are (x, y, z, time-of-day)
+     REAL, allocatable, DIMENSION(:,:,:,:) :: buffer !< coordinates of the buffer and counter are (x,
+                                                     !! y, z, time-of-day)
      REAL, allocatable, DIMENSION(:,:,:,:) :: counter !< coordinates of the buffer and counter are (x,
                                                       !! y, z, time-of-day)
      ! the following two counters are used in time-averaging for some

--- a/diag_manager/diag_grid.F90
+++ b/diag_manager/diag_grid.F90
@@ -77,9 +77,11 @@ use platform_mod
   type, private :: diag_global_grid_type
      REAL, allocatable, DIMENSION(:,:) :: glo_lat !< The latitude values on the global grid.
      REAL, allocatable, DIMENSION(:,:) :: glo_lon !< The longitude values on the global grid.
-     REAL, allocatable, DIMENSION(:,:) :: aglo_lat !< The latitude values on the global a-grid.  Here we expect isc-1:iec+1 and
+     REAL, allocatable, DIMENSION(:,:) :: aglo_lat !< The latitude values on the global a-grid.  Here
+                                                   !! we expect isc-1:iec+1 and
                                                    !! jsc=1:jec+1 to be passed in.
-     REAL, allocatable, DIMENSION(:,:) :: aglo_lon !< The longitude values on the global a-grid.  Here we expec isc-1:iec+j and
+     REAL, allocatable, DIMENSION(:,:) :: aglo_lon !< The longitude values on the global a-grid.  Here
+                                                   !! we expec isc-1:iec+j and
                                                    !! jsc-1:jec+1 to be passed in.
      INTEGER :: myXbegin !< The starting index of the compute domain on the current PE.
      INTEGER :: myYbegin !< The starting index of the compute domain on the current PE.

--- a/diag_manager/diag_manager.F90
+++ b/diag_manager/diag_manager.F90
@@ -2254,7 +2254,7 @@ CONTAINS
                                   i1 = i-l_start(1)-hi+1
                                   j1 =  j-l_start(2)-hj+1
                                   IF ( pow_value /= 1 ) THEN
-                                     output_fields(out_num)%buffer(i1,j1,:,sample)= & 
+                                     output_fields(out_num)%buffer(i1,j1,:,sample)= &
                                           & output_fields(out_num)%buffer(i1,j1,:,sample)+ &
                                           & (field(i-is+1+hi,j-js+1+hj,l_start(3):l_end(3))*weight1)**(pow_value)
                                   ELSE
@@ -2566,7 +2566,7 @@ CONTAINS
                       IF( numthreads > 1 .AND. phys_window ) then
                          DO j = js, je
                             DO i = is, ie
-                               IF ( l_start(1)+hi <= i .AND. i <= l_end(1)+hi .AND. l_start(2)+hj <= j .AND. & 
+                               IF ( l_start(1)+hi <= i .AND. i <= l_end(1)+hi .AND. l_start(2)+hj <= j .AND. &
                                   & j <= l_end(2)+hj ) THEN
                                   i1 = i-l_start(1)-hi+1
                                   j1=  j-l_start(2)-hj+1
@@ -2972,7 +2972,7 @@ CONTAINS
                    k1 = k - l_start(3) + 1
                    DO j = js, je
                       DO i = is, ie
-                         IF ( l_start(1)+hi <= i .AND. i <= l_end(1)+hi .AND. l_start(2)+hj <= j .AND. & 
+                         IF ( l_start(1)+hi <= i .AND. i <= l_end(1)+hi .AND. l_start(2)+hj <= j .AND. &
                             & j <= l_end(2)+hj ) THEN
                             i1 = i-l_start(1)-hi+1
                             j1 =  j-l_start(2)-hj+1

--- a/diag_manager/diag_manager.F90
+++ b/diag_manager/diag_manager.F90
@@ -3669,7 +3669,7 @@ CONTAINS
        err_msg_local = ''
        WRITE (err_msg_local,'(ES8.1E2)') CMOR_MISSING_VALUE
        CALL error_mesg('diag_manager_mod::diag_manager_init', 'Using CMOR missing value ('//TRIM(err_msg_local)// &
-        & ').', NOTE)
+            & ').', NOTE)
     END IF
 
     ! How to handle Out of Range Warnings.

--- a/diag_manager/diag_manager.F90
+++ b/diag_manager/diag_manager.F90
@@ -92,7 +92,8 @@
 !!          </UL>
 !!          The 'file duration', if absent, will be equal to frequency for creating a new file.
 !!
-!!          Thus, the above means: create a new file every 10 days, each file will last 6 hours from creation time, no files will
+!!          Thus, the above means: create a new file every 10 days, each file will last 6 hours
+!!          from creation time, no files will
 !!          be created before time "1 1 7 0 0 0".
 !!
 !!          In this example the string
@@ -105,22 +106,29 @@
 !!     <LI> New time axis for time averaged fields.  Users can use a namelist option to handle the time value written
 !!          to time axis for time averaged fields.
 !!
-!!          If <TT>mix_snapshot_average_fields=.true.</TT> then a time averaged file will have time values corresponding to
-!!          ending time_bound e.g. January monthly average is labeled Feb01. Users can have both snapshot and averaged fields in
+!!          If <TT>mix_snapshot_average_fields=.true.</TT> then a time averaged file will have
+!!          time values corresponding to
+!!          ending time_bound e.g. January monthly average is labeled Feb01. Users can have
+!!          both snapshot and averaged fields in
 !!          one file.
 !!
-!!          If <TT>mix_snapshot_average_fields=.false.</TT> The time value written to time axis for time averaged fields is the
+!!          If <TT>mix_snapshot_average_fields=.false.</TT> The time value written to time
+!!          axis for time averaged fields is the
 !!          middle on the averaging time. For example, January monthly mean will be written at Jan 16 not Feb 01 as
-!!          before. However, to use this new feature users should <B>separate</B> snapshot fields and time averaged fields in
+!!          before. However, to use this new feature users should <B>separate</B> snapshot
+!!          fields and time averaged fields in
 !!          <B>different</B> files or a fatal error will occur.
 !!
 !!          The namelist <B>default</B> value is <TT>mix_snapshot_average_fields=.false.</TT></LI>
-!!     <LI> Time average, Root Mean Square, Max and Min, and diurnal. In addition to time average users can also get then Root Mean Square, Max or Min value
+!!     <LI> Time average, Root Mean Square, Max and Min, and diurnal. In addition to time average
+!!     users can also get then Root Mean Square, Max or Min value
 !!          during the same interval of time as time average. For this purpose, in the diag table users must replace
-!!          <TT>.true.</TT> or <TT>.false.</TT> by <TT>rms</TT>, <TT>max</TT> or <TT>min</TT>.  <B><I>Note:</I></B> Currently, max
+!!          <TT>.true.</TT> or <TT>.false.</TT> by <TT>rms</TT>, <TT>max</TT> or <TT>min</TT>.
+!!           <B><I>Note:</I></B> Currently, max
 !!          and min are not available for regional output.
 !!
-!!          A diurnal average or the average of an integer power can also be requested using <TT>diurnal##</TT> or <TT>pow##</TT> where
+!!          A diurnal average or the average of an integer power can also be requested using
+!!          <TT>diurnal##</TT> or <TT>pow##</TT> where
 !!          <TT>##</TT> are the number of diurnal sections or integer power to average.</LI>
 !!     <LI> <TT>standard_name</TT> is added as optional argument in @ref register_diag_field. </LI>
 !!     <LI>When namelist variable <TT>debug_diag_manager = .true.</TT> array
@@ -164,12 +172,15 @@ use platform_mod
   !     CMOR standard value of -1.0e20.
   !   </DATA>
   !   <DATA NAME="issue_oor_warnings" TYPE="LOGICAL" DEFAULT=".TRUE.">
-  !     If <TT>.TRUE.</TT>, then the <TT>diag_manager</TT> will check for values outside the valid range.  This range is defined in
-  !     the model, and passed to the <TT>diag_manager_mod</TT> via the OPTIONAL variable range in the <TT>register_diag_field</TT>
+  !     If <TT>.TRUE.</TT>, then the <TT>diag_manager</TT> will check for values outside the
+  !     valid range.  This range is defined in
+  !     the model, and passed to the <TT>diag_manager_mod</TT> via the OPTIONAL variable range
+  !     in the <TT>register_diag_field</TT>
   !     function.
   !   </DATA>
   !   <DATA NAME="oor_warnings_fatal" TYPE="LOGICAL" DEFAULT=".FALSE.">
-  !     If <TT>.TRUE.</TT> then <TT>diag_manager_mod</TT> will issue a <TT>FATAL</TT> error if any values for the output field are
+  !     If <TT>.TRUE.</TT> then <TT>diag_manager_mod</TT> will issue a <TT>FATAL</TT> error
+  !     if any values for the output field are
   !     outside the given range.
   !   </DATA>
   !   <DATA NAME="max_field_attributes" TYPE="INTEGER" DEFAULT="4">
@@ -179,13 +190,16 @@ use platform_mod
   !     Maximum number of user definable global attributes per file.
   !   </DATA>
   !   <DATA NAME="prepend_date" TYPE="LOGICAL" DEFAULT=".TRUE.">
-  !     If <TT>.TRUE.</TT> then prepend the file start date to the output file.  <TT>.TRUE.</TT> is only supported if the
-  !      diag_manager_init routine is called with the optional time_init parameter.  Note: This was usually done by FRE after the
+  !     If <TT>.TRUE.</TT> then prepend the file start date to the output file.  <TT>.TRUE.</TT>
+  !     is only supported if the
+  !      diag_manager_init routine is called with the optional time_init parameter.  Note:
+  !      This was usually done by FRE after the
   !     model run.
   !   </DATA>
   !   <DATA NAME="region_out_use_alt_value" TYPE="LOGICAL" DEFAULT=".TRUE.">
   !     Will determine which value to use when checking a regional output if the region is the full axis or a sub-axis.
-  !     The values are defined as <TT>GLO_REG_VAL</TT> (-999) and <TT>GLO_REG_VAL_ALT</TT> (-1) in <TT>diag_data_mod</TT>.
+  !     The values are defined as <TT>GLO_REG_VAL</TT> (-999) and <TT>GLO_REG_VAL_ALT</TT>
+  !     (-1) in <TT>diag_data_mod</TT>.
   !   </DATA>
   !   <DATA NAME="use_mpp_io" TYPE="LOGICAL" DEFAULT=".false.">
   !    Set to true, diag_manager uses mpp_io.  Default is fms2_io.
@@ -1137,8 +1151,8 @@ CONTAINS
     IF ( PRESENT(volume) ) THEN
        IF ( volume.LE.0 ) THEN
           IF ( fms_error_handler('diag_manager_mod::init_field_cell_measure',&
-               & 'VOLUME field not in diag_table for field '//TRIM(input_fields(output_field%input_field)%module_name)//&
-               & '/'//TRIM(input_fields(output_field%input_field)%field_name), err_msg) ) RETURN
+              & 'VOLUME field not in diag_table for field '//TRIM(input_fields(output_field%input_field)%module_name)//&
+              & '/'//TRIM(input_fields(output_field%input_field)%field_name), err_msg) ) RETURN
        END IF
     END IF
 
@@ -1488,7 +1502,7 @@ CONTAINS
 
     IF ( PRESENT(rmask) ) WHERE ( rmask < 0.5 ) mask_out = .FALSE.
     IF ( PRESENT(mask) .OR. PRESENT(rmask) ) THEN
-       send_data_3d_r8 = send_data_3d(diag_field_id, field_out, time, is_in=is_in, js_in=js_in, ks_in=ks_in, mask=mask_out,&
+       send_data_3d_r8 = send_data_3d(diag_field_id,field_out,time,is_in=is_in, js_in=js_in,ks_in=ks_in,mask=mask_out,&
             & ie_in=ie_in, je_in=je_in, ke_in=ke_in, weight=weight, err_msg=err_msg)
     ELSE
        send_data_3d_r8 = send_data_3d(diag_field_id, field_out, time, is_in=is_in, js_in=js_in, ks_in=ks_in,&
@@ -1637,14 +1651,16 @@ CONTAINS
     IF ( PRESENT(ke_in) ) ke = ke_in
     twohi = n1-(ie-is+1)
     IF ( MOD(twohi,2) /= 0 ) THEN
-       IF ( fms_error_handler('diag_manager_mod::send_data_3d', 'non-symmetric halos in first dimension', err_msg) ) THEN
+       IF ( fms_error_handler('diag_manager_mod::send_data_3d', 'non-symmetric halos in first dimension', &
+          &  err_msg) ) THEN
           DEALLOCATE(oor_mask)
           RETURN
        END IF
     END IF
     twohj = n2-(je-js+1)
     IF ( MOD(twohj,2) /= 0 ) THEN
-       IF ( fms_error_handler('diag_manager_mod::send_data_3d', 'non-symmetric halos in second dimension', err_msg) ) THEN
+       IF ( fms_error_handler('diag_manager_mod::send_data_3d', 'non-symmetric halos in second dimension', &
+          &  err_msg) ) THEN
           DEALLOCATE(oor_mask)
           RETURN
        END IF
@@ -1787,7 +1803,8 @@ CONTAINS
        sample = 1
        IF ( PRESENT(time) ) THEN
           CALL get_time(time,second,day,tick) ! current date
-          sample = floor((second+real(tick)/get_ticks_per_second())*output_fields(out_num)%n_diurnal_samples/SECONDS_PER_DAY) + 1
+          sample = floor( (second+real(tick)/get_ticks_per_second()) &
+                       & * output_fields(out_num)%n_diurnal_samples/SECONDS_PER_DAY) + 1
        END IF
 
        ! Get the vertical layer start and end index.
@@ -1845,8 +1862,8 @@ CONTAINS
                       WRITE (error_string,'(a,"/",a)')&
                            & TRIM(input_fields(diag_field_id)%module_name), &
                            & TRIM(output_fields(out_num)%output_name)
-                      IF ( fms_error_handler('diag_manager_mod::send_data_3d', 'module/output_field '//TRIM(error_string)//&
-                           & ' is skipped one time level in output data', err_msg)) THEN
+                      IF ( fms_error_handler('diag_manager_mod::send_data_3d', 'module/output_field '//&
+                           & TRIM(error_string)//' is skipped one time level in output data', err_msg)) THEN
                          DEALLOCATE(oor_mask)
                          RETURN
                       END IF
@@ -1856,8 +1873,8 @@ CONTAINS
                 status = writing_field(out_num, .FALSE., error_string, time)
                 IF(status == -1) THEN
                    IF ( mpp_pe() .EQ. mpp_root_pe() ) THEN
-                      IF(fms_error_handler('diag_manager_mod::send_data_3d','module/output_field '//TRIM(error_string)//&
-                           & ', write EMPTY buffer', err_msg)) THEN
+                      IF(fms_error_handler('diag_manager_mod::send_data_3d','module/output_field '//TRIM(error_string)&
+                           & //', write EMPTY buffer', err_msg)) THEN
                          DEALLOCATE(oor_mask)
                          RETURN
                       END IF
@@ -1999,7 +2016,7 @@ CONTAINS
                    WRITE (error_string,'(a,"/",a)')&
                         & TRIM(input_fields(diag_field_id)%module_name), &
                         & TRIM(output_fields(out_num)%output_name)
-                   IF ( fms_error_handler('diag_manager_mod::send_data_3d', 'module/output_field '//TRIM(error_string)//&
+                   IF (fms_error_handler('diag_manager_mod::send_data_3d', 'module/output_field '//TRIM(error_string)//&
                         & ', variable mask but no missing value defined', err_msg)) THEN
                       DEALLOCATE(oor_mask)
                       RETURN
@@ -2024,7 +2041,8 @@ CONTAINS
                             k1 = k-l_start(3)+1
                             DO j = js, je
                                DO i = is, ie
-                                  IF ( l_start(1)+hi <= i .AND. i <= l_end(1)+hi .AND. l_start(2)+hj <= j .AND. j <= l_end(2)+hj ) THEN
+                                  IF ( l_start(1)+hi <= i .AND. i <= l_end(1)+hi .AND. l_start(2)+hj <= j .AND. &
+                                     & j <= l_end(2)+hj ) THEN
                                      i1 = i-l_start(1)-hi+1
                                      j1=  j-l_start(2)-hj+1
                                      IF ( mask(i-is+1+hi, j-js+1+hj, k) ) THEN
@@ -2050,7 +2068,8 @@ CONTAINS
                             k1 = k-l_start(3)+1
                             DO j = js, je
                                DO i = is, ie
-                                  IF ( l_start(1)+hi <= i .AND. i <= l_end(1)+hi .AND. l_start(2)+hj <= j .AND. j <= l_end(2)+hj ) THEN
+                                  IF ( l_start(1)+hi <= i .AND. i <= l_end(1)+hi .AND. l_start(2)+hj <= j .AND. &
+                                     & j <= l_end(2)+hj ) THEN
                                      i1 = i-l_start(1)-hi+1
                                      j1=  j-l_start(2)-hj+1
                                      IF ( mask(i-is+1+hi, j-js+1+hj, k) ) THEN
@@ -2075,7 +2094,8 @@ CONTAINS
 !$OMP CRITICAL
                       DO j = js, je
                          DO i = is, ie
-                            IF ( l_start(1)+hi <= i .AND. i <= l_end(1)+hi .AND. l_start(2)+hj <= j .AND. j <= l_end(2)+hj ) THEN
+                            IF ( l_start(1)+hi <= i .AND. i <= l_end(1)+hi .AND. l_start(2)+hj <= j .AND. &
+                               & j <= l_end(2)+hj ) THEN
                                output_fields(out_num)%num_elements(sample) = &
                                     output_fields(out_num)%num_elements(sample) + l_end(3) - l_start(3) + 1
                             END IF
@@ -2211,14 +2231,17 @@ CONTAINS
                       IF (numthreads>1 .AND. phys_window) then
                          DO j = js, je
                             DO i = is, ie
-                               IF ( l_start(1)+hi <= i .AND. i <= l_end(1)+hi .AND. l_start(2)+hj <= j .AND. j <= l_end(2)+hj ) THEN
+                               IF ( l_start(1)+hi <= i .AND. i <= l_end(1)+hi .AND. l_start(2)+hj <= j .AND. &
+                                  & j <= l_end(2)+hj ) THEN
                                   i1 = i-l_start(1)-hi+1
                                   j1 =  j-l_start(2)-hj+1
                                   IF ( pow_value /= 1 ) THEN
-                                     output_fields(out_num)%buffer(i1,j1,:,sample)= output_fields(out_num)%buffer(i1,j1,:,sample)+ &
+                                     output_fields(out_num)%buffer(i1,j1,:,sample)= &
+                                          & output_fields(out_num)%buffer(i1,j1,:,sample)+ &
                                           & (field(i-is+1+hi,j-js+1+hj,l_start(3):l_end(3))*weight1)**(pow_value)
                                   ELSE
-                                     output_fields(out_num)%buffer(i1,j1,:,sample)= output_fields(out_num)%buffer(i1,j1,:,sample)+ &
+                                     output_fields(out_num)%buffer(i1,j1,:,sample)= &
+                                          & output_fields(out_num)%buffer(i1,j1,:,sample)+ &
                                           & field(i-is+1+hi,j-js+1+hj,l_start(3):l_end(3))*weight1
                                END IF
                                END IF
@@ -2228,14 +2251,17 @@ CONTAINS
 !$OMP CRITICAL
                          DO j = js, je
                             DO i = is, ie
-                               IF ( l_start(1)+hi <= i .AND. i <= l_end(1)+hi .AND. l_start(2)+hj <= j .AND. j <= l_end(2)+hj ) THEN
+                               IF ( l_start(1)+hi <= i .AND. i <= l_end(1)+hi .AND. l_start(2)+hj <= j .AND. &
+                                  & j <= l_end(2)+hj ) THEN
                                   i1 = i-l_start(1)-hi+1
                                   j1 =  j-l_start(2)-hj+1
                                   IF ( pow_value /= 1 ) THEN
-                                     output_fields(out_num)%buffer(i1,j1,:,sample)= output_fields(out_num)%buffer(i1,j1,:,sample)+ &
+                                     output_fields(out_num)%buffer(i1,j1,:,sample)= & 
+                                          & output_fields(out_num)%buffer(i1,j1,:,sample)+ &
                                           & (field(i-is+1+hi,j-js+1+hj,l_start(3):l_end(3))*weight1)**(pow_value)
                                   ELSE
-                                     output_fields(out_num)%buffer(i1,j1,:,sample)= output_fields(out_num)%buffer(i1,j1,:,sample)+ &
+                                     output_fields(out_num)%buffer(i1,j1,:,sample)= &
+                                          & output_fields(out_num)%buffer(i1,j1,:,sample)+ &
                                           & field(i-is+1+hi,j-js+1+hj,l_start(3):l_end(3))*weight1
                                END IF
                                END IF
@@ -2246,7 +2272,8 @@ CONTAINS
 !$OMP CRITICAL
                       DO j = js, je
                          DO i = is, ie
-                            IF ( l_start(1)+hi <= i .AND. i <= l_end(1)+hi .AND. l_start(2)+hj <= j .AND. j <= l_end(2)+hj ) THEN
+                            IF ( l_start(1)+hi <= i .AND. i <= l_end(1)+hi .AND. l_start(2)+hj <= j .AND. &
+                               & j <= l_end(2)+hj ) THEN
                                output_fields(out_num)%num_elements(sample)=&
                                     & output_fields(out_num)%num_elements(sample)+l_end(3)-l_start(3)+1
 
@@ -2330,7 +2357,8 @@ CONTAINS
                             k1 = k - l_start(3) + 1
                             DO j = js, je
                                DO i = is, ie
-                                  IF ( l_start(1)+hi <= i .AND. i <= l_end(1)+hi .AND. l_start(2)+hj <= j .AND. j <= l_end(2)+hj) THEN
+                                  IF ( l_start(1)+hi <= i .AND. i <= l_end(1)+hi .AND. l_start(2)+hj <= j .AND. &
+                                     & j <= l_end(2)+hj) THEN
                                      i1 = i-l_start(1)-hi+1
                                      j1=  j-l_start(2)-hj+1
                                      IF ( field(i-is+1+hi,j-js+1+hj,k) /= missvalue ) THEN
@@ -2356,7 +2384,8 @@ CONTAINS
                             k1 = k - l_start(3) + 1
                             DO j = js, je
                                DO i = is, ie
-                                  IF ( l_start(1)+hi <= i .AND. i <= l_end(1)+hi .AND. l_start(2)+hj <= j .AND. j <= l_end(2)+hj) THEN
+                                  IF ( l_start(1)+hi <= i .AND. i <= l_end(1)+hi .AND. l_start(2)+hj <= j .AND. &
+                                     & j <= l_end(2)+hj) THEN
                                      i1 = i-l_start(1)-hi+1
                                      j1=  j-l_start(2)-hj+1
                                      IF ( field(i-is+1+hi,j-js+1+hj,k) /= missvalue ) THEN
@@ -2381,7 +2410,8 @@ CONTAINS
 !$OMP CRITICAL
                       DO j = js, je
                          DO i = is, ie
-                            IF ( l_start(1)+hi <= i .AND. i <= l_end(1)+hi .AND. l_start(2)+hj <= j .AND. j <= l_end(2)+hj) THEN
+                            IF ( l_start(1)+hi <= i .AND. i <= l_end(1)+hi .AND. l_start(2)+hj <= j .AND. &
+                               & j <= l_end(2)+hj) THEN
                                output_fields(out_num)%num_elements(sample) =&
                                     & output_fields(out_num)%num_elements(sample) + l_end(3) - l_start(3) + 1
                             END IF
@@ -2392,7 +2422,8 @@ CONTAINS
                             DO j=l_start(2)+hj, l_end(2)+hj
                                DO i=l_start(1)+hi, l_end(1)+hi
                                   IF ( field(i,j,k) /= missvalue ) THEN
-                                     output_fields(out_num)%count_0d(sample) = output_fields(out_num)%count_0d(sample) + weight1
+                                     output_fields(out_num)%count_0d(sample) = output_fields(out_num)%count_0d(sample) &
+                                                                             & + weight1
                                      EXIT outer0
                                   END IF
                                END DO
@@ -2456,7 +2487,8 @@ CONTAINS
                          DO j=f3, f4
                             DO i=f1, f2
                                IF ( field(i,j,k) /= missvalue ) THEN
-                                  output_fields(out_num)%count_0d(sample) = output_fields(out_num)%count_0d(sample) + weight1
+                                  output_fields(out_num)%count_0d(sample) = output_fields(out_num)%count_0d(sample) &
+                                                                          & + weight1
                                   EXIT outer3
                                END IF
                             END DO
@@ -2522,7 +2554,8 @@ CONTAINS
                          DO j=f3, f4
                             DO i=f1, f2
                                IF ( field(i,j,k) /= missvalue ) THEN
-                                  output_fields(out_num)%count_0d(sample) = output_fields(out_num)%count_0d(sample) + weight1
+                                  output_fields(out_num)%count_0d(sample) = output_fields(out_num)%count_0d(sample) &
+                                                                          & + weight1
                                   EXIT outer1
                                END IF
                             END DO
@@ -2535,14 +2568,17 @@ CONTAINS
                       IF( numthreads > 1 .AND. phys_window ) then
                          DO j = js, je
                             DO i = is, ie
-                               IF ( l_start(1)+hi <= i .AND. i <= l_end(1)+hi .AND. l_start(2)+hj <= j .AND. j <= l_end(2)+hj ) THEN
+                               IF ( l_start(1)+hi <= i .AND. i <= l_end(1)+hi .AND. l_start(2)+hj <= j .AND. & 
+                                  & j <= l_end(2)+hj ) THEN
                                   i1 = i-l_start(1)-hi+1
                                   j1=  j-l_start(2)-hj+1
                                   IF ( pow_value /= 1 ) THEN
-                                     output_fields(out_num)%buffer(i1,j1,:,sample)= output_fields(out_num)%buffer(i1,j1,:,sample) +&
+                                     output_fields(out_num)%buffer(i1,j1,:,sample)= &
+                                          & output_fields(out_num)%buffer(i1,j1,:,sample) +&
                                           & (field(i-is+1+hi,j-js+1+hj,l_start(3):l_end(3))*weight1)**(pow_value)
                                   ELSE
-                                     output_fields(out_num)%buffer(i1,j1,:,sample)= output_fields(out_num)%buffer(i1,j1,:,sample) +&
+                                     output_fields(out_num)%buffer(i1,j1,:,sample)= &
+                                          & output_fields(out_num)%buffer(i1,j1,:,sample) +&
                                           & field(i-is+1+hi,j-js+1+hj,l_start(3):l_end(3))*weight1
                                END IF
                                END IF
@@ -2552,14 +2588,17 @@ CONTAINS
 !$OMP CRITICAL
                          DO j = js, je
                             DO i = is, ie
-                               IF ( l_start(1)+hi <= i .AND. i <= l_end(1)+hi .AND. l_start(2)+hj <= j .AND. j <= l_end(2)+hj ) THEN
+                               IF ( l_start(1)+hi <= i .AND. i <= l_end(1)+hi .AND. l_start(2)+hj <= j .AND. &
+                                  & j <= l_end(2)+hj ) THEN
                                   i1 = i-l_start(1)-hi+1
                                   j1=  j-l_start(2)-hj+1
                                   IF ( pow_value /= 1 ) THEN
-                                     output_fields(out_num)%buffer(i1,j1,:,sample)= output_fields(out_num)%buffer(i1,j1,:,sample) +&
+                                     output_fields(out_num)%buffer(i1,j1,:,sample)= &
+                                          & output_fields(out_num)%buffer(i1,j1,:,sample) +&
                                           & (field(i-is+1+hi,j-js+1+hj,l_start(3):l_end(3))*weight1)**(pow_value)
                                   ELSE
-                                     output_fields(out_num)%buffer(i1,j1,:,sample)= output_fields(out_num)%buffer(i1,j1,:,sample) +&
+                                     output_fields(out_num)%buffer(i1,j1,:,sample)= &
+                                          & output_fields(out_num)%buffer(i1,j1,:,sample) +&
                                           & field(i-is+1+hi,j-js+1+hj,l_start(3):l_end(3))*weight1
                                END IF
                                END IF
@@ -2571,7 +2610,8 @@ CONTAINS
 !$OMP CRITICAL
                       DO j = js, je
                          DO i = is, ie
-                            IF ( l_start(1)+hi <= i .AND. i <= l_end(1)+hi .AND. l_start(2)+hj <= j .AND. j <= l_end(2)+hj ) THEN
+                            IF ( l_start(1)+hi <= i .AND. i <= l_end(1)+hi .AND. l_start(2)+hj <= j .AND. &
+                               & j <= l_end(2)+hj ) THEN
                                output_fields(out_num)%num_elements(sample) =&
                                     & output_fields(out_num)%num_elements(sample)+l_end(3)-l_start(3)+1
                             END IF
@@ -2663,7 +2703,8 @@ CONTAINS
                    k1 = k - l_start(3) + 1
                    DO j = js, je
                       DO i = is, ie
-                         IF ( l_start(1)+hi <= i .AND. i <= l_end(1)+hi .AND. l_start(2)+hj <= j .AND. j <= l_end(2)+hj ) THEN
+                         IF ( l_start(1)+hi <= i .AND. i <= l_end(1)+hi .AND. l_start(2)+hj <= j .AND. &
+                            & j <= l_end(2)+hj ) THEN
                             i1 = i-l_start(1)-hi+1
                             j1=  j-l_start(2)-hj+1
                             IF ( mask(i-is+1+hi,j-js+1+hj,k) .AND.&
@@ -2702,7 +2743,8 @@ CONTAINS
                    k1 = k - l_start(3) + 1
                    DO j = js, je
                       DO i = is, ie
-                         IF(l_start(1)+hi <= i .AND. i <= l_end(1)+hi .AND. l_start(2)+hj <= j .AND. j <= l_end(2)+hj ) THEN
+                         IF(l_start(1)+hi <= i .AND. i <= l_end(1)+hi .AND. l_start(2)+hj <= j .AND. &
+                          & j <= l_end(2)+hj ) THEN
                             i1 = i-l_start(1)-hi+1
                             j1 =  j-l_start(2)-hj+1
                             IF ( field(i-is+1+hi,j-js+1+hj,k) > output_fields(out_num)%buffer(i1,j1,k1,sample) ) THEN
@@ -2729,7 +2771,7 @@ CONTAINS
                       END IF
                    END IF
                 END IF
-                WHERE ( field(f1:f2,f3:f4,ks:ke) > output_fields(out_num)%buffer(is-hi:ie-hi,js-hj:je-hj,ks:ke,sample) ) &
+                WHERE ( field(f1:f2,f3:f4,ks:ke) > output_fields(out_num)%buffer(is-hi:ie-hi,js-hj:je-hj,ks:ke,sample))&
                      & output_fields(out_num)%buffer(is-hi:ie-hi,js-hj:je-hj,ks:ke,sample) = field(f1:f2,f3:f4,ks:ke)
              END IF
           END IF
@@ -2741,7 +2783,8 @@ CONTAINS
                    k1 = k - l_start(3) + 1
                    DO j = js, je
                       DO i = is, ie
-                         IF ( l_start(1)+hi <= i .AND. i <= l_end(1)+hi .AND. l_start(2)+hj <= j .AND. j <= l_end(2)+hj ) THEN
+                         IF ( l_start(1)+hi <= i .AND. i <= l_end(1)+hi .AND. l_start(2)+hj <= j .AND. &
+                            & j <= l_end(2)+hj ) THEN
                             i1 = i-l_start(1)-hi+1
                             j1 =  j-l_start(2)-hj+1
                             IF ( mask(i-is+1+hi,j-js+1+hj,k) .AND.&
@@ -2771,7 +2814,7 @@ CONTAINS
                    END IF
                 END IF
                 WHERE ( mask(f1:f2,f3:f4,ks:ke) .AND.&
-                     & field(f1:f2,f3:f4,ks:ke) < output_fields(out_num)%buffer(is-hi:ie-hi,js-hj:je-hj,ks:ke,sample) ) &
+                     & field(f1:f2,f3:f4,ks:ke) < output_fields(out_num)%buffer(is-hi:ie-hi,js-hj:je-hj,ks:ke,sample)) &
                      & output_fields(out_num)%buffer(is-hi:ie-hi,js-hj:je-hj,ks:ke,sample) = field(f1:f2,f3:f4,ks:ke)
              END IF
           ELSE
@@ -2807,7 +2850,7 @@ CONTAINS
                       END IF
                    END IF
                 END IF
-                WHERE ( field(f1:f2,f3:f4,ks:ke) < output_fields(out_num)%buffer(is-hi:ie-hi,js-hj:je-hj,ks:ke,sample) )&
+                WHERE ( field(f1:f2,f3:f4,ks:ke) < output_fields(out_num)%buffer(is-hi:ie-hi,js-hj:je-hj,ks:ke,sample))&
                      & output_fields(out_num)%buffer(is-hi:ie-hi,js-hj:je-hj,ks:ke,sample) = field(f1:f2,f3:f4,ks:ke)
              END IF
           END IF
@@ -2819,7 +2862,8 @@ CONTAINS
                    k1 = k - l_start(3) + 1
                    DO j = js, je
                       DO i = is, ie
-                         IF ( l_start(1)+hi <= i .AND. i <= l_end(1)+hi .AND. l_start(2)+hj <= j .AND. j <= l_end(2)+hj ) THEN
+                         IF ( l_start(1)+hi <= i .AND. i <= l_end(1)+hi .AND. l_start(2)+hj <= j .AND. &
+                            & j <= l_end(2)+hj ) THEN
                             i1 = i-l_start(1)-hi+1
                             j1 =  j-l_start(2)-hj+1
                             IF ( mask(i-is+1+hi,j-js+1+hj,k) ) THEN
@@ -2930,7 +2974,8 @@ CONTAINS
                    k1 = k - l_start(3) + 1
                    DO j = js, je
                       DO i = is, ie
-                         IF ( l_start(1)+hi <= i .AND. i <= l_end(1)+hi .AND. l_start(2)+hj <= j .AND. j <= l_end(2)+hj ) THEN
+                         IF ( l_start(1)+hi <= i .AND. i <= l_end(1)+hi .AND. l_start(2)+hj <= j .AND. & 
+                            & j <= l_end(2)+hj ) THEN
                             i1 = i-l_start(1)-hi+1
                             j1 =  j-l_start(2)-hj+1
                             IF ( .NOT.mask(i-is+1+hi,j-js+1+hj,k) )&
@@ -2981,7 +3026,8 @@ CONTAINS
                 k1 = k - l_start(3) + 1
                 DO j = js, je
                    DO i = is, ie
-                      IF ( l_start(1)+hi <= i .AND. i <= l_end(1)+hi .AND. l_start(2)+hj <= j .AND. j <= l_end(2)+hj ) THEN
+                      IF ( l_start(1)+hi <= i .AND. i <= l_end(1)+hi .AND. l_start(2)+hj <= j .AND. &
+                         & j <= l_end(2)+hj ) THEN
                          i1 = i-l_start(1)-hi+1
                          j1 =  j-l_start(2)-hj+1
                          IF ( rmask(i-is+1+hi,j-js+1+hj,k) < 0.5 ) &
@@ -3110,7 +3156,8 @@ CONTAINS
   LOGICAL FUNCTION send_tile_averaged_data3d( id, field, area, time, mask )
     INTEGER, INTENT(in) :: id !< id of the diagnostic field
     REAL, DIMENSION(:,:,:,:), INTENT(in) :: field !< (lon, lat, tile, lev) field to average and send
-    REAL, DIMENSION(:,:,:), INTENT(in) :: area (:,:,:) !< (lon, lat, tile) tile areas ( == averaging weights), arbitrary units
+    REAL, DIMENSION(:,:,:), INTENT(in) :: area (:,:,:) !< (lon, lat, tile) tile areas ( == averaging
+                                                       !! weights), arbitrary units
     TYPE(time_type), INTENT(in)  :: time !< current time
     LOGICAL, DIMENSION(:,:,:), INTENT(in), OPTIONAL :: mask !< (lon, lat, tile) land mask
 
@@ -3434,8 +3481,8 @@ CONTAINS
              status = writing_field(out_num, .FALSE., error_string, next_time)
              IF ( status == -1 ) THEN
                 IF ( mpp_pe() .EQ. mpp_root_pe() ) THEN
-                   IF(fms_error_handler('diag_manager_mod::diag_send_complete','module/output_field '//TRIM(error_string)//&
-                        & ', write EMPTY buffer', err_msg)) RETURN
+                   IF(fms_error_handler('diag_manager_mod::diag_send_complete','module/output_field '//&
+                        & TRIM(error_string)//', write EMPTY buffer', err_msg)) RETURN
                 END IF
              END IF
           END IF  !time > output_fields(out_num)%next_output
@@ -3575,7 +3622,8 @@ CONTAINS
     ! Determine pack_size from how many bytes a real value has (how compiled)
     pack_size = SIZE(TRANSFER(0.0_DblKind, (/0.0, 0.0, 0.0, 0.0/)))
     IF ( pack_size.NE.1 .AND. pack_size.NE.2 ) THEN
-       IF ( fms_error_handler('diag_manager_mod::diag_manager_init', 'unknown pack_size.  Must be 1, or 2.', err_msg) ) RETURN
+       IF ( fms_error_handler('diag_manager_mod::diag_manager_init', 'unknown pack_size.  Must be 1, or 2.', &
+          &  err_msg) ) RETURN
     END IF
 
     ! Get min and max values for real(kind=R4_KIND)
@@ -3597,7 +3645,8 @@ CONTAINS
        IF ( diag_model_subset >= DIAG_OTHER .AND. diag_model_subset <= DIAG_ALL ) THEN
           diag_subset_output = diag_model_subset
        ELSE
-          IF ( fms_error_handler('diag_manager_mod::diag_manager_init', 'invalid value of diag_model_subset',err_msg) ) RETURN
+          IF ( fms_error_handler('diag_manager_mod::diag_manager_init', 'invalid value of diag_model_subset', &
+             & err_msg) ) RETURN
        END IF
     END IF
 
@@ -3606,8 +3655,8 @@ CONTAINS
 
     IF ( check_nml_error(IOSTAT=mystat, NML_NAME='DIAG_MANAGER_NML') < 0 ) THEN
        IF ( mpp_pe() == mpp_root_pe() ) THEN
-          CALL error_mesg('diag_manager_mod::diag_manager_init', 'DIAG_MANAGER_NML not found in input nml file.  Using defaults.',&
-               & WARNING)
+          CALL error_mesg('diag_manager_mod::diag_manager_init', &
+               & 'DIAG_MANAGER_NML not found in input nml file.  Using defaults.', WARNING)
        END IF
     END IF
 
@@ -3619,7 +3668,8 @@ CONTAINS
     IF ( use_cmor ) THEN
        err_msg_local = ''
        WRITE (err_msg_local,'(ES8.1E2)') CMOR_MISSING_VALUE
-       CALL error_mesg('diag_manager_mod::diag_manager_init', 'Using CMOR missing value ('//TRIM(err_msg_local)//').', NOTE)
+       CALL error_mesg('diag_manager_mod::diag_manager_init', 'Using CMOR missing value ('//TRIM(err_msg_local)// &
+        & ').', NOTE)
     END IF
 
     ! How to handle Out of Range Warnings.
@@ -3871,14 +3921,15 @@ CONTAINS
              ! Checking to see if num_attributes == max_field_attributes, and return error message
              IF ( this_attribute .GT. max_field_attributes ) THEN
                 ! <ERROR STATUS="FATAL">
-                !   Number of attributes exceeds max_field_attributes for attribute <name> to module/input_field <module_name>/<field_name>.
+                !   Number of attributes exceeds max_field_attributes for attribute <name>
+                !   to module/input_field <module_name>/<field_name>.
                 !   Increase diag_manager_nml:max_field_attributes.
                 ! </ERROR>
                 CALL error_mesg('diag_manager_mod::diag_field_add_attribute',&
                      & 'Number of attributes exceeds max_field_attributes for attribute "'&
                      &//TRIM(name)//'" to module/input_field "'//TRIM(input_fields(diag_field_id)%module_name)//'/'&
-                     &//TRIM(input_fields(diag_field_id)%field_name)//'".  Increase diag_manager_nml:max_field_attributes.',&
-                     & FATAL)
+                     &//TRIM(input_fields(diag_field_id)%field_name)&
+                     &//'".  Increase diag_manager_nml:max_field_attributes.', FATAL)
              ELSE
                 output_fields(out_field)%num_attributes = this_attribute
                 ! Set name and type
@@ -3893,7 +3944,8 @@ CONTAINS
           CASE (NF90_INT)
              IF ( .NOT.PRESENT(ival) ) THEN
                 ! <ERROR STATUS="FATAL">
-                !   Number type claims INTEGER, but ival not present for attribute <name> to module/input_field <module_name>/<field_name>.
+                !   Number type claims INTEGER, but ival not present for attribute <name> to
+                !   module/input_field <module_name>/<field_name>.
                 !   Contact the developers.
                 ! </ERROR>
                 CALL error_mesg('diag_manager_mod::diag_field_add_attribute',&
@@ -3918,7 +3970,8 @@ CONTAINS
           CASE (NF90_FLOAT)
              IF ( .NOT.PRESENT(rval) ) THEN
                 ! <ERROR STATUS="FATAL">
-                !   Attribute type claims READ, but rval not present for attribute <name> to module/input_field <module_name>/<field_name>.
+                !   Attribute type claims READ, but rval not present for attribute <name> to
+                !   module/input_field <module_name>/<field_name>.
                 !   Contact the developers.
                 ! </ERROR>
                 CALL error_mesg('diag_manager_mod::diag_field_add_attribute',&
@@ -3943,7 +3996,8 @@ CONTAINS
           CASE (NF90_CHAR)
              IF ( .NOT.PRESENT(cval) ) THEN
                 ! <ERROR STATUS="FATAL">
-                !   Attribute type claims CHARACTER, but cval not present for attribute <name> to module/input_field <module_name>/<field_name>.
+                !   Attribute type claims CHARACTER, but cval not present for attribute <name>
+                !   to module/input_field <module_name>/<field_name>.
                 !   Contact the developers.
                 ! </ERROR>
                 CALL error_mesg('diag_manager_mod::diag_field_add_attribute',&

--- a/diag_manager/diag_manager.F90
+++ b/diag_manager/diag_manager.F90
@@ -233,7 +233,7 @@ use platform_mod
        & diag_log_unit, time_unit_list, pelist_name, max_axes, module_is_initialized, max_num_axis_sets,&
        & use_cmor, issue_oor_warnings, oor_warnings_fatal, oor_warning, pack_size,&
        & max_out_per_in_field, flush_nc_files, region_out_use_alt_value, max_field_attributes, output_field_type,&
-       & max_file_attributes, max_axis_attributes, prepend_date, DIAG_FIELD_NOT_FOUND, diag_init_time, diag_data_init, &
+       & max_file_attributes, max_axis_attributes, prepend_date, DIAG_FIELD_NOT_FOUND, diag_init_time, diag_data_init,&
        & use_mpp_io
   USE diag_data_mod, ONLY:  fileobj, fileobjU, fnum_for_domain, fileobjND
   USE diag_table_mod, ONLY: parse_diag_table
@@ -1151,7 +1151,7 @@ CONTAINS
     IF ( PRESENT(volume) ) THEN
        IF ( volume.LE.0 ) THEN
           IF ( fms_error_handler('diag_manager_mod::init_field_cell_measure',&
-              & 'VOLUME field not in diag_table for field '//TRIM(input_fields(output_field%input_field)%module_name)//&
+              &'VOLUME field not in diag_table for field '//TRIM(input_fields(output_field%input_field)%module_name)//&
               & '/'//TRIM(input_fields(output_field%input_field)%field_name), err_msg) ) RETURN
        END IF
     END IF
@@ -1461,7 +1461,7 @@ CONTAINS
 
     IF ( PRESENT(rmask) ) WHERE ( rmask < 0.5 ) mask_out(:, :, 1) = .FALSE.
     IF ( PRESENT(mask) .OR. PRESENT(rmask) ) THEN
-       send_data_2d_r8 = send_data_3d(diag_field_id, field_out, time, is_in=is_in, js_in=js_in, ks_in=1, mask=mask_out,&
+       send_data_2d_r8 =send_data_3d(diag_field_id, field_out, time, is_in=is_in, js_in=js_in, ks_in=1, mask=mask_out,&
             & ie_in=ie_in, je_in=je_in, ke_in=1, weight=weight, err_msg=err_msg)
     ELSE
        send_data_2d_r8 = send_data_3d(diag_field_id, field_out, time, is_in=is_in, js_in=js_in, ks_in=1,&
@@ -2016,7 +2016,7 @@ CONTAINS
                    WRITE (error_string,'(a,"/",a)')&
                         & TRIM(input_fields(diag_field_id)%module_name), &
                         & TRIM(output_fields(out_num)%output_name)
-                   IF (fms_error_handler('diag_manager_mod::send_data_3d', 'module/output_field '//TRIM(error_string)//&
+                   IF(fms_error_handler('diag_manager_mod::send_data_3d', 'module/output_field '//TRIM(error_string)//&
                         & ', variable mask but no missing value defined', err_msg)) THEN
                       DEALLOCATE(oor_mask)
                       RETURN
@@ -2422,7 +2422,7 @@ CONTAINS
                             DO j=l_start(2)+hj, l_end(2)+hj
                                DO i=l_start(1)+hi, l_end(1)+hi
                                   IF ( field(i,j,k) /= missvalue ) THEN
-                                     output_fields(out_num)%count_0d(sample) = output_fields(out_num)%count_0d(sample) &
+                                     output_fields(out_num)%count_0d(sample) = output_fields(out_num)%count_0d(sample)&
                                                                              & + weight1
                                      EXIT outer0
                                   END IF
@@ -2758,7 +2758,7 @@ CONTAINS
              ELSE IF ( reduced_k_range ) THEN
                 ksr = l_start(3)
                 ker = l_end(3)
-                WHERE ( field(f1:f2,f3:f4,ksr:ker) > output_fields(out_num)%buffer(is-hi:ie-hi,js-hj:je-hj,:,sample) ) &
+                WHERE ( field(f1:f2,f3:f4,ksr:ker) > output_fields(out_num)%buffer(is-hi:ie-hi,js-hj:je-hj,:,sample) )&
                      & output_fields(out_num)%buffer(is-hi:ie-hi,js-hj:je-hj,:,sample) = field(f1:f2,f3:f4,ksr:ker)
              ELSE
                 IF ( debug_diag_manager ) THEN
@@ -2771,7 +2771,7 @@ CONTAINS
                       END IF
                    END IF
                 END IF
-                WHERE ( field(f1:f2,f3:f4,ks:ke) > output_fields(out_num)%buffer(is-hi:ie-hi,js-hj:je-hj,ks:ke,sample))&
+                WHERE (field(f1:f2,f3:f4,ks:ke) > output_fields(out_num)%buffer(is-hi:ie-hi,js-hj:je-hj,ks:ke,sample))&
                      & output_fields(out_num)%buffer(is-hi:ie-hi,js-hj:je-hj,ks:ke,sample) = field(f1:f2,f3:f4,ks:ke)
              END IF
           END IF
@@ -2814,7 +2814,7 @@ CONTAINS
                    END IF
                 END IF
                 WHERE ( mask(f1:f2,f3:f4,ks:ke) .AND.&
-                     & field(f1:f2,f3:f4,ks:ke) < output_fields(out_num)%buffer(is-hi:ie-hi,js-hj:je-hj,ks:ke,sample)) &
+                     & field(f1:f2,f3:f4,ks:ke) < output_fields(out_num)%buffer(is-hi:ie-hi,js-hj:je-hj,ks:ke,sample))&
                      & output_fields(out_num)%buffer(is-hi:ie-hi,js-hj:je-hj,ks:ke,sample) = field(f1:f2,f3:f4,ks:ke)
              END IF
           ELSE
@@ -2837,7 +2837,7 @@ CONTAINS
              ELSE IF ( reduced_k_range ) THEN
                 ksr= l_start(3)
                 ker= l_end(3)
-                WHERE ( field(f1:f2,f3:f4,ksr:ker) < output_fields(out_num)%buffer(is-hi:ie-hi,js-hj:je-hj,:,sample) ) &
+                WHERE ( field(f1:f2,f3:f4,ksr:ker) < output_fields(out_num)%buffer(is-hi:ie-hi,js-hj:je-hj,:,sample) )&
                      output_fields(out_num)%buffer(is-hi:ie-hi,js-hj:je-hj,:,sample) = field(f1:f2,f3:f4,ksr:ker)
              ELSE
                 IF ( debug_diag_manager ) THEN
@@ -2850,7 +2850,7 @@ CONTAINS
                       END IF
                    END IF
                 END IF
-                WHERE ( field(f1:f2,f3:f4,ks:ke) < output_fields(out_num)%buffer(is-hi:ie-hi,js-hj:je-hj,ks:ke,sample))&
+                WHERE (field(f1:f2,f3:f4,ks:ke) < output_fields(out_num)%buffer(is-hi:ie-hi,js-hj:je-hj,ks:ke,sample))&
                      & output_fields(out_num)%buffer(is-hi:ie-hi,js-hj:je-hj,ks:ke,sample) = field(f1:f2,f3:f4,ks:ke)
              END IF
           END IF
@@ -2942,7 +2942,7 @@ CONTAINS
           IF ( need_compute ) THEN
              DO j = js, je
                 DO i = is, ie
-                   IF ( l_start(1)+hi <= i .AND. i <= l_end(1)+hi .AND. l_start(2)+hj <= j .AND. j <= l_end(2)+hj ) THEN
+                   IF ( l_start(1)+hi <= i .AND. i <= l_end(1)+hi .AND. l_start(2)+hj <= j .AND. j <= l_end(2)+hj) THEN
                       i1 = i-l_start(1)-hi+1
                       j1 = j-l_start(2)-hj+1
                       output_fields(out_num)%buffer(i1,j1,:,sample) = field(i-is+1+hi,j-js+1+hj,l_start(3):l_end(3))
@@ -3960,7 +3960,7 @@ CONTAINS
                 ! <ERROR STATUS="FATAL">
                 !   Unable to allocate iatt for attribute <name> to module/input_field <module_name>/<field_name>
                 ! </ERROR>
-                CALL error_mesg('diag_manager_mod::diag_field_add_attribute', 'Unable to allocate iatt for attribute "'&
+                CALL error_mesg('diag_manager_mod::diag_field_add_attribute','Unable to allocate iatt for attribute "'&
                      &//TRIM(name)//'" to module/input_field "'//TRIM(input_fields(diag_field_id)%module_name)//'/'&
                      &//TRIM(input_fields(diag_field_id)%field_name)//'"', FATAL)
              END IF
@@ -3986,7 +3986,7 @@ CONTAINS
                 ! <ERROR STATUS="FATAL">
                 !   Unable to allocate fatt for attribute <name> to module/input_field <module_name>/<field_name>
                 ! </ERROR>
-                CALL error_mesg('diag_manager_mod::diag_field_add_attribute', 'Unable to allocate fatt for attribute "'&
+                CALL error_mesg('diag_manager_mod::diag_field_add_attribute','Unable to allocate fatt for attribute "'&
                      &//TRIM(name)//'" to module/input_field "'//TRIM(input_fields(diag_field_id)%module_name)//'/'&
                      &//TRIM(input_fields(diag_field_id)%field_name)//'"', FATAL)
              END IF

--- a/diag_manager/diag_manager.F90
+++ b/diag_manager/diag_manager.F90
@@ -2836,7 +2836,7 @@ CONTAINS
                 ksr= l_start(3)
                 ker= l_end(3)
                 WHERE ( field(f1:f2,f3:f4,ksr:ker) < output_fields(out_num)%buffer(is-hi:ie-hi,js-hj:je-hj,:,sample) )&
-                     output_fields(out_num)%buffer(is-hi:ie-hi,js-hj:je-hj,:,sample) = field(f1:f2,f3:f4,ksr:ker)
+                    & output_fields(out_num)%buffer(is-hi:ie-hi,js-hj:je-hj,:,sample) = field(f1:f2,f3:f4,ksr:ker)
              ELSE
                 IF ( debug_diag_manager ) THEN
                    CALL update_bounds(out_num, is-hi, ie-hi, js-hj, je-hj, ks, ke)

--- a/diag_manager/diag_output.F90
+++ b/diag_manager/diag_output.F90
@@ -382,10 +382,10 @@ integer :: domain_size, axis_length, axis_pos
 
           call register_variable_attribute(fileob, axis_name, "calendar_type", &
                                     UPPERCASE(TRIM(valid_calendar_types(calendar))), &
-                                             &  str_len=len_trim(valid_calendar_types(calendar)) )
+                                  & str_len=len_trim(valid_calendar_types(calendar)) )
           call register_variable_attribute(fileob, axis_name, "calendar", &
                                     lowercase(TRIM(valid_calendar_types(calendar))), &
-                                             &  str_len=len_trim(valid_calendar_types(calendar)) )
+                                  & str_len=len_trim(valid_calendar_types(calendar)) )
           IF ( time_ops1 ) THEN
              call register_variable_attribute(fileob, axis_name, 'bounds', TRIM(axis_name)//'_bnds', &
                                              & str_len=len_trim(TRIM(axis_name)//'_bnds'))
@@ -443,11 +443,11 @@ integer :: domain_size, axis_length, axis_pos
           call register_axis(fileob, axis_name, size(axis_data) )
           call register_field(fileob, axis_name, type_str, (/axis_name/) )
           if(trim(axis_units) .ne. "none") call register_variable_attribute(fileob, axis_name, "units", &
-            &  trim(axis_units), str_len=len_trim(axis_units))
+                                              & trim(axis_units), str_len=len_trim(axis_units))
           call register_variable_attribute(fileob, axis_name, "long_name", trim(axis_long_name), &
                                           &  str_len=len_trim(axis_long_name))
           if(trim(axis_cart_name).ne."N") call register_variable_attribute(fileob, axis_name, "axis", &
-            & trim(axis_cart_name), str_len=len_trim(axis_cart_name))
+                                             & trim(axis_cart_name), str_len=len_trim(axis_cart_name))
           select case (axis_direction)
              case (1)
                 call register_variable_attribute(fileob, axis_name, "positive", "up", str_len=len_trim("up"))
@@ -655,7 +655,7 @@ character(len=128),dimension(size(axes)) :: axis_names
                &"Pack values must be 1 or 2. Contact the developers.", FATAL)
      end select
      if (trim(units) .ne. "none") call register_variable_attribute(fileob,name,"units",trim(units), &
-        &  str_len=len_trim(units))
+                                     & str_len=len_trim(units))
      call register_variable_attribute(fileob,name,"long_name",long_name, str_len=len_trim(long_name))
      IF (present(time_method) ) then
           call register_variable_attribute(fileob,name,'cell_methods','time: '//trim(time_method), &
@@ -667,7 +667,7 @@ character(len=128),dimension(size(axes)) :: axis_names
        IF ( PRESENT(attributes) ) THEN
           IF ( num_attributes .GT. 0 .AND. allocated(attributes) ) THEN
              CALL write_attribute_meta(file_unit, num_attributes, attributes, time_method, err_msg, &
-                                      &  fileob=fileob, varname=name)
+                                     & fileob=fileob, varname=name)
              IF ( LEN_TRIM(err_msg) .GT. 0 ) THEN
                 CALL error_mesg('diag_output_mod::write_field_meta_data',&
                      & TRIM(err_msg)//" Contact the developers.", FATAL)
@@ -754,8 +754,8 @@ character(len=128),dimension(size(axes)) :: axis_names
                 RETURN
              END IF
           END IF
-          if (present(varname))call register_variable_attribute(fileob, varname,TRIM(attributes(i)%name)  , &
-             &  attributes(i)%iatt)
+          if (present(varname))call register_variable_attribute(fileob, varname,TRIM(attributes(i)%name), &
+                                                              & attributes(i)%iatt)
        CASE (NF90_FLOAT)
           IF ( .NOT.allocated(attributes(i)%fatt) ) THEN
              IF ( fms_error_handler('diag_output_mod::write_attribute_meta',&
@@ -764,8 +764,8 @@ character(len=128),dimension(size(axes)) :: axis_names
                 RETURN
              END IF
           END IF
-          if (present(varname))call register_variable_attribute(fileob, varname,TRIM(attributes(i)%name)  , &
-             &  real(attributes(i)%fatt,4) )
+          if (present(varname))call register_variable_attribute(fileob, varname,TRIM(attributes(i)%name), &
+                                                              & real(attributes(i)%fatt,4) )
        CASE (NF90_CHAR)
           att_str = attributes(i)%catt
           att_len = attributes(i)%len

--- a/diag_manager/diag_output.F90
+++ b/diag_manager/diag_output.F90
@@ -209,7 +209,8 @@ CONTAINS
     INTEGER, INTENT(in) :: axes(:) !< Array of axis ID's, including the time axis
     class(FmsNetcdfFile_t) , intent(inout) :: fileob !< FMS2_io fileobj
     LOGICAL, INTENT(in), OPTIONAL :: time_ops !< .TRUE. if this file contains any min, max, time_rms, or time_average
-    logical, intent(inout) , optional :: time_axis_registered !< .TRUE. if the time axis was already written to the file
+    logical, intent(inout) , optional :: time_axis_registered !< .TRUE. if the time axis was already
+                                                              !! written to the file
 
     TYPE(domain1d)       :: Domain
     TYPE(domainUG)       :: domainU
@@ -386,8 +387,8 @@ integer :: domain_size, axis_length, axis_pos
                                     lowercase(TRIM(valid_calendar_types(calendar))), &
                                              &  str_len=len_trim(valid_calendar_types(calendar)) )
           IF ( time_ops1 ) THEN
-             call register_variable_attribute(fileob, axis_name, 'bounds', TRIM(axis_name)//'_bnds', str_len=len_trim(TRIM(axis_name)// &
-              & '_bnds'))
+             call register_variable_attribute(fileob, axis_name, 'bounds', TRIM(axis_name)//'_bnds', &
+                                             & str_len=len_trim(TRIM(axis_name)//'_bnds'))
           END IF
           call set_fileobj_time_name(fileob, axis_name)
        ELSE
@@ -428,7 +429,8 @@ integer :: domain_size, axis_length, axis_pos
             & axis_direction, axis_edges, Domain, DomainU, axis_data)
 
        !  ---- write edges attribute to original axis ----
-       call register_variable_attribute(fileob, axis_name_current, "edges",trim(axis_name), str_len=len_trim(axis_name))
+       call register_variable_attribute(fileob, axis_name_current, "edges",trim(axis_name), &
+                                       &  str_len=len_trim(axis_name))
        !  ---- add edges index to axis list ----
        !  ---- assume this is not a time axis ----
        num_axis_in_file = num_axis_in_file + 1
@@ -656,8 +658,8 @@ character(len=128),dimension(size(axes)) :: axis_names
         &  str_len=len_trim(units))
      call register_variable_attribute(fileob,name,"long_name",long_name, str_len=len_trim(long_name))
      IF (present(time_method) ) then
-          call register_variable_attribute(fileob,name,'cell_methods','time: '//trim(time_method), str_len=len_trim('time: '// &
-           & trim(time_method)))
+          call register_variable_attribute(fileob,name,'cell_methods','time: '//trim(time_method), &
+                                         & str_len=len_trim('time: '//trim(time_method)))
      ENDIF
   endif
     !---- write user defined attributes -----

--- a/diag_manager/diag_output.F90
+++ b/diag_manager/diag_output.F90
@@ -182,7 +182,8 @@ CONTAINS
              call register_global_attribute(fileob, TRIM(attributes(i)%name), attributes(i)%fatt)
           CASE (NF90_CHAR)
 
-             call register_global_attribute(fileob, TRIM(attributes(i)%name), attributes(i)%catt, str_len=len_trim(attributes(i)%catt))
+             call register_global_attribute(fileob, TRIM(attributes(i)%name), attributes(i)%catt, &
+                                           &  str_len=len_trim(attributes(i)%catt))
           CASE default
              ! <ERROR STATUS="FATAL">
              !   Unknown attribute type for attribute <name> to module/input_field <module_name>/<field_name>.
@@ -302,7 +303,8 @@ integer :: domain_size, axis_length, axis_pos
                 call register_variable_attribute(fileob, axis_name, "domain_decomposition", &
                       (/gstart, gend, cstart, cend/))
              type is (FmsNetcdfDomainFile_t)
-                !> If the axis is domain decomposed and the type is FmsNetcdfDomainFile_t, this is a domain decomposed dimension
+                !> If the axis is domain decomposed and the type is FmsNetcdfDomainFile_t,
+                !! this is a domain decomposed dimension
                 !! so register it as one
                 call register_axis(fileob, axis_name, lowercase(trim(axis_cart_name)), domain_position=axis_pos )
                 call get_global_io_domain_indices(fileob, trim(axis_name), istart, iend)
@@ -312,7 +314,8 @@ integer :: domain_size, axis_length, axis_pos
        ELSE IF ( DomainU .NE. null_domainUG) THEN
           select type(fileob)
              type is (FmsNetcdfUnstructuredDomainFile_t)
-               !> If the axis is in unstructured domain and the type is FmsNetcdfUnstructuredDomainFile_t, this is an unstrucutred axis
+               !> If the axis is in unstructured domain and the type is FmsNetcdfUnstructuredDomainFile_t,
+               !! this is an unstrucutred axis
                !! so register it as one
                call register_axis(fileob, axis_name )
           end select
@@ -328,8 +331,10 @@ integer :: domain_size, axis_length, axis_pos
        ENDIF !! IF ( Domain .NE. null_domain1d )
 
        if (length <= 0) then
-          !> @note Check if the time variable is registered.  It's possible that is_time_axis_registered is set to true if using
-          !! time-templated files because they aren't closed when done writing.  An alternative to this set up would be to put
+          !> @note Check if the time variable is registered.  It's possible that is_time_axis_registered
+          !! is set to true if using
+          !! time-templated files because they aren't closed when done writing.  An alternative
+          !! to this set up would be to put
           !! variable_exists into the if statement with an .or. so that it gets registered.
           is_time_axis_registered = variable_exists(fileob,trim(axis_name),.true.)
           if (.not. is_time_axis_registered) then
@@ -341,9 +346,12 @@ integer :: domain_size, axis_length, axis_pos
        endif !! if (length <= 0)
 
        !> Add the attributes
-       if(trim(axis_units) .ne. "none") call register_variable_attribute(fileob, axis_name, "units", trim(axis_units), str_len=len_trim(axis_units))
-       call register_variable_attribute(fileob, axis_name, "long_name", trim(axis_long_name), str_len=len_trim(axis_long_name))
-       if(trim(axis_cart_name).ne."N") call register_variable_attribute(fileob, axis_name, "axis",trim(axis_cart_name), str_len=len_trim(axis_cart_name))
+       if(trim(axis_units) .ne. "none") call register_variable_attribute(fileob, axis_name, "units", &
+         &  trim(axis_units), str_len=len_trim(axis_units))
+       call register_variable_attribute(fileob, axis_name, "long_name", trim(axis_long_name), &
+                                       &  str_len=len_trim(axis_long_name))
+       if(trim(axis_cart_name).ne."N") call register_variable_attribute(fileob, axis_name, "axis", &
+         & trim(axis_cart_name), str_len=len_trim(axis_cart_name))
 
        if (length > 0 ) then
           !> If not a time axis, add the positive attribute and write the data
@@ -372,11 +380,14 @@ integer :: domain_size, axis_length, axis_pos
 
 
           call register_variable_attribute(fileob, axis_name, "calendar_type", &
-                                    UPPERCASE(TRIM(valid_calendar_types(calendar))), str_len=len_trim(valid_calendar_types(calendar)) )
+                                    UPPERCASE(TRIM(valid_calendar_types(calendar))), &
+                                             &  str_len=len_trim(valid_calendar_types(calendar)) )
           call register_variable_attribute(fileob, axis_name, "calendar", &
-                                    lowercase(TRIM(valid_calendar_types(calendar))), str_len=len_trim(valid_calendar_types(calendar)) )
+                                    lowercase(TRIM(valid_calendar_types(calendar))), &
+                                             &  str_len=len_trim(valid_calendar_types(calendar)) )
           IF ( time_ops1 ) THEN
-             call register_variable_attribute(fileob, axis_name, 'bounds', TRIM(axis_name)//'_bnds', str_len=len_trim(TRIM(axis_name)//'_bnds'))
+             call register_variable_attribute(fileob, axis_name, 'bounds', TRIM(axis_name)//'_bnds', str_len=len_trim(TRIM(axis_name)// &
+              & '_bnds'))
           END IF
           call set_fileobj_time_name(fileob, axis_name)
        ELSE
@@ -429,9 +440,12 @@ integer :: domain_size, axis_length, axis_pos
        if (.not.variable_exists(fileob, axis_name)) then
           call register_axis(fileob, axis_name, size(axis_data) )
           call register_field(fileob, axis_name, type_str, (/axis_name/) )
-          if(trim(axis_units) .ne. "none") call register_variable_attribute(fileob, axis_name, "units", trim(axis_units), str_len=len_trim(axis_units))
-          call register_variable_attribute(fileob, axis_name, "long_name", trim(axis_long_name), str_len=len_trim(axis_long_name))
-          if(trim(axis_cart_name).ne."N") call register_variable_attribute(fileob, axis_name, "axis",trim(axis_cart_name), str_len=len_trim(axis_cart_name))
+          if(trim(axis_units) .ne. "none") call register_variable_attribute(fileob, axis_name, "units", &
+            &  trim(axis_units), str_len=len_trim(axis_units))
+          call register_variable_attribute(fileob, axis_name, "long_name", trim(axis_long_name), &
+                                          &  str_len=len_trim(axis_long_name))
+          if(trim(axis_cart_name).ne."N") call register_variable_attribute(fileob, axis_name, "axis", &
+            & trim(axis_cart_name), str_len=len_trim(axis_cart_name))
           select case (axis_direction)
              case (1)
                 call register_variable_attribute(fileob, axis_name, "positive", "up", str_len=len_trim("up"))
@@ -638,17 +652,20 @@ character(len=128),dimension(size(axes)) :: axis_names
           CALL error_mesg('diag_output_mod::write_field_meta_data',&
                &"Pack values must be 1 or 2. Contact the developers.", FATAL)
      end select
-     if (trim(units) .ne. "none") call register_variable_attribute(fileob,name,"units",trim(units), str_len=len_trim(units))
+     if (trim(units) .ne. "none") call register_variable_attribute(fileob,name,"units",trim(units), &
+        &  str_len=len_trim(units))
      call register_variable_attribute(fileob,name,"long_name",long_name, str_len=len_trim(long_name))
      IF (present(time_method) ) then
-          call register_variable_attribute(fileob,name,'cell_methods','time: '//trim(time_method), str_len=len_trim('time: '//trim(time_method)))
+          call register_variable_attribute(fileob,name,'cell_methods','time: '//trim(time_method), str_len=len_trim('time: '// &
+           & trim(time_method)))
      ENDIF
   endif
     !---- write user defined attributes -----
     IF ( PRESENT(num_attributes) ) THEN
        IF ( PRESENT(attributes) ) THEN
           IF ( num_attributes .GT. 0 .AND. allocated(attributes) ) THEN
-             CALL write_attribute_meta(file_unit, num_attributes, attributes, time_method, err_msg, fileob=fileob, varname=name)
+             CALL write_attribute_meta(file_unit, num_attributes, attributes, time_method, err_msg, &
+                                      &  fileob=fileob, varname=name)
              IF ( LEN_TRIM(err_msg) .GT. 0 ) THEN
                 CALL error_mesg('diag_output_mod::write_field_meta_data',&
                      & TRIM(err_msg)//" Contact the developers.", FATAL)
@@ -691,11 +708,13 @@ character(len=128),dimension(size(axes)) :: axis_names
          call register_variable_attribute(fileob,name,'coordinates',TRIM(coord_att), str_len=len_trim(coord_att))
     ENDIF
     IF ( TRIM(standard_name2) /= 'none' ) then
-         call register_variable_attribute(fileob,name,'standard_name',TRIM(standard_name2), str_len=len_trim(standard_name2))
+         call register_variable_attribute(fileob,name,'standard_name',TRIM(standard_name2), &
+                                         &  str_len=len_trim(standard_name2))
     ENDIF
     !---- write attribute for interp_method ----
     IF( PRESENT(interp_method) ) THEN
-       call register_variable_attribute(fileob,name,'interp_method', TRIM(interp_method), str_len=len_trim(interp_method))
+       call register_variable_attribute(fileob,name,'interp_method', TRIM(interp_method), &
+                                       &  str_len=len_trim(interp_method))
     END IF
 
     !---- get axis domain ----
@@ -733,7 +752,8 @@ character(len=128),dimension(size(axes)) :: axis_names
                 RETURN
              END IF
           END IF
-          if (present(varname))call register_variable_attribute(fileob, varname,TRIM(attributes(i)%name)  , attributes(i)%iatt)
+          if (present(varname))call register_variable_attribute(fileob, varname,TRIM(attributes(i)%name)  , &
+             &  attributes(i)%iatt)
        CASE (NF90_FLOAT)
           IF ( .NOT.allocated(attributes(i)%fatt) ) THEN
              IF ( fms_error_handler('diag_output_mod::write_attribute_meta',&
@@ -742,7 +762,8 @@ character(len=128),dimension(size(axes)) :: axis_names
                 RETURN
              END IF
           END IF
-          if (present(varname))call register_variable_attribute(fileob, varname,TRIM(attributes(i)%name)  , real(attributes(i)%fatt,4) )
+          if (present(varname))call register_variable_attribute(fileob, varname,TRIM(attributes(i)%name)  , &
+             &  real(attributes(i)%fatt,4) )
        CASE (NF90_CHAR)
           att_str = attributes(i)%catt
           att_len = attributes(i)%len
@@ -752,7 +773,8 @@ character(len=128),dimension(size(axes)) :: axis_names
              att_len = LEN_TRIM(att_str)
           END IF
           if (present(varname))&
-               call register_variable_attribute(fileob, varname,TRIM(attributes(i)%name)  , att_str(1:att_len), str_len=att_len)
+               call register_variable_attribute(fileob, varname,TRIM(attributes(i)%name)  , att_str(1:att_len), &
+                                               &  str_len=att_len)
 
        CASE default
           IF ( fms_error_handler('diag_output_mod::write_attribute_meta', 'Invalid type for attribute '&
@@ -777,7 +799,8 @@ character(len=128),dimension(size(axes)) :: axis_names
   END SUBROUTINE done_meta_data
 
   !> \brief Writes diagnostic data out using fms2_io routine.
-  subroutine diag_field_write (varname, buffer, static, file_num, fileobjU, fileobj, fileobjND, fnum_for_domain, time_in)
+  subroutine diag_field_write (varname, buffer, static, file_num, fileobjU, fileobj, fileobjND, &
+                              &  fnum_for_domain, time_in)
     CHARACTER(len=*), INTENT(in)    :: varname                             !< Variable name
     REAL ,            INTENT(inout) :: buffer(:,:,:,:)                     !< Buffer containing the variable data
     logical,          intent(in)    :: static                              !< Flag indicating if a variable is static

--- a/diag_manager/diag_table.F90
+++ b/diag_manager/diag_table.F90
@@ -18,8 +18,10 @@
 !***********************************************************************
 !> @defgroup diag_table_mod diag_table_mod
 !> @ingroup diag_manager
-!! @brief <TT>diag_table_mod</TT> is a set of subroutines use to parse out the data from a <TT>diag_table</TT>.  This module
-!!   will also setup the arrays required to store the information by counting the number of input fields, output files, and
+!! @brief <TT>diag_table_mod</TT> is a set of subroutines use to parse out the data from a
+!! <TT>diag_table</TT>.  This module
+!!   will also setup the arrays required to store the information by counting the number of
+!!   input fields, output files, and
 !!   files.
 !! @author Seth Underwood
 !!
@@ -27,27 +29,36 @@
 !!   needed for the <TT>diag_manager_mod</TT> to correctly write out the model history files.
 !!
 !!   The <I>diagnostics table</I> allows users to specify sampling rates and the choice of fields at run time.  The
-!!   <TT>diag_table</TT> file consists of comma-separated ASCII values.  The <TT>diag_table</TT> essentially has three sections:
-!!   <B>Global</B>, <B>File</B>, and <B>Field</B> sections.  The <B>Global</B> section must be the first two lines of the file,
+!!   <TT>diag_table</TT> file consists of comma-separated ASCII values.  The <TT>diag_table</TT>
+!!   essentially has three sections:
+!!   <B>Global</B>, <B>File</B>, and <B>Field</B> sections.  The <B>Global</B> section must
+!!   be the first two lines of the file,
 !!   whereas the <B>File</B> and <B>Field</B> sections can be inter mixed to allow the file to be organized as desired.
-!!   Comments can be added to the <TT>diag_table</TT> file by using the hash symbol (#) as the first character in the line.
+!!   Comments can be added to the <TT>diag_table</TT> file by using the hash symbol (#) as
+!!   the first character in the line.
 !!
-!!   All errors in the <TT>diag_table</TT> will throw a <TT>FATAL</TT> error.  A simple utility <TT>diag_table_chk</TT>has been
-!!   added to the FRE tools suite to check a <TT>diag_table</TT> for errors.  A brief usage statement can be obtained by running
-!!   <TT>diag_table_chk --help</TT>, and a man page like description can views by running <TT>perldoc diag_table_chk</TT>.
+!!   All errors in the <TT>diag_table</TT> will throw a <TT>FATAL</TT> error.  A simple utility
+!!   <TT>diag_table_chk</TT>has been
+!!   added to the FRE tools suite to check a <TT>diag_table</TT> for errors.  A brief usage
+!!   statement can be obtained by running
+!!   <TT>diag_table_chk --help</TT>, and a man page like description can views by running <TT>perldoc
+!!   diag_table_chk</TT>.
 !!
 !!   Below is a description of the three sections.
 !!   <OL>
 !!     <LI>
-!!       <B>Global Section:</B>  The first two lines of the <TT>diag_table</TT> must contain the <I>title</I> and the <I>base
-!!       date</I> of the experiment respectively.  The <I>title</I> must be a Fortran CHARACTER string.  The <I>base date</I>
+!!       <B>Global Section:</B>  The first two lines of the <TT>diag_table</TT> must contain
+!!       the <I>title</I> and the <I>base
+!!       date</I> of the experiment respectively.  The <I>title</I> must be a Fortran CHARACTER
+!!       string.  The <I>base date</I>
 !!       is the reference time used for the time units, and must be greater than or equal to the model start time.
 !!       The <I>base date</I> consists of six space-separated integer in the following format.<BR />
 !!       <TT> year month day hour minute second </TT><BR />
 !!     </LI>
 !!     <LI>
 !!       <B>File Section:</B> File lines contain 6 required and 5 optional fields (optional fields are surrounded with
-!!       square brackets ([]).  File lines can be intermixed with the field lines, but the file must be defined before any
+!!       square brackets ([]).  File lines can be intermixed with the field lines, but the
+!!       file must be defined before any
 !!       fields that are to be written to the file.  File lines have the following format:<BR />
 !!         "file_name", output_freq, "output_freq_units", file_format, "time_axis_units", "time_axis_name"
 !!         [, new_file_freq, "new_file_freq_units"[, "start_time"[, file_duration, "file_duration_units"]]]
@@ -58,9 +69,12 @@
 !!         <DD>
 !!           Output file name without the trailing <TT>".nc"</TT>.
 !!
-!!           A single file description can produce multiple files using special time string suffix keywords.  This time string
-!!           will append the time strings to the base file name each time a new file is opened.  They syntax for the time string
-!!           suffix keywords are <TT>%#tt</TT> Where <TT>#</TT> is a mandatory single digit number specifying the width of the
+!!           A single file description can produce multiple files using special time string
+!!           suffix keywords.  This time string
+!!           will append the time strings to the base file name each time a new file is opened.
+!!            They syntax for the time string
+!!           suffix keywords are <TT>%#tt</TT> Where <TT>#</TT> is a mandatory single digit
+!!           number specifying the width of the
 !!           field, and <TT>tt</TT> can be as follows:
 !!           <UL>
 !!             <LI><TT>yr</TT>  Years</LI>
@@ -70,9 +84,12 @@
 !!             <LI><TT>mi</TT>  Minutes</LI>
 !!             <LI><TT>sc</TT>  Seconds</LI>
 !!           </UL>
-!!           Thus, a file name of <TT>file2_yr_dy%1yr%3dy</TT> will have a base file name of <TT>file2_yr_dy_1_001</TT> if the
-!!           file is created on year 1 day 1 of the model run.  <B><I>NOTE:</I></B> The time suffix keywords must be used if the
-!!           optional fields <TT>new_file_freq</TT> and <TT>new_file_freq_units</TT> are used, otherwise a <TT>FATAL</TT> error
+!!           Thus, a file name of <TT>file2_yr_dy%1yr%3dy</TT> will have a base file name of
+!!           <TT>file2_yr_dy_1_001</TT> if the
+!!           file is created on year 1 day 1 of the model run.  <B><I>NOTE:</I></B> The time
+!!           suffix keywords must be used if the
+!!           optional fields <TT>new_file_freq</TT> and <TT>new_file_freq_units</TT> are used,
+!!           otherwise a <TT>FATAL</TT> error
 !!           will occur.
 !!         </DD>
 !!
@@ -103,7 +120,8 @@
 !!         </DD>
 !!         <DT><TT>CHARACTER(len=128) :: time_axis_name</TT></DT>
 !!         <DD>
-!!           Axis name for the output file time axis.  The character sting must contain the string 'time'. (mixed upper and
+!!           Axis name for the output file time axis.  The character sting must contain the
+!!           string 'time'. (mixed upper and
 !!           lowercase allowed.)
 !!         </DD>
 !!         <DT><TT>INTEGER, OPTIONAL :: new_file_freq</TT></DT>
@@ -113,36 +131,45 @@
 !!         <DT><TT>CHARACTER(len=10), OPTIONAL :: new_file_freq_units</TT></DT>
 !!         <DD>
 !!           Time units for creating a new file.  Can be either <TT>years</TT>, <TT>months</TT>, <TT>days</TT>,
-!!           <TT>minutes</TT>, <TT>hours</TT>, or <TT>seconds</TT>.  <B><I>NOTE:</I></B> If the <TT>new_file_freq</TT> field is
+!!           <TT>minutes</TT>, <TT>hours</TT>, or <TT>seconds</TT>.  <B><I>NOTE:</I></B> If
+!!           the <TT>new_file_freq</TT> field is
 !!           present, then this field must also be present.
 !!         </DD>
 !!         <DT><TT>CHARACTER(len=25), OPTIONAL :: start_time</TT></DT>
 !!         <DD>
-!!           Time to start the file for the first time.  The format of this string is the same as the <I>global date</I>.  <B><I>
-!!           NOTE:</I></B> The <TT>new_file_freq</TT> and the <TT>new_file_freq_units</TT> fields must be present to use this field.
+!!           Time to start the file for the first time.  The format of this string is the same
+!!           as the <I>global date</I>.  <B><I>
+!!           NOTE:</I></B> The <TT>new_file_freq</TT> and the <TT>new_file_freq_units</TT>
+!!           fields must be present to use this field.
 !!         </DD>
 !!         <DT><TT>INTEGER, OPTIONAL :: file_duration</TT></DT>
 !!         <DD>
-!!           How long file should receive data after start time in <TT>file_duration_units</TT>.  This optional field can only
-!!           be used if the <TT>start_time</TT> field is present.  If this field is absent, then the file duration will be equal
-!!           to the frequency for creating new files.  <B><I>NOTE:</I></B> The <TT>file_duration_units</TT> field must also be
+!!           How long file should receive data after start time in <TT>file_duration_units</TT>.
+!!            This optional field can only
+!!           be used if the <TT>start_time</TT> field is present.  If this field is absent,
+!!           then the file duration will be equal
+!!           to the frequency for creating new files.  <B><I>NOTE:</I></B> The <TT>file_duration_units</TT>
+!!           field must also be
 !!           present if this field is present.
 !!         </DD>
 !!         <DT><TT>CHARACTER(len=10), OPTIONAL :: file_duration_units</TT></DT>
 !!         <DD>
 !!           File duration units. Can be either <TT>years</TT>, <TT>months</TT>, <TT>days</TT>,
-!!           <TT>minutes</TT>, <TT>hours</TT>, or <TT>seconds</TT>.  <B><I>NOTE:</I></B> If the <TT>file_duration</TT> field is
+!!           <TT>minutes</TT>, <TT>hours</TT>, or <TT>seconds</TT>.  <B><I>NOTE:</I></B> If
+!!           the <TT>file_duration</TT> field is
 !!           present, then this field must also be present.
 !!         </DD>
 !!       </DL>
 !!     </LI>
 !!     <LI>
-!!       <B>Field Section:</B> Field lines contain 8 fields.  Field lines can be intermixed with file lines.  Fields line can contain
+!!       <B>Field Section:</B> Field lines contain 8 fields.  Field lines can be intermixed
+!!       with file lines.  Fields line can contain
 !!       fields that are not written to any files.  The file name for these fields is <TT>null</TT>.
 !!
 !!       Field lines have the following format:<BR />
 !!       <PRE>
-!! "module_name", "field_name", "output_name", "file_name", "time_sampling", "reduction_method", "regional_section", packing
+!! "module_name", "field_name", "output_name", "file_name", "time_sampling", "reduction_method",
+!! "regional_section", packing
 !!       </PRE>
 !!       with the following descriptions.
 !!       <DL>
@@ -169,7 +196,8 @@
 !!             <DT><TT>.FALSE.</TT>, none</DT>
 !!             <DD>No reduction performed.  Write current time step value only.</DD>
 !!             <DT>rms</DT> <DD>Calculate the root mean square from the last time written to the current time.</DD>
-!!             <DT>pow##</DT> <DD>Calculate the mean of the power ## from the last time written to the current time.</DD>
+!!             <DT>pow##</DT> <DD>Calculate the mean of the power ## from the last time written
+!!             to the current time.</DD>
 !!             <DT>min</DT> <DD>Minimum value from last write to current time.</DD>
 !!             <DT>max</DT> <DD>Maximum value from last write to current time.</DD>
 !!             <DT>diurnal##</DT> <DD>## diurnal averages</DD>
@@ -177,7 +205,8 @@
 !!         </DD>
 !!         <DT><TT>CHARACTER(len=50) :: regional_section</TT></DT>
 !!         <DD>
-!!           Bounds of the regional section to capture.  A value of <TT>none</TT> indicates a global region.  The regional
+!!           Bounds of the regional section to capture.  A value of <TT>none</TT> indicates
+!!           a global region.  The regional
 !!           section has the following format:<BR />
 !!           <TT>lat_min, lat_max, lon_min, lon_max, vert_min, vert_max</TT><BR />
 !!           Use <TT>vert_min = -1</TT> and <TT>vert_max = -1</TT> to get the entire vertical axis.  <B><I>NOTE:</I></B>
@@ -226,8 +255,8 @@ MODULE diag_table_mod
   USE time_manager_mod, ONLY: get_calendar_type, NO_CALENDAR, set_date, set_time, month_name, time_type
   USE constants_mod, ONLY: SECONDS_PER_HOUR, SECONDS_PER_MINUTE
 
-  USE diag_data_mod, ONLY: global_descriptor, base_time, base_year, base_month, base_day, base_hour, base_minute, base_second,&
-       & DIAG_OTHER, DIAG_OCEAN, DIAG_ALL, coord_type, append_pelist_name, pelist_name
+  USE diag_data_mod, ONLY: global_descriptor, base_time, base_year, base_month, base_day, base_hour, base_minute, &
+       & base_second, DIAG_OTHER, DIAG_OCEAN, DIAG_ALL, coord_type, append_pelist_name, pelist_name
   USE diag_util_mod, ONLY: init_file, check_duplicate_output_fields, init_input_field, init_output_field
 
   IMPLICIT NONE
@@ -277,12 +306,16 @@ MODULE diag_table_mod
 CONTAINS
 
   !> @brief Parse the <TT>diag_table</TT> in preparation for diagnostic output.
-  !! @details <TT>parse_diag_table</TT> is the public interface to parse the diag_table, and setup the arrays needed to store the
-  !!     requested diagnostics from the <TT>diag_table</TT>.  <TT>parse_diag_table</TT> will return a non-zero <TT>istat</TT> if
+  !! @details <TT>parse_diag_table</TT> is the public interface to parse the diag_table, and
+  !! setup the arrays needed to store the
+  !!     requested diagnostics from the <TT>diag_table</TT>.  <TT>parse_diag_table</TT> will
+  !!     return a non-zero <TT>istat</TT> if
   !!     a problem parsing the <TT>diag_table</TT>.
   !!
-  !!     NOT YET IMPLEMENTED: <TT>parse_diag_table</TT> will parse through the <TT>diag_table</TT> twice.  The first pass, will be
-  !!     to get a good "guess" of array sizes.  These arrays, that will hold the requested diagnostic fields and files, will then be
+  !!     NOT YET IMPLEMENTED: <TT>parse_diag_table</TT> will parse through the <TT>diag_table</TT>
+  !!     twice.  The first pass, will be
+  !!     to get a good "guess" of array sizes.  These arrays, that will hold the requested
+  !!     diagnostic fields and files, will then be
   !!     allocated to the size of the "guess" plus a slight increase.
   SUBROUTINE parse_diag_table(diag_subset, istat, err_msg)
     INTEGER, INTENT(in), OPTIONAL :: diag_subset !< Diagnostic sampling subset.
@@ -337,22 +370,24 @@ CONTAINS
     READ (UNIT=diag_table(1), FMT=*, IOSTAT=mystat) global_descriptor
     IF ( mystat /= 0 ) THEN
        pstat = mystat
-       IF ( fms_error_handler('diag_table_mod::parse_diag_table', 'Error reading the global descriptor from the diagnostic table.',&
-            & err_msg) ) RETURN
+       IF ( fms_error_handler('diag_table_mod::parse_diag_table', &
+            'Error reading the global descriptor from the diagnostic table.', err_msg) ) RETURN
     END IF
 
     ! Read in the base date
     READ (UNIT=diag_table(2), FMT=*, IOSTAT=mystat) base_year, base_month, base_day, base_hour, base_minute, base_second
     IF ( mystat /= 0 ) THEN
        pstat = mystat
-       IF ( fms_error_handler('diag_manager_init', 'Error reading the base date from the diagnostic table.', err_msg) ) RETURN
+       IF ( fms_error_handler('diag_manager_init', 'Error reading the base date from the diagnostic table.', &
+          &  err_msg) ) RETURN
     END IF
 
     ! Set up the time type for base time
     IF ( get_calendar_type() /= NO_CALENDAR ) THEN
        IF ( base_year==0 .OR. base_month==0 .OR. base_day==0 ) THEN
           pstat = 101
-          IF ( fms_error_handler('diag_table_mod::parse_diag_table', 'The base_year/month/day can not equal zero', err_msg) ) RETURN
+          IF ( fms_error_handler('diag_table_mod::parse_diag_table', &
+             &  'The base_year/month/day can not equal zero', err_msg) ) RETURN
        END IF
        base_time = set_date(base_year, base_month, base_day, base_hour, base_minute, base_second)
        amonth = month_name(base_month)
@@ -409,16 +444,20 @@ CONTAINS
                         & CALL error_mesg("diag_table_mod::parse_diag_table",&
                         & TRIM(local_err_msg)//" (line: "//TRIM(line_number)//").", WARNING)
                    CYCLE parser
-                ELSE IF ( (diag_subset_output == DIAG_OTHER .AND. INDEX(lowercase(temp_file%file_name), "ocean") .NE. 0).OR.&
-                     &    (diag_subset_output == DIAG_OCEAN .AND. INDEX(lowercase(temp_file%file_name), "ocean") .EQ. 0) ) THEN
+                ELSE IF ( (diag_subset_output == DIAG_OTHER .AND. INDEX(lowercase(temp_file%file_name), "ocean").NE.0)&
+                   & .OR. (diag_subset_output == DIAG_OCEAN .AND. INDEX(lowercase(temp_file%file_name), "ocean").EQ.0)&
+                   &  ) THEN
                    CYCLE parser
-                ELSE IF ( temp_file%new_file_freq > 0 ) THEN ! Call the init_file subroutine.  The '1' is for the tile_count
-                   CALL init_file(temp_file%file_name, temp_file%output_freq, temp_file%iOutput_freq_units, temp_file%file_format,&
-                        & temp_file%iTime_units, temp_file%long_name, 1, temp_file%new_file_freq, temp_file%iNew_file_freq_units,&
-                        & temp_file%start_time, temp_file%file_duration, temp_file%iFile_duration_units, temp_file%filename_time_bounds)
+                ELSE IF ( temp_file%new_file_freq > 0 ) THEN ! Call the init_file subroutine.  The '1'
+                                                             !! is for the tile_count
+                   CALL init_file(temp_file%file_name, temp_file%output_freq, temp_file%iOutput_freq_units, &
+                        & temp_file%file_format, temp_file%iTime_units, temp_file%long_name, 1, &
+                        & temp_file%new_file_freq, temp_file%iNew_file_freq_units,&
+                        & temp_file%start_time, temp_file%file_duration, temp_file%iFile_duration_units, &
+                        &  temp_file%filename_time_bounds)
                 ELSE
-                   CALL init_file(temp_file%file_name, temp_file%output_freq, temp_file%iOutput_freq_units, temp_file%file_format,&
-                        & temp_file%iTime_units, temp_file%long_name, 1)
+                   CALL init_file(temp_file%file_name, temp_file%output_freq, temp_file%iOutput_freq_units, &
+                        & temp_file%file_format, temp_file%iTime_units, temp_file%long_name, 1)
                 END IF
 
                 ! Increment number of files
@@ -437,17 +476,18 @@ CONTAINS
                         & CALL error_mesg("diag_table_mod::Parse_diag_table",&
                         & TRIM(local_err_msg)//" (line: "//TRIM(line_number)//").",WARNING)
                    CYCLE parser
-                ELSE IF ( (diag_subset_output == DIAG_OTHER .AND. INDEX(lowercase(temp_field%file_name), "ocean") .NE. 0).OR.&
-                     &    (diag_subset_output == DIAG_OCEAN .AND. INDEX(lowercase(temp_field%file_name), "ocean") .EQ. 0) ) THEN
+                ELSE IF ( (diag_subset_output == DIAG_OTHER .AND. INDEX(lowercase(temp_field%file_name), "ocean").NE.0)&
+                   & .OR. (diag_subset_output == DIAG_OCEAN .AND. INDEX(lowercase(temp_field%file_name), "ocean").EQ.0)&
+                   &  ) THEN
                    CYCLE parser
                 ELSE IF ( lowercase(TRIM(temp_field%spatial_ops)) == 'none' ) THEN
                    CALL init_input_field(temp_field%module_name, temp_field%field_name, 1)
-                   CALL init_output_field(temp_field%module_name, temp_field%field_name, temp_field%output_name, temp_field%file_name,&
-                        & temp_field%time_method, temp_field%pack, 1)
+                   CALL init_output_field(temp_field%module_name, temp_field%field_name, temp_field%output_name, &
+                        & temp_field%file_name, temp_field%time_method, temp_field%pack, 1)
                 ELSE
                    CALL init_input_field(temp_field%module_name, temp_field%field_name, 1)
-                   CALL init_output_field(temp_field%module_name, temp_field%field_name, temp_field%output_name, temp_field%file_name,&
-                        & temp_field%time_method, temp_field%pack, 1, temp_field%regional_coords)
+                   CALL init_output_field(temp_field%module_name, temp_field%field_name, temp_field%output_name, &
+                        & temp_field%file_name, temp_field%time_method, temp_field%pack, 1, temp_field%regional_coords)
                 END IF
 
                 ! Increment number of fields
@@ -470,15 +510,18 @@ CONTAINS
   END SUBROUTINE parse_diag_table
 
   !> @brief <TT>parse_file_line</TT> parses a file description line from the <TT>diag_table</TT> file, and returns a
-  !!     <TT>TYPE(file_description_type)</TT>.  The calling function, would then need to call the <TT>init_file</TT> to initialize
+  !!     <TT>TYPE(file_description_type)</TT>.  The calling function, would then need to call
+  !!     the <TT>init_file</TT> to initialize
   !!     the diagnostic output file.
   !! @return file_description_type parse_file_line
   TYPE(file_description_type) FUNCTION parse_file_line(line, istat, err_msg)
     CHARACTER(len=*), INTENT(in) :: line !< Line to parse from the <TT>diag_table</TT> file.
     INTEGER, INTENT(out), OPTIONAL, TARGET :: istat !< Return state of the function.  A value of 0 indicates success.
                                                     !! A positive value indicates a <TT>FATAL</TT> error occurred,
-                                                    !! and a negative value indicates a <TT>WARNING</TT> should be issued.
-    CHARACTER(len=*), INTENT(out), OPTIONAL :: err_msg !< Error string to include in the <TT>FATAL</TT> or <TT>WARNING</TT> message.
+                                                    !! and a negative value indicates a <TT>WARNING</TT>
+                                                    !! should be issued.
+    CHARACTER(len=*), INTENT(out), OPTIONAL :: err_msg !< Error string to include in the <TT>FATAL</TT>
+                                                       !! or <TT>WARNING</TT> message.
 
     INTEGER, TARGET :: mystat
     INTEGER, POINTER :: pstat
@@ -501,14 +544,15 @@ CONTAINS
     parse_file_line%filename_time_bounds = ''
 
     ! Read in the file description line..
-    READ (line, FMT=*, IOSTAT=mystat) parse_file_line%file_name, parse_file_line%output_freq, parse_file_line%output_freq_units,&
+    READ (line, FMT=*, IOSTAT=mystat) parse_file_line%file_name, parse_file_line%output_freq, &
+         & parse_file_line%output_freq_units,&
          & parse_file_line%file_format, parse_file_line%time_units, parse_file_line%long_name,&
          & parse_file_line%new_file_freq, parse_file_line%new_file_freq_units, parse_file_line%start_time_s,&
          & parse_file_line%file_duration, parse_file_line%file_duration_units, parse_file_line%filename_time_bounds
     IF ( mystat > 0 ) THEN
        pstat = mystat
-       IF ( fms_error_handler('diag_table_mod::parse_file_line', 'Incorrect file description format in diag_table.', err_msg) )&
-            & RETURN
+       IF ( fms_error_handler('diag_table_mod::parse_file_line', 'Incorrect file description format in diag_table.', &
+                             & err_msg) ) RETURN
     END IF
 
     ! Check for unallowed characters in strings
@@ -555,8 +599,9 @@ CONTAINS
     ! Verify values / formats are correct
     IF ( parse_file_line%file_format > 2 .OR. parse_file_line%file_format < 1 ) THEN
        pstat = 1
-       IF ( fms_error_handler('diag_table_mod::parse_file_line', 'Invalid file format for file description in the diag_table.',&
-            & err_msg) ) RETURN
+       IF ( fms_error_handler('diag_table_mod::parse_file_line', &
+                            & 'Invalid file format for file description in the diag_table.',&
+                            & err_msg) ) RETURN
     END IF
 
     ! check for known units
@@ -572,17 +617,17 @@ CONTAINS
     END IF
     IF ( parse_file_line%iOutput_freq_units < 0 ) THEN
        pstat = 1
-       IF ( fms_error_handler('diag_table_mod::parse_file_line', 'Invalid output frequency units in diag_table.', err_msg) )&
-            & RETURN
+       IF ( fms_error_handler('diag_table_mod::parse_file_line', 'Invalid output frequency units in diag_table.', &
+                            &  err_msg) ) RETURN
     END IF
     IF ( parse_file_line%iNew_file_freq_units < 0 .AND. parse_file_line%new_file_freq > 0 ) THEN
        pstat = 1
-       IF ( fms_error_handler('diag_table_mod::parse_file_line', 'Invalid new file frequency units in diag_table.', err_msg) )&
-            & RETURN
+       IF ( fms_error_handler('diag_table_mod::parse_file_line', 'Invalid new file frequency units in diag_table.', &
+                             & err_msg) ) RETURN
     END IF
     IF ( parse_file_line%iFile_duration_units < 0 .AND. parse_file_line%file_duration > 0 ) THEN
        pstat = 1
-       IF ( fms_error_handler('diag_table_mod::parse_file_line', 'Invalid file duration units in diag_table.', err_msg) )&
+       IF ( fms_error_handler('diag_table_mod::parse_file_line', 'Invalid file duration units in diag_table.',err_msg))&
             & RETURN
     END IF
 
@@ -634,14 +679,17 @@ CONTAINS
   !> @brief Parse a field description line from the <TT>diag_table</TT> file.
   !! @return field_description_type parse_field_line
   !! @details <TT>parse_field_line</TT> parses a field description line from the <TT>diag_table</TT> file, and returns a
-  !!     <TT>TYPE(field_description_type)</TT>.  The calling function, would then need to call the <TT>init_input_field</TT> and
+  !!     <TT>TYPE(field_description_type)</TT>.  The calling function, would then need to call
+  !!     the <TT>init_input_field</TT> and
   !!     <TT>init_output_field</TT> to initialize the diagnostic output field.
   TYPE(field_description_type) FUNCTION parse_field_line(line, istat, err_msg)
     CHARACTER(len=*), INTENT(in) :: line !< Line to parse from the <TT>diag_table</TT> file.
     INTEGER, INTENT(out), OPTIONAL, TARGET :: istat !< Return state of the function.  A value of 0 indicates success.
                                                     !! A positive value indicates a <TT>FATAL</TT> error occurred,
-                                                    !! and a negative value indicates a <TT>WARNING</TT> should be issued.
-    CHARACTER(len=*), OPTIONAL, INTENT(out) :: err_msg !< Error string to include in the <TT>FATAL</TT> or <TT>WARNING</TT> message.
+                                                    !! and a negative value indicates a <TT>WARNING</TT>
+                                                    !! should be issued.
+    CHARACTER(len=*), OPTIONAL, INTENT(out) :: err_msg !< Error string to include in the <TT>FATAL</TT>
+                                                       !! or <TT>WARNING</TT> message.
 
     INTEGER, TARGET :: mystat
     INTEGER, POINTER :: pstat
@@ -653,9 +701,9 @@ CONTAINS
     END IF
     pstat = 0 ! default success return value
 
-    READ (line, FMT=*, IOSTAT=mystat) parse_field_line%module_name, parse_field_line%field_name, parse_field_line%output_name,&
-         & parse_field_line%file_name, parse_field_line%time_sampling, parse_field_line%time_method, parse_field_line%spatial_ops,&
-         & parse_field_line%pack
+    READ (line, FMT=*, IOSTAT=mystat) parse_field_line%module_name, parse_field_line%field_name, &
+         & parse_field_line%output_name, parse_field_line%file_name, parse_field_line%time_sampling, &
+         & parse_field_line%time_method, parse_field_line%spatial_ops, parse_field_line%pack
     IF ( mystat /= 0 ) THEN
        pstat = 1
        IF ( fms_error_handler('diag_table_mod::parse_field_line',&
@@ -720,7 +768,8 @@ CONTAINS
 
   !> @brief Determines if a line from the diag_table file is a file
   !! @return Logical is_a_file
-  !! @details <TT>is_a_file</TT> checks a diag_table line to determine if the line describes a file.  If the line describes a file, the
+  !! @details <TT>is_a_file</TT> checks a diag_table line to determine if the line describes
+  !! a file.  If the line describes a file, the
   !!     <TT>is_a_file</TT> will return <TT>.TRUE.</TT>.  Otherwise, it will return <TT>.FALSE.</TT>
   PURE LOGICAL FUNCTION is_a_file(line)
     CHARACTER(len=*), INTENT(in) :: line !< String containing the <TT>diag_table</TT> line.
@@ -730,14 +779,16 @@ CONTAINS
     INTEGER :: mystat !< IO status from read
 
 #if defined __PATHSCALE__ || defined _CRAYFTN
-    ! This portion is to 'fix' pathscale's and Cray's Fortran compilers inability to handle the FMT=* correctly in the read
+    ! This portion is to 'fix' pathscale's and Cray's Fortran compilers inability to handle
+    ! the FMT=* correctly in the read
     ! statement.
     CHARACTER(len=10) :: secondString
     INTEGER :: comma1, comma2, linelen
 
     linelen = LEN(line)
     comma1 = INDEX(line,',') + 1 ! +1 to go past the comma
-    comma2 = INDEX(line(comma1:linelen),',') + comma1 - 2 ! -2 to get rid of +1 in comma1 and to get 1 character before the comma
+    comma2 = INDEX(line(comma1:linelen),',') + comma1 - 2 ! -2 to get rid of +1 in comma1 and to get
+                                                          !! 1 character before the comma
 
     secondString = ADJUSTL(line(comma1:comma2))
     READ (UNIT=secondString, FMT='(I)', IOSTAT=mystat) second

--- a/diag_manager/diag_table.F90
+++ b/diag_manager/diag_table.F90
@@ -188,7 +188,8 @@
 !!         <DD>Currently not used.  Please use the string "all".</DD>
 !!         <DT><TT>CHARACTER(len=50) :: reduction_method</TT></DT>
 !!         <DD>
-!!           The data reduction method to perform prior to writing data to disk.  Valid options are (redundant names are
+!!           The data reduction method to perform prior to writing data to disk.  Valid options
+!!           are (redundant names are
 !!           separated with commas):
 !!           <DL>
 !!             <DT><TT>.TRUE.</TT>, average, avg, mean</DT>
@@ -209,7 +210,8 @@
 !!           a global region.  The regional
 !!           section has the following format:<BR />
 !!           <TT>lat_min, lat_max, lon_min, lon_max, vert_min, vert_max</TT><BR />
-!!           Use <TT>vert_min = -1</TT> and <TT>vert_max = -1</TT> to get the entire vertical axis.  <B><I>NOTE:</I></B>
+!!           Use <TT>vert_min = -1</TT> and <TT>vert_max = -1</TT> to get the entire vertical
+!!           axis.  <B><I>NOTE:</I></B>
 !!           Currently, the defined region <I>MUST</I> be confined to a single tile.
 !!         </DD>
 !!         <DT><TT>INTEGER :: packing</TT></DT>
@@ -375,7 +377,8 @@ CONTAINS
     END IF
 
     ! Read in the base date
-    READ (UNIT=diag_table(2), FMT=*, IOSTAT=mystat) base_year, base_month, base_day, base_hour, base_minute, base_second
+    READ (UNIT=diag_table(2), FMT=*, IOSTAT=mystat) base_year, base_month, base_day, base_hour, base_minute, &
+         &  base_second
     IF ( mystat /= 0 ) THEN
        pstat = mystat
        IF ( fms_error_handler('diag_manager_init', 'Error reading the base date from the diagnostic table.', &
@@ -393,7 +396,8 @@ CONTAINS
        amonth = month_name(base_month)
     ELSE
        ! No calendar - ignore year and month
-       base_time = set_time(NINT(base_hour*SECONDS_PER_HOUR)+NINT(base_minute*SECONDS_PER_MINUTE)+base_second, base_day)
+       base_time = set_time(NINT(base_hour*SECONDS_PER_HOUR)+NINT(base_minute*SECONDS_PER_MINUTE)+base_second, &
+                           &  base_day)
        base_year = 0
        base_month = 0
        amonth = 'day'
@@ -476,8 +480,8 @@ CONTAINS
                         & CALL error_mesg("diag_table_mod::Parse_diag_table",&
                         & TRIM(local_err_msg)//" (line: "//TRIM(line_number)//").",WARNING)
                    CYCLE parser
-                ELSE IF ( (diag_subset_output == DIAG_OTHER .AND. INDEX(lowercase(temp_field%file_name), "ocean").NE.0)&
-                   & .OR. (diag_subset_output == DIAG_OCEAN .AND. INDEX(lowercase(temp_field%file_name), "ocean").EQ.0)&
+                ELSE IF ((diag_subset_output == DIAG_OTHER .AND. INDEX(lowercase(temp_field%file_name), "ocean").NE.0)&
+                   &.OR. (diag_subset_output == DIAG_OCEAN .AND. INDEX(lowercase(temp_field%file_name), "ocean").EQ.0)&
                    &  ) THEN
                    CYCLE parser
                 ELSE IF ( lowercase(TRIM(temp_field%spatial_ops)) == 'none' ) THEN
@@ -627,7 +631,7 @@ CONTAINS
     END IF
     IF ( parse_file_line%iFile_duration_units < 0 .AND. parse_file_line%file_duration > 0 ) THEN
        pstat = 1
-       IF ( fms_error_handler('diag_table_mod::parse_file_line', 'Invalid file duration units in diag_table.',err_msg))&
+       IF (fms_error_handler('diag_table_mod::parse_file_line', 'Invalid file duration units in diag_table.',err_msg))&
             & RETURN
     END IF
 
@@ -678,7 +682,8 @@ CONTAINS
 
   !> @brief Parse a field description line from the <TT>diag_table</TT> file.
   !! @return field_description_type parse_field_line
-  !! @details <TT>parse_field_line</TT> parses a field description line from the <TT>diag_table</TT> file, and returns a
+  !! @details <TT>parse_field_line</TT> parses a field description line from the <TT>diag_table</TT>
+  !! file, and returns a
   !!     <TT>TYPE(field_description_type)</TT>.  The calling function, would then need to call
   !!     the <TT>init_input_field</TT> and
   !!     <TT>init_output_field</TT> to initialize the diagnostic output field.

--- a/diag_manager/diag_table.F90
+++ b/diag_manager/diag_table.F90
@@ -258,7 +258,7 @@ MODULE diag_table_mod
   USE constants_mod, ONLY: SECONDS_PER_HOUR, SECONDS_PER_MINUTE
 
   USE diag_data_mod, ONLY: global_descriptor, base_time, base_year, base_month, base_day, base_hour, base_minute, &
-       & base_second, DIAG_OTHER, DIAG_OCEAN, DIAG_ALL, coord_type, append_pelist_name, pelist_name
+                         & base_second, DIAG_OTHER, DIAG_OCEAN, DIAG_ALL, coord_type, append_pelist_name, pelist_name
   USE diag_util_mod, ONLY: init_file, check_duplicate_output_fields, init_input_field, init_output_field
 
   IMPLICIT NONE

--- a/diag_manager/diag_util.F90
+++ b/diag_manager/diag_util.F90
@@ -32,7 +32,8 @@ use,intrinsic :: iso_c_binding, only: c_double,c_float,c_int64_t, &
                                       c_int32_t,c_int16_t,c_intptr_t
 
   !   <FUTURE>
-  !     Make an interface <TT>check_bounds_are_exact</TT> for the subroutines <TT>check_bounds_are_exact_static</TT> and
+  !     Make an interface <TT>check_bounds_are_exact</TT> for the subroutines <TT>check_bounds_are_exact_static</TT>
+  !     and
   !     <TT>check_bounds_are_exact_dynamic</TT>.
   !     <PRE>
   !       INTERFACE check_bounds_are_exact
@@ -1732,7 +1733,7 @@ CONTAINS
           CALL write_axis_meta_data(files(file)%file_unit, axes(1:actual_num_axes),fileobj(file), time_ops=time_ops, &
                                    time_axis_registered=files(file)%is_time_axis_registered)
        elseif (fnum_for_domain(file) == "nd") then
-          CALL write_axis_meta_data(files(file)%file_unit, axes(1:actual_num_axes),fileobjnd(file), time_ops=time_ops, &
+          CALL write_axis_meta_data(files(file)%file_unit, axes(1:actual_num_axes),fileobjnd(file), time_ops=time_ops,&
                                    time_axis_registered=files(file)%is_time_axis_registered)
        elseif (fnum_for_domain(file) == "ug") then
           CALL write_axis_meta_data(files(file)%file_unit, axes(1:actual_num_axes),fileobjU(file), time_ops=time_ops, &
@@ -1781,9 +1782,9 @@ CONTAINS
                 !   Create a new file or set mix_snapshot_average_fields=.TRUE. in the namelist diag_manager_nml.
                 ! </ERROR>
                 CALL error_mesg('diag_util_mod::opening_file','file '//TRIM(files(file)%name)// &
-                     & ' can NOT have BOTH time average AND instantaneous fields.'//&
-                     & ' Create a new file or set mix_snapshot_average_fields=.TRUE. in the namelist diag_manager_nml.'&
-                     & , FATAL)
+                     &' can NOT have BOTH time average AND instantaneous fields.'//&
+                     &' Create a new file or set mix_snapshot_average_fields=.TRUE. in the namelist diag_manager_nml.'&
+                     &, FATAL)
              END IF
           END IF
        END IF

--- a/diag_manager/diag_util.F90
+++ b/diag_manager/diag_util.F90
@@ -144,7 +144,8 @@ CONTAINS
     REAL, ALLOCATABLE :: subaxis_z(:) !< containing local coordinates in x,y,z axes
     CHARACTER(len=128) :: msg
     INTEGER :: ishift, jshift
-    INTEGER :: grv !< Value used to determine if the region defined in the diag_table is for the whole axis, or a sub-axis
+    INTEGER :: grv !< Value used to determine if the region defined in the diag_table is for the whole
+                   !! axis, or a sub-axis
     CHARACTER(len=128), DIMENSION(2) :: axis_domain_name
 
     !initilization for local output
@@ -725,12 +726,14 @@ CONTAINS
     output_fields(out_num)%kmax = MAX(output_fields(out_num)%kmax, upper_k)
   END SUBROUTINE update_bounds
 
-  !> @brief Checks if the array indices for <TT>output_fields(out_num)</TT> are outside the <TT>output_fields(out_num)%buffer</TT> upper
+  !> @brief Checks if the array indices for <TT>output_fields(out_num)</TT> are outside the
+  !! <TT>output_fields(out_num)%buffer</TT> upper
   !!     and lower bounds.
   SUBROUTINE check_out_of_bounds(out_num, diag_field_id, err_msg)
     INTEGER, INTENT(in) :: out_num !< Output field ID number.
     INTEGER, INTENT(in) :: diag_field_id !< Input field ID number.
-    CHARACTER(len=*), INTENT(out) :: err_msg !< Return status of <TT>check_out_of_bounds</TT>.  An empty error string indicates the x, y, and z indices are not outside the
+    CHARACTER(len=*), INTENT(out) :: err_msg !< Return status of <TT>check_out_of_bounds</TT>.  An empty
+                                             !! error string indicates the x, y, and z indices are not outside the
                                              !!     buffer array boundaries.
 
     CHARACTER(len=128) :: error_string1, error_string2
@@ -771,7 +774,8 @@ CONTAINS
 
   END SUBROUTINE check_out_of_bounds
 
-  !> @brief  Check if the array indices for <TT>output_fields(out_num)</TT> are equal to the <TT>output_fields(out_num)%buffer</TT>
+  !> @brief  Check if the array indices for <TT>output_fields(out_num)</TT> are equal to the
+  !! <TT>output_fields(out_num)%buffer</TT>
   !!     upper and lower bounds.
   SUBROUTINE check_bounds_are_exact_dynamic(out_num, diag_field_id, Time, err_msg)
     INTEGER, INTENT(in) :: out_num !< Output field ID number.
@@ -837,7 +841,8 @@ CONTAINS
     END IF
   END SUBROUTINE check_bounds_are_exact_dynamic
 
-  !> @brief Check if the array indices for <TT>output_fields(out_num)</TT> are equal to the <TT>output_fields(out_num)%buffer</TT>
+  !> @brief Check if the array indices for <TT>output_fields(out_num)</TT> are equal to the
+  !! <TT>output_fields(out_num)%buffer</TT>
   !!     upper and lower bounds.
   SUBROUTINE check_bounds_are_exact_static(out_num, diag_field_id, err_msg)
     INTEGER, INTENT(in) :: out_num !< Output field ID
@@ -1246,7 +1251,8 @@ CONTAINS
     INTEGER :: num_fields, i, method_selected, l1
     INTEGER :: ioerror
     REAL :: pow_value
-    INTEGER :: grv !< Value used to determine if the region defined in the diag_table is for the whole axis, or a sub-axis
+    INTEGER :: grv !< Value used to determine if the region defined in the diag_table is for the whole
+                   !! axis, or a sub-axis
     CHARACTER(len=128) :: error_msg
     CHARACTER(len=50) :: t_method
     character(len=256) :: tmp_name
@@ -1279,7 +1285,8 @@ CONTAINS
        ELSE
           WRITE (error_msg,'(A,"/",A)') TRIM(module_name),TRIM(field_name)
        END IF
-       ! <ERROR STATUS="FATAL">module_name/field_name <module_name>/<field_name>[/tile_count=<tile_count>] NOT registered</ERROR>
+       ! <ERROR STATUS="FATAL">module_name/field_name <module_name>/<field_name>[/tile_count=<tile_count>]
+       ! NOT registered</ERROR>
        CALL error_mesg('diag_util_mod::init_output_field',&
             & 'module_name/field_name '//TRIM(error_msg)//' NOT registered', FATAL)
     END IF
@@ -1289,7 +1296,8 @@ CONTAINS
          & input_fields(in_num)%num_output_fields + 1
     IF ( input_fields(in_num)%num_output_fields > max_out_per_in_field ) THEN
        ! <ERROR STATUS="FATAL">
-       !   MAX_OUT_PER_IN_FIELD = <MAX_OUT_PER_IN_FIELD> exceeded for <module_name>/<field_name>, increase MAX_OUT_PER_IN_FIELD
+       !   MAX_OUT_PER_IN_FIELD = <MAX_OUT_PER_IN_FIELD> exceeded for <module_name>/<field_name>,
+       !   increase MAX_OUT_PER_IN_FIELD
        !   in the diag_manager_nml namelist.
        ! </ERROR>
        WRITE (UNIT=error_msg,FMT=*) MAX_OUT_PER_IN_FIELD
@@ -1344,7 +1352,8 @@ CONTAINS
        !   MAX_FIELDS_PER_FILE = <MAX_FIELDS_PER_FILE> exceeded.  Increase MAX_FIELDS_PER_FILE in diag_data.F90.
        ! </ERROR>
        CALL error_mesg('diag_util_mod::init_output_field',&
-            & 'MAX_FIELDS_PER_FILE = '//TRIM(error_msg)//' exceeded.  Increase MAX_FIELDS_PER_FILE in diag_data.F90.', FATAL)
+            & 'MAX_FIELDS_PER_FILE = '//TRIM(error_msg)// &
+             & ' exceeded.  Increase MAX_FIELDS_PER_FILE in diag_data.F90.', FATAL)
     END IF
     num_fields = files(file_num)%num_fields
     files(file_num)%fields(num_fields) = out_num
@@ -1526,7 +1535,8 @@ CONTAINS
     ! WARNING: Assumes that all data structures are fully initialized
     INTEGER, INTENT(in) :: file !< File ID.
     TYPE(time_type), INTENT(in) :: time !< Time for the file time stamp
-    TYPE(time_type), INTENT(in), optional :: filename_time !< Time used in setting the filename when writting periodic files
+    TYPE(time_type), INTENT(in), optional :: filename_time !< Time used in setting the filename when
+                                                           !! writting periodic files
 
     TYPE(time_type) :: fname_time !< Time used in setting the filename when writting periodic files
     REAL, DIMENSION(2) :: DATA
@@ -1659,10 +1669,6 @@ CONTAINS
           WRITE (error_string,'(A,"/",A)') TRIM(input_fields(input_field_num)%module_name),&
                & TRIM(input_fields(input_field_num)%field_name)
           IF(mpp_pe() .EQ. mpp_root_pe()) THEN
-             ! <ERROR STATUS="WARNING">
-             !   module/field_name (<input_fields(input_field_num)%module_name>/<input_fields(input_field_num)%field_name>)
-             !   NOT registered
-             ! </ERROR>
              CALL error_mesg('diag_util_mod::opening_file',&
                   & 'module/field_name ('//TRIM(error_string)//') NOT registered', WARNING)
           END IF
@@ -1774,9 +1780,10 @@ CONTAINS
                 !   <files(file)%name> can NOT have BOTH time average AND instantaneous fields.
                 !   Create a new file or set mix_snapshot_average_fields=.TRUE. in the namelist diag_manager_nml.
                 ! </ERROR>
-                CALL error_mesg('diag_util_mod::opening_file','file '//&
-                     & TRIM(files(file)%name)//' can NOT have BOTH time average AND instantaneous fields.'//&
-                     & ' Create a new file or set mix_snapshot_average_fields=.TRUE. in the namelist diag_manager_nml.' , FATAL)
+                CALL error_mesg('diag_util_mod::opening_file','file '//TRIM(files(file)%name)// &
+                     & ' can NOT have BOTH time average AND instantaneous fields.'//&
+                     & ' Create a new file or set mix_snapshot_average_fields=.TRUE. in the namelist diag_manager_nml.'&
+                     & , FATAL)
              END IF
           END IF
        END IF
@@ -1940,7 +1947,8 @@ CONTAINS
        !   found in file <file_name>
        ! </ERROR>
        IF ( mpp_pe() == mpp_root_pe() ) CALL error_mesg('diag_util_mod::opening_file',&
-            &'one axis has auxiliary but the corresponding field is NOT found in file '//TRIM(files(file)%name), WARNING)
+            &'one axis has auxiliary but the corresponding field is NOT found in file '// &
+             & TRIM(files(file)%name), WARNING)
     END IF
     IF( req_present .AND. .NOT.match_req_fields ) THEN
        ! <ERROR STATUS="FATAL">
@@ -2152,7 +2160,8 @@ CONTAINS
     TYPE(time_type), INTENT(in) :: time !< Current model time.
     LOGICAL, OPTIONAL, INTENT(in):: final_call_in !< <TT>.TRUE.</TT> if this is the last write for file.
     LOGICAL, OPTIONAL, INTENT(in):: static_write_in !< <TT>.TRUE.</TT> if static fields are to be written to file.
-    type(time_type), intent(in), optional :: filename_time !< Time used in setting the filename when writting periodic files
+    type(time_type), intent(in), optional :: filename_time !< Time used in setting the filename when
+                                                           !! writting periodic files
 
     LOGICAL :: final_call, do_write, static_write
     INTEGER :: i, num
@@ -2257,7 +2266,8 @@ CONTAINS
     TYPE(time_type), INTENT(in) :: time !< Current model time.
     LOGICAL, INTENT(out) :: do_write !< <TT>.TRUE.</TT> if file is expecting more data to write,
                                      !! <TT>.FALSE.</TT> otherwise.
-    TYPE(time_type), INTENT(in), optional :: filename_time !< Time used in setting the filename when writting periodic files
+    TYPE(time_type), INTENT(in), optional :: filename_time !< Time used in setting the filename when
+                                                           !! writting periodic files
 
     IF ( time >= files(file)%start_time ) THEN
        IF ( files(file)%file_unit < 0 ) THEN ! need to open a new file
@@ -2283,7 +2293,8 @@ CONTAINS
                 !   check file duration and frequency
                 ! </ERROR>
                 CALL error_mesg('diag_util_mod::check_and_open',&
-                     & files(file)%name//' has close time GREATER than next_open time, check file duration and frequency',FATAL)
+                     & files(file)%name// &
+                      & ' has close time GREATER than next_open time, check file duration and frequency',FATAL)
              END IF
           END IF ! no need to open new file, simply return file_unit
        END IF
@@ -2486,7 +2497,8 @@ CONTAINS
           ! <ERROR STATUS="FATAL">
           !   Unable to allocate memory for file attributes
           ! </ERROR>
-          IF ( fms_error_handler('diag_util_mod::attribute_init_file', 'Unable to allocate memory for file attributes', err_msg) ) THEN
+          IF ( fms_error_handler('diag_util_mod::attribute_init_file', &
+             &  'Unable to allocate memory for file attributes', err_msg) ) THEN
              RETURN
           END IF
        ELSE

--- a/docs/layout.xml
+++ b/docs/layout.xml
@@ -11,7 +11,7 @@
     </tab>
     <tab type="classes" visible="yes" title="">
       <tab type="classlist" visible="yes" title="" intro=""/>
-      <tab type="classindex" visible="$ALPHABETICAL_INDEX" title=""/> 
+      <tab type="classindex" visible="$ALPHABETICAL_INDEX" title=""/>
       <tab type="hierarchy" visible="yes" title="" intro=""/>
       <tab type="classmembers" visible="yes" title="" intro=""/>
     </tab>
@@ -19,7 +19,7 @@
       <tab type="filelist" visible="yes" title="" intro=""/>
       <tab type="globals" visible="yes" title="" intro=""/>
     </tab>
-    <tab type="examples" visible="yes" title="" intro=""/>  
+    <tab type="examples" visible="yes" title="" intro=""/>
   </navindex>
 
   <!-- Layout definition for a class page -->

--- a/drifters/cloud_interpolator.F90
+++ b/drifters/cloud_interpolator.F90
@@ -16,7 +16,8 @@
 !* You should have received a copy of the GNU Lesser General Public
 !* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
 !***********************************************************************
-! nf95 -r8 -g -I ~/regression/ia64/23-Jun-2005/CM2.1U_Control-1990_E1.k32pe/include/ -D_TEST_CLOUD_INTERPOLATOR -D_F95 cloud_interpolator.F90
+! nf95 -r8 -g -I ~/regression/ia64/23-Jun-2005/CM2.1U_Control-1990_E1.k32pe/include/ -D_TEST_CLOUD_INTERPOLATOR
+! -D_F95 cloud_interpolator.F90
 
 #define _FLATTEN(A) reshape((A), (/size((A))/) )
 

--- a/drifters/drifters.F90
+++ b/drifters/drifters.F90
@@ -93,7 +93,7 @@ module drifters_mod
                                 drifters_io_set_position_names, drifters_io_set_position_units, &
                                 drifters_io_set_field_names, drifters_io_set_field_units, drifters_io_write
 
-  use drifters_comm_mod,  only: drifters_comm_type, drifters_comm_new, drifters_comm_del, drifters_comm_set_pe_neighbors, &
+  use drifters_comm_mod,  only: drifters_comm_type,drifters_comm_new,drifters_comm_del,drifters_comm_set_pe_neighbors,&
                                 drifters_comm_set_domain, drifters_comm_gather, drifters_comm_update
 
   use cloud_interpolator_mod, only: cld_ntrp_linear_cell_interp, cld_ntrp_locate_cell, cld_ntrp_get_cell_values

--- a/drifters/drifters_core.F90
+++ b/drifters/drifters_core.F90
@@ -17,7 +17,8 @@
 !* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
 !***********************************************************************
 !
-! nf95 -r8 -g -I ~/regression/ia64/23-Jun-2005/CM2.1U_Control-1990_E1.k32pe/include/ -D_TEST_DRIFTERS -D_F95 quicksort.F90 drifters_core.F90
+! nf95 -r8 -g -I ~/regression/ia64/23-Jun-2005/CM2.1U_Control-1990_E1.k32pe/include/ -D_TEST_DRIFTERS
+! -D_F95 quicksort.F90 drifters_core.F90
 
 !> @defgroup drifters_core_mod drifters_core_mod
 !> @ingroup drifters
@@ -220,7 +221,8 @@ subroutine drifters_core_remove_and_add(self, indices_to_remove_in, &
 
     ! cannot remove more than there are elements
     if(self%np + n_diff < 0) then
-       ermesg = 'drifters::ERROR attempting to remove more elements than there are elements in drifters_core_remove_and_add'
+       ermesg = 'drifters::ERROR attempting to remove more elements than there are elements in '// &
+               &'drifters_core_remove_and_add'
        return
     endif
 

--- a/exchange/stock_constants.F90
+++ b/exchange/stock_constants.F90
@@ -325,8 +325,8 @@ contains
 
           write(stocks_file,'(a)'  ) ' '!blank line
           formatString = '(a,a,a,6x,es22.15)'
-          write(stocks_file,formatString) 'Lost Stocks in the exchange between Ice and Ocean ',trim(STOCK_NAMES(elem)),trim(STOCK_UNITS(elem)),  &
-                                        & f_ice_grid(ISTOCK_OCN) - f_ocn_grid(ISTOCK_OCN) + f_ocn_btf(ISTOCK_OCN)
+          write(stocks_file,formatString) 'Lost Stocks in the exchange between Ice and Ocean ',trim(STOCK_NAMES(elem))&
+                     &,trim(STOCK_UNITS(elem)), f_ice_grid(ISTOCK_OCN) - f_ocn_grid(ISTOCK_OCN) + f_ocn_btf(ISTOCK_OCN)
 
           write(stocks_file,'(a)') ' ' !blank line
           write(stocks_file,'(a)') ' ' !blank line

--- a/exchange/stock_constants.F90
+++ b/exchange/stock_constants.F90
@@ -180,7 +180,8 @@ contains
     real    :: days
     integer :: diagID , comp,elem,i
     integer, parameter :: initID = -2 !< initial value for diag IDs. Must not be equal to the value
-                                      !! that register_diag_field returns when it can't register the filed -- otherwise the registration
+                                      !! that register_diag_field returns when it can't register
+                                      !! the filed -- otherwise the registration
                                       !! is attempted every time this subroutine is called
 
     integer, dimension(NCOMPS,NELEMS), save :: f_valueDiagID = initID
@@ -286,10 +287,11 @@ contains
              if (DiagID > 0)  used = send_data(DiagID, diagField, Time)
 
 
-             !             formatString = '(a,a,a,i16,2x,es22.15,2x,es22.15,2x,es22.15,2x,es22.15,2x,es22.15,2x,es22.15)'
+             ! formatString = '(a,a,a,i16,2x,es22.15,2x,es22.15,2x,es22.15,2x,es22.15,2x,es22.15,2x,es22.15)'
              !
              !             write(stocks_file,formatString) trim(COMP_NAMES(comp)),STOCK_NAMES(elem),STOCK_UNITS(elem) &
-             !                  ,hours, q_now, q_now-q_start, f_value, f_value - (q_now - q_start), (f_value - (q_now - q_start))/q_start
+             !                  ,hours, q_now, q_now-q_start, f_value, f_value - (q_now - q_start),
+             !                  (f_value - (q_now - q_start))/q_start
 
 
           endif
@@ -302,9 +304,11 @@ contains
 !          write(stocks_file,'(a)'  )   ' '!blank line
 !          write(stocks_file,'(a,30x,a,20x,a,20x,a,20x,a)') 'Component ','ATM','LND','ICE','OCN'
 !          write(stocks_file,'(55x,a,20x,a,20x,a,20x,a)')  'ATM','LND','ICE','OCN'
-!          write(stocks_file,'(a,f12.3,12x,a,20x,a,20x,a,20x,a)') 't = TimeSinceStart[days]= ',days,'ATM','LND','ICE','OCN'
+!          write(stocks_file,'(a,f12.3,12x,a,20x,a,20x,a,20x,a)') 't = TimeSinceStart[days]=
+!          ',days,'ATM','LND','ICE','OCN'
 
-          write(stocks_file,'(a,a,40x,a,20x,a,20x,a,20x,a)') 'Stocks of ',trim(STOCK_NAMES(elem)),'ATM','LND','ICE','OCN'
+          write(stocks_file,'(a,a,40x,a,20x,a,20x,a,20x,a)') 'Stocks of ',trim(STOCK_NAMES(elem)),'ATM','LND', &
+               & 'ICE','OCN'
           formatString = '(a,a,2x,es22.15,2x,es22.15,2x,es22.15,2x,es22.15)'
 
           write(stocks_file,formatString) 'Total =S(t)               ',STOCK_UNITS(elem),&
@@ -316,12 +320,13 @@ contains
           write(stocks_file,formatString) 'Diff  =F(t) - (S(t)-S(0)) ',STOCK_UNITS(elem),&
                ( f_value(i) - c_value(i), i=1,NCOMPS)
           write(stocks_file,formatString) 'Error =Diff/S(0)          ','[NonDim]    ', &
-               ((f_value(i) - c_value(i))/(1+q_start(i)), i=1,NCOMPS)  !added 1 to avoid div by zero. Assuming q_start large
+               ((f_value(i) - c_value(i))/(1+q_start(i)), i=1,NCOMPS)  !added 1 to avoid div by zero.
+                                                                       !! Assuming q_start large
 
           write(stocks_file,'(a)'  ) ' '!blank line
           formatString = '(a,a,a,6x,es22.15)'
           write(stocks_file,formatString) 'Lost Stocks in the exchange between Ice and Ocean ',trim(STOCK_NAMES(elem)),trim(STOCK_UNITS(elem)),  &
-               f_ice_grid(ISTOCK_OCN) - f_ocn_grid(ISTOCK_OCN) + f_ocn_btf(ISTOCK_OCN)
+                                        & f_ice_grid(ISTOCK_OCN) - f_ocn_grid(ISTOCK_OCN) + f_ocn_btf(ISTOCK_OCN)
 
           write(stocks_file,'(a)') ' ' !blank line
           write(stocks_file,'(a)') ' ' !blank line

--- a/exchange/xgrid.F90
+++ b/exchange/xgrid.F90
@@ -796,8 +796,8 @@ logical,        intent(in)             :: use_higher_order
            if(variable_exists(fileobj, "scale")) then
               allocate(scale(isc:iec))
               write(out_unit, *)"NOTE from load_xgrid(xgrid_mod): field 'scale' exist in the file "// &
-                   trim(grid_file)// &
-                      & ", this field will be read and the exchange grid cell area will be multiplied by scale"
+                  & trim(grid_file)//", this field will be read and the exchange grid cell area will be"// &
+                  & " multiplied by scale"
               call read_data(fileobj, "scale", tmp, corner=start, edge_lengths=nread)
               scale = tmp(:,1)
               scale_exist = .true.
@@ -1767,9 +1767,9 @@ subroutine setup_xmap(xmap, grid_ids, grid_domains, grid_file, atm_grid, lnd_ug_
               if(.NOT. present(atm_grid)) call error_mesg('xgrid_mod', &
                                           'when first grid is "ATM", atm_grid should be present', FATAL)
               if(grid%is_me-grid%isd_me .NE. 1 .or. grid%ied_me-grid%ie_me .NE. 1 .or.               &
-                   grid%js_me-grid%jsd_me .NE. 1 .or. grid%jed_me-grid%je_me .NE. 1 ) call error_mesg( &
-                   'xgrid_mod', 'for non-latlon grid (cubic grid), &
-                                                     &  the halo size should be 1 in all four direction', FATAL)
+                   grid%js_me-grid%jsd_me .NE. 1 .or. grid%jed_me-grid%je_me .NE. 1 ) &
+                       & call error_mesg('xgrid_mod', 'for non-latlon grid (cubic grid), '//&
+                                       & 'the halo size should be 1 in all four direction', FATAL)
               if(.NOT.( ASSOCIATED(atm_grid%dx) .AND. ASSOCIATED(atm_grid%dy) .AND. ASSOCIATED(atm_grid%edge_w) .AND. &
                    ASSOCIATED(atm_grid%edge_e) .AND. ASSOCIATED(atm_grid%edge_s) .AND.ASSOCIATED(atm_grid%edge_n).AND.&
                    ASSOCIATED(atm_grid%en1) .AND. ASSOCIATED(atm_grid%en2) .AND. ASSOCIATED(atm_grid%vlon) .AND.      &

--- a/exchange/xgrid.F90
+++ b/exchange/xgrid.F90
@@ -796,7 +796,8 @@ logical,        intent(in)             :: use_higher_order
            if(variable_exists(fileobj, "scale")) then
               allocate(scale(isc:iec))
               write(out_unit, *)"NOTE from load_xgrid(xgrid_mod): field 'scale' exist in the file "// &
-                   trim(grid_file)//", this field will be read and the exchange grid cell area will be multiplied by scale"
+                   trim(grid_file)// &
+                      & ", this field will be read and the exchange grid cell area will be multiplied by scale"
               call read_data(fileobj, "scale", tmp, corner=start, edge_lengths=nread)
               scale = tmp(:,1)
               scale_exist = .true.
@@ -1767,10 +1768,11 @@ subroutine setup_xmap(xmap, grid_ids, grid_domains, grid_file, atm_grid, lnd_ug_
                                           'when first grid is "ATM", atm_grid should be present', FATAL)
               if(grid%is_me-grid%isd_me .NE. 1 .or. grid%ied_me-grid%ie_me .NE. 1 .or.               &
                    grid%js_me-grid%jsd_me .NE. 1 .or. grid%jed_me-grid%je_me .NE. 1 ) call error_mesg( &
-                   'xgrid_mod', 'for non-latlon grid (cubic grid), the halo size should be 1 in all four direction', FATAL)
-              if(.NOT.( ASSOCIATED(atm_grid%dx) .AND. ASSOCIATED(atm_grid%dy) .AND. ASSOCIATED(atm_grid%edge_w) .AND.    &
-                   ASSOCIATED(atm_grid%edge_e) .AND. ASSOCIATED(atm_grid%edge_s) .AND. ASSOCIATED(atm_grid%edge_n) .AND. &
-                   ASSOCIATED(atm_grid%en1) .AND. ASSOCIATED(atm_grid%en2) .AND. ASSOCIATED(atm_grid%vlon) .AND.         &
+                   'xgrid_mod', 'for non-latlon grid (cubic grid), &
+                                                     &  the halo size should be 1 in all four direction', FATAL)
+              if(.NOT.( ASSOCIATED(atm_grid%dx) .AND. ASSOCIATED(atm_grid%dy) .AND. ASSOCIATED(atm_grid%edge_w) .AND. &
+                   ASSOCIATED(atm_grid%edge_e) .AND. ASSOCIATED(atm_grid%edge_s) .AND.ASSOCIATED(atm_grid%edge_n).AND.&
+                   ASSOCIATED(atm_grid%en1) .AND. ASSOCIATED(atm_grid%en2) .AND. ASSOCIATED(atm_grid%vlon) .AND.      &
                    ASSOCIATED(atm_grid%vlat) ) )  call error_mesg( 'xgrid_mod', &
                    'for non-latlon grid (cubic grid), all the fields in atm_grid data type should be allocated', FATAL)
               nxc = grid%ie_me  - grid%is_me  + 1
@@ -1789,9 +1791,9 @@ subroutine setup_xmap(xmap, grid_ids, grid_domains, grid_file, atm_grid, lnd_ug_
                    call error_mesg( 'xgrid_mod', 'incorrect dimension size of atm_grid%en1', FATAL)
               if(size(atm_grid%en2,1) .NE. 3 .OR. size(atm_grid%en2,2) .NE. nxc+1 .OR. size(atm_grid%en2,3) .NE. nyc) &
                    call error_mesg( 'xgrid_mod', 'incorrect dimension size of atm_grid%en2', FATAL)
-              if(size(atm_grid%vlon,1) .NE. 3 .OR. size(atm_grid%vlon,2) .NE. nxc .OR. size(atm_grid%vlon,3) .NE. nyc)   &
+              if(size(atm_grid%vlon,1) .NE. 3 .OR. size(atm_grid%vlon,2) .NE. nxc .OR. size(atm_grid%vlon,3) .NE. nyc)&
                    call error_mesg('xgrid_mod', 'incorrect dimension size of atm_grid%vlon', FATAL)
-              if(size(atm_grid%vlat,1) .NE. 3 .OR. size(atm_grid%vlat,2) .NE. nxc .OR. size(atm_grid%vlat,3) .NE. nyc)   &
+              if(size(atm_grid%vlat,1) .NE. 3 .OR. size(atm_grid%vlat,2) .NE. nxc .OR. size(atm_grid%vlat,3) .NE. nyc)&
                    call error_mesg('xgrid_mod', 'incorrect dimension size of atm_grid%vlat', FATAL)
               allocate(grid%box%dx    (grid%is_me:grid%ie_me,   grid%js_me:grid%je_me+1 ))
               allocate(grid%box%dy    (grid%is_me:grid%ie_me+1, grid%js_me:grid%je_me   ))
@@ -1888,7 +1890,8 @@ subroutine setup_xmap(xmap, grid_ids, grid_domains, grid_file, atm_grid, lnd_ug_
               do i = 1, nxgrid_file
                  xgrid_file = 'INPUT/'//trim(xgrid_filelist(i))
                  if(.not. open_file(fileobj,xgrid_file, "read")) then
-                     call error_mesg('xgrid_mod(setup_xmap)', 'Error when opening xgrid file '//trim(xgrid_file), FATAL)
+                     call error_mesg('xgrid_mod(setup_xmap)', 'Error when opening xgrid file '// &
+                                   & trim(xgrid_file), FATAL)
                  endif
 
                  ! find the tile number of side 1 and side 2 mosaic, which is contained in field contact
@@ -3192,7 +3195,8 @@ subroutine put_side1_to_xgrid(d, grid_id, x, xmap, remap_method, complete)
      endif
 
      if(is_complete) then
-        !--- when exchange_monotonic is true and the side 1 ia atm, will always use monotonic second order conservative.
+        !--- when exchange_monotonic is true and the side 1 ia atm, will always use monotonic
+        !second order conservative.
         if(monotonic_exchange .AND. grid_id == 'ATM') then
            call put_1_to_xgrid_order_2(d_addrs, x_addrs, xmap, isize, jsize, xsize, lsize)
         else if(method == FIRST_ORDER) then
@@ -3296,7 +3300,8 @@ subroutine get_side1_from_xgrid(d, grid_id, x, xmap, complete)
         set_mismatch = set_mismatch .OR. (grid_id_saved /= grid_id)
         if(set_mismatch)then
            write( text,'(i2)' ) lsize
-           call error_mesg ('xgrid_mod', 'Incompatible field at count '//text//' for group get_side1_from_xgrid', FATAL )
+           call error_mesg ('xgrid_mod', 'Incompatible field at count '//text// &
+                          & ' for group get_side1_from_xgrid', FATAL )
         endif
      endif
 
@@ -3750,7 +3755,8 @@ subroutine put_1_to_xgrid_order_2(d_addrs, x_addrs, xmap, isize, jsize, xsize, l
            enddo
            do i=1,xmap%size_put1
               pos = xmap%x1_put(i)%pos
-              x(i) = unpack_buffer(3*pos-2) + unpack_buffer(3*pos-1)*xmap%x1_put(i)%dj + unpack_buffer(3*pos)*xmap%x1_put(i)%di
+              x(i) = unpack_buffer(3*pos-2) + unpack_buffer(3*pos-1)*xmap%x1_put(i)%dj + unpack_buffer(3*pos) &
+                   & * xmap%x1_put(i)%di
            end do
         enddo
      endif
@@ -4774,7 +4780,8 @@ subroutine get_side1_from_xgrid_ug(d, grid_id, x, xmap, complete)
         set_mismatch = set_mismatch .OR. (grid_id_saved /= grid_id)
         if(set_mismatch)then
            write( text,'(i2)' ) lsize
-           call error_mesg ('xgrid_mod', 'Incompatible field at count '//text//' for group get_side1_from_xgrid_ug', FATAL )
+           call error_mesg ('xgrid_mod', 'Incompatible field at count '//text// &
+                          & ' for group get_side1_from_xgrid_ug', FATAL )
         endif
      endif
 
@@ -4854,7 +4861,8 @@ subroutine put_side1_to_xgrid_ug(d, grid_id, x, xmap, complete)
         set_mismatch = set_mismatch .OR. (grid_id_saved /= grid_id)
         if(set_mismatch)then
            write( text,'(i2)' ) lsize
-           call error_mesg ('xgrid_mod', 'Incompatible field at count '//text//' for group put_side1_to_xgrid_ug', FATAL )
+           call error_mesg ('xgrid_mod', 'Incompatible field at count '//text// &
+                          & ' for group put_side1_to_xgrid_ug', FATAL )
         endif
      endif
 

--- a/exchange/xgrid.F90
+++ b/exchange/xgrid.F90
@@ -4155,7 +4155,8 @@ integer, intent(in), optional :: remap_method
        endif
        call get_from_xgrid (d2, grid2%id, x_over, xmap) ! get onto side 2's
        if(grid2%on_this_pe) then
-          conservation_check_ug_side1(2) = conservation_check_ug_side1(2) + sum( grid2%area * sum(grid2%frac_area*d2,DIM=3) )
+          conservation_check_ug_side1(2) = conservation_check_ug_side1(2) &
+                                         & + sum( grid2%area * sum(grid2%frac_area*d2,DIM=3) )
        endif
        call put_to_xgrid (d2, grid2%id, x_back, xmap) ! put from side 2's
        if(allocated(d2))deallocate (d2)

--- a/field_manager/field_manager.F90
+++ b/field_manager/field_manager.F90
@@ -712,7 +712,8 @@ do while (.TRUE.)
              text_names%mod_name = lowercase(trim(text_names_short%mod_name))
              text_names%fld_name = lowercase(trim(text_names_short%mod_name))
            case(2)
-! If there is only the method_type string then the last 2 strings need to be blank and there are only 2 '"' in the record.
+! If there is only the method_type string then the last 2 strings need to be blank and there
+! are only 2 '"' in the record.
              read(record,*,end=79,err=79) text_names_short
              text_names%fld_type = lowercase(trim(text_names_short%fld_type))
              text_names%mod_name = lowercase(trim(text_names_short%mod_name))
@@ -857,7 +858,8 @@ do while (.TRUE.)
           control_str = text_method_short%method_name
 
         case(2)
-! If there is only the method_type string then the last 2 strings need to be blank and there are only 2 '"' in the record.
+! If there is only the method_type string then the last 2 strings need to be blank and there
+! are only 2 '"' in the record.
           read(record,*,end=99,err=99) text_method_very_short
           fields(num_fields)%methods(m)%method_type = lowercase(trim(text_method_very_short%method_type))
           fields(num_fields)%methods(m)%method_name = " "
@@ -1034,7 +1036,8 @@ do i=1,num_fields-1
        fields(i)%model      == fields(num_fields)%model      .and. &
        fields(i)%field_name == fields(num_fields)%field_name ) then
     if (mpp_pe() .eq. mpp_root_pe()) then
-      call mpp_error(WARNING,'Error in field_manager_mod. Duplicate field name: Field type='//trim(fields(i)%field_type)// &
+      call mpp_error(WARNING,'Error in field_manager_mod. Duplicate field name: Field type='//&
+         trim(fields(i)%field_type)// &
          ',  Model='//trim(MODEL_NAMES(fields(i)%model))// &
          ',  Duplicated name='//trim(fields(i)%field_name))
     endif
@@ -1202,7 +1205,8 @@ do i = 1, num_elem
 
       if ( scan(val_name, set_nonexp ) > 0 ) then
         if (verb .gt. verb_level_warn) then
-!     <ERROR MSG="First character of value is numerical but the value does not appear to be numerical." STATUS="WARNING">
+!     <ERROR MSG="First character of value is numerical but the value does not appear to be
+!     numerical." STATUS="WARNING">
 !       The value may not be numerical. This is a warning as the user may wish to use a value of 2nd_order.
 !     </ERROR>
           call mpp_error(WARNING, trim(warn_header)//                                  &

--- a/field_manager/fm_util.F90
+++ b/field_manager/fm_util.F90
@@ -2300,7 +2300,8 @@ endif  !}
 if (present(no_create)) then  !{
   create = .not. no_create
   if (no_create .and. (present(append) .or. present(index))) then  !{
-    call mpp_error(FATAL, trim(error_header) // ' append or index are present when no_create is true for ' // trim(name))
+    call mpp_error(FATAL, trim(error_header) // &
+                   &  ' append or index are present when no_create is true for ' // trim(name))
   endif  !}
 else  !}{
   create = .true.
@@ -2471,7 +2472,8 @@ endif  !}
 if (present(no_create)) then  !{
   create = .not. no_create
   if (no_create .and. (present(append) .or. present(index))) then  !{
-    call mpp_error(FATAL, trim(error_header) // ' append or index are present when no_create is true for ' // trim(name))
+    call mpp_error(FATAL, trim(error_header) // &
+                   &  ' append or index are present when no_create is true for ' // trim(name))
   endif  !}
 else  !}{
   create = .true.
@@ -2642,7 +2644,8 @@ endif  !}
 if (present(no_create)) then  !{
   create = .not. no_create
   if (no_create .and. (present(append) .or. present(index))) then  !{
-    call mpp_error(FATAL, trim(error_header) // ' append or index are present when no_create is true for ' // trim(name))
+    call mpp_error(FATAL, trim(error_header) // &
+                   &  ' append or index are present when no_create is true for ' // trim(name))
   endif  !}
 else  !}{
   create = .true.
@@ -2813,7 +2816,8 @@ endif  !}
 if (present(no_create)) then  !{
   create = .not. no_create
   if (no_create .and. (present(append) .or. present(index))) then  !{
-    call mpp_error(FATAL, trim(error_header) // ' append or index are present when no_create is true for ' // trim(name))
+    call mpp_error(FATAL, trim(error_header) // &
+                   &  ' append or index are present when no_create is true for ' // trim(name))
   endif  !}
 else  !}{
   create = .true.
@@ -3114,9 +3118,11 @@ endif  !}
 !
 
 if (path .ne. save_path) then  !{
-  call mpp_error(FATAL, trim(error_header) // ' Path "' // trim(path) // '" does not match saved path "' // trim(save_path) // '"')
+  call mpp_error(FATAL, trim(error_header) // &
+                 &  ' Path "' // trim(path) // '" does not match saved path "' // trim(save_path) // '"')
 elseif (name .ne. save_name) then  !}{
-  call mpp_error(FATAL, trim(error_header) // ' Name "' // trim(name) // '" does not match saved name "' // trim(save_name) // '"')
+  call mpp_error(FATAL, trim(error_header) // &
+                 &  ' Name "' // trim(name) // '" does not match saved name "' // trim(save_name) // '"')
 endif  !}
 
 !

--- a/fms/fms.F90
+++ b/fms/fms.F90
@@ -487,7 +487,7 @@ end subroutine fms_end
 !#######################################################################
 
  !> @brief Print notes, warnings and error messages; terminates program for warning
- !!     and error messages. Usage of @ref mpp_error is preferable. (use error levels NOTE,WARNING,FATAL, see example below)
+ !! and error messages. Usage of @ref mpp_error is preferable. (use error levels NOTE,WARNING,FATAL, see example below)
  !! @details Print notes, warnings and error messages; and terminates the program for
  !!     error messages. This routine is a wrapper around mpp_error, and is provided
  !!     for backward compatibility. This module also publishes mpp_error,
@@ -599,7 +599,8 @@ end subroutine fms_end
 
     ! Everything else is a FATAL
     IF ( (IOSTAT == nml_errors%badType1 .OR. IOSTAT == nml_errors%badType2) .OR. IOSTAT == nml_errors%missingVar ) THEN
-       WRITE (err_str,*) 'Unknown namelist, or mistyped namelist variable in namelist ',TRIM(NML_NAME),', (IOSTAT = ',IOSTAT,')'
+       WRITE (err_str,*) 'Unknown namelist, or mistyped namelist variable in namelist ',TRIM(NML_NAME),', &
+             &  (IOSTAT = ',IOSTAT,')'
        CALL error_mesg ('check_nml_error in fms_mod', err_str, FATAL)
        CALL mpp_sync()
     ELSE

--- a/fms/fms_io.F90
+++ b/fms/fms_io.F90
@@ -524,7 +524,8 @@ integer, private :: isd,ied,jsd,jed  !< data domain
 integer, private :: isg,ieg,jsg,jeg  !< global domain
 character(len=128),      dimension(:), allocatable         :: registered_file !< file names
                                                                             !! registered through register_restart_file
-type(restart_file_type), dimension(:), allocatable         :: files_read  !< store files that are read through read_data
+type(restart_file_type), dimension(:), allocatable         :: files_read  !< store files that are read
+                                                                          !! through read_data
 type(restart_file_type), dimension(:), allocatable, target :: files_write !< store files that
                                                                           !! are written through write_data
 type(domain2d), dimension(max_domains), target, save  :: array_domain
@@ -1087,7 +1088,7 @@ subroutine write_data_3d_new(filename, fieldname, data, domain, no_domain, scala
   if(is_no_domain) then
      if(PRESENT(domain)) &
        call mpp_error(FATAL, &
-                    & 'fms_io(write_data_3d_new): no_domain cannot be .true. when optional argument domain is present.')
+                   & 'fms_io(write_data_3d_new): no_domain cannot be .true. when optional argument domain is present.')
   else if(PRESENT(domain))then
      d_ptr => domain
   else if (ASSOCIATED(Current_domain)) then
@@ -2678,7 +2679,7 @@ subroutine save_compressed_restart(fileObj,restartpath,append,time_level)
       mpp_action = MPP_APPEND
       write_meta_data = .false. ! Assuming meta data is already written when routine is called to append to field data.
       if(time_level < 0.0) then
-        call mpp_error(FATAL, 'fms_io(save_compressed_restart): time_level cannot be negative when append is .true.'// &
+        call mpp_error(FATAL, 'fms_io(save_compressed_restart): time_level cannot be negative when append is .true.'//&
                       ' for file '//trim(fileObj%name))
       endif
     endif
@@ -2921,7 +2922,7 @@ subroutine save_compressed_restart(fileObj,restartpath,append,time_level)
                      fileObj%axes(idx)%nelems(:), tstamp=tlev, default_data=cur_var%default_data)
                 deallocate(r2d)
              else
-                call mpp_error(FATAL, "fms_io(save_restart): There is no pointer associated with the data of field "// &
+                call mpp_error(FATAL, "fms_io(save_restart): There is no pointer associated with the data of field "//&
                        trim(cur_var%name)//" of file "//trim(fileObj%name) )
              endif
           endif
@@ -3030,7 +3031,8 @@ subroutine save_default_restart(fileObj,restartpath)
   type(restart_file_type), intent(inout) :: fileObj
   character(len=336)                     :: restartpath ! The restart file path (dir/file).
 
-  character(len=8)   :: suffix               ! A suffix (like _2) that is appended to the name of files after the first.
+  character(len=8)   :: suffix               ! A suffix (like _2) that is appended to the name of files
+                                             !! after the first.
   integer            :: var_sz, size_in_file ! The size in bytes of each variable and of the
                                              !! variables already in a file.
   integer            :: unit                 ! The mpp unit of the open file.
@@ -3296,7 +3298,8 @@ subroutine save_default_restart(fileObj,restartpath)
            cpack_size = 1
            check_val(k) = mpp_chksum(fileObj%p3dr8(k,j)%p(cur_var%is:cur_var%is+iadd, cur_var%js:cur_var%js+jadd, :) )
         else if ( Associated(fileObj%p4dr(k,j)%p) ) then
-           check_val(k) = mpp_chksum(fileObj%p4dr(k,j)%p(cur_var%is:cur_var%is+iadd, cur_var%js:cur_var%js+jadd, :, :) )
+           check_val(k) = mpp_chksum(fileObj%p4dr(k,j)%p(cur_var%is:cur_var%is+iadd, &
+                    &  cur_var%js:cur_var%js+jadd, :, :) )
         else if ( Associated(fileObj%p0di(k,j)%p) ) then
            check_val(k) = fileObj%p0di(k,j)%p
         else if ( Associated(fileObj%p1di(k,j)%p) ) then
@@ -3407,7 +3410,7 @@ subroutine save_default_restart(fileObj,restartpath)
                  call mpp_write(unit, cur_var%field, r3d,                  tlev)
                  deallocate(r3d)
               else
-                 call mpp_error(FATAL,"fms_io(save_restart): There is no pointer associated with the data of field "// &
+                 call mpp_error(FATAL,"fms_io(save_restart): There is no pointer associated with the data of field "//&
                       & trim(cur_var%name)//" of file "//trim(fileObj%name) )
               end if
            end if
@@ -3837,8 +3840,9 @@ subroutine restore_state_border(fileObj, directory, nonfatal_missing_files)
                     trim(cur_var%name)//" in file "//trim(fileObj%name) )
             end if
             if ((fileObj%is_root_pe) .and. (is_there_a_checksum) .and. (checksum_file(k)/=checksum_data)) then
-              write (mesg,'(a,Z16,a,Z16,a)') "Checksum of input field "// uppercase(trim(varname))//" ", checksum_data,&
-                           " does not match value ", checksum_file(k), " stored in "//uppercase(trim(fileObj%name)//".")
+              write (mesg,'(a,Z16,a,Z16,a)')"Checksum of input field "// uppercase(trim(varname))//" ", checksum_data,&
+                           " does not match value ", checksum_file(k), " stored in "//uppercase(trim(fileObj%name)// &
+                           & ".")
               call mpp_error(FATAL, "fms_io(restore_state_border): "//trim(mesg) )
             endif
           end do
@@ -3944,7 +3948,7 @@ subroutine write_chksum(fileObj, action)
                    trim(cur_var%name)//" of file "//trim(fileObj%name) )
            end if
            outunit = stdout()
-           write(outunit,'(a, I1, a, Z16)')'fms_io('//trim(routine_name)//'): At time level = ', k, ', chksum for "'// &
+           write(outunit,'(a, I1, a, Z16)')'fms_io('//trim(routine_name)//'): At time level = ', k, ', chksum for "'//&
                 trim(cur_var%name)// '" of "'// trim(fileObj%name)// '" = ', data_chksum
 
         enddo
@@ -4555,7 +4559,8 @@ subroutine restore_state_one_field(fileObj, id_field, directory, nonfatal_missin
                  else if( Associated(fileObj%p4dr(k,j)%p) ) then
                     call mpp_read(unit(n), fields(l), fileObj%p4dr(k,j)%p, tlev)
                     if ( is_there_a_checksum ) checksum_data =&
-                         & mpp_chksum(fileObj%p4dr(k,j)%p(cur_var%is:cur_var%is+iadd,cur_var%js:cur_var%js+jadd, :, :) )
+                         & mpp_chksum(fileObj%p4dr(k,j)%p(cur_var%is:cur_var%is+iadd, &
+                                     & cur_var%js:cur_var%js+jadd, :, :) )
                  else if( Associated(fileObj%p0di(k,j)%p) ) then
                     call mpp_read(unit(n), fields(l), r0d, tlev)
                     fileObj%p0di(k,j)%p = r0d
@@ -4677,7 +4682,7 @@ subroutine setup_one_field(fileObj, filename, fieldname, field_siz, index_field,
   if(is_no_domain) then
      if(PRESENT(domain)) &
        call mpp_error(FATAL, &
-                      & 'fms_io(setup_one_field): no_domain cannot be .true. when optional argument domain is present.')
+                     & 'fms_io(setup_one_field): no_domain cannot be .true. when optional argument domain is present.')
   else if(PRESENT(domain))then
      d_ptr => domain
   else if (ASSOCIATED(Current_domain)) then
@@ -4775,7 +4780,7 @@ subroutine setup_one_field(fileObj, filename, fieldname, field_siz, index_field,
 
   if(index_field > 0) then
      cur_var   => fileObj%var(index_field)
-     if(cur_var%siz(1) .NE. field_siz(1) .OR. cur_var%siz(2) .NE. field_siz(2) .OR. cur_var%siz(3) .NE. field_siz(3) ) &
+     if(cur_var%siz(1) .NE. field_siz(1) .OR. cur_var%siz(2) .NE. field_siz(2) .OR. cur_var%siz(3) .NE. field_siz(3)) &
         call mpp_error(FATAL, 'fms_io(setup_one_field): field size mismatch for field '// &
                        trim(fieldname)//' of file '//trim(filename) )
 
@@ -5449,7 +5454,7 @@ subroutine read_data_3d_new(filename,fieldname,data,domain,timelevel, &
   if (PRESENT(no_domain)) THEN
      if(PRESENT(domain) .AND. no_domain) &
        call mpp_error(FATAL, &
-                     & 'fms_io(read_data_3d_new): no_domain cannot be .true. when optional argument domain is present.')
+                    & 'fms_io(read_data_3d_new): no_domain cannot be .true. when optional argument domain is present.')
      is_no_domain = no_domain
   endif
 
@@ -5490,7 +5495,8 @@ subroutine read_data_3d_new(filename,fieldname,data,domain,timelevel, &
          (size(data,2) .NE. cysize .AND. size(data,2) .NE. dysize) )then
        call mpp_error(FATAL,'fms_io(read_data_3d_new): data should be on either compute domain '//&
                             'or data domain when domain is present. '//&
-                            'shape(data)=',shape(data),'  cxsize,cysize,dxsize,dysize=',(/cxsize,cysize,dxsize,dysize/))
+                            'shape(data)=',shape(data),'  cxsize,cysize,dxsize,dysize=',(/cxsize,cysize,dxsize, &
+                                  & dysize/))
      end if
   endif
 
@@ -7158,8 +7164,9 @@ subroutine set_initialized_r2d(fileObj, f_ptr, name, is_set)
 
   if (m>fileObj%nvar .AND. mpp_pe() == mpp_root_pe() ) then
     call mpp_error(NOTE,"fms_io(set_initialized_r2d): Unable to find "// &
-          trim(name)//" queried by pointer, "//"probably because of the suspect comparison of pointers by ASSOCIATED"//&
-                        " when attempting to set initialization.")
+          & trim(name)//" queried by pointer, "//& 
+          & "probably because of the suspect comparison of pointers by ASSOCIATED"//&
+          & " when attempting to set initialization.")
   end if
 
   do m=1,fileObj%nvar
@@ -7205,8 +7212,9 @@ subroutine set_initialized_r3d(fileObj, f_ptr, name, is_set)
 
   if (m>fileObj%nvar .AND. mpp_pe() == mpp_root_pe() ) then
     call mpp_error(NOTE,"fms_io(set_initialized_r3d): Unable to find "// &
-          trim(name)//" queried by pointer, "//"probably because of the suspect comparison of pointers by ASSOCIATED"//&
-                        " when attempting to set initialization.")
+          & trim(name)//" queried by pointer, "// &
+          & "probably because of the suspect comparison of pointers by ASSOCIATED"//&
+          & " when attempting to set initialization.")
   end if
 
   do m=1,fileObj%nvar
@@ -7253,8 +7261,9 @@ subroutine set_initialized_r4d(fileObj, f_ptr, name, is_set)
 
   if (m>fileObj%nvar .AND. mpp_pe() == mpp_root_pe() ) then
     call mpp_error(NOTE,"fms_io(set_initialized_r4d): Unable to find "// &
-          trim(name)//" queried by pointer, "//"probably because of the suspect comparison of pointers by ASSOCIATED"//&
-                        " when attempting to set initialization.")
+          & trim(name)//" queried by pointer, "// &
+          & "probably because of the suspect comparison of pointers by ASSOCIATED"//&
+          & " when attempting to set initialization.")
   end if
 
   do m=1,fileObj%nvar

--- a/fms/fms_io.F90
+++ b/fms/fms_io.F90
@@ -7163,7 +7163,7 @@ subroutine set_initialized_r2d(fileObj, f_ptr, name, is_set)
 
   if (m>fileObj%nvar .AND. mpp_pe() == mpp_root_pe() ) then
     call mpp_error(NOTE,"fms_io(set_initialized_r2d): Unable to find "// &
-          & trim(name)//" queried by pointer, "//& 
+          & trim(name)//" queried by pointer, "//&
           & "probably because of the suspect comparison of pointers by ASSOCIATED"//&
           & " when attempting to set initialization.")
   end if

--- a/fms/fms_io.F90
+++ b/fms/fms_io.F90
@@ -45,7 +45,8 @@
 ! </DATA>
 ! <DATA NAME="fms_netcdf_override" TYPE="logical">
 !   .true. : fms_netcdf_restart overrides individual do_netcdf_restart value (default behavior)
-!   .false.: individual module settings has a precedence over the global setting, therefore fms_netcdf_restart is ignored
+!   .false.: individual module settings has a precedence over the global setting, therefore
+!   fms_netcdf_restart is ignored
 ! </DATA>
 ! <DATA NAME="fms_netcdf_restart" TYPE="logical">
 !   .true. : all modules deal with restart files will operate under netCDF mode (default behavior)
@@ -200,7 +201,8 @@ type, private :: ax_type
 !----------
 !ug support
    type(domainUG),pointer :: domain_ug => null()     !< A pointer to an unstructured mpp domain.
-   integer(INT_KIND)      :: nelems_for_current_rank !< The number of grid points registered to the current rank (used for error checking).
+   integer(INT_KIND)      :: nelems_for_current_rank !< The number of grid points registered
+                                                     !! to the current rank (used for error checking).
 !----------
 
 end type ax_type
@@ -216,7 +218,8 @@ type, private :: var_type
    integer                                :: domain_idx = -1
    logical                                :: is_dimvar = .FALSE.
    logical                                :: read_only = .FALSE.
-   logical                                :: owns_data = .FALSE. !< if true, restart owns the data and will deallocate them when freed
+   logical                                :: owns_data = .FALSE. !< if true, restart owns the
+                                                                 !! data and will deallocate them when freed
    type(fieldtype)                        :: field
    type(axistype)                         :: axis
    integer                                :: position
@@ -237,7 +240,8 @@ type, private :: var_type
 !----------
 !ug support
     type(domainUG),pointer            :: domain_ug => null()   !< A pointer to an unstructured mpp domain.
-    integer(INT_KIND),dimension(5)    :: field_dimension_order !< Array telling the ordering of the dimensions for the field.
+    integer(INT_KIND),dimension(5)    :: field_dimension_order !< Array telling the ordering
+                                                               !! of the dimensions for the field.
     integer(INT_KIND),dimension(NIDX) :: field_dimension_sizes !< Array of sizes of the dimensions for the field.
 !----------
 
@@ -518,9 +522,11 @@ type(domain2D), pointer, private :: Current_domain =>NULL()
 integer, private :: is,ie,js,je      !< compute domain
 integer, private :: isd,ied,jsd,jed  !< data domain
 integer, private :: isg,ieg,jsg,jeg  !< global domain
-character(len=128),      dimension(:), allocatable         :: registered_file !< file names registered through register_restart_file
+character(len=128),      dimension(:), allocatable         :: registered_file !< file names
+                                                                            !! registered through register_restart_file
 type(restart_file_type), dimension(:), allocatable         :: files_read  !< store files that are read through read_data
-type(restart_file_type), dimension(:), allocatable, target :: files_write !< store files that are written through write_data
+type(restart_file_type), dimension(:), allocatable, target :: files_write !< store files that
+                                                                          !! are written through write_data
 type(domain2d), dimension(max_domains), target, save  :: array_domain
 type(domain1d), dimension(max_domains), save       :: domain_x, domain_y
 public  :: read_data, read_compressed, write_data, read_distributed
@@ -796,7 +802,8 @@ subroutine fms_io_exit()
     enddo
 
     ! each field has an associated domain type (may be undefined).
-    ! each file only needs to write unique axes (i.e. if 2 fields share an identical axis, then only write the axis once)
+    ! each file only needs to write unique axes (i.e. if 2 fields share an identical axis,
+    ! then only write the axis once)
     ! unique axes are defined by the global size and domain decomposition (i.e. can support identical axis sizes with
     ! different domain decomposition)
 
@@ -1079,7 +1086,8 @@ subroutine write_data_3d_new(filename, fieldname, data, domain, no_domain, scala
 
   if(is_no_domain) then
      if(PRESENT(domain)) &
-       call mpp_error(FATAL, 'fms_io(write_data_3d_new): no_domain cannot be .true. when optional argument domain is present.')
+       call mpp_error(FATAL, &
+                    & 'fms_io(write_data_3d_new): no_domain cannot be .true. when optional argument domain is present.')
   else if(PRESENT(domain))then
      d_ptr => domain
   else if (ASSOCIATED(Current_domain)) then
@@ -1884,7 +1892,8 @@ function register_restart_field_i0d(fileObj, filename, fieldname, data, domain, 
 
   if(.not.module_is_initialized) call mpp_error(FATAL,'fms_io(register_restart_field_i0d): need to call fms_io_init')
 
-  if (KIND(data_default)/=KIND(data)) call mpp_error(FATAL,'fms_io(register_restart_field_i0d): data_default and data different KIND()')
+  if (KIND(data_default)/=KIND(data)) call mpp_error(FATAL, &
+      & 'fms_io(register_restart_field_i0d): data_default and data different KIND()')
   data_default_r = TRANSFER(MPP_FILL_INT,data_default_r)
   if (present(data_default)) data_default_r = TRANSFER(data_default ,data_default_r)
 
@@ -1924,7 +1933,8 @@ function register_restart_field_i1d(fileObj, filename, fieldname, data, domain, 
 
   if(.not.module_is_initialized) call mpp_error(FATAL,'fms_io(register_restart_field_i1d): need to call fms_io_init')
 
-  if (KIND(data_default)/=KIND(data)) call mpp_error(FATAL,'fms_io(register_restart_field_i1d): data_default and data different KIND()')
+  if (KIND(data_default)/=KIND(data)) call mpp_error(FATAL, &
+      & 'fms_io(register_restart_field_i1d): data_default and data different KIND()')
   data_default_r = TRANSFER(MPP_FILL_INT,data_default_r)
   if (present(data_default)) data_default_r = TRANSFER(data_default ,data_default_r)
 
@@ -1968,7 +1978,8 @@ function register_restart_field_i2d(fileObj, filename, fieldname, data, domain, 
   is_compressed = .false.
   if(present(compressed)) is_compressed=compressed
 
-  if (KIND(data_default)/=KIND(data)) call mpp_error(FATAL,'fms_io(register_restart_field_i2d): data_default and data different KIND()')
+  if (KIND(data_default)/=KIND(data)) call mpp_error(FATAL, &
+      & 'fms_io(register_restart_field_i2d): data_default and data different KIND()')
   data_default_r = TRANSFER(MPP_FILL_INT,data_default_r)
   if (present(data_default)) data_default_r = TRANSFER(data_default ,data_default_r)
 
@@ -2007,7 +2018,8 @@ function register_restart_field_i3d(fileObj, filename, fieldname, data, domain, 
 
   if(.not.module_is_initialized) call mpp_error(FATAL,'fms_io(register_restart_field_i3d): need to call fms_io_init')
 
-  if (KIND(data_default)/=KIND(data)) call mpp_error(FATAL,'fms_io(register_restart_field_i3d): data_default and data different KIND()')
+  if (KIND(data_default)/=KIND(data)) call mpp_error(FATAL, &
+      & 'fms_io(register_restart_field_i3d): data_default and data different KIND()')
   data_default_r = TRANSFER(MPP_FILL_INT,data_default_r)
   if (present(data_default)) data_default_r = TRANSFER(data_default ,data_default_r)
 
@@ -2249,8 +2261,10 @@ function register_restart_field_i0d_2level(fileObj, filename, fieldname, data1, 
   if(.not.module_is_initialized) call mpp_error(FATAL, &
       'fms_io(register_restart_field_i0d_2level): need to call fms_io_init')
 
-  if (KIND(data_default)/=KIND(data1)) call mpp_error(FATAL,'fms_io(register_restart_field_i0d_2level): data_default and data1 different KIND()')
-  if (KIND(data_default)/=KIND(data2)) call mpp_error(FATAL,'fms_io(register_restart_field_i0d_2level): data_default and data2 different KIND()')
+  if (KIND(data_default)/=KIND(data1)) call mpp_error(FATAL, &
+      & 'fms_io(register_restart_field_i0d_2level): data_default and data1 different KIND()')
+  if (KIND(data_default)/=KIND(data2)) call mpp_error(FATAL, &
+      & 'fms_io(register_restart_field_i0d_2level): data_default and data2 different KIND()')
   data_default_r = TRANSFER(MPP_FILL_INT,data_default_r)
   if (present(data_default)) data_default_r = TRANSFER(data_default ,data_default_r)
 
@@ -2290,8 +2304,10 @@ function register_restart_field_i1d_2level(fileObj, filename, fieldname, data1, 
   if(.not.module_is_initialized) call mpp_error(FATAL, &
       'fms_io(register_restart_field_i1d_2level): need to call fms_io_init')
 
-  if (KIND(data_default)/=KIND(data1)) call mpp_error(FATAL,'fms_io(register_restart_field_i1d_2level): data_default and data1 different KIND()')
-  if (KIND(data_default)/=KIND(data2)) call mpp_error(FATAL,'fms_io(register_restart_field_i1d_2level): data_default and data2 different KIND()')
+  if (KIND(data_default)/=KIND(data1)) call mpp_error(FATAL, &
+      & 'fms_io(register_restart_field_i1d_2level): data_default and data1 different KIND()')
+  if (KIND(data_default)/=KIND(data2)) call mpp_error(FATAL, &
+      & 'fms_io(register_restart_field_i1d_2level): data_default and data2 different KIND()')
   data_default_r = TRANSFER(MPP_FILL_INT,data_default_r)
   if (present(data_default)) data_default_r = TRANSFER(data_default ,data_default_r)
 
@@ -2331,8 +2347,10 @@ function register_restart_field_i2d_2level(fileObj, filename, fieldname, data1, 
   if(.not.module_is_initialized) call mpp_error(FATAL, &
       'fms_io(register_restart_field_i2d_2level): need to call fms_io_init')
 
-  if (KIND(data_default)/=KIND(data1)) call mpp_error(FATAL,'fms_io(register_restart_field_i2d_2level): data_default and data1 different KIND()')
-  if (KIND(data_default)/=KIND(data2)) call mpp_error(FATAL,'fms_io(register_restart_field_i2d_2level): data_default and data2 different KIND()')
+  if (KIND(data_default)/=KIND(data1)) call mpp_error(FATAL, &
+      & 'fms_io(register_restart_field_i2d_2level): data_default and data1 different KIND()')
+  if (KIND(data_default)/=KIND(data2)) call mpp_error(FATAL, &
+      & 'fms_io(register_restart_field_i2d_2level): data_default and data2 different KIND()')
   data_default_r = TRANSFER(MPP_FILL_INT,data_default_r)
   if (present(data_default)) data_default_r = TRANSFER(data_default ,data_default_r)
 
@@ -2372,8 +2390,10 @@ function register_restart_field_i3d_2level(fileObj, filename, fieldname, data1, 
   if(.not.module_is_initialized) call mpp_error(FATAL, &
       'fms_io(register_restart_field_i3d_2level): need to call fms_io_init')
 
-  if (KIND(data_default)/=KIND(data1)) call mpp_error(FATAL,'fms_io(register_restart_field_i3d_2level): data_default and data1 different KIND()')
-  if (KIND(data_default)/=KIND(data2)) call mpp_error(FATAL,'fms_io(register_restart_field_i3d_2level): data_default and data2 different KIND()')
+  if (KIND(data_default)/=KIND(data1)) call mpp_error(FATAL, &
+      & 'fms_io(register_restart_field_i3d_2level): data_default and data1 different KIND()')
+  if (KIND(data_default)/=KIND(data2)) call mpp_error(FATAL, &
+      & 'fms_io(register_restart_field_i3d_2level): data_default and data2 different KIND()')
   data_default_r = TRANSFER(MPP_FILL_INT,data_default_r)
   if (present(data_default)) data_default_r = TRANSFER(data_default ,data_default_r)
 
@@ -2666,7 +2686,8 @@ subroutine save_compressed_restart(fileObj,restartpath,append,time_level)
 
   write_field_data = .true.
   if(present(time_level)) then
-    write_field_data = time_level >= 0.0 ! Using negative value of time_level as a flag that there is no valid field data to write.
+    write_field_data = time_level >= 0.0 ! Using negative value of time_level as a flag that
+                                         !! there is no valid field data to write.
   endif
 
   call mpp_open(unit,trim(restartpath),action=mpp_action,form=form, &
@@ -2731,7 +2752,8 @@ subroutine save_compressed_restart(fileObj,restartpath,append,time_level)
     ! write out time axis
     axis => fileobj%axes(TIDX)
     if(ASSOCIATED(axis%data))then
-       call mpp_write_meta(unit,t_axis, axis%name, units=axis%units, longname=axis%longname, cartesian='T', calendar=axis%calendar)
+       call mpp_write_meta(unit,t_axis, axis%name, units=axis%units, longname=axis%longname, cartesian='T', &
+                          &  calendar=axis%calendar)
     else
        call mpp_write_meta(unit,t_axis, 'Time','time level','Time',cartesian='T')
     endif
@@ -2815,8 +2837,8 @@ subroutine save_compressed_restart(fileObj,restartpath,append,time_level)
               check_val(k) = mpp_chksum(fileObj%p2di(k,j)%p(:,:), mask_val=cur_var%default_data)
               cpack = 0  ! Write data as integer*4
            else if ( Associated(fileObj%p3di(k,j)%p) ) then
-              call mpp_error(FATAL, "fms_io(save_compressed_restart): integer 3D restart fields are not currently supported"// &
-                   trim(cur_var%name)//" of file "//trim(fileObj%name) )
+              call mpp_error(FATAL, "fms_io(save_compressed_restart): integer 3D restart fields are not currently"//&
+                           & " supported"//trim(cur_var%name)//" of file "//trim(fileObj%name) )
            else
               call mpp_error(FATAL, "fms_io(save_restart): There is no pointer associated with the data of field "// &
                    trim(cur_var%name)//" of file "//trim(fileObj%name) )
@@ -3009,7 +3031,8 @@ subroutine save_default_restart(fileObj,restartpath)
   character(len=336)                     :: restartpath ! The restart file path (dir/file).
 
   character(len=8)   :: suffix               ! A suffix (like _2) that is appended to the name of files after the first.
-  integer            :: var_sz, size_in_file ! The size in bytes of each variable and of the variables already in a file.
+  integer            :: var_sz, size_in_file ! The size in bytes of each variable and of the
+                                             !! variables already in a file.
   integer            :: unit                 ! The mpp unit of the open file.
   real, dimension(max_axis_size)      :: axisdata
   integer,        dimension(max_axes) :: id_x_axes, siz_x_axes
@@ -3384,8 +3407,8 @@ subroutine save_default_restart(fileObj,restartpath)
                  call mpp_write(unit, cur_var%field, r3d,                  tlev)
                  deallocate(r3d)
               else
-                 call mpp_error(FATAL, "fms_io(save_restart): There is no pointer associated with the data of  field "// &
-                      trim(cur_var%name)//" of file "//trim(fileObj%name) )
+                 call mpp_error(FATAL,"fms_io(save_restart): There is no pointer associated with the data of field "// &
+                      & trim(cur_var%name)//" of file "//trim(fileObj%name) )
               end if
            end if
         end if
@@ -3815,7 +3838,7 @@ subroutine restore_state_border(fileObj, directory, nonfatal_missing_files)
             end if
             if ((fileObj%is_root_pe) .and. (is_there_a_checksum) .and. (checksum_file(k)/=checksum_data)) then
               write (mesg,'(a,Z16,a,Z16,a)') "Checksum of input field "// uppercase(trim(varname))//" ", checksum_data,&
-                           " does not match value ", checksum_file(k), " stored in "//uppercase(trim(fileObj%name)//"." )
+                           " does not match value ", checksum_file(k), " stored in "//uppercase(trim(fileObj%name)//".")
               call mpp_error(FATAL, "fms_io(restore_state_border): "//trim(mesg) )
             endif
           end do
@@ -3906,7 +3929,8 @@ subroutine write_chksum(fileObj, action)
            else if ( Associated(fileObj%p3dr(k,j)%p) ) then
               data_chksum = mpp_chksum(fileObj%p3dr(k,j)%p(cur_var%is:cur_var%is+iadd,cur_var%js:cur_var%js+jadd, :) )
            else if ( Associated(fileObj%p4dr(k,j)%p) ) then
-              data_chksum = mpp_chksum(fileObj%p4dr(k,j)%p(cur_var%is:cur_var%is+iadd,cur_var%js:cur_var%js+jadd, :, :) )
+              data_chksum = mpp_chksum(fileObj%p4dr(k,j)%p(cur_var%is:cur_var%is+iadd, &
+                                      & cur_var%js:cur_var%js+jadd, :, :) )
            else if ( Associated(fileObj%p0di(k,j)%p) ) then
               data_chksum = fileObj%p0di(k,j)%p
            else if ( Associated(fileObj%p1di(k,j)%p) ) then
@@ -4133,23 +4157,28 @@ subroutine restore_state_all(fileObj, directory, nonfatal_missing_files)
                     else if( Associated(fileObj%p2dr(k,j)%p) ) then
                        call mpp_read(unit(n), fields(l), array_domain(domain_idx), fileObj%p2dr(k,j)%p, tlev)
                        if ( is_there_a_checksum ) &
-                         checksum_data = mpp_chksum(fileObj%p2dr(k,j)%p(cur_var%is:cur_var%is+iadd,cur_var%js:cur_var%js+jadd) )
+                         checksum_data = mpp_chksum(fileObj%p2dr(k,j)%p(cur_var%is:cur_var%is+iadd, &
+                                                   & cur_var%js:cur_var%js+jadd) )
                     else if( Associated(fileObj%p3dr(k,j)%p) ) then
                        call mpp_read(unit(n), fields(l), array_domain(domain_idx), fileObj%p3dr(k,j)%p, tlev)
                        if ( is_there_a_checksum ) &
-                         checksum_data = mpp_chksum(fileObj%p3dr(k,j)%p(cur_var%is:cur_var%is+iadd,cur_var%js:cur_var%js+jadd, :) )
+                         checksum_data = mpp_chksum(fileObj%p3dr(k,j)%p(cur_var%is:cur_var%is+iadd, &
+                                                   & cur_var%js:cur_var%js+jadd, :) )
                     else if( Associated(fileObj%p2dr8(k,j)%p) ) then
                        call mpp_read(unit(n), fields(l), array_domain(domain_idx), fileObj%p2dr8(k,j)%p, tlev)
                        if ( is_there_a_checksum ) &
-                         checksum_data = mpp_chksum(fileObj%p2dr8(k,j)%p(cur_var%is:cur_var%is+iadd,cur_var%js:cur_var%js+jadd) )
+                         checksum_data = mpp_chksum(fileObj%p2dr8(k,j)%p(cur_var%is:cur_var%is+iadd, &
+                                                   & cur_var%js:cur_var%js+jadd) )
                     else if( Associated(fileObj%p3dr8(k,j)%p) ) then
                        call mpp_read(unit(n), fields(l), array_domain(domain_idx), fileObj%p3dr8(k,j)%p, tlev)
                        if ( is_there_a_checksum ) &
-                         checksum_data = mpp_chksum(fileObj%p3dr8(k,j)%p(cur_var%is:cur_var%is+iadd,cur_var%js:cur_var%js+jadd, :) )
+                         checksum_data = mpp_chksum(fileObj%p3dr8(k,j)%p(cur_var%is:cur_var%is+iadd, &
+                                                   & cur_var%js:cur_var%js+jadd, :) )
                     else if( Associated(fileObj%p4dr(k,j)%p) ) then
                        call mpp_read(unit(n), fields(l), array_domain(domain_idx), fileObj%p4dr(k,j)%p, tlev)
                        if ( is_there_a_checksum ) &
-                         checksum_data = mpp_chksum(fileObj%p4dr(k,j)%p(cur_var%is:cur_var%is+iadd,cur_var%js:cur_var%js+jadd,:,:))
+                         checksum_data = mpp_chksum(fileObj%p4dr(k,j)%p(cur_var%is:cur_var%is+iadd, &
+                                                   & cur_var%js:cur_var%js+jadd,:,:))
                     else if( Associated(fileObj%p0di(k,j)%p) ) then
                        call mpp_read(unit(n), fields(l), r0d, tlev)
                        fileObj%p0di(k,j)%p = r0d
@@ -4166,7 +4195,8 @@ subroutine restore_state_all(fileObj, directory, nonfatal_missing_files)
                        call mpp_read(unit(n), fields(l), array_domain(domain_idx), r2d, tlev)
                        fileObj%p2di(k,j)%p(isc:iec,jsc:jec) = r2d(isc:iec,jsc:jec)
                        if ( is_there_a_checksum ) &
-                         checksum_data = mpp_chksum(fileObj%p2di(k,j)%p(cur_var%is:cur_var%is+iadd,cur_var%js:cur_var%js+jadd) )
+                         checksum_data = mpp_chksum(fileObj%p2di(k,j)%p(cur_var%is:cur_var%is+iadd, &
+                                                   & cur_var%js:cur_var%js+jadd) )
                        deallocate(r2d)
                     else if( Associated(fileObj%p3di(k,j)%p) ) then
                        allocate(r3d(cur_var%siz(1), cur_var%siz(2), cur_var%siz(3)) )
@@ -4174,11 +4204,13 @@ subroutine restore_state_all(fileObj, directory, nonfatal_missing_files)
                        call mpp_read(unit(n), fields(l), array_domain(domain_idx), r3d, tlev)
                        fileObj%p3di(k,j)%p(isc:iec,jsc:jec,:) = r3d(isc:iec,jsc:jec,:)
                        if ( is_there_a_checksum ) &
-                         checksum_data = mpp_chksum(fileObj%p3di(k,j)%p(cur_var%is:cur_var%is+iadd,cur_var%js:cur_var%js+jadd, :))
+                         checksum_data = mpp_chksum(fileObj%p3di(k,j)%p(cur_var%is:cur_var%is+iadd, &
+                                                   & cur_var%js:cur_var%js+jadd, :))
                        deallocate(r3d)
                     else
-                       call mpp_error(FATAL, "fms_io(restore_state_all): domain is present for the field "//trim(varname)// &
-                            " of file "//trim(fileObj%name)//", but none of p2dr, p3dr, p2di and p3di is associated")
+                       call mpp_error(FATAL, "fms_io(restore_state_all): domain is present for the field "// &
+                                   & trim(varname)//" of file "//trim(fileObj%name)// &
+                                   & ", but none of p2dr, p3dr, p2di and p3di is associated")
                     end if
                  else
                     if( Associated(fileObj%p0dr(k,j)%p) ) then
@@ -4190,15 +4222,18 @@ subroutine restore_state_all(fileObj, directory, nonfatal_missing_files)
                     else if( Associated(fileObj%p2dr(k,j)%p) ) then
                        call mpp_read(unit(n), fields(l), fileObj%p2dr(k,j)%p, tlev)
                        if ( is_there_a_checksum ) &
-                         checksum_data = mpp_chksum(fileObj%p2dr(k,j)%p(cur_var%is:cur_var%is+iadd,cur_var%js:cur_var%js+jadd) )
+                         checksum_data = mpp_chksum(fileObj%p2dr(k,j)%p(cur_var%is:cur_var%is+iadd, &
+                                                   & cur_var%js:cur_var%js+jadd) )
                     else if( Associated(fileObj%p3dr(k,j)%p) ) then
                        call mpp_read(unit(n), fields(l), fileObj%p3dr(k,j)%p, tlev)
                        if ( is_there_a_checksum ) &
-                         checksum_data = mpp_chksum(fileObj%p3dr(k,j)%p(cur_var%is:cur_var%is+iadd,cur_var%js:cur_var%js+jadd, :) )
+                         checksum_data = mpp_chksum(fileObj%p3dr(k,j)%p(cur_var%is:cur_var%is+iadd, &
+                                                   & cur_var%js:cur_var%js+jadd, :) )
                     else if( Associated(fileObj%p4dr(k,j)%p) ) then
                        call mpp_read(unit(n), fields(l), fileObj%p4dr(k,j)%p, tlev)
                        if ( is_there_a_checksum ) &
-                         checksum_data = mpp_chksum(fileObj%p4dr(k,j)%p(cur_var%is:cur_var%is+iadd,cur_var%js:cur_var%js+jadd,:,:))
+                         checksum_data = mpp_chksum(fileObj%p4dr(k,j)%p(cur_var%is:cur_var%is+iadd, &
+                                                   & cur_var%js:cur_var%js+jadd,:,:))
                     else if( Associated(fileObj%p0di(k,j)%p) ) then
                        call mpp_read(unit(n), fields(l), r0d, tlev)
                        fileObj%p0di(k,j)%p = r0d
@@ -4215,7 +4250,8 @@ subroutine restore_state_all(fileObj, directory, nonfatal_missing_files)
                        call mpp_read(unit(n), fields(l), r2d, tlev)
                        fileObj%p2di(k,j)%p = r2d
                        if ( is_there_a_checksum ) &
-                         checksum_data = mpp_chksum(fileObj%p2di(k,j)%p(cur_var%is:cur_var%is+iadd,cur_var%js:cur_var%js+jadd) )
+                         checksum_data = mpp_chksum(fileObj%p2di(k,j)%p(cur_var%is:cur_var%is+iadd, &
+                                                   & cur_var%js:cur_var%js+jadd) )
                        deallocate(r2d)
                     else if( Associated(fileObj%p3di(k,j)%p) ) then
                        allocate(r3d(cur_var%siz(1), cur_var%siz(2), cur_var%siz(3)) )
@@ -4223,7 +4259,8 @@ subroutine restore_state_all(fileObj, directory, nonfatal_missing_files)
                        call mpp_read(unit(n), fields(l), r3d, tlev)
                        fileObj%p3di(k,j)%p = r3d
                        if ( is_there_a_checksum ) &
-                         checksum_data = mpp_chksum(fileObj%p3di(k,j)%p(cur_var%is:cur_var%is+iadd,cur_var%js:cur_var%js+jadd, :))
+                         checksum_data = mpp_chksum(fileObj%p3di(k,j)%p(cur_var%is:cur_var%is+iadd, &
+                                                   & cur_var%js:cur_var%js+jadd, :))
                        deallocate(r3d)
                     else
                        call mpp_error(FATAL, "fms_io(restore_state_all): There is no pointer "//&
@@ -4231,8 +4268,9 @@ subroutine restore_state_all(fileObj, directory, nonfatal_missing_files)
                     end if
                  end if
                  if ( ( is_there_a_checksum ) .and. (checksum_file(k) /= checksum_data) ) then
-                   write (mesg,'(a,Z16,a,Z16,a)') "Checksum of input field "// uppercase(trim(varname))//" ", checksum_data,&
-                                " does not match value ", checksum_file(k), " stored in "//uppercase(trim(fileObj%name)//"." )
+                   write (mesg,'(a,Z16,a,Z16,a)') "Checksum of input field "// uppercase(trim(varname))//" ", &
+                          & checksum_data," does not match value ", checksum_file(k), " stored in "// &
+                          & uppercase(trim(fileObj%name)// "." )
                    call mpp_error(FATAL, "fms_io(restore_state_all): "//trim(mesg) )
                  endif
               end do
@@ -4495,8 +4533,9 @@ subroutine restore_state_one_field(fileObj, id_field, directory, nonfatal_missin
                          & mpp_chksum(fileObj%p3di(k,j)%p(cur_var%is:cur_var%is+iadd,cur_var%js:cur_var%js+jadd, :))
                     deallocate(r3d)
                  else
-                    call mpp_error(FATAL, "fms_io(restore_state_one_field): domain is present for the field "//trim(varname)// &
-                         " of file "//trim(fileObj%name)//", but none of p2dr, p3dr, p2di and p3di is associated")
+                    call mpp_error(FATAL, "fms_io(restore_state_one_field): domain is present for the field "// &
+                                  & trim(varname)//" of file "//trim(fileObj%name)// &
+                                  & ", but none of p2dr, p3dr, p2di and p3di is associated")
                  end if
               else
                  if( Associated(fileObj%p0dr(k,j)%p) ) then
@@ -4550,7 +4589,8 @@ subroutine restore_state_one_field(fileObj, id_field, directory, nonfatal_missin
               end if
               if ( (is_there_a_checksum ) .and. (checksum_file(k) /= checksum_data) )  then
                 write (mesg,'(a,Z16,a,Z16,a)') "Checksum of input field "// uppercase(trim(varname)), checksum_data,&
-                             " does not match value ", checksum_file(k), "stored in "//uppercase(trim(fileObj%name)//"." )
+                             " does not match value ", checksum_file(k), "stored in "//uppercase(trim(fileObj%name)// &
+       & "." )
                 call mpp_error(FATAL, "fms_io(restore_state_one_field): "//trim(mesg) )
               endif
           end do
@@ -4636,7 +4676,8 @@ subroutine setup_one_field(fileObj, filename, fieldname, field_siz, index_field,
 
   if(is_no_domain) then
      if(PRESENT(domain)) &
-       call mpp_error(FATAL, 'fms_io(setup_one_field): no_domain cannot be .true. when optional argument domain is present.')
+       call mpp_error(FATAL, &
+                      & 'fms_io(setup_one_field): no_domain cannot be .true. when optional argument domain is present.')
   else if(PRESENT(domain))then
      d_ptr => domain
   else if (ASSOCIATED(Current_domain)) then
@@ -4893,7 +4934,8 @@ subroutine write_data_scalar_new(filename, fieldname, data, domain, &
   logical, intent(in), optional          :: no_domain
   integer, intent(in), optional          :: tile_count
 
-  if(.not.module_is_initialized) call mpp_error(FATAL,'fms_io(write_data_scalar_new):  module not initialized: '//fieldname)
+  if(.not.module_is_initialized) call mpp_error(FATAL,'fms_io(write_data_scalar_new):  module not initialized: '// &
+     & fieldname)
 
   data_3d(1,1,1) = data
   call write_data_3d_new(filename, fieldname, data_3d,domain, &
@@ -5127,7 +5169,8 @@ function dimension_size(filename, dimname, domain, no_domain )
   endif
 
   if(.not. found) call mpp_error(FATAL, &
-         'fms_io_mod(dimesion_size): failed at inquiring size of dimesion '//trim(dimname)//' from file '//trim(filename))
+         'fms_io_mod(dimesion_size): failed at inquiring size of dimesion '//trim(dimname)//' from file '// &
+                 & trim(filename))
 
   return
 end function dimension_size
@@ -5405,7 +5448,8 @@ subroutine read_data_3d_new(filename,fieldname,data,domain,timelevel, &
   is_no_domain = .false.
   if (PRESENT(no_domain)) THEN
      if(PRESENT(domain) .AND. no_domain) &
-       call mpp_error(FATAL, 'fms_io(read_data_3d_new): no_domain cannot be .true. when optional argument domain is present.')
+       call mpp_error(FATAL, &
+                     & 'fms_io(read_data_3d_new): no_domain cannot be .true. when optional argument domain is present.')
      is_no_domain = no_domain
   endif
 
@@ -5576,7 +5620,8 @@ subroutine read_compressed_2d(filename,fieldname,data,domain,timelevel,start,nre
   if (files_read(file_index)%var(index_field)%is_dimvar) then
      call mpp_get_axis_data(files_read(file_index)%var(index_field)%axis,data(:,1))
   else
-     call mpp_read_compressed(unit,files_read(file_index)%var(index_field)%field,d_ptr,data,timelevel,start,nread,threading)
+     call mpp_read_compressed(unit,files_read(file_index)%var(index_field)%field,d_ptr,data,timelevel,start, &
+                             & nread,threading)
   endif
   d_ptr =>NULL()
 end subroutine read_compressed_2d
@@ -5969,9 +6014,12 @@ subroutine read_data_4d_new(filename,fieldname,data,domain,timelevel,&
                         no_domain,.false., position,tile_count)
 
   if(PRESENT(domain)) then
-     call mpp_get_global_domain( domain,isg,ieg,jsg,jeg,xsize=xsize_g,ysize=ysize_g, tile_count=tile_count, position=position)
-     call mpp_get_compute_domain( domain,isc,iec,jsc,jec,xsize=xsize_c,ysize=ysize_c, tile_count=tile_count, position=position)
-     call mpp_get_data_domain( domain,isd,ied,jsd,jed,xsize=xsize_d,ysize=ysize_d, tile_count=tile_count, position=position)
+     call mpp_get_global_domain( domain,isg,ieg,jsg,jeg,xsize=xsize_g,ysize=ysize_g, tile_count=tile_count, &
+                               &  position=position)
+     call mpp_get_compute_domain( domain,isc,iec,jsc,jec,xsize=xsize_c,ysize=ysize_c, tile_count=tile_count, &
+                                &  position=position)
+     call mpp_get_data_domain( domain,isd,ied,jsd,jed,xsize=xsize_d,ysize=ysize_d, tile_count=tile_count, &
+                             &  position=position)
      call mpp_get_domain_shift  (domain, ishift, jshift, position)
      if(((size(data,1)==xsize_c) .and. (size(data,2)==ysize_c))) then !on_comp_domain
         i = 0
@@ -6047,9 +6095,12 @@ subroutine read_data_2d_new(filename,fieldname,data,domain,timelevel,&
                         no_domain,.false., position,tile_count)
 
   if(PRESENT(domain)) then
-     call mpp_get_global_domain( domain,isg,ieg,jsg,jeg,xsize=xsize_g,ysize=ysize_g, tile_count=tile_count, position=position)
-     call mpp_get_compute_domain( domain,isc,iec,jsc,jec,xsize=xsize_c,ysize=ysize_c, tile_count=tile_count, position=position)
-     call mpp_get_data_domain( domain,isd,ied,jsd,jed,xsize=xsize_d,ysize=ysize_d, tile_count=tile_count, position=position)
+     call mpp_get_global_domain( domain,isg,ieg,jsg,jeg,xsize=xsize_g,ysize=ysize_g, tile_count=tile_count, &
+                               &  position=position)
+     call mpp_get_compute_domain( domain,isc,iec,jsc,jec,xsize=xsize_c,ysize=ysize_c, tile_count=tile_count, &
+                                &  position=position)
+     call mpp_get_data_domain( domain,isd,ied,jsd,jed,xsize=xsize_d,ysize=ysize_d, tile_count=tile_count, &
+                             &  position=position)
      call mpp_get_domain_shift  (domain, ishift, jshift, position)
      if(((size(data,1)==xsize_c) .and. (size(data,2)==ysize_c))) then !on_comp_domain
         data(:,:) = data_3d(:,:,1)
@@ -7107,7 +7158,7 @@ subroutine set_initialized_r2d(fileObj, f_ptr, name, is_set)
 
   if (m>fileObj%nvar .AND. mpp_pe() == mpp_root_pe() ) then
     call mpp_error(NOTE,"fms_io(set_initialized_r2d): Unable to find "// &
-          trim(name)//" queried by pointer, "//"probably because of the suspect comparison of pointers by ASSOCIATED"// &
+          trim(name)//" queried by pointer, "//"probably because of the suspect comparison of pointers by ASSOCIATED"//&
                         " when attempting to set initialization.")
   end if
 
@@ -7258,7 +7309,8 @@ function open_namelist_file (file) result (unit)
   character(len=128) :: filename
 
 #ifdef INTERNAL_FILE_NML
-  if(show_open_namelist_file_warning) call mpp_error(WARNING, "fms_io_mod: open_namelist_file should not be called when INTERNAL_FILE_NML is defined")
+  if(show_open_namelist_file_warning) call mpp_error(WARNING, &
+     &  "fms_io_mod: open_namelist_file should not be called when INTERNAL_FILE_NML is defined")
 #endif
 
   if (.not.module_is_initialized) call fms_io_init ( )
@@ -8518,7 +8570,8 @@ subroutine parse_mask_table_2d(mask_table, maskmap, modelname)
   call mpp_broadcast(mask_list, 2*nmask, mpp_root_pe())
   do n = 1, nmask
      if(debug_mask_list) then
-       write(stdoutunit,*) "==>NOTE from parse_mask_table_2d: ", trim(modelname), " mask_list = ", mask_list(n,1), mask_list(n,2)
+       write(stdoutunit,*) "==>NOTE from parse_mask_table_2d: ", trim(modelname), " mask_list = ", mask_list(n, &
+            & 1), mask_list(n,2)
      endif
      maskmap(mask_list(n,1),mask_list(n,2)) = .false.
   enddo

--- a/fms/fms_io.F90
+++ b/fms/fms_io.F90
@@ -4594,8 +4594,7 @@ subroutine restore_state_one_field(fileObj, id_field, directory, nonfatal_missin
               end if
               if ( (is_there_a_checksum ) .and. (checksum_file(k) /= checksum_data) )  then
                 write (mesg,'(a,Z16,a,Z16,a)') "Checksum of input field "// uppercase(trim(varname)), checksum_data,&
-                             " does not match value ", checksum_file(k), "stored in "//uppercase(trim(fileObj%name)// &
-       & "." )
+                          " does not match value ", checksum_file(k), "stored in "//uppercase(trim(fileObj%name)//".")
                 call mpp_error(FATAL, "fms_io(restore_state_one_field): "//trim(mesg) )
               endif
           end do
@@ -4940,7 +4939,7 @@ subroutine write_data_scalar_new(filename, fieldname, data, domain, &
   integer, intent(in), optional          :: tile_count
 
   if(.not.module_is_initialized) call mpp_error(FATAL,'fms_io(write_data_scalar_new):  module not initialized: '// &
-     & fieldname)
+                                              & fieldname)
 
   data_3d(1,1,1) = data
   call write_data_3d_new(filename, fieldname, data_3d,domain, &
@@ -5496,7 +5495,7 @@ subroutine read_data_3d_new(filename,fieldname,data,domain,timelevel, &
        call mpp_error(FATAL,'fms_io(read_data_3d_new): data should be on either compute domain '//&
                             'or data domain when domain is present. '//&
                             'shape(data)=',shape(data),'  cxsize,cysize,dxsize,dysize=',(/cxsize,cysize,dxsize, &
-                                  & dysize/))
+                             dysize/))
      end if
   endif
 
@@ -8579,8 +8578,8 @@ subroutine parse_mask_table_2d(mask_table, maskmap, modelname)
   call mpp_broadcast(mask_list, 2*nmask, mpp_root_pe())
   do n = 1, nmask
      if(debug_mask_list) then
-       write(stdoutunit,*) "==>NOTE from parse_mask_table_2d: ", trim(modelname), " mask_list = ", mask_list(n, &
-            & 1), mask_list(n,2)
+       write(stdoutunit,*) "==>NOTE from parse_mask_table_2d: ", trim(modelname), " mask_list = ", mask_list(n,1), &
+                         & mask_list(n,2)
      endif
      maskmap(mask_list(n,1),mask_list(n,2)) = .false.
   enddo

--- a/fms/fms_io_unstructured_field_exist.inc
+++ b/fms/fms_io_unstructured_field_exist.inc
@@ -35,11 +35,14 @@ function fms_io_unstructured_field_exist(file_name, &
     logical(INT_KIND)           :: does_field_exist !<Flag telling if the inputted field exists in the inputted file.
 
    !Local variables
-    logical(INT_KIND)                        :: file_exist !<Flag telling if the inputted file or one of its variants exists.
+    logical(INT_KIND)                        :: file_exist !<Flag telling if the inputted file
+                                                           !! or one of its variants exists.
     character(len=256)                       :: fname      !<Actual name of the found file.
-    logical(INT_KIND)                        :: read_dist  !<Flag telling if the file is "distributed" (has IO domain tile id appended onto the end).
+    logical(INT_KIND)                        :: read_dist  !<Flag telling if the file is "distributed"
+                                                           !! (has IO domain tile id appended onto the end).
     integer(INT_KIND)                        :: funit      !<A file unit.
-    integer(INT_KIND)                        :: nfile      !<Index of the inputted file in the "files_read" module array.
+    integer(INT_KIND)                        :: nfile      !<Index of the inputted file in
+                                                           !! the "files_read" module array.
     integer(INT_KIND)                        :: i          !<Loop variable.
     integer(INT_KIND)                        :: ndim       !<Number of dimensions in a file.
     integer(INT_KIND)                        :: nvar       !<Number of fields in a file.

--- a/fms/fms_io_unstructured_file_unit.inc
+++ b/fms/fms_io_unstructured_file_unit.inc
@@ -35,7 +35,8 @@ subroutine fms_io_unstructured_file_unit(filename, &
    !Local variables
     logical(INT_KIND)  :: found_file  !<Flag telling if the file exists.
     character(len=256) :: actual_file !<Name of the found file.
-    logical(INT_KIND)  :: read_dist   !<Flag telling if the file is "distributed" (has IO domain tile id appended to the end).
+    logical(INT_KIND)  :: read_dist   !<Flag telling if the file is "distributed" (has IO domain
+                                      !! tile id appended to the end).
     integer(INT_KIND)  :: nfile       !<Index of the inputted file in the "files_read" module array.
 
    !Get the actual name of the file, searching for all possible variants. If

--- a/fms/fms_io_unstructured_get_field_size.inc
+++ b/fms/fms_io_unstructured_get_field_size.inc
@@ -33,23 +33,32 @@ subroutine fms_io_unstructured_get_field_size(filename, &
     character(len=*),intent(in)        :: filename              !<The name of a file.
     character(len=*),intent(in)        :: fieldname             !<The name of a field in the input file.
     integer,dimension(:),intent(inout) :: field_dimension_sizes !<Array of dimension sizes for the inputted field.
-    type(domainUG),intent(in)          :: domain                !<An unstructured mpp domain associated with the input file.
-    logical,intent(out),optional       :: field_found           !<Flag telling if the inputted field was found in the inputted file.
+    type(domainUG),intent(in)          :: domain                !<An unstructured mpp domain
+                                                                !! associated with the input file.
+    logical,intent(out),optional       :: field_found           !<Flag telling if the inputted
+                                                                !! field was found in the inputted file.
 
    !Local variables
     type(domainUG),pointer                     :: io_domain       !<Pointer to the unstructured I/O domain.
     integer(INT_KIND)                          :: io_domain_npes  !<The total number of ranks in an I/O domain pelist.
     integer(INT_KIND),dimension(:),allocatable :: pelist          !<A pelist.
     integer(INT_KIND)                          :: funit           !<File unit for the inputted file.
-    integer(INT_KIND)                          :: num_axes        !<The total number of axes contained in the inputted file.
-    integer(INT_KIND)                          :: num_fields      !<The total number of fields contained in the inputted file.
-    integer(INT_KIND)                          :: num_atts        !<The total number of global attributes contained in the inputted file.
-    integer(INT_KIND)                          :: num_time_levels !<The total number of time levels contained in the inputted file.
-    type(fieldtype),dimension(max_fields)      :: file_fields     !<An array of all fields contained in the inputted file (max_fields is a module variable).
+    integer(INT_KIND)                          :: num_axes        !<The total number of axes
+                                                                  !! contained in the inputted file.
+    integer(INT_KIND)                          :: num_fields      !<The total number of fields
+                                                                  !! contained in the inputted file.
+    integer(INT_KIND)                          :: num_atts        !<The total number of global
+                                                                  !! attributes contained in the inputted file.
+    integer(INT_KIND)                          :: num_time_levels !<The total number of time
+                                                                  !! levels contained in the inputted file.
+    type(fieldtype),dimension(max_fields)      :: file_fields     !<An array of all fields
+                                                   !! contained in the inputted file (max_fields is a module variable).
     logical(INT_KIND)                          :: found           !<Flag telling if the field was found in the file.
     character(len=128)                         :: file_field_name !<Name of a field from the inputted file.
-    integer(INT_KIND)                          :: file_field_ndim !<Number of dimensions of a field from the inputted file.
-    type(axistype),dimension(max_fields)       :: file_field_axes !<An array of all axes of a field contained in the inputted file (max_fields is a module variable).
+    integer(INT_KIND)                          :: file_field_ndim !<Number of dimensions of
+                                                                  !! a field from the inputted file.
+    type(axistype),dimension(max_fields)       :: file_field_axes !<An array of all axes of
+                                           !! a field contained in the inputted file (max_fields is a module variable).
     character(len=128)                         :: file_axis_name  !<Name of an axis from the inputted file.
     integer(INT_KIND)                          :: file_axis_size  !<Size of an axis from the inputted file.
     integer(INT_KIND)                          :: i               !<Loop variable.

--- a/fms/fms_io_unstructured_get_file_name.inc
+++ b/fms/fms_io_unstructured_get_file_name.inc
@@ -51,7 +51,8 @@ function fms_io_unstructured_get_file_name(orig_file, &
    !Inputs/Outputs
     character(len=*),intent(in)   :: orig_file       !<The name of file we're looking for.
     character(len=*),intent(out)  :: actual_file     !<Name of the file we found.
-    logical(INT_KIND),intent(out) :: read_dist       !<Flag telling if the file is "distributed" (has IO domain tile id appended onto the end).
+    logical(INT_KIND),intent(out) :: read_dist       !<Flag telling if the file is "distributed"
+                                                     !! (has IO domain tile id appended onto the end).
     type(domainUG),intent(in)     :: domain          !<Unstructured mpp domain.
     logical(INT_KIND)             :: does_file_exist !<Flag telling if the inputted file exists or one its variants.
 

--- a/fms/fms_io_unstructured_get_file_unit.inc
+++ b/fms/fms_io_unstructured_get_file_unit.inc
@@ -34,7 +34,8 @@ subroutine fms_io_unstructured_get_file_unit(filename, &
     character(len=*),intent(in)   :: filename   !<Name of the file to be read from.
     integer(INT_KIND),intent(out) :: funit      !<File unit for the inputted file.
     integer(INT_KIND),intent(out) :: index_file !<Index of the inputted file in the "files_read" module array.
-    logical(INT_KIND),intent(in)  :: read_dist  !<Flag telling if the IO domain tile id string exists at the end of the inputted file name.
+    logical(INT_KIND),intent(in)  :: read_dist  !<Flag telling if the IO domain tile id string
+                                                !! exists at the end of the inputted file name.
     type(domainUG),intent(in)     :: domain     !<An unstructured mpp domain.
 
    !Local variables

--- a/fms/fms_io_unstructured_read.inc
+++ b/fms/fms_io_unstructured_read.inc
@@ -97,7 +97,8 @@ subroutine fms_io_unstructured_read_r_1D(filename, &
    !Local variables
     logical(INT_KIND)  :: found_file  !<Flag telling if the input file or any of its variants exist.
     character(len=256) :: fname       !<Name of file that is actually found.
-    logical(INT_KIND)  :: read_dist   !<Flag telling if the file is "distributed" (has I/O domain tile id appended onto the end).
+    logical(INT_KIND)  :: read_dist   !<Flag telling if the file is "distributed" (has I/O
+                                      !! domain tile id appended onto the end).
     integer(INT_KIND)  :: funit       !<File unit for the inputted file.
     integer(INT_KIND)  :: file_index  !<Index of the inputted file in the "files_read" module array.
     integer(INT_KIND)  :: index_field !<Index of the inputted field in the files_read(file_index)%var array.
@@ -184,7 +185,8 @@ subroutine fms_io_unstructured_read_r_2D(filename, &
    !Local variables
     logical(INT_KIND)  :: found_file  !<Flag telling if the input file or any of its variants exist.
     character(len=256) :: fname       !<Name of file that is actually found.
-    logical(INT_KIND)  :: read_dist   !<Flag telling if the file is "distributed" (has I/O domain tile id appended onto the end).
+    logical(INT_KIND)  :: read_dist   !<Flag telling if the file is "distributed" (has I/O
+                                      !! domain tile id appended onto the end).
     integer(INT_KIND)  :: funit       !<File unit for the inputted file.
     integer(INT_KIND)  :: file_index  !<Index of the inputted file in the "files_read" module array.
     integer(INT_KIND)  :: index_field !<Index of the inputted field in the files_read(file_index)%var array.
@@ -271,7 +273,8 @@ subroutine fms_io_unstructured_read_r_3D(filename, &
    !Local variables
     logical(INT_KIND)  :: found_file  !<Flag telling if the input file or any of its variants exist.
     character(len=256) :: fname       !<Name of file that is actually found.
-    logical(INT_KIND)  :: read_dist   !<Flag telling if the file is "distributed" (has I/O domain tile id appended onto the end).
+    logical(INT_KIND)  :: read_dist   !<Flag telling if the file is "distributed" (has I/O
+                                      !! domain tile id appended onto the end).
     integer(INT_KIND)  :: funit       !<File unit for the inputted file.
     integer(INT_KIND)  :: file_index  !<Index of the inputted file in the "files_read" module array.
     integer(INT_KIND)  :: index_field !<Index of the inputted field in the files_read(file_index)%var array.

--- a/fms/fms_io_unstructured_register_restart_axis.inc
+++ b/fms/fms_io_unstructured_register_restart_axis.inc
@@ -50,14 +50,20 @@ subroutine fms_io_unstructured_register_restart_axis_r1D(fileObj, &
 
    !Local variables
     integer(INT_KIND)                          :: input_filename_length !<The length of the trimmed input filename.
-    character(len=256)                         :: tmp_filename          !<A character buffer used to store various file names.
-    character(len=256)                         :: filename_suffix       !<A string appended to the end of the inputted file name.
-    character(len=256)                         :: mosaic_filename       !<The filename returned by the get_mosaic_tile_file_ug routine.
-    integer(INT_KIND)                          :: axis_index            !<Index of the inputted axis in the fileObj%axes array.
+    character(len=256)                         :: tmp_filename          !<A character buffer
+                                                                        !! used to store various file names.
+    character(len=256)                         :: filename_suffix       !<A string appended
+                                                                        !! to the end of the inputted file name.
+    character(len=256)                         :: mosaic_filename       !<The filename returned
+                                                                        !! by the get_mosaic_tile_file_ug routine.
+    integer(INT_KIND)                          :: axis_index            !<Index of the inputted
+                                                                        !! axis in the fileObj%axes array.
     type(domainUG),pointer                     :: io_domain             !<Pointer to an unstructured I/O domain.
-    integer(INT_KIND)                          :: io_domain_npes        !<The total number of ranks in an I/O domain pelist.
+    integer(INT_KIND)                          :: io_domain_npes        !<The total number
+                                                                        !! of ranks in an I/O domain pelist.
     integer(INT_KIND),dimension(:),allocatable :: pelist                !<A pelist.
-    integer(INT_KIND),dimension(:),allocatable :: fdata_sizes           !<Size of the axis data for each rank in the I/O domain pelist.
+    integer(INT_KIND),dimension(:),allocatable :: fdata_sizes           !<Size of the axis
+                                                                        !! data for each rank in the I/O domain pelist.
 
    !Make sure that the module is initialized.
     if (.not. module_is_initialized) then
@@ -269,12 +275,17 @@ subroutine fms_io_unstructured_register_restart_axis_i1D(fileObj, &
 
    !Local variables
     integer(INT_KIND)                          :: input_filename_length !<The length of the trimmed input filename.
-    character(len=256)                         :: tmp_filename          !<A character buffer used to store various file names.
-    character(len=256)                         :: filename_suffix       !<A string appended to the end of the inputted file name.
-    character(len=256)                         :: mosaic_filename       !<The filename returned by the get_mosaic_tile_file_ug routine.
-    integer(INT_KIND)                          :: axis_index            !<Index of the inputted axis in the fileObj%axes array.
+    character(len=256)                         :: tmp_filename          !<A character buffer
+                                                                        !! used to store various file names.
+    character(len=256)                         :: filename_suffix       !<A string appended
+                                                                        !! to the end of the inputted file name.
+    character(len=256)                         :: mosaic_filename       !<The filename returned
+                                                                        !! by the get_mosaic_tile_file_ug routine.
+    integer(INT_KIND)                          :: axis_index            !<Index of the inputted
+                                                                        !! axis in the fileObj%axes array.
     type(domainUG),pointer                     :: io_domain             !<Pointer to an unstructured I/O domain.
-    integer(INT_KIND)                          :: io_domain_npes        !<The total number of ranks in an I/O domain pelist.
+    integer(INT_KIND)                          :: io_domain_npes        !<The total number
+                                                                        !! of ranks in an I/O domain pelist.
     integer(INT_KIND),dimension(:),allocatable :: pelist                !<A pelist.
 
    !Make sure that the module is initialized.
@@ -468,12 +479,17 @@ subroutine fms_io_unstructured_register_restart_axis_u(fileObj, &
 
    !Local variables
     integer(INT_KIND)                          :: input_filename_length !<The length of the trimmed input filename.
-    character(len=256)                         :: tmp_filename          !<A character buffer used to store various file names.
-    character(len=256)                         :: filename_suffix       !<A string appended to the end of the inputted file name.
-    character(len=256)                         :: mosaic_filename       !<The filename returned by the get_mosaic_tile_file_ug routine.
-    integer(INT_KIND)                          :: axis_index            !<Index of the inputted axis in the fileObj%axes array.
+    character(len=256)                         :: tmp_filename          !<A character buffer
+                                                                        !! used to store various file names.
+    character(len=256)                         :: filename_suffix       !<A string appended
+                                                                        !! to the end of the inputted file name.
+    character(len=256)                         :: mosaic_filename       !<The filename returned
+                                                                        !! by the get_mosaic_tile_file_ug routine.
+    integer(INT_KIND)                          :: axis_index            !<Index of the inputted
+                                                                        !! axis in the fileObj%axes array.
     type(domainUG),pointer                     :: io_domain             !<Pointer to an unstructured I/O domain.
-    integer(INT_KIND)                          :: io_domain_npes        !<The total number of ranks in an I/O domain pelist.
+    integer(INT_KIND)                          :: io_domain_npes        !<The total number
+                                                                        !! of ranks in an I/O domain pelist.
     integer(INT_KIND),dimension(:),allocatable :: pelist                !<A pelist.
 
    !Make sure that the module is initialized.

--- a/fms/fms_io_unstructured_register_restart_field.inc
+++ b/fms/fms_io_unstructured_register_restart_field.inc
@@ -47,18 +47,23 @@ function fms_io_unstructured_register_restart_field_r_0d(fileObj, &
     real,intent(in),optional              :: data_default      !<A default value for the data.
     character(len=*),intent(in),optional  :: longname          !<A more descriptive name of the field.
     character(len=*),intent(in),optional  :: units             !<Units for the field.
-    logical(INT_KIND),intent(in),optional :: read_only         !<Tells whether or not the variable will be written to the restart file.
-    logical(INT_KIND),intent(in),optional :: restart_owns_data !<Tells if the data will be deallocated when the restart object is deallocated.
+    logical(INT_KIND),intent(in),optional :: read_only         !<Tells whether or not the variable
+                                                               !! will be written to the restart file.
+    logical(INT_KIND),intent(in),optional :: restart_owns_data !<Tells if the data will be
+                                                               !! deallocated when the restart object is deallocated.
     integer(INT_KIND)                     :: restart_index     !<Index of the inputted field in the fileObj%var array.
 
    !Local variables
     type(domainUG),pointer                     :: io_domain             !<Pointer to an unstructured I/O domain.
-    integer(INT_KIND)                          :: io_domain_npes        !<The number of ranks in the unstructured I/O domain pelist.
+    integer(INT_KIND)                          :: io_domain_npes        !<The number of ranks
+                                                                        !! in the unstructured I/O domain pelist.
     integer(INT_KIND),dimension(:),allocatable :: pelist                !<A pelist.
     real,dimension(:),allocatable              :: fdata_per_rank        !<Array used to gather the scalar field values.
-    integer(INT_KIND)                          :: index_field           !<Index of the inputted field in the fileObj%var array.
+    integer(INT_KIND)                          :: index_field           !<Index of the inputted
+                                                                        !! field in the fileObj%var array.
     integer(INT_KIND),dimension(NIDX)          :: field_dimension_sizes !<Array of dimension sizes for the field.
-    integer(INT_KIND),dimension(1)             :: field_dimension_order !<Array telling the ordering of the dimensions for the field.
+    integer(INT_KIND),dimension(1)             :: field_dimension_order !<Array telling the
+                                                                        !! ordering of the dimensions for the field.
 
    !Make sure that the module has been initialized.
     if (.not. module_is_initialized) then
@@ -160,8 +165,10 @@ function fms_io_unstructured_register_restart_field_r_1d(fileObj, &
     real,intent(in),optional              :: data_default      !<A default value for the data.
     character(len=*),intent(in),optional  :: longname          !<A more descriptive name of the field.
     character(len=*),intent(in),optional  :: units             !<Units for the field.
-    logical(INT_KIND),intent(in),optional :: read_only         !<Tells whether or not the variable will be written to the restart file.
-    logical(INT_KIND),intent(in),optional :: restart_owns_data !<Tells if the data will be deallocated when the restart object is deallocated.
+    logical(INT_KIND),intent(in),optional :: read_only         !<Tells whether or not the variable
+                                                               !! will be written to the restart file.
+    logical(INT_KIND),intent(in),optional :: restart_owns_data !<Tells if the data will be
+                                                               !! deallocated when the restart object is deallocated.
     integer(INT_KIND)                     :: restart_index     !<Index of the inputted field in the fileObj%var array.
 
    !Local variables
@@ -277,8 +284,10 @@ function fms_io_unstructured_register_restart_field_r_2d(fileObj, &
     real,intent(in),optional              :: data_default      !<A default value for the data.
     character(len=*),intent(in),optional  :: longname          !<A more descriptive name of the field.
     character(len=*),intent(in),optional  :: units             !<Units for the field.
-    logical(INT_KIND),intent(in),optional :: read_only         !<Tells whether or not the variable will be written to the restart file.
-    logical(INT_KIND),intent(in),optional :: restart_owns_data !<Tells if the data will be deallocated when the restart object is deallocated.
+    logical(INT_KIND),intent(in),optional :: read_only         !<Tells whether or not the variable
+                                                               !! will be written to the restart file.
+    logical(INT_KIND),intent(in),optional :: restart_owns_data !<Tells if the data will be
+                                                               !! deallocated when the restart object is deallocated.
     integer(INT_KIND)                     :: restart_index     !<Index of the inputted field in the fileObj%var array.
 
    !Local variables
@@ -431,12 +440,15 @@ function fms_io_unstructured_register_restart_field_r_3d(fileObj, &
     real,dimension(:,:,:),intent(in),target :: fdata_3d          !<Some data.
     integer(INT_KIND),dimension(3)          :: fdata_3d_axes     !<An array describing the axes for the data.
     type(domainUG),intent(in),target        :: domain            !<An unstructured mpp_domain.
-    logical,intent(in),optional             :: mandatory         !<Flag telling if the field is mandatory for the restart.
+    logical,intent(in),optional             :: mandatory         !<Flag telling if the field
+                                                                 !! is mandatory for the restart.
     real,intent(in),optional                :: data_default      !<A default value for the data.
     character(len=*),intent(in),optional    :: longname          !<A more descriptive name of the field.
     character(len=*),intent(in),optional    :: units             !<Units for the field.
-    logical(INT_KIND),intent(in),optional   :: read_only         !<Tells whether or not the variable will be written to the restart file.
-    logical(INT_KIND),intent(in),optional   :: restart_owns_data !<Tells if the data will be deallocated when the restart object is deallocated.
+    logical(INT_KIND),intent(in),optional   :: read_only         !<Tells whether or not the
+                                                                 !! variable will be written to the restart file.
+    logical(INT_KIND),intent(in),optional   :: restart_owns_data !<Tells if the data will be
+                                                                 !! deallocated when the restart object is deallocated.
     integer(INT_KIND)                       :: restart_index     !<Index of the inputted field in the fileObj%var array.
 
    !Local variables
@@ -622,8 +634,10 @@ function fms_io_unstructured_register_restart_field_r8_2d(fileObj, &
     real(DOUBLE_KIND),intent(in),optional              :: data_default      !<A default value for the data.
     character(len=*),intent(in),optional  :: longname          !<A more descriptive name of the field.
     character(len=*),intent(in),optional  :: units             !<Units for the field.
-    logical(INT_KIND),intent(in),optional :: read_only         !<Tells whether or not the variable will be written to the restart file.
-    logical(INT_KIND),intent(in),optional :: restart_owns_data !<Tells if the data will be deallocated when the restart object is deallocated.
+    logical(INT_KIND),intent(in),optional :: read_only         !<Tells whether or not the variable
+                                                               !! will be written to the restart file.
+    logical(INT_KIND),intent(in),optional :: restart_owns_data !<Tells if the data will be
+                                                               !! deallocated when the restart object is deallocated.
     integer(INT_KIND)                     :: restart_index     !<Index of the inputted field in the fileObj%var array.
 
    !Local variables
@@ -781,12 +795,15 @@ function fms_io_unstructured_register_restart_field_r8_3d(fileObj, &
     real(DOUBLE_KIND),dimension(:,:,:),intent(in),target :: fdata_3d          !<Some data.
     integer(INT_KIND),dimension(3)          :: fdata_3d_axes     !<An array describing the axes for the data.
     type(domainUG),intent(in),target        :: domain            !<An unstructured mpp_domain.
-    logical,intent(in),optional             :: mandatory         !<Flag telling if the field is mandatory for the restart.
+    logical,intent(in),optional             :: mandatory         !<Flag telling if the field
+                                                                 !! is mandatory for the restart.
     real(DOUBLE_KIND),intent(in),optional                :: data_default      !<A default value for the data.
     character(len=*),intent(in),optional    :: longname          !<A more descriptive name of the field.
     character(len=*),intent(in),optional    :: units             !<Units for the field.
-    logical(INT_KIND),intent(in),optional   :: read_only         !<Tells whether or not the variable will be written to the restart file.
-    logical(INT_KIND),intent(in),optional   :: restart_owns_data !<Tells if the data will be deallocated when the restart object is deallocated.
+    logical(INT_KIND),intent(in),optional   :: read_only         !<Tells whether or not the
+                                                                 !! variable will be written to the restart file.
+    logical(INT_KIND),intent(in),optional   :: restart_owns_data !<Tells if the data will be
+                                                                 !! deallocated when the restart object is deallocated.
     integer(INT_KIND)                       :: restart_index     !<Index of the inputted field in the fileObj%var array.
 
    !Local variables
@@ -973,18 +990,23 @@ function fms_io_unstructured_register_restart_field_i_0d(fileObj, &
     real,intent(in),optional              :: data_default      !<A default value for the data.
     character(len=*),intent(in),optional  :: longname          !<A more descriptive name of the field.
     character(len=*),intent(in),optional  :: units             !<Units for the field.
-    logical(INT_KIND),intent(in),optional :: read_only         !<Tells whether or not the variable will be written to the restart file.
-    logical(INT_KIND),intent(in),optional :: restart_owns_data !<Tells if the data will be deallocated when the restart object is deallocated.
+    logical(INT_KIND),intent(in),optional :: read_only         !<Tells whether or not the variable
+                                                               !! will be written to the restart file.
+    logical(INT_KIND),intent(in),optional :: restart_owns_data !<Tells if the data will be
+                                                               !! deallocated when the restart object is deallocated.
     integer(INT_KIND)                     :: restart_index     !<Index of the inputted field in the fileObj%var array.
 
    !Local variables
     type(domainUG),pointer                     :: io_domain             !<Pointer to an unstructured I/O domain.
-    integer(INT_KIND)                          :: io_domain_npes        !<The number of ranks in the unstructured I/O domain pelist.
+    integer(INT_KIND)                          :: io_domain_npes        !<The number of ranks
+                                                                        !! in the unstructured I/O domain pelist.
     integer(INT_KIND),dimension(:),allocatable :: pelist                !<A pelist.
     integer,dimension(:),allocatable           :: fdata_per_rank        !<Array used to gather the scalar field values.
-    integer(INT_KIND)                          :: index_field           !<Index of the inputted field in the fileObj%var array.
+    integer(INT_KIND)                          :: index_field           !<Index of the inputted
+                                                                        !! field in the fileObj%var array.
     integer(INT_KIND),dimension(NIDX)          :: field_dimension_sizes !<Array of dimension sizes for the field.
-    integer(INT_KIND),dimension(1)             :: field_dimension_order !<Array telling the ordering of the dimensions for the field.
+    integer(INT_KIND),dimension(1)             :: field_dimension_order !<Array telling the
+                                                                        !! ordering of the dimensions for the field.
 
    !Make sure that the module has been initialized.
     if (.not. module_is_initialized) then
@@ -1082,12 +1104,15 @@ function fms_io_unstructured_register_restart_field_i_1d(fileObj, &
     integer,dimension(:),intent(in),target :: fdata_1d          !<Some data.
     integer(INT_KIND),dimension(1)         :: fdata_1d_axes     !<An array describing the axes for the data.
     type(domainUG),intent(in),target       :: domain            !<An unstructured mpp_domain.
-    logical,intent(in),optional            :: mandatory         !<Flag telling if the field is mandatory for the restart.
+    logical,intent(in),optional            :: mandatory         !<Flag telling if the field
+                                                                !! is mandatory for the restart.
     real,intent(in),optional               :: data_default      !<A default value for the data.
     character(len=*),intent(in),optional   :: longname          !<A more descriptive name of the field.
     character(len=*),intent(in),optional   :: units             !<Units for the field.
-    logical(INT_KIND),intent(in),optional  :: read_only         !<Tells whether or not the variable will be written to the restart file.
-    logical(INT_KIND),intent(in),optional  :: restart_owns_data !<Tells if the data will be deallocated when the restart object is deallocated.
+    logical(INT_KIND),intent(in),optional  :: read_only         !<Tells whether or not the
+                                                                !! variable will be written to the restart file.
+    logical(INT_KIND),intent(in),optional  :: restart_owns_data !<Tells if the data will be
+                                                                !! deallocated when the restart object is deallocated.
     integer(INT_KIND)                      :: restart_index     !<Index of the inputted field in the fileObj%var array.
 
    !Local variables
@@ -1199,13 +1224,17 @@ function fms_io_unstructured_register_restart_field_i_2d(fileObj, &
     integer,dimension(:,:),intent(in),target :: fdata_2d          !<Some data.
     integer(INT_KIND),dimension(2)           :: fdata_2d_axes     !<An array describing the axes for the data.
     type(domainUG),intent(in),target         :: domain            !<An unstructured mpp_domain.
-    logical,intent(in),optional              :: mandatory         !<Flag telling if the field is mandatory for the restart.
+    logical,intent(in),optional              :: mandatory         !<Flag telling if the field
+                                                                  !! is mandatory for the restart.
     real,intent(in),optional                 :: data_default      !<A default value for the data.
     character(len=*),intent(in),optional     :: longname          !<A more descriptive name of the field.
     character(len=*),intent(in),optional     :: units             !<Units for the field.
-    logical(INT_KIND),intent(in),optional    :: read_only         !<Tells whether or not the variable will be written to the restart file.
-    logical(INT_KIND),intent(in),optional    :: restart_owns_data !<Tells if the data will be deallocated when the restart object is deallocated.
-    integer(INT_KIND)                        :: restart_index     !<Index of the inputted field in the fileObj%var array.
+    logical(INT_KIND),intent(in),optional    :: read_only         !<Tells whether or not the
+                                                                  !! variable will be written to the restart file.
+    logical(INT_KIND),intent(in),optional    :: restart_owns_data !<Tells if the data will
+                                                              !! be deallocated when the restart object is deallocated.
+    integer(INT_KIND)                        :: restart_index     !<Index of the inputted field
+                                                                  !! in the fileObj%var array.
 
    !Local variables
     integer(INT_KIND)                 :: index_field           !<Index of the inputted field in the fileObj%var array.

--- a/fms/fms_io_unstructured_register_restart_field.inc
+++ b/fms/fms_io_unstructured_register_restart_field.inc
@@ -43,7 +43,8 @@ function fms_io_unstructured_register_restart_field_r_0d(fileObj, &
     character(len=*),intent(in)           :: fieldname         !<The name of a field.
     real,intent(in),target                :: fdata_0d          !<Some data.
     type(domainUG),intent(in),target      :: domain            !<An unstructured mpp_domain.
-    logical,intent(in),optional           :: mandatory         !<Flag telling if the field is mandatory for the restart.
+    logical,intent(in),optional           :: mandatory         !<Flag telling if the field is mandatory
+                                                               !! for the restart.
     real,intent(in),optional              :: data_default      !<A default value for the data.
     character(len=*),intent(in),optional  :: longname          !<A more descriptive name of the field.
     character(len=*),intent(in),optional  :: units             !<Units for the field.
@@ -161,7 +162,8 @@ function fms_io_unstructured_register_restart_field_r_1d(fileObj, &
     real,dimension(:),intent(in),target   :: fdata_1d          !<Some data.
     integer(INT_KIND),dimension(1)        :: fdata_1d_axes     !<An array describing the axes for the data.
     type(domainUG),intent(in),target      :: domain            !<An unstructured mpp_domain.
-    logical,intent(in),optional           :: mandatory         !<Flag telling if the field is mandatory for the restart.
+    logical,intent(in),optional           :: mandatory         !<Flag telling if the field is mandatory
+                                                               !! for the restart.
     real,intent(in),optional              :: data_default      !<A default value for the data.
     character(len=*),intent(in),optional  :: longname          !<A more descriptive name of the field.
     character(len=*),intent(in),optional  :: units             !<Units for the field.
@@ -280,7 +282,8 @@ function fms_io_unstructured_register_restart_field_r_2d(fileObj, &
     real,dimension(:,:),intent(in),target :: fdata_2d          !<Some data.
     integer(INT_KIND),dimension(2)        :: fdata_2d_axes     !<An array describing the axes for the data.
     type(domainUG),intent(in),target      :: domain            !<An unstructured mpp_domain.
-    logical,intent(in),optional           :: mandatory         !<Flag telling if the field is mandatory for the restart.
+    logical,intent(in),optional           :: mandatory         !<Flag telling if the field is mandatory
+                                                               !! for the restart.
     real,intent(in),optional              :: data_default      !<A default value for the data.
     character(len=*),intent(in),optional  :: longname          !<A more descriptive name of the field.
     character(len=*),intent(in),optional  :: units             !<Units for the field.
@@ -449,7 +452,8 @@ function fms_io_unstructured_register_restart_field_r_3d(fileObj, &
                                                                  !! variable will be written to the restart file.
     logical(INT_KIND),intent(in),optional   :: restart_owns_data !<Tells if the data will be
                                                                  !! deallocated when the restart object is deallocated.
-    integer(INT_KIND)                       :: restart_index     !<Index of the inputted field in the fileObj%var array.
+    integer(INT_KIND)                       :: restart_index     !<Index of the inputted field in the
+                                                                 !! fileObj%var array.
 
    !Local variables
     integer(INT_KIND)                 :: index_field           !<Index of the inputted field in the fileObj%var array.
@@ -630,7 +634,8 @@ function fms_io_unstructured_register_restart_field_r8_2d(fileObj, &
     real(DOUBLE_KIND),dimension(:,:),intent(in),target :: fdata_2d          !<Some data.
     integer(INT_KIND),dimension(2)        :: fdata_2d_axes     !<An array describing the axes for the data.
     type(domainUG),intent(in),target      :: domain            !<An unstructured mpp_domain.
-    logical,intent(in),optional           :: mandatory         !<Flag telling if the field is mandatory for the restart.
+    logical,intent(in),optional           :: mandatory         !<Flag telling if the field is mandatory
+                                                               !! for the restart.
     real(DOUBLE_KIND),intent(in),optional              :: data_default      !<A default value for the data.
     character(len=*),intent(in),optional  :: longname          !<A more descriptive name of the field.
     character(len=*),intent(in),optional  :: units             !<Units for the field.
@@ -804,7 +809,8 @@ function fms_io_unstructured_register_restart_field_r8_3d(fileObj, &
                                                                  !! variable will be written to the restart file.
     logical(INT_KIND),intent(in),optional   :: restart_owns_data !<Tells if the data will be
                                                                  !! deallocated when the restart object is deallocated.
-    integer(INT_KIND)                       :: restart_index     !<Index of the inputted field in the fileObj%var array.
+    integer(INT_KIND)                       :: restart_index     !<Index of the inputted field in the
+                                                                 !! fileObj%var array.
 
    !Local variables
     integer(INT_KIND)                 :: index_field           !<Index of the inputted field in the fileObj%var array.
@@ -986,7 +992,8 @@ function fms_io_unstructured_register_restart_field_i_0d(fileObj, &
     character(len=*),intent(in)           :: fieldname         !<The name of a field.
     integer,intent(in),target             :: fdata_0d          !<Some data.
     type(domainUG),intent(in),target      :: domain            !<An unstructured mpp_domain.
-    logical,intent(in),optional           :: mandatory         !<Flag telling if the field is mandatory for the restart.
+    logical,intent(in),optional           :: mandatory         !<Flag telling if the field is mandatory
+                                                               !! for the restart.
     real,intent(in),optional              :: data_default      !<A default value for the data.
     character(len=*),intent(in),optional  :: longname          !<A more descriptive name of the field.
     character(len=*),intent(in),optional  :: units             !<Units for the field.

--- a/fms/fms_io_unstructured_save_restart.inc
+++ b/fms/fms_io_unstructured_save_restart.inc
@@ -33,7 +33,8 @@ subroutine fms_io_unstructured_save_restart(fileObj, &
     type(restart_file_type),intent(inout),target :: fileObj     !<A restart object.
     character(len=*),intent(in),optional         :: time_stamp  !<A time stamp for the file.
     character(len=*),intent(in),optional         :: directory   !<The directory where the restart file lives.
-    logical(INT_KIND),intent(in),optional        :: append      !<Flag telling whether to append to or overwrite the restart file.
+    logical(INT_KIND),intent(in),optional        :: append      !<Flag telling whether to append to or
+                                                                !! overwrite the restart file.
     real,intent(in),optional                     :: time_level  !<A time level value (do not specify a kind value).
 
    !Optional arguments:
@@ -56,36 +57,58 @@ subroutine fms_io_unstructured_save_restart(fileObj, &
 
    !Local variables
     type(domainUG),pointer                      :: domain            !<A pointer to an unstructured mpp domain.
-    integer(INT_KIND)                           :: mpp_action        !<Parameter specifying how the file will be acted on (overwritten or appended to).
-    logical(INT_KIND)                           :: write_meta_data   !<Flag telling whether or not metadata will be written to the restart file.
-    logical(INT_KIND)                           :: write_field_data  !<Flag telling whether or not field data will be written to the restart file.
+    integer(INT_KIND)                           :: mpp_action        !<Parameter specifying how the file
+                                                                     !! will be acted on (overwritten or appended to).
+    logical(INT_KIND)                           :: write_meta_data   !<Flag telling whether or not metadata
+                                                                     !! will be written to the restart file.
+    logical(INT_KIND)                           :: write_field_data  !<Flag telling whether or not field
+                                                                     !! data will be written to the restart file.
     character(len=128)                          :: dir               !<Directory where the restart file lives.
     character(len=80)                           :: restartname       !<The name of the restart file.
     character(len=256)                          :: restartpath       !<The restart file path (dir/file).
     integer(INT_KIND)                           :: funit             !<The file unit returned by mpp_open.
     type(ax_type),pointer                       :: axis              !<A pointer to an fms_io_axis_type.
-    type(axistype)                              :: x_axis            !<An mpp_io_axis_type, used to write the x-axis to the restart file.
-    logical(INT_KIND)                           :: x_axis_defined    !<Flag telling whether or not a x-axis has been define for the inputted restart object.
-    type(axistype)                              :: y_axis            !<An mpp_io_axis_type, used to write the y-axis to the restart file.
-    logical(INT_KIND)                           :: y_axis_defined    !<Flag telling whether or not a y-axis has been define for the inputted restart object.
-    type(axistype)                              :: z_axis            !<An mpp_io_axis_type, used to write the z-axis to the restart file.
-    logical(INT_KIND)                           :: z_axis_defined    !<Flag telling whether or not a z-axis has been define for the inputted restart object.
-    type(axistype)                              :: cc_axis           !<An mpp_io_axis_type, used to write the cc-axis (???) to the restart file.
-    logical(INT_KIND)                           :: cc_axis_defined   !<Flag telling whether or not a cc-axis (???) has been define for the inputted restart object.
-    type(axistype)                              :: c_axis            !<An mpp_io_axis_type, used to write the compressed c-axis (???) to the restart file.
-    logical(INT_KIND)                           :: c_axis_defined    !<Flag telling whether or not a compressed c-axis (???) has been define for the inputted restart object.
-    type(axistype)                              :: h_axis            !<An mpp_io_axis_type, used to write the compressed h-axis (???) to the restart file.
-    logical(INT_KIND)                           :: h_axis_defined    !<Flag telling whether or not a compressed h-axis (???) has been define for the inputted restart object.
-    type(axistype)                              :: t_axis            !<An mpp_io_axis_type, used to write the t-axis to the restart file.
+    type(axistype)                              :: x_axis            !<An mpp_io_axis_type, used to write
+                                                                     !! the x-axis to the restart file.
+    logical(INT_KIND)                           :: x_axis_defined    !<Flag telling whether or not a
+                                                             !! x-axis has been define for the inputted restart object.
+    type(axistype)                              :: y_axis            !<An mpp_io_axis_type, used to write
+                                                                     !! the y-axis to the restart file.
+    logical(INT_KIND)                           :: y_axis_defined    !<Flag telling whether or not a
+                                                             !! y-axis has been define for the inputted restart object.
+    type(axistype)                              :: z_axis            !<An mpp_io_axis_type, used to write
+                                                                     !! the z-axis to the restart file.
+    logical(INT_KIND)                           :: z_axis_defined    !<Flag telling whether or not a
+                                                             !! z-axis has been define for the inputted restart object.
+    type(axistype)                              :: cc_axis           !<An mpp_io_axis_type, used to write
+                                                                     !! the cc-axis (???) to the restart file.
+    logical(INT_KIND)                           :: cc_axis_defined   !<Flag telling whether or not a
+                                                      !! cc-axis (???) has been define for the inputted restart object.
+    type(axistype)                              :: c_axis            !<An mpp_io_axis_type, used to write
+                                                                    !! the compressed c-axis (???) to the restart file.
+    logical(INT_KIND)                           :: c_axis_defined    !<Flag telling whether or not a
+                                            !! compressed c-axis (???) has been define for the inputted restart object.
+    type(axistype)                              :: h_axis            !<An mpp_io_axis_type, used to write
+                                                                    !! the compressed h-axis (???) to the restart file.
+    logical(INT_KIND)                           :: h_axis_defined    !<Flag telling whether or not a
+                                            !! compressed h-axis (???) has been define for the inputted restart object.
+    type(axistype)                              :: t_axis            !<An mpp_io_axis_type, used to write
+                                                                     !! the t-axis to the restart file.
     type(var_type),pointer                      :: cur_var           !<A pointer to an fms_io_field_type.
     integer(INT_KIND)                           :: num_var_axes      !<Number of dimensions for a field.
     type(axistype),dimension(4)                 :: var_axes          !<Array of axis for each field.
-    integer(INT_KIND)                           :: cpack             !<(Number of bits in a real(8))/(Number of bits in a real)
-    integer(LONG_KIND),dimension(:),allocatable :: check_val         !<An array of check-sums of a field at each time level.
-    real                                        :: tlev              !<Time value for a time level (do not specify a kind value).
-    real                                        :: r0d               !<Used to convert a scalar integer field into a scalar real field.
-    real,dimension(:),allocatable               :: r1d               !<Used to convert a 1D integer field into a 1D real field.
-    real,dimension(:,:),allocatable             :: r2d               !<Used to convert a 2D integer field into a 2D real field.
+    integer(INT_KIND)                           :: cpack             !<(Number of bits in a real(8))/(Number
+                                                                     !! of bits in a real)
+    integer(LONG_KIND),dimension(:),allocatable :: check_val         !<An array of check-sums of a field
+                                                                     !! at each time level.
+    real                                        :: tlev              !<Time value for a time level (do
+                                                                     !! not specify a kind value).
+    real                                        :: r0d               !<Used to convert a scalar integer
+                                                                     !! field into a scalar real field.
+    real,dimension(:),allocatable               :: r1d               !<Used to convert a 1D integer field
+                                                                     !! into a 1D real field.
+    real,dimension(:,:),allocatable             :: r2d               !<Used to convert a 2D integer field
+                                                                     !! into a 2D real field.
     integer(INT_KIND)                           :: i                 !<Loop variable.
     integer(INT_KIND)                           :: j                 !<Loop variable.
     integer(INT_KIND)                           :: k                 !<Loop variable.

--- a/fms/fms_io_unstructured_setup_one_field.inc
+++ b/fms/fms_io_unstructured_setup_one_field.inc
@@ -41,22 +41,30 @@ subroutine fms_io_unstructured_setup_one_field(fileObj, &
     type(restart_file_type),intent(inout)        :: fileObj               !<A restart object.
     character(len=*),intent(in)                  :: filename              !<The name of the restart file.
     character(len=*),intent(in)                  :: fieldname             !<The name of a field.
-    integer(INT_KIND),dimension(:),intent(in)    :: field_dimension_order !<Array telling the ordering of the dimensions for the field.
-    integer(INT_KIND),dimension(NIDX),intent(in) :: field_dimension_sizes !<Array of sizes of the dimensions of the inputted field.
-    integer(INT_KIND),intent(out)                :: index_field           !<Index of the inputted field in the fileObj%var array.
+    integer(INT_KIND),dimension(:),intent(in)    :: field_dimension_order !<Array telling the ordering
+                                                                          !! of the dimensions for the field.
+    integer(INT_KIND),dimension(NIDX),intent(in) :: field_dimension_sizes !<Array of sizes of the dimensions
+                                                                          !! of the inputted field.
+    integer(INT_KIND),intent(out)                :: index_field           !<Index of the inputted field
+                                                                          !! in the fileObj%var array.
     type(domainUG),intent(in),target             :: domain                !<An unstructured mpp domain.
-    logical(INT_KIND),intent(in),optional        :: mandatory             !<Flag telling if the field is mandatory for the restart.
+    logical(INT_KIND),intent(in),optional        :: mandatory             !<Flag telling if the field
+                                                                          !! is mandatory for the restart.
     real,intent(in),optional                     :: data_default          !<A default value for the data.
     character(len=*),intent(in),optional         :: longname              !<A more descriptive name of the field.
     character(len=*),intent(in),optional         :: units                 !<Units for the field.
-    logical(INT_KIND),intent(in),optional        :: read_only             !<Tells whether or not the variable will be written to the restart file.
-    logical(INT_KIND),intent(in),optional        :: owns_data             !<Tells if the data will be deallocated when the restart object is deallocated.
+    logical(INT_KIND),intent(in),optional        :: read_only             !<Tells whether or not the
+                                                                       !! variable will be written to the restart file.
+    logical(INT_KIND),intent(in),optional        :: owns_data             !<Tells if the data will be
+                                                                 !! deallocated when the restart object is deallocated.
 
    !Local variables
-    real(DOUBLE_KIND)      :: default_data    !<The "default" data value.  This defaults to MPP_FILL_DOUBLE. Shouldn't this be a real(DOUBLE_KIND)?
+    real(DOUBLE_KIND)      :: default_data    !<The "default" data value.  This defaults to MPP_FILL_DOUBLE.
+                                              !! Shouldn't this be a real(DOUBLE_KIND)?
     character(len=256)     :: filename2       !<A string used to manipulate the inputted filename.
     integer(INT_KIND)      :: length          !<the length of the (trimmed) inputted file name.
-    character(len=256)     :: append_string   !<A string used to append the filename_appendix module variable string to the inputted filename.
+    character(len=256)     :: append_string   !<A string used to append the filename_appendix module
+                                              !! variable string to the inputted filename.
     character(len=256)     :: fname           !<A string to hold a file name.
     type(var_type),pointer :: cur_var         !<A convenience pointer.
     integer(INT_KIND)      :: i               !<Loop variable.

--- a/fms2_io/fms_io_utils.F90
+++ b/fms2_io/fms_io_utils.F90
@@ -437,7 +437,8 @@ subroutine io_domain_tile_filepath_mangle(dest, source, io_domain_tile_id)
   integer, intent(in) :: io_domain_tile_id !< I/O domain tile id.
 
   if (has_io_domain_tile_string(source)) then
-    call error("The file "//trim(source)//" has already had a domain tile id (.nc.XXXX) added. Check your open_file call.")
+    call error("The file "//trim(source)// &
+             & " has already had a domain tile id (.nc.XXXX) added. Check your open_file call.")
   endif
   write(dest,'(a,i4.4)') trim(source)//".", io_domain_tile_id
 end subroutine io_domain_tile_filepath_mangle
@@ -586,7 +587,8 @@ subroutine parse_mask_table_2d(mask_table, maskmap, modelname)
         if (iocheck > 0) then
             call mpp_error(FATAL, "fms2_io(parse_mask_table_2d): Error in reading mask_list from record variable")
         elseif (iocheck < 0) then
-            call mpp_error(FATAL, "fms2_io(parse_mask_table_2d): Error: mask_list not completely read from record variable")
+            call mpp_error(FATAL, &
+                           &  "fms2_io(parse_mask_table_2d): Error: mask_list not completely read from record variable")
         endif
      enddo
 
@@ -689,7 +691,8 @@ subroutine parse_mask_table_3d(mask_table, maskmap, modelname)
         if (iocheck > 0) then
             call mpp_error(FATAL, "fms2_io(parse_mask_table_3d): Error in reading mask_list from record variable")
         elseif (iocheck < 0) then
-            call mpp_error(FATAL, "fms2_io(parse_mask_table_3d): Error: mask_list not completely read from record variable")
+            call mpp_error(FATAL, &
+                           &  "fms2_io(parse_mask_table_3d): Error: mask_list not completely read from record variable")
         endif
      enddo
 

--- a/fms2_io/fms_io_utils.F90
+++ b/fms2_io/fms_io_utils.F90
@@ -588,7 +588,7 @@ subroutine parse_mask_table_2d(mask_table, maskmap, modelname)
             call mpp_error(FATAL, "fms2_io(parse_mask_table_2d): Error in reading mask_list from record variable")
         elseif (iocheck < 0) then
             call mpp_error(FATAL, &
-                           &  "fms2_io(parse_mask_table_2d): Error: mask_list not completely read from record variable")
+                        &  "fms2_io(parse_mask_table_2d): Error: mask_list not completely read from record variable")
         endif
      enddo
 
@@ -692,7 +692,7 @@ subroutine parse_mask_table_3d(mask_table, maskmap, modelname)
             call mpp_error(FATAL, "fms2_io(parse_mask_table_3d): Error in reading mask_list from record variable")
         elseif (iocheck < 0) then
             call mpp_error(FATAL, &
-                           &  "fms2_io(parse_mask_table_3d): Error: mask_list not completely read from record variable")
+                          &  "fms2_io(parse_mask_table_3d): Error: mask_list not completely read from record variable")
         endif
      enddo
 

--- a/fms2_io/fms_netcdf_domain_io.F90
+++ b/fms2_io/fms_netcdf_domain_io.F90
@@ -400,7 +400,8 @@ function open_domain_file(fileobj, path, mode, domain, nc_format, is_restart, do
         success2 = netcdf_file_open(fileobj2, combined_filepath, mode, nc_format, pelist, &
                                     is_restart, dont_add_res_to_filename)
         if (success2) then
-          call error("The domain decomposed file:"//trim(fileobj%path)//" contains both combined (*.nc) and distributed files (*.nc.XXXX).")
+          call error("The domain decomposed file:"//trim(fileobj%path)// &
+                   & " contains both combined (*.nc) and distributed files (*.nc.XXXX).")
         endif
       endif
     else
@@ -467,20 +468,23 @@ subroutine register_domain_decomposed_dimension(fileobj, dim_name, xory, domain_
   io_domain => mpp_get_io_domain(fileobj%domain)
   if (string_compare(xory, x, .true.)) then
     if (dpos .ne. center .and. dpos .ne. east) then
-      call error("Only domain_position=center or domain_position=EAST is supported for x dimensions. Fix your register_axis call for file:"&
+      call error("Only domain_position=center or domain_position=EAST is supported for x dimensions."// &
+                  & " Fix your register_axis call for file:"&
                   &//trim(fileobj%path)//" and dimension:"//trim(dim_name))
     endif
     call mpp_get_global_domain(io_domain, xsize=domain_size, position=dpos)
     call append_domain_decomposed_dimension(dim_name, dpos, fileobj%xdims, fileobj%nx)
   elseif (string_compare(xory, y, .true.)) then
     if (dpos .ne. center .and. dpos .ne. north) then
-      call error("Only domain_position=center or domain_position=NORTH is supported for y dimensions. Fix your register_axis call for file:"&
+      call error("Only domain_position=center or domain_position=NORTH is supported for y dimensions."// &
+                  & " Fix your register_axis call for file:"&
                   &//trim(fileobj%path)//" and dimension:"//trim(dim_name))
     endif
     call mpp_get_global_domain(io_domain, ysize=domain_size, position=dpos)
     call append_domain_decomposed_dimension(dim_name, dpos, fileobj%ydims, fileobj%ny)
   else
-    call error("The register_axis call for file:"//trim(fileobj%path)//" and dimension:"//trim(dim_name)//" has an unrecognized xory flag value:"&
+    call error("The register_axis call for file:"//trim(fileobj%path)//" and dimension:"//trim(dim_name)// &
+               & " has an unrecognized xory flag value:"&
                &//trim(xory)//" only 'x' and 'y' are allowed.")
   endif
   if (fileobj%is_readonly .or. (fileobj%mode_is_append .and. dimension_exists(fileobj, dim_name))) then
@@ -570,7 +574,8 @@ subroutine save_domain_restart(fileobj, unlim_dim_level)
   logical :: is_decomposed
 
   if (.not. fileobj%is_restart) then
-    call error("file "//trim(fileobj%path)//" is not a restart file. You must set is_restart=.true. in your open_file call.")
+    call error("file "//trim(fileobj%path)// &
+             & " is not a restart file. You must set is_restart=.true. in your open_file call.")
   endif
 
 ! Calculate the variable's checksum and write it to the netcdf file
@@ -638,7 +643,8 @@ subroutine restore_domain_state(fileobj, unlim_dim_level)
   logical :: is_decomposed
 
   if (.not. fileobj%is_restart) then
-    call error("file "//trim(fileobj%path)//" is not a restart file. You must set is_restart=.true. in your open_file call.")
+    call error("file "//trim(fileobj%path)// &
+             & " is not a restart file. You must set is_restart=.true. in your open_file call.")
   endif
   do i = 1, fileobj%num_restart_vars
     if (associated(fileobj%restart_vars(i)%data0d)) then
@@ -657,7 +663,8 @@ subroutine restore_domain_state(fileobj, unlim_dim_level)
         call get_variable_attribute(fileobj, fileobj%restart_vars(i)%varname, &
                                     "checksum", chksum_in_file)
         if (.not. string_compare(trim(adjustl(chksum_in_file)), trim(adjustl(chksum)))) then
-          call error("The checksum in the file:"//trim(fileobj%path)//" and variable:"//trim(fileobj%restart_vars(i)%varname)//&
+          call error("The checksum in the file:"//trim(fileobj%path)//" and variable:"// &
+                     & trim(fileobj%restart_vars(i)%varname)// &
                      &" does not match the checksum calculated from the data. file:"//trim(adjustl(chksum_in_file))//&
                      &" from data:"//trim(adjustl(chksum)))
         endif
@@ -672,7 +679,8 @@ subroutine restore_domain_state(fileobj, unlim_dim_level)
         call get_variable_attribute(fileobj, fileobj%restart_vars(i)%varname, &
                                     "checksum", chksum_in_file(1:len(chksum_in_file)))
         if (.not. string_compare(trim(adjustl(chksum_in_file)), trim(adjustl(chksum)))) then
-          call error("The checksum in the file:"//trim(fileobj%path)//" and variable:"//trim(fileobj%restart_vars(i)%varname)//&
+          call error("The checksum in the file:"//trim(fileobj%path)//" and variable:"// &
+                     &trim(fileobj%restart_vars(i)%varname)// &
                      &" does not match the checksum calculated from the data. file:"//trim(adjustl(chksum_in_file))//&
                      &" from data:"//trim(adjustl(chksum)))
         endif
@@ -687,7 +695,8 @@ subroutine restore_domain_state(fileobj, unlim_dim_level)
         call get_variable_attribute(fileobj, fileobj%restart_vars(i)%varname, &
                                     "checksum", chksum_in_file)
         if (.not. string_compare(trim(adjustl(chksum_in_file)), trim(adjustl(chksum)))) then
-          call error("The checksum in the file:"//trim(fileobj%path)//" and variable:"//trim(fileobj%restart_vars(i)%varname)//&
+          call error("The checksum in the file:"//trim(fileobj%path)//" and variable:"// &
+                     & trim(fileobj%restart_vars(i)%varname)// &
                      &" does not match the checksum calculated from the data. file:"//trim(adjustl(chksum_in_file))//&
                      &" from data:"//trim(adjustl(chksum)))
         endif
@@ -724,7 +733,8 @@ subroutine get_compute_domain_dimension_indices(fileobj, dimname, indices)
       dpos = fileobj%ydims(dpos)%pos
       call mpp_get_compute_domain(io_domain, ybegin=s, yend=e, position=dpos)
     else
-      call error("get_compute_domain_dimension_indices: the input dimension:"//trim(dimname)//" is not domain decomposed.")
+      call error("get_compute_domain_dimension_indices: the input dimension:"//trim(dimname)// &
+               & " is not domain decomposed.")
     endif
   endif
   if (allocated(indices)) then

--- a/fms2_io/include/compute_global_checksum.inc
+++ b/fms2_io/include/compute_global_checksum.inc
@@ -128,7 +128,8 @@ function compute_global_checksum_2d(fileobj, variable_name, variable_data, is_de
       endif
       deallocate(buf_r8_kind)
     class default
-      call error("unsupported variable type: compute_global_checksum_2d: file: "//trim(fileobj%path)//" variable:"//trim(variable_name))
+      call error("unsupported variable type: compute_global_checksum_2d: file: "//trim(fileobj%path)//" variable:"// &
+               & trim(variable_name))
   end select
   chksum = ""
   write(chksum, "(Z16)") chksum_val
@@ -243,7 +244,8 @@ function compute_global_checksum_3d(fileobj, variable_name, variable_data, is_de
       endif
       deallocate(buf_r8_kind)
     class default
-      call error("unsupported variable type: compute_global_checksum_3d: file: "//trim(fileobj%path)//" variable:"//trim(variable_name))
+      call error("unsupported variable type: compute_global_checksum_3d: file: "//trim(fileobj%path)//" variable:"// &
+               & trim(variable_name))
   end select
   chksum = ""
   write(chksum, "(Z16)") chksum_val
@@ -359,7 +361,8 @@ function compute_global_checksum_4d(fileobj, variable_name, variable_data, is_de
       endif
       deallocate(buf_r8_kind)
     class default
-      call error("unsupported variable type: compute_global_checksum_4d: file: "//trim(fileobj%path)//" variable:"//trim(variable_name))
+      call error("unsupported variable type: compute_global_checksum_4d: file: "//trim(fileobj%path)//" variable:"// &
+               & trim(variable_name))
   end select
   chksum = ""
   write(chksum, "(Z16)") chksum_val

--- a/fms2_io/include/domain_read.inc
+++ b/fms2_io/include/domain_read.inc
@@ -253,7 +253,8 @@ subroutine domain_read_2d(fileobj, variable_name, vdata, unlim_dim_level, &
           endif
           deallocate(buf_r8_kind)
         class default
-          call error("unsupported variable type: domain_read_2d: file: "//trim(fileobj%path)//" variable:"//trim(variable_name))
+          call error("unsupported variable type: domain_read_2d: file: "//trim(fileobj%path)//" variable:"// &
+                   & trim(variable_name))
       end select
     enddo
     deallocate(pe_isc)
@@ -289,7 +290,8 @@ subroutine domain_read_2d(fileobj, variable_name, vdata, unlim_dim_level, &
         call put_array_section(buf_r8_kind, vdata, c, e)
         deallocate(buf_r8_kind)
       class default
-        call error("unsupported variable type: domain_read_2d: file: "//trim(fileobj%path)//" variable:"//trim(variable_name))
+        call error("unsupported variable type: domain_read_2d: file: "//trim(fileobj%path)//" variable:"// &
+                 & trim(variable_name))
     end select
   endif
 end subroutine domain_read_2d
@@ -472,7 +474,8 @@ subroutine domain_read_3d(fileobj, variable_name, vdata, unlim_dim_level, &
           endif
           deallocate(buf_r8_kind)
         class default
-          call error("unsupported variable type: domain_read_3d: file: "//trim(fileobj%path)//" variable:"//trim(variable_name))
+          call error("unsupported variable type: domain_read_3d: file: "//trim(fileobj%path)//" variable:"// &
+                   & trim(variable_name))
       end select
     enddo
     deallocate(pe_isc)
@@ -508,7 +511,8 @@ subroutine domain_read_3d(fileobj, variable_name, vdata, unlim_dim_level, &
         call put_array_section(buf_r8_kind, vdata, c, e)
         deallocate(buf_r8_kind)
       class default
-        call error("unsupported variable type: domain_read_3d: file: "//trim(fileobj%path)//" variable:"//trim(variable_name))
+        call error("unsupported variable type: domain_read_3d: file: "//trim(fileobj%path)//" variable:"// &
+                 & trim(variable_name))
     end select
   endif
 end subroutine domain_read_3d
@@ -691,7 +695,8 @@ subroutine domain_read_4d(fileobj, variable_name, vdata, unlim_dim_level, &
           endif
           deallocate(buf_r8_kind)
         class default
-          call error("unsupported variable type: domain_read_4d: file: "//trim(fileobj%path)//" variable:"//trim(variable_name))
+          call error("unsupported variable type: domain_read_4d: file: "//trim(fileobj%path)//" variable:"// &
+                   & trim(variable_name))
       end select
     enddo
     deallocate(pe_isc)
@@ -727,7 +732,8 @@ subroutine domain_read_4d(fileobj, variable_name, vdata, unlim_dim_level, &
         call put_array_section(buf_r8_kind, vdata, c, e)
         deallocate(buf_r8_kind)
       class default
-        call error("unsupported variable type: domain_read_4d: file: "//trim(fileobj%path)//" variable:"//trim(variable_name))
+        call error("unsupported variable type: domain_read_4d: file: "//trim(fileobj%path)//" variable:"// &
+                 & trim(variable_name))
     end select
   endif
 end subroutine domain_read_4d
@@ -912,7 +918,8 @@ subroutine domain_read_5d(fileobj, variable_name, vdata, unlim_dim_level, &
           endif
           deallocate(buf_r8_kind)
         class default
-          call error("unsupported variable type: domain_read_5d: file: "//trim(fileobj%path)//" variable:"//trim(variable_name))
+          call error("unsupported variable type: domain_read_5d: file: "//trim(fileobj%path)//" variable:"// &
+                   & trim(variable_name))
       end select
     enddo
     deallocate(pe_isc)
@@ -948,7 +955,8 @@ subroutine domain_read_5d(fileobj, variable_name, vdata, unlim_dim_level, &
         call put_array_section(buf_r8_kind, vdata, c, e)
         deallocate(buf_r8_kind)
       class default
-        call error("unsupported variable type: domain_read_5d: file: "//trim(fileobj%path)//" variable:"//trim(variable_name))
+        call error("unsupported variable type: domain_read_5d: file: "//trim(fileobj%path)//" variable:"// &
+                 & trim(variable_name))
     end select
   endif
 end subroutine domain_read_5d

--- a/fms2_io/include/domain_write.inc
+++ b/fms2_io/include/domain_write.inc
@@ -198,7 +198,8 @@ subroutine domain_write_2d(fileobj, variable_name, vdata, unlim_dim_level, &
             global_buf_r8_kind = fill_r8_kind
         endif
       class default
-      call error("unsupported variable type: domain_write_2d: file: "//trim(fileobj%path)//" variable:"//trim(variable_name))
+      call error("unsupported variable type: domain_write_2d: file: "//trim(fileobj%path)//" variable:"// &
+               & trim(variable_name))
     end select
 
     do i = 1, size(fileobj%pelist)
@@ -361,7 +362,8 @@ subroutine domain_write_2d(fileobj, variable_name, vdata, unlim_dim_level, &
         call mpp_sync_self(check=event_send)
         deallocate(buf_r8_kind)
       class default
-        call error("unsupported variable type: domain_write_2d: file: "//trim(fileobj%path)//" variable:"//trim(variable_name))
+        call error("unsupported variable type: domain_write_2d: file: "//trim(fileobj%path)//" variable:"// &
+                 & trim(variable_name))
     end select
   endif
 end subroutine domain_write_2d
@@ -492,7 +494,8 @@ subroutine domain_write_3d(fileobj, variable_name, vdata, unlim_dim_level, &
             global_buf_r8_kind = fill_r8_kind
         endif
       class default
-        call error("unsupported variable type: domain_write_3d: file: "//trim(fileobj%path)//" variable:"//trim(variable_name))
+        call error("unsupported variable type: domain_write_3d: file: "//trim(fileobj%path)//" variable:"// &
+                 & trim(variable_name))
     end select
 
     do i = 1, size(fileobj%pelist)
@@ -655,7 +658,8 @@ subroutine domain_write_3d(fileobj, variable_name, vdata, unlim_dim_level, &
         call mpp_sync_self(check=event_send)
         deallocate(buf_r8_kind)
       class default
-        call error("unsupported variable type: domain_write_3d: file: "//trim(fileobj%path)//" variable:"//trim(variable_name))
+        call error("unsupported variable type: domain_write_3d: file: "//trim(fileobj%path)//" variable:"// &
+                 & trim(variable_name))
     end select
   endif
 end subroutine domain_write_3d
@@ -786,7 +790,8 @@ subroutine domain_write_4d(fileobj, variable_name, vdata, unlim_dim_level, &
             global_buf_r8_kind = fill_r8_kind
         endif
       class default
-        call error("unsupported variable type: domain_write_4d: file: "//trim(fileobj%path)//" variable:"//trim(variable_name))
+        call error("unsupported variable type: domain_write_4d: file: "//trim(fileobj%path)//" variable:"// &
+                 & trim(variable_name))
     end select
 
     do i = 1, size(fileobj%pelist)
@@ -949,7 +954,8 @@ subroutine domain_write_4d(fileobj, variable_name, vdata, unlim_dim_level, &
         call mpp_sync_self(check=event_send)
         deallocate(buf_r8_kind)
       class default
-        call error("unsupported variable type: domain_write_4d: file: "//trim(fileobj%path)//" variable:"//trim(variable_name))
+        call error("unsupported variable type: domain_write_4d: file: "//trim(fileobj%path)//" variable:"// &
+                 & trim(variable_name))
     end select
   endif
 end subroutine domain_write_4d
@@ -1080,7 +1086,8 @@ subroutine domain_write_5d(fileobj, variable_name, vdata, unlim_dim_level, &
             global_buf_r8_kind = fill_r8_kind
         endif
       class default
-        call error("unsupported variable type: domain_write_5d: file: "//trim(fileobj%path)//" variable:"//trim(variable_name))
+        call error("unsupported variable type: domain_write_5d: file: "//trim(fileobj%path)//" variable:"// &
+                 & trim(variable_name))
     end select
 
     do i = 1, size(fileobj%pelist)
@@ -1243,7 +1250,8 @@ subroutine domain_write_5d(fileobj, variable_name, vdata, unlim_dim_level, &
         call mpp_sync_self(check=event_send)
         deallocate(buf_r8_kind)
       class default
-        call error("unsupported variable type: domain_write_5d: file: "//trim(fileobj%path)//" variable:"//trim(variable_name))
+        call error("unsupported variable type: domain_write_5d: file: "//trim(fileobj%path)//" variable:"// &
+                 & trim(variable_name))
     end select
   endif
 end subroutine domain_write_5d

--- a/fms2_io/include/get_global_attribute.inc
+++ b/fms2_io/include/get_global_attribute.inc
@@ -50,9 +50,10 @@ subroutine get_global_attribute_0d(fileobj, &
                                    trim(attribute_name), &
                                    attribute_value)
             type is (integer(kind=i8_kind))
-            if ( .not. fileobj%allow_int8) call error(trim(fileobj%path)//": 64 bit integers are only supported with 'netcdf4' file format"//&
-                                                     &". Set netcdf_default_format='netcdf4' in the fms2_io namelist OR "//&
-                                                     &"add nc_format='netcdf4' to your open_file call")
+            if ( .not. fileobj%allow_int8) call error(trim(fileobj%path)// &
+                                            & ": 64 bit integers are only supported with 'netcdf4' file format"//&
+                                            & ". Set netcdf_default_format='netcdf4' in the fms2_io namelist OR "//&
+                                            & "add nc_format='netcdf4' to your open_file call")
                 err = nf90_get_att(fileobj%ncid, &
                                    nf90_global, &
                                    trim(attribute_name), &
@@ -71,7 +72,8 @@ subroutine get_global_attribute_0d(fileobj, &
                 call error("get_global_attribute_0d: unsupported type for "//&
                 &trim(attribute_name)//" for file: "//trim(fileobj%path)//"")
         end select
-        call check_netcdf_code(err, "get_global_attribute_0d: file:"//trim(fileobj%path)//"- attribute:"//trim(attribute_name))
+        call check_netcdf_code(err, "get_global_attribute_0d: file:"//trim(fileobj%path)//"- attribute:"// &
+                             & trim(attribute_name))
     endif
     if (present(broadcast)) then
         if (.not. broadcast) then
@@ -132,9 +134,10 @@ subroutine get_global_attribute_1d(fileobj, &
                                    trim(attribute_name), &
                                    attribute_value)
             type is (integer(kind=i8_kind))
-                if ( .not. fileobj%allow_int8) call error(trim(fileobj%path)//": 64 bit integers are only supported with 'netcdf4' file format"//&
-                                                     &". Set netcdf_default_format='netcdf4' in the fms2_io namelist OR "//&
-                                                     &"add nc_format='netcdf4' to your open_file call")
+                if ( .not. fileobj%allow_int8) call error(trim(fileobj%path)// &
+                                               & ": 64 bit integers are only supported with 'netcdf4' file format"//&
+                                               & ". Set netcdf_default_format='netcdf4' in the fms2_io namelist OR "//&
+                                               & "add nc_format='netcdf4' to your open_file call")
                 err = nf90_get_att(fileobj%ncid, &
                                    nf90_global, &
                                    trim(attribute_name), &
@@ -153,7 +156,8 @@ subroutine get_global_attribute_1d(fileobj, &
                 call error("get_global_attribute_1d: unsupported type for "//&
                 &trim(attribute_name)//" for file: "//trim(fileobj%path)//"")
         end select
-        call check_netcdf_code(err, "get_global_attribute_1d: file:"//trim(fileobj%path)//"- attribute:"//trim(attribute_name))
+        call check_netcdf_code(err, "get_global_attribute_1d: file:"//trim(fileobj%path)//"- attribute:"// &
+                             & trim(attribute_name))
     endif
     if (present(broadcast)) then
         if (.not. broadcast) then

--- a/fms2_io/include/get_variable_attribute.inc
+++ b/fms2_io/include/get_variable_attribute.inc
@@ -65,9 +65,10 @@ subroutine get_variable_attribute_0d(fileobj, variable_name, attribute_name, &
       type is (integer(kind=i4_kind))
         err = nf90_get_att(fileobj%ncid, varid, trim(attribute_name), attribute_value)
       type is (integer(kind=i8_kind))
-        if ( .not. fileobj%allow_int8) call error(trim(fileobj%path)//": 64 bit integers are only supported with 'netcdf4' file format"//&
-                                                 &". Set netcdf_default_format='netcdf4' in the fms2_io namelist OR "//&
-                                                 &"add nc_format='netcdf4' to your open_file call")
+        if ( .not. fileobj%allow_int8) call error(trim(fileobj%path)// &
+                                           & ": 64 bit integers are only supported with 'netcdf4' file format"//&
+                                           &". Set netcdf_default_format='netcdf4' in the fms2_io namelist OR "//&
+                                           &"add nc_format='netcdf4' to your open_file call")
         err = nf90_get_att(fileobj%ncid, varid, trim(attribute_name), attribute_value)
       type is (real(kind=r4_kind))
         err = nf90_get_att(fileobj%ncid, varid, trim(attribute_name), attribute_value)
@@ -133,9 +134,10 @@ subroutine get_variable_attribute_1d(fileobj, variable_name, attribute_name, &
       type is (integer(kind=i4_kind))
         err = nf90_get_att(fileobj%ncid, varid, trim(attribute_name), attribute_value)
       type is (integer(kind=i8_kind))
-        if ( .not. fileobj%allow_int8) call error(trim(fileobj%path)//": 64 bit integers are only supported with 'netcdf4' file format"//&
-                                                 &". Set netcdf_default_format='netcdf4' in the fms2_io namelist OR "//&
-                                                 &"add nc_format='netcdf4' to your open_file call")
+        if ( .not. fileobj%allow_int8) call error(trim(fileobj%path)// &
+                                                &": 64 bit integers are only supported with 'netcdf4' file format"//&
+                                                &". Set netcdf_default_format='netcdf4' in the fms2_io namelist OR "//&
+                                                &"add nc_format='netcdf4' to your open_file call")
         err = nf90_get_att(fileobj%ncid, varid, trim(attribute_name), attribute_value)
       type is (real(kind=r4_kind))
         err = nf90_get_att(fileobj%ncid, varid, trim(attribute_name), attribute_value)

--- a/fms2_io/include/netcdf_add_restart_variable.inc
+++ b/fms2_io/include/netcdf_add_restart_variable.inc
@@ -421,7 +421,8 @@ subroutine register_restart_region_3d(fileobj, variable_name, vdata, indices, gl
   class(*), dimension(:,:,:), intent(in), target :: vdata !< Pointer to variable data
   integer, dimension(4), intent(in)                 :: indices !< Indices for the halo region for the variable
                                                                !! (starting x, ending x, starting y, ending y)
-  integer, dimension(:), intent(in)                 :: global_size !> Global_size(1:3) == size of the variable in (x,y,z)
+  integer, dimension(:), intent(in)                 :: global_size !> Global_size(1:3) == size of the
+                                                                   !! variable in (x,y,z)
   integer, dimension(:), intent(in)                 :: pelist !> List of pelist that have the data for
                                                               !! the variable
   logical, intent(in)                               :: is_root_pe !> Flag indicating if this is the root_pe

--- a/fms2_io/include/register_global_attribute.inc
+++ b/fms2_io/include/register_global_attribute.inc
@@ -44,9 +44,10 @@ subroutine register_global_attribute_0d(fileobj, &
                                    trim(attribute_name), &
                                    attribute_value)
             type is (integer(kind=i8_kind))
-                if ( .not. fileobj%allow_int8) call error(trim(fileobj%path)//": 64 bit integers are only supported with 'netcdf4' file format"//&
-                                                       &". Set netcdf_default_format='netcdf4' in the fms2_io namelist OR "//&
-                                                       &"add nc_format='netcdf4' to your open_file call")
+                if ( .not. fileobj%allow_int8) call error(trim(fileobj%path)// &
+                                               & ": 64 bit integers are only supported with 'netcdf4' file format"//  &
+                                               & ". Set netcdf_default_format='netcdf4' in the fms2_io namelist OR "//&
+                                               & "add nc_format='netcdf4' to your open_file call")
                 err = nf90_put_att(fileobj%ncid, &
                                    nf90_global, &
                                    trim(attribute_name), &
@@ -65,7 +66,8 @@ subroutine register_global_attribute_0d(fileobj, &
                 call error("register_global_attribute_0d: unsupported type for "//&
                 trim(attribute_name)//" for file: "//trim(fileobj%path)//"")
         end select
-        call check_netcdf_code(err, "register_global_attribute_0d: file:"//trim(fileobj%path)//"- attribute:"//trim(attribute_name))
+        call check_netcdf_code(err, "register_global_attribute_0d: file:"//trim(fileobj%path)//"- attribute:"// &
+                             & trim(attribute_name))
     endif
 end subroutine register_global_attribute_0d
 !> @brief Add a global attribute.
@@ -88,9 +90,10 @@ subroutine register_global_attribute_1d(fileobj, &
                                    trim(attribute_name), &
                                    attribute_value)
             type is (integer(kind=i8_kind))
-                if ( .not. fileobj%allow_int8) call error(trim(fileobj%path)//": 64 bit integers are only supported with 'netcdf4' file format"//&
-                                                       &". Set netcdf_default_format='netcdf4' in the fms2_io namelist OR "//&
-                                                       &"add nc_format='netcdf4' to your open_file call")
+                if ( .not. fileobj%allow_int8) call error(trim(fileobj%path)// &
+                                                &": 64 bit integers are only supported with 'netcdf4' file format"//&
+                                                &". Set netcdf_default_format='netcdf4' in the fms2_io namelist OR "//&
+                                                &"add nc_format='netcdf4' to your open_file call")
                 err = nf90_put_att(fileobj%ncid, &
                                    nf90_global, &
                                    trim(attribute_name), &
@@ -109,6 +112,7 @@ subroutine register_global_attribute_1d(fileobj, &
                 call error("register_global_attribute_1d: unsupported type for "//&
                 trim(attribute_name)//" for file: "//trim(fileobj%path)//"")
         end select
-        call check_netcdf_code(err, "register_global_attribute_1d: file:"//trim(fileobj%path)//"- attribute:"//trim(attribute_name))
+        call check_netcdf_code(err, "register_global_attribute_1d: file:"//trim(fileobj%path)//"- attribute:"// &
+                             & trim(attribute_name))
     endif
 end subroutine register_global_attribute_1d

--- a/fms2_io/include/register_variable_attribute.inc
+++ b/fms2_io/include/register_variable_attribute.inc
@@ -54,9 +54,10 @@ subroutine register_variable_attribute_0d(fileobj, variable_name, attribute_name
         err = nf90_put_att(fileobj%ncid, varid, trim(attribute_name), &
                            attribute_value)
       type is (integer(kind=i8_kind))
-        if ( .not. fileobj%allow_int8) call error(trim(fileobj%path)//": 64 bit integers are only supported with 'netcdf4' file format"//&
-                                                 &". Set netcdf_default_format='netcdf4' in the fms2_io namelist OR "//&
-                                                 &"add nc_format='netcdf4' to your open_file call")
+        if ( .not. fileobj%allow_int8) call error(trim(fileobj%path)//&
+                                               & ": 64 bit integers are only supported with 'netcdf4' file format"//  &
+                                               & ". Set netcdf_default_format='netcdf4' in the fms2_io namelist OR "//&
+                                               & "add nc_format='netcdf4' to your open_file call")
         err = nf90_put_att(fileobj%ncid, varid, trim(attribute_name), &
                            attribute_value)
       type is (real(kind=r4_kind))
@@ -157,9 +158,10 @@ subroutine register_variable_attribute_1d(fileobj, variable_name, attribute_name
         err = nf90_put_att(fileobj%ncid, varid, trim(attribute_name), &
                            attribute_value)
       type is (integer(kind=i8_kind))
-        if ( .not. fileobj%allow_int8) call error(trim(fileobj%path)//": 64 bit integers are only supported with 'netcdf4' file format"//&
-                                                 &". Set netcdf_default_format='netcdf4' in the fms2_io namelist OR "//&
-                                                 &"add nc_format='netcdf4' to your open_file call")
+        if ( .not. fileobj%allow_int8) call error(trim(fileobj%path)// &
+                                               & ": 64 bit integers are only supported with 'netcdf4' file format"//  &
+                                               & ". Set netcdf_default_format='netcdf4' in the fms2_io namelist OR "//&
+                                               & "add nc_format='netcdf4' to your open_file call")
         err = nf90_put_att(fileobj%ncid, varid, trim(attribute_name), &
                            attribute_value)
       type is (real(kind=r4_kind))

--- a/fms2_io/include/scatter_data_bc.inc
+++ b/fms2_io/include/scatter_data_bc.inc
@@ -82,7 +82,8 @@ subroutine scatter_data_bc_2d(fileobj, varname, vdata, bc_info, unlim_dim_level)
             chksum = ""
             write(chksum, "(Z16)") chksum_val
             if (.not. string_compare(adjustl(chksum), adjustl(chksum_read))) then
-                call error("scatter_data_bc_2d: "//trim(varname)//" chksum_in:"//(chksum)//" chksum_out:"//(chksum_read))
+                call error("scatter_data_bc_2d: "//trim(varname)//" chksum_in:"//(chksum)//" chksum_out:"// &
+                         & (chksum_read))
             endif
          endif
       endif
@@ -233,7 +234,8 @@ subroutine scatter_data_bc_3d(fileobj, varname, vdata, bc_info, unlim_dim_level)
             chksum = ""
             write(chksum, "(Z16)") chksum_val
             if (.not. string_compare(adjustl(chksum), adjustl(chksum_read))) then
-                call error("scatter_data_bc_2d: "//trim(varname)//" chksum_in:"//(chksum)//" chksum_out:"//(chksum_read))
+                call error("scatter_data_bc_2d: "//trim(varname)//" chksum_in:"//(chksum)//" chksum_out:"// &
+                         & (chksum_read))
             endif
          endif
       endif

--- a/fms2_io/netcdf_io.F90
+++ b/fms2_io/netcdf_io.F90
@@ -143,7 +143,8 @@ type, public :: FmsNetcdfFile_t
   integer :: num_compressed_dims !< Number of compressed dimensions.
   logical :: is_diskless !< Flag telling whether this is a diskless file.
   character (len=20) :: time_name
-  type(dimension_information) :: bc_dimensions !<information about the current dimensions for regional restart variables
+  type(dimension_information) :: bc_dimensions !<information about the current dimensions for regional
+                                               !! restart variables
 
 endtype FmsNetcdfFile_t
 
@@ -815,7 +816,8 @@ subroutine netcdf_add_dimension(fileobj, dimension_name, dimension_length, &
   if (fileobj%is_root .and. .not. fileobj%is_readonly) then
     call set_netcdf_mode(fileobj%ncid, define_mode)
     err = nf90_def_dim(fileobj%ncid, trim(dimension_name), dim_len, dimid)
-    call check_netcdf_code(err, "Netcdf_add_dimension: file:"//trim(fileobj%path)//" dimension name:"//trim(dimension_name))
+    call check_netcdf_code(err, "Netcdf_add_dimension: file:"//trim(fileobj%path)//" dimension name:"// &
+                         & trim(dimension_name))
   endif
 end subroutine netcdf_add_dimension
 
@@ -873,7 +875,8 @@ subroutine netcdf_add_variable(fileobj, variable_name, variable_type, dimensions
     if (string_compare(variable_type, "int", .true.)) then
       vtype = nf90_int
     elseif (string_compare(variable_type, "int64", .true.)) then
-      if ( .not. fileobj%allow_int8) call error(trim(fileobj%path)//": 64 bit integers are only supported with 'netcdf4' file format"//&
+      if ( .not. fileobj%allow_int8) call error(trim(fileobj%path)//&
+                                               &": 64 bit integers are only supported with 'netcdf4' file format"//&
                                                &". Set netcdf_default_format='netcdf4' in the fms2_io namelist OR "//&
                                                &"add nc_format='netcdf4' to your open_file call")
       vtype = nf90_int64
@@ -1543,8 +1546,8 @@ subroutine get_variable_dimension_names(fileobj, variable_name, dim_names, &
                    &" and variable:"//trim(variable_name))
       endif
     else
-      call error("get_variable_dimension_names: the variable: "//trim(variable_name)//" in file: "//trim(fileobj%path)//&
-                &" does not any dimensions. ")
+      call error("get_variable_dimension_names: the variable: "//trim(variable_name)//" in file: "//trim(fileobj%path)&
+                & //" does not any dimensions. ")
     endif
     dim_names(:) = ""
     do i = 1, ndims
@@ -1566,8 +1569,8 @@ subroutine get_variable_dimension_names(fileobj, variable_name, dim_names, &
                    &" and variable:"//trim(variable_name))
       endif
     else
-      call error("get_variable_dimension_names: the variable: "//trim(variable_name)//" in file: "//trim(fileobj%path)//&
-                &" does not any dimensions. ")
+      call error("get_variable_dimension_names: the variable: "//trim(variable_name)//" in file: "//trim(fileobj%path)&
+                & //" does not any dimensions. ")
     endif
     dim_names(:) = ""
   endif

--- a/horiz_interp/horiz_interp.F90
+++ b/horiz_interp/horiz_interp.F90
@@ -966,8 +966,10 @@ contains
 !-----------------------------------------------------------------------
       real, intent(in),  dimension(:,:) :: data_in !< Global input data stored from west to east
                                         !! (1st dimension), south to north (2nd dimension)
-      real, intent(in)                  :: wb !< Longitude (radians) that correspond to western-most                                              !! boundary of grid box j=1 in array data_in
-      real, intent(in)                  :: sb !< Latitude (radians) that correspond to western-most                                              !! boundary of grid box j=1 in array data_in
+      real, intent(in)                  :: wb !< Longitude (radians) that correspond to western-most
+                                              !! boundary of grid box j=1 in array data_in
+      real, intent(in)                  :: sb !< Latitude (radians) that correspond to western-most
+                                              !! boundary of grid box j=1 in array data_in
       real, intent(in)                  :: dx !< Grid spacing (in radians) for the longitude axis
                                               !! (first dimension) for the input data
       real, intent(in)                  :: dy !< Grid spacing (in radians) for the latitude axis

--- a/horiz_interp/horiz_interp_bicubic.F90
+++ b/horiz_interp/horiz_interp_bicubic.F90
@@ -270,10 +270,14 @@ module horiz_interp_bicubic_mod
           else
              Interp%rat_y(i,j) = (yz - Interp%lat_in(jcl))/(Interp%lat_in(jcu) - Interp%lat_in(jcl))
           endif
-!          if(yz.gt.Interp%lat_in(jcu)) call mpp_error(FATAL, ' horiz_interp_bicubic_new_1d_s: yf < ycl, no valid boundary point')
-!          if(yz.lt.Interp%lat_in(jcl)) call mpp_error(FATAL, ' horiz_interp_bicubic_new_1d_s: yf > ycu, no valid boundary point')
-!          if(xz.gt.Interp%lon_in(icu)) call mpp_error(FATAL, ' horiz_interp_bicubic_new_1d_s: xf < xcl, no valid boundary point')
-!          if(xz.lt.Interp%lon_in(icl)) call mpp_error(FATAL, ' horiz_interp_bicubic_new_1d_s: xf > xcu, no valid boundary point')
+!          if(yz.gt.Interp%lat_in(jcu)) call mpp_error(FATAL, ' horiz_interp_bicubic_new_1d_s:
+!          yf < ycl, no valid boundary point')
+!          if(yz.lt.Interp%lat_in(jcl)) call mpp_error(FATAL, ' horiz_interp_bicubic_new_1d_s:
+!          yf > ycu, no valid boundary point')
+!          if(xz.gt.Interp%lon_in(icu)) call mpp_error(FATAL, ' horiz_interp_bicubic_new_1d_s:
+!          xf < xcl, no valid boundary point')
+!          if(xz.lt.Interp%lon_in(icl)) call mpp_error(FATAL, ' horiz_interp_bicubic_new_1d_s:
+!          xf > xcu, no valid boundary point')
         enddo
       enddo
   end subroutine horiz_interp_bicubic_new_1d_s
@@ -415,17 +419,22 @@ module horiz_interp_bicubic_mod
           else
              Interp%rat_y(i,j) = (yz - Interp%lat_in(jcl))/(Interp%lat_in(jcu) - Interp%lat_in(jcl))
           endif
-!          if(yz.gt.lat_in(jcu)) call mpp_error(FATAL, ' horiz_interp_bicubic_new_1d: yf < ycl, no valid boundary point')
-!          if(yz.lt.lat_in(jcl)) call mpp_error(FATAL, ' horiz_interp_bicubic_new_1d: yf > ycu, no valid boundary point')
-!          if(xz.gt.lon_in(icu)) call mpp_error(FATAL, ' horiz_interp_bicubic_new_1d: xf < xcl, no valid boundary point')
-!          if(xz.lt.lon_in(icl)) call mpp_error(FATAL, ' horiz_interp_bicubic_new_1d: xf > xcu, no valid boundary point')
+!          if(yz.gt.lat_in(jcu)) call mpp_error(FATAL, ' horiz_interp_bicubic_new_1d: yf <
+!          ycl, no valid boundary point')
+!          if(yz.lt.lat_in(jcl)) call mpp_error(FATAL, ' horiz_interp_bicubic_new_1d: yf >
+!          ycu, no valid boundary point')
+!          if(xz.gt.lon_in(icu)) call mpp_error(FATAL, ' horiz_interp_bicubic_new_1d: xf <
+!          xcl, no valid boundary point')
+!          if(xz.lt.lon_in(icl)) call mpp_error(FATAL, ' horiz_interp_bicubic_new_1d: xf >
+!          xcu, no valid boundary point')
         enddo
       enddo
 
   end subroutine horiz_interp_bicubic_new_1d
 
   !> @brief Perform bicubic horizontal interpolation
-  subroutine horiz_interp_bicubic( Interp, data_in, data_out, verbose, mask_in, mask_out, missing_value, missing_permit)
+  subroutine horiz_interp_bicubic( Interp, data_in, data_out, verbose, mask_in, mask_out, missing_value, &
+                                 &  missing_permit)
     type (horiz_interp_type), intent(in)        :: Interp
     real, intent(in),  dimension(:,:)           :: data_in
     real, intent(out), dimension(:,:)           :: data_out

--- a/horiz_interp/horiz_interp_conserve.F90
+++ b/horiz_interp/horiz_interp_conserve.F90
@@ -423,8 +423,8 @@ contains
           allocate(lat_in_r8(size(lat_in)))
           lon_in_r8 = lon_in
           lat_in_r8 = lat_in
-          nxgrid = create_xgrid_1DX2D_order1(nlon_in, nlat_in, nlon_out, nlat_out, lon_in_r8, lat_in_r8, lon_out_r8, lat_out_r8, &
-                                          mask_src, i_src, j_src, i_dst, j_dst, xgrid_area)
+          nxgrid = create_xgrid_1DX2D_order1(nlon_in, nlat_in, nlon_out, nlat_out, lon_in_r8, lat_in_r8, lon_out_r8, &
+                                           & lat_out_r8, mask_src, i_src, j_src, i_dst, j_dst, xgrid_area)
           deallocate(lon_in_r8,lat_in_r8)
        endif
     else
@@ -441,8 +441,8 @@ contains
           do j = 1, nlat_in
              mask_src_flip(:,j) = mask_src(:,nlat_in+1-j)
           enddo
-          nxgrid = create_xgrid_great_circle(nlon_in, nlat_in, nlon_out, nlat_out, lon_src, lat_src, lon_out_r8, lat_out_r8, &
-                                             mask_src_flip, i_src, j_src, i_dst, j_dst, xgrid_area, clon, clat)
+          nxgrid = create_xgrid_great_circle(nlon_in, nlat_in, nlon_out, nlat_out, lon_src, lat_src, lon_out_r8, &
+                                       & lat_out_r8, mask_src_flip, i_src, j_src, i_dst, j_dst, xgrid_area, clon, clat)
           deallocate(mask_src_flip)
        else
           do j = 1, nlat_in+1
@@ -451,8 +451,8 @@ contains
                 lat_src(i,j) = lat_in(j)
              enddo
           enddo
-          nxgrid =  create_xgrid_great_circle(nlon_in, nlat_in, nlon_out, nlat_out, lon_src, lat_src, lon_out_r8, lat_out_r8, &
-                                             mask_src, i_src, j_src, i_dst, j_dst, xgrid_area, clon, clat)
+          nxgrid =  create_xgrid_great_circle(nlon_in, nlat_in, nlon_out, nlat_out, lon_src, lat_src, lon_out_r8, &
+                                      & lat_out_r8, mask_src, i_src, j_src, i_dst, j_dst, xgrid_area, clon, clat)
        endif
        deallocate(lon_src, lat_src, clon, clat)
     endif
@@ -486,7 +486,8 @@ contains
          'horiz_interp_conserve_mod: size mismatch between mask_out and lon_out/lat_out')
        mask_out = 0.0
        do i = 1, nxgrid
-          mask_out(Interp%i_dst(i),Interp%j_dst(i)) = mask_out(Interp%i_dst(i),Interp%j_dst(i)) + Interp%area_frac_dst(i)
+          mask_out(Interp%i_dst(i),Interp%j_dst(i)) = mask_out(Interp%i_dst(i), &
+                  & Interp%j_dst(i)) + Interp%area_frac_dst(i)
        end do
     end if
 
@@ -562,8 +563,8 @@ contains
              lat_dst(i,j) = lat_out(j)
           enddo
        enddo
-       nxgrid =  create_xgrid_great_circle(nlon_in, nlat_in, nlon_out, nlat_out, lon_in_r8, lat_in_r8, lon_dst, lat_dst, &
-                                          mask_src, i_src, j_src, i_dst, j_dst, xgrid_area, clon, clat)
+       nxgrid =  create_xgrid_great_circle(nlon_in, nlat_in, nlon_out, nlat_out, lon_in_r8, lat_in_r8, lon_dst, &
+                                         & lat_dst, mask_src, i_src, j_src, i_dst, j_dst, xgrid_area, clon, clat)
        deallocate(lon_in_r8, lat_in_r8, lon_dst, lat_dst, clon, clat)
     endif
     allocate(Interp%i_src(nxgrid), Interp%j_src(nxgrid) )
@@ -592,7 +593,8 @@ contains
          'horiz_interp_conserve_mod: size mismatch between mask_out and lon_out/lat_out')
        mask_out = 0.0
        do i = 1, nxgrid
-          mask_out(Interp%i_dst(i),Interp%j_dst(i)) = mask_out(Interp%i_dst(i),Interp%j_dst(i)) + Interp%area_frac_dst(i)
+          mask_out(Interp%i_dst(i),Interp%j_dst(i)) = mask_out(Interp%i_dst(i), &
+                  & Interp%j_dst(i)) + Interp%area_frac_dst(i)
        end do
     end if
 
@@ -658,12 +660,12 @@ contains
     lat_out_r8 = lat_out
 
     if( .not. great_circle_algorithm ) then
-       nxgrid = create_xgrid_2DX2D_order1(nlon_in, nlat_in, nlon_out, nlat_out, lon_in_r8, lat_in_r8, lon_out_r8, lat_out_r8, &
-                                       mask_src, i_src, j_src, i_dst, j_dst, xgrid_area)
+       nxgrid = create_xgrid_2DX2D_order1(nlon_in, nlat_in, nlon_out, nlat_out, lon_in_r8, lat_in_r8, lon_out_r8, &
+                                        & lat_out_r8, mask_src, i_src, j_src, i_dst, j_dst, xgrid_area)
     else
        allocate(clon(maxxgrid), clat(maxxgrid))
-       nxgrid =  create_xgrid_great_circle(nlon_in, nlat_in, nlon_out, nlat_out, lon_in_r8, lat_in_r8, lon_out_r8, lat_out_r8, &
-                                          mask_src, i_src, j_src, i_dst, j_dst, xgrid_area, clon, clat)
+       nxgrid =  create_xgrid_great_circle(nlon_in, nlat_in, nlon_out, nlat_out, lon_in_r8, lat_in_r8, lon_out_r8, &
+                                         & lat_out_r8, mask_src, i_src, j_src, i_dst, j_dst, xgrid_area, clon, clat)
        deallocate(clon, clat)
     endif
 
@@ -696,7 +698,8 @@ contains
          'horiz_interp_conserve_mod: size mismatch between mask_out and lon_out/lat_out')
        mask_out = 0.0
        do i = 1, nxgrid
-          mask_out(Interp%i_dst(i),Interp%j_dst(i)) = mask_out(Interp%i_dst(i),Interp%j_dst(i)) + Interp%area_frac_dst(i)
+          mask_out(Interp%i_dst(i),Interp%j_dst(i)) = mask_out(Interp%i_dst(i), &
+                  & Interp%j_dst(i)) + Interp%area_frac_dst(i)
        end do
     end if
 
@@ -739,8 +742,8 @@ contains
     case (1)
        call horiz_interp_conserve_version1(Interp, data_in, data_out, verbose, mask_in, mask_out)
     case (2)
-       if(present(mask_in) .OR. present(mask_out) ) call mpp_error(FATAL,  &
-            'horiz_interp_conserve: for version 2, mask_in and mask_out must be passed in horiz_interp_new, not in horiz_interp')
+       if(present(mask_in) .OR. present(mask_out) ) call mpp_error(FATAL, 'horiz_interp_conserve:'// &
+            & ' for version 2, mask_in and mask_out must be passed in horiz_interp_new, not in horiz_interp')
        call horiz_interp_conserve_version2(Interp, data_in, data_out, verbose)
     end select
 

--- a/horiz_interp/horiz_interp_type.F90
+++ b/horiz_interp/horiz_interp_type.F90
@@ -86,15 +86,19 @@ end interface
                                                             !! =3, spherical regrid
                                                             !! =4, bicubic regrid
    real,    dimension(:,:), pointer   :: rat_x =>NULL() !< the ratio of coordinates of the dest grid
-                                                        !! (x_dest -x_src_r)/(x_src_l -x_src_r) and (y_dest -y_src_r)/(y_src_l -y_src_r)
+                                                        !! (x_dest -x_src_r)/(x_src_l -x_src_r)
+                                                        !! and (y_dest -y_src_r)/(y_src_l -y_src_r)
    real,    dimension(:,:), pointer   :: rat_y =>NULL() !< the ratio of coordinates of the dest grid
-                                                        !! (x_dest -x_src_r)/(x_src_l -x_src_r) and (y_dest -y_src_r)/(y_src_l -y_src_r)
+                                                        !! (x_dest -x_src_r)/(x_src_l -x_src_r)
+                                                        !! and (y_dest -y_src_r)/(y_src_l -y_src_r)
    real,    dimension(:), pointer     :: lon_in =>NULL()  !< the coordinates of the source grid
    real,    dimension(:), pointer     :: lat_in =>NULL()  !< the coordinates of the source grid
    logical                            :: I_am_initialized=.false.
-   integer                            :: version                            !< indicate conservative interpolation version with value 1 or 2
+   integer                            :: version                            !< indicate conservative
+                                                                            !! interpolation version with value 1 or 2
    !--- The following are for conservative interpolation scheme version 2 ( through xgrid)
-   integer                            :: nxgrid                             !< number of exchange grid between src and dst grid.
+   integer                            :: nxgrid                             !< number of exchange grid
+                                                                            !! between src and dst grid.
    integer, dimension(:), pointer     :: i_src=>NULL()       !< indices in source grid.
    integer, dimension(:), pointer     :: j_src=>NULL()       !< indices in source grid.
    integer, dimension(:), pointer     :: i_dst=>NULL()       !< indices in destination grid.
@@ -179,7 +183,7 @@ contains
 
  end subroutine stats
 
-!#################################################################################################################################
+!######################################################################################################################
  subroutine horiz_interp_type_eq(horiz_interp_out, horiz_interp_in)
     type(horiz_interp_type), intent(inout) :: horiz_interp_out
     type(horiz_interp_type), intent(in)    :: horiz_interp_in
@@ -223,7 +227,7 @@ contains
     end if
 
  end subroutine horiz_interp_type_eq
-!#################################################################################################################################
+!######################################################################################################################
 
 end module horiz_interp_type_mod
 !> @}

--- a/interpolator/interpolator.F90
+++ b/interpolator/interpolator.F90
@@ -290,18 +290,16 @@ integer, parameter :: PRESSURE = 1, SIGMA = 2          !< Flags to indicate wher
 ! Vertical interpolation scheme requires mixing ratio at this time.
 integer, parameter :: NO_CONV = 1, KG_M2 = 2          !< Flags to indicate whether the climatology units
                                                       !! are mixing ratio (kg/kg) or column integral (kg/m2).
-                                                                 !< Vertical interpolation
-                                                                 !! scheme requires mixing ratio at this time.
+                                                      !! Vertical interpolation scheme requires mixing ratio at
+                                                      !! this time.
 
 ! Flags to indicate what to do when the model surface pressure exceeds the  climatology surface pressure level.
-integer, parameter, public :: CONSTANT = 1, ZERO = 2          !< Flags to indicate what to do when the
-                                                              !! model surface pressure
-                                                                           !< exceeds the 
-                                                                           !! climatology surface pressure level.
+integer, parameter, public :: CONSTANT = 1, ZERO = 2  !< Flags to indicate what to do when the model surface
+                                                      !! pressure exceeds the climatology surface pressure level.
 
 ! Flags to indicate the type of vertical interpolation
-integer, parameter, public :: INTERP_WEIGHTED_P = 10, INTERP_LINEAR_P = 20, INTERP_LOG_P = 30     !< Flags
-                                                                      !! to indicate the type of vertical interpolation
+integer, parameter, public :: INTERP_WEIGHTED_P = 10, INTERP_LINEAR_P = 20, INTERP_LOG_P = 30 !< Flags to indicate
+                                                                             !! the type of vertical interpolation
 !--lwh
 
 real, parameter :: TPI = (2.0*PI) ! 4.*acos(0.)

--- a/interpolator/interpolator.F90
+++ b/interpolator/interpolator.F90
@@ -216,7 +216,8 @@ logical                  :: climatological_year !< Is data for year = 0000?
 !Field specific data  for nfields
 character(len=64), pointer :: field_name(:) =>NULL()   !< name of this field
 logical,           pointer :: has_level(:) =>NULL()    !< indicate if the variable has level dimension
-integer,           pointer :: time_init(:,:) =>NULL()  !< second index is the number of time_slices being kept. 2 or ntime.
+integer,           pointer :: time_init(:,:) =>NULL()  !< second index is the number of time_slices being
+                                                       !! kept. 2 or ntime.
 integer,           pointer :: mr(:) =>NULL()           !< Flag for conversion of climatology to mixing ratio.
 integer,           pointer :: out_of_bounds(:) =>NULL()!< Flag for when surface pressure is out of bounds.
 !++lwh
@@ -270,28 +271,37 @@ integer           :: sense                                        !< No descript
 integer, parameter :: max_diag_fields = 30                    !< No description
 
 ! flags to indicate direction of vertical axis in  data file
-integer, parameter :: INCREASING_DOWNWARD = 1, INCREASING_UPWARD = -1          !< Flags to indicate direction of vertical axis in  data file
+integer, parameter :: INCREASING_DOWNWARD = 1, INCREASING_UPWARD = -1          !< Flags to indicate direction
+                                                                               !! of vertical axis in  data file
 !++lwh
 ! Flags to indicate whether the time interpolation should be linear or some other scheme for seasonal data.
 ! NOTIME indicates that data file has no time axis.
-integer, parameter :: LINEAR = 1, SEASONAL = 2, BILINEAR = 3, NOTIME = 4     !< Flags to indicate whether the time interpolation
-                                                                                               !! should be linear or some other scheme for seasonal data.
-                                                                                               !! NOTIME indicates that data file has no time axis.
+integer, parameter :: LINEAR = 1, SEASONAL = 2, BILINEAR = 3, NOTIME = 4     !< Flags to indicate whether the time
+                                                                             !! interpolation should be linear or some
+                                                                             !! other scheme for seasonal data.
+                                                                             !! NOTIME indicates
+                                                                             !! that data file has no time axis.
 
 ! Flags to indicate where climatology pressure levels are pressure or sigma levels
-integer, parameter :: PRESSURE = 1, SIGMA = 2          !< Flags to indicate where climatology pressure levels are pressure or sigma levels
+integer, parameter :: PRESSURE = 1, SIGMA = 2          !< Flags to indicate where climatology pressure
+                                                       !! levels are pressure or sigma levels
 
 ! Flags to indicate whether the climatology units are mixing ratio (kg/kg) or column integral (kg/m2).
 ! Vertical interpolation scheme requires mixing ratio at this time.
-integer, parameter :: NO_CONV = 1, KG_M2 = 2          !< Flags to indicate whether the climatology units are mixing ratio (kg/kg) or column integral (kg/m2).
-                                                                 !< Vertical interpolation scheme requires mixing ratio at this time.
+integer, parameter :: NO_CONV = 1, KG_M2 = 2          !< Flags to indicate whether the climatology units
+                                                      !! are mixing ratio (kg/kg) or column integral (kg/m2).
+                                                                 !< Vertical interpolation
+                                                                 !! scheme requires mixing ratio at this time.
 
 ! Flags to indicate what to do when the model surface pressure exceeds the  climatology surface pressure level.
-integer, parameter, public :: CONSTANT = 1, ZERO = 2          !< Flags to indicate what to do when the model surface pressure
-                                                                           !< exceeds the  climatology surface pressure level.
+integer, parameter, public :: CONSTANT = 1, ZERO = 2          !< Flags to indicate what to do when the
+                                                              !! model surface pressure
+                                                                           !< exceeds the 
+                                                                           !! climatology surface pressure level.
 
 ! Flags to indicate the type of vertical interpolation
-integer, parameter, public :: INTERP_WEIGHTED_P = 10, INTERP_LINEAR_P = 20, INTERP_LOG_P = 30     !< Flags to indicate the type of vertical interpolation
+integer, parameter, public :: INTERP_WEIGHTED_P = 10, INTERP_LINEAR_P = 20, INTERP_LOG_P = 30     !< Flags
+                                                                      !! to indicate the type of vertical interpolation
 !--lwh
 
 real, parameter :: TPI = (2.0*PI) ! 4.*acos(0.)
@@ -416,12 +426,14 @@ logical,          intent(out), optional :: single_year_file
 !  lonb_mod   :: The corners of the model grid-box longitudes.
 !  latb_mod   :: The corners of the model grid_box latitudes.
 !  data_names :: A list of the names of components within the climatology file which you wish to read.
-!  data_out_of_bounds :: A list of the flags that are to be used in determining what to do if the pressure levels in the model
+!  data_out_of_bounds :: A list of the flags that are to be used in determining what to do
+!  if the pressure levels in the model
 !                        go out of bounds from those of the climatology.
 !  vert_interp:: Flag to determine type of vertical interpolation
 !
 ! INTENT OUT
-!  clim_type  :: An interpolate type containing the necessary file and field data to be passed to the interpolator routine.
+!  clim_type  :: An interpolate type containing the necessary file and field data to be passed
+!  to the interpolator routine.
 !  clim_units :: A list of the units for the components listed in data_names.
 !
 integer :: io, ierr
@@ -1040,7 +1052,8 @@ if(present(data_names)) then
          clim_type%has_level(j) = .false.
          if(ndim > 2) then
             call get_variable_dimension_names(fileobj, data_names(j), var_dimname(1:ndim))
-            if(trim(var_dimname(3)) == "pfull" .OR. trim(var_dimname(3)) == "sigma_full") clim_type%has_level(j) = .true.
+            if(trim(var_dimname(3)) == "pfull" .OR. trim(var_dimname(3)) == "sigma_full") &
+               & clim_type%has_level(j) = .true.
          endif
 
          units=chomp(units)
@@ -1158,7 +1171,8 @@ subroutine get_axis_latlon_data(fileobj, name, data)
    if(variable_exists(fileobj, name)) then
       call fms2_io_read_data(fileobj, name, data)
    else
-      call mpp_error(FATAL,'get_axis_latlon_data: variable '//trim(name)//' does not exist in file '//trim(fileobj%path) )
+      call mpp_error(FATAL,'get_axis_latlon_data: variable '// &
+                     & trim(name)//' does not exist in file '//trim(fileobj%path) )
    endif
    call get_variable_units(fileobj, name, units)
    select case(units(1:6))
@@ -1166,7 +1180,8 @@ subroutine get_axis_latlon_data(fileobj, name, data)
       data = data*dtr
    case('radian')
    case default
-      call mpp_error(FATAL, "get_axis_latlon_data : Units for '//trim(name)//' not recognised in file "//trim(fileobj%path))
+      call mpp_error(FATAL, "get_axis_latlon_data : Units for '// &
+                     & trim(name)//' not recognised in file "//trim(fileobj%path))
    end select
 
 end subroutine get_axis_latlon_data
@@ -1183,7 +1198,8 @@ subroutine get_axis_level_data(fileobj, name, data, level_type, vertical_indices
    if(variable_exists(fileobj, name)) then
       call fms2_io_read_data(fileobj, name, data)
    else
-      call mpp_error(FATAL,'get_axis_level_data: variable '//trim(name)//' does not exist in file '//trim(fileobj%path) )
+      call mpp_error(FATAL,'get_axis_level_data: variable '// &
+                     & trim(name)//' does not exist in file '//trim(fileobj%path) )
    endif
    call get_variable_units(fileobj, name, units)
    level_type = PRESSURE
@@ -1439,7 +1455,8 @@ climo_diag_id(i+num_clim_diag) =  register_diag_field('climo',clim_type%field_na
 hinterp_id(i+num_clim_diag) =  register_diag_field('hinterp',clim_type%field_name(i),mod_axes(1:2),init_time,&
                                 'interp_'//clim_type%field_name(i),'kg/kg' , missing_value)
 enddo
-! Total number of climatology diagnostics (num_clim_diag). This can be from multiple climatology fields with different spatial axes.
+! Total number of climatology diagnostics (num_clim_diag). This can be from multiple climatology
+! fields with different spatial axes.
 ! It is simply a holder for the diagnostic indices.
 num_clim_diag = num_clim_diag+size(clim_type%field_name(:))
 
@@ -1497,7 +1514,8 @@ character(len=256) :: err_msg
        if (size(clim_type%time_slice) > 1) then
           call time_interp(Time, clim_type%time_slice, clim_type%tweight, taum, taup, modtime=YEAR, err_msg=err_msg )
           if(trim(err_msg) /= '') then
-             call mpp_error(FATAL,'interpolator_timeslice 1: '//trim(err_msg)//' file='//trim(clim_type%file_name), FATAL)
+             call mpp_error(FATAL,'interpolator_timeslice 1: '// &
+                            & trim(err_msg)//' file='//trim(clim_type%file_name), FATAL)
           endif
        else
           taum = 1
@@ -1567,7 +1585,8 @@ character(len=256) :: err_msg
                         climyear, climmonth, climday, climhour, climminute, climsecond)
           month(2) = set_date(yearp, indexp, climday, climhour, climminute, climsecond)
 
-        call time_interp(Time, month, clim_type%tweight3, taum, taup, err_msg=err_msg ) ! tweight3 is the time weight between the months.
+        call time_interp(Time, month, clim_type%tweight3, taum, taup, err_msg=err_msg ) ! tweight3 is
+                                                                                 !! the time weight between the months.
         if ( .not. retain_cm3_bug ) then
            if (taum==2 .and. taup==2) clim_type%tweight3 = 1. ! protect against post-perth time_interp behavior
         end if
@@ -1579,24 +1598,28 @@ character(len=256) :: err_msg
         month(2) = clim_type%time_slice(indexm+climatology*12)
         call get_date(month(1), climyear, climmonth, climday, climhour, climminute, climsecond)
         t_prev = set_date(yearm, climmonth, climday, climhour, climminute, climsecond)
-        call time_interp(t_prev, month, clim_type%tweight1, taum, taup, err_msg=err_msg ) !tweight1 is the time weight between the climatology years.
+        call time_interp(t_prev, month, clim_type%tweight1, taum, taup, err_msg=err_msg ) !tweight1 is
+                                                                      !! the time weight between the climatology years.
         if ( .not. retain_cm3_bug ) then
            if (taum==2 .and. taup==2) clim_type%tweight1 = 1. ! protect against post-perth time_interp behavior
         end if
         if(trim(err_msg) /= '') then
-           call mpp_error(FATAL,'interpolator_timeslice 4: '//trim(err_msg)//' file='//trim(clim_type%file_name), FATAL)
+           call mpp_error(FATAL,'interpolator_timeslice 4: '// &
+                          & trim(err_msg)//' file='//trim(clim_type%file_name), FATAL)
         endif
 
         month(1) = clim_type%time_slice(indexp+(climatology-1)*12)
         month(2) = clim_type%time_slice(indexp+climatology*12)
         call get_date(month(1), climyear, climmonth, climday, climhour, climminute, climsecond)
         t_next = set_date(yearp, climmonth, climday, climhour, climminute, climsecond)
-        call time_interp(t_next, month, clim_type%tweight2, taum, taup, err_msg=err_msg ) !tweight1 is the time weight between the climatology years.
+        call time_interp(t_next, month, clim_type%tweight2, taum, taup, err_msg=err_msg ) !tweight1 is
+                                                                      !! the time weight between the climatology years.
         if ( .not. retain_cm3_bug ) then
            if (taum==2 .and. taup==2) clim_type%tweight2 = 1. ! protect against post-perth time_interp behavior
         end if
         if(trim(err_msg) /= '') then
-           call mpp_error(FATAL,'interpolator_timeslice 5: '//trim(err_msg)//' file='//trim(clim_type%file_name), FATAL)
+           call mpp_error(FATAL,'interpolator_timeslice 5: '// &
+                          & trim(err_msg)//' file='//trim(clim_type%file_name), FATAL)
         endif
 
         if (indexm == clim_type%indexm(1) .and.  &
@@ -1930,7 +1953,8 @@ if ( .not. clim_type%separate_time_vary_calc) then
                         climyear, climmonth, climday, climhour, climminute, climsecond)
           month(2) = set_date(yearp, indexp, climday, climhour, climminute, climsecond)
 
-        call time_interp(Time, month, clim_type%tweight3, taum, taup, err_msg=err_msg ) ! tweight3 is the time weight between the months.
+        call time_interp(Time, month, clim_type%tweight3, taum, taup, err_msg=err_msg ) ! tweight3 is
+                                                                                 !! the time weight between the months.
         if ( .not. retain_cm3_bug ) then
            if (taum==2 .and. taup==2) clim_type%tweight3 = 1. ! protect against post-perth time_interp behavior
         end if
@@ -1942,7 +1966,8 @@ if ( .not. clim_type%separate_time_vary_calc) then
         month(2) = clim_type%time_slice(indexm+climatology*12)
         call get_date(month(1), climyear, climmonth, climday, climhour, climminute, climsecond)
         t_prev = set_date(yearm, climmonth, climday, climhour, climminute, climsecond)
-        call time_interp(t_prev, month, clim_type%tweight1, taum, taup, err_msg=err_msg ) !tweight1 is the time weight between the climatology years.
+        call time_interp(t_prev, month, clim_type%tweight1, taum, taup, err_msg=err_msg ) !tweight1 is
+                                                                      !! the time weight between the climatology years.
         if ( .not. retain_cm3_bug ) then
            if (taum==2 .and. taup==2) clim_type%tweight1 = 1. ! protect against post-perth time_interp behavior
         end if
@@ -1953,7 +1978,8 @@ if ( .not. clim_type%separate_time_vary_calc) then
         month(2) = clim_type%time_slice(indexp+climatology*12)
         call get_date(month(1), climyear, climmonth, climday, climhour, climminute, climsecond)
         t_next = set_date(yearp, climmonth, climday, climhour, climminute, climsecond)
-        call time_interp(t_next, month, clim_type%tweight2, taum, taup, err_msg=err_msg ) !tweight1 is the time weight between the climatology years.
+        call time_interp(t_next, month, clim_type%tweight2, taum, taup, err_msg=err_msg ) !tweight1 is
+                                                                      !! the time weight between the climatology years.
         if ( .not. retain_cm3_bug ) then
            if (taum==2 .and. taup==2) clim_type%tweight2 = 1. ! protect against post-perth time_interp behavior
         end if
@@ -2383,7 +2409,8 @@ if ( .not. clim_type%separate_time_vary_calc) then
                       climyear, climmonth, climday, climhour, climminute, climsecond)
         month(2) = set_date(yearp, indexp, climday, climhour, climminute, climsecond)
 
-        call time_interp(Time, month, clim_type%tweight3, taum, taup, err_msg=err_msg ) ! tweight3 is the time weight between the months.
+        call time_interp(Time, month, clim_type%tweight3, taum, taup, err_msg=err_msg ) ! tweight3 is
+                                                                                 !! the time weight between the months.
         if ( .not. retain_cm3_bug ) then
            if (taum==2 .and. taup==2) clim_type%tweight3 = 1. ! protect against post-perth time_interp behavior
         end if
@@ -2395,7 +2422,8 @@ if ( .not. clim_type%separate_time_vary_calc) then
         month(2) = clim_type%time_slice(indexm+climatology*12)
         call get_date(month(1), climyear, climmonth, climday, climhour, climminute, climsecond)
         t_prev = set_date(yearm, climmonth, climday, climhour, climminute, climsecond)
-        call time_interp(t_prev, month, clim_type%tweight1, taum, taup, err_msg=err_msg ) !tweight1 is the time weight between the climatology years.
+        call time_interp(t_prev, month, clim_type%tweight1, taum, taup, err_msg=err_msg ) !tweight1 is
+                                                                      !! the time weight between the climatology years.
         if ( .not. retain_cm3_bug ) then
            if (taum==2 .and. taup==2) clim_type%tweight1 = 1. ! protect against post-perth time_interp behavior
         end if
@@ -2407,7 +2435,8 @@ if ( .not. clim_type%separate_time_vary_calc) then
         month(2) = clim_type%time_slice(indexp+climatology*12)
         call get_date(month(1), climyear, climmonth, climday, climhour, climminute, climsecond)
         t_next = set_date(yearp, climmonth, climday, climhour, climminute, climsecond)
-        call time_interp(t_next, month, clim_type%tweight2, taum, taup, err_msg=err_msg ) !tweight1 is the time weight between the climatology years.
+        call time_interp(t_next, month, clim_type%tweight2, taum, taup, err_msg=err_msg ) !tweight1 is
+                                                                      !! the time weight between the climatology years.
         if ( .not. retain_cm3_bug ) then
            if (taum==2 .and. taup==2) clim_type%tweight2 = 1. ! protect against post-perth time_interp behavior
         end if
@@ -2828,7 +2857,8 @@ if ( .not. clim_type%separate_time_vary_calc) then
                       climyear, climmonth, climday, climhour, climminute, climsecond)
         month(2) = set_date(yearp, indexp, climday, climhour, climminute, climsecond)
 
-        call time_interp(Time, month, clim_type%tweight3, taum, taup, err_msg=err_msg ) ! tweight3 is the time weight between the months.
+        call time_interp(Time, month, clim_type%tweight3, taum, taup, err_msg=err_msg ) ! tweight3 is
+                                                                                 !! the time weight between the months.
         if ( .not. retain_cm3_bug ) then
            if (taum==2 .and. taup==2) clim_type%tweight3 = 1. ! protect against post-perth time_interp behavior
         end if
@@ -2840,7 +2870,8 @@ if ( .not. clim_type%separate_time_vary_calc) then
         month(2) = clim_type%time_slice(indexm+climatology*12)
         call get_date(month(1), climyear, climmonth, climday, climhour, climminute, climsecond)
         t_prev = set_date(yearm, climmonth, climday, climhour, climminute, climsecond)
-        call time_interp(t_prev, month, clim_type%tweight1, taum, taup, err_msg=err_msg ) !tweight1 is the time weight between the climatology years.
+        call time_interp(t_prev, month, clim_type%tweight1, taum, taup, err_msg=err_msg ) !tweight1 is
+                                                                      !! the time weight between the climatology years.
         if ( .not. retain_cm3_bug ) then
            if (taum==2 .and. taup==2) clim_type%tweight1 = 1. ! protect against post-perth time_interp behavior
         end if
@@ -2852,7 +2883,8 @@ if ( .not. clim_type%separate_time_vary_calc) then
         month(2) = clim_type%time_slice(indexp+climatology*12)
         call get_date(month(1), climyear, climmonth, climday, climhour, climminute, climsecond)
         t_next = set_date(yearp, climmonth, climday, climhour, climminute, climsecond)
-        call time_interp(t_next, month, clim_type%tweight2, taum, taup, err_msg=err_msg ) !tweight1 is the time weight between the climatology years.
+        call time_interp(t_next, month, clim_type%tweight2, taum, taup, err_msg=err_msg ) !tweight1 is
+                                                                      !! the time weight between the climatology years.
         if ( .not. retain_cm3_bug ) then
            if (taum==2 .and. taup==2) clim_type%tweight2 = 1. ! protect against post-perth time_interp behavior
         end if

--- a/mosaic/gradient.F90
+++ b/mosaic/gradient.F90
@@ -78,10 +78,14 @@ subroutine gradient_cubic(pin, dx, dy, area, edge_w, edge_e, edge_s, edge_n,    
   nx = size(grad_x,1)
   ny = size(grad_x,2)
 
-  if(size(pin,1) .NE. nx+2 .OR. size(pin,2) .NE. ny+2)call mpp_error(FATAL, "gradient_mod:size of pin should be (nx+2, ny+2)")
-  if(size(dx,1) .NE. nx .OR. size(dx,2) .NE. ny+1 ) call mpp_error(FATAL, "gradient_mod: size of dx should be (nx,ny+1)")
-  if(size(dy,1) .NE. nx+1 .OR. size(dy,2) .NE. ny ) call mpp_error(FATAL, "gradient_mod: size of dy should be (nx+1,ny)")
-  if(size(area,1) .NE. nx .OR. size(area,2) .NE. ny ) call mpp_error(FATAL, "gradient_mod: size of area should be (nx,ny)")
+  if(size(pin,1) .NE. nx+2 .OR. size(pin,2) .NE. ny+2)call mpp_error(FATAL, &
+     &  "gradient_mod:size of pin should be (nx+2, ny+2)")
+  if(size(dx,1) .NE. nx .OR. size(dx,2) .NE. ny+1 ) call mpp_error(FATAL, &
+     &  "gradient_mod: size of dx should be (nx,ny+1)")
+  if(size(dy,1) .NE. nx+1 .OR. size(dy,2) .NE. ny ) call mpp_error(FATAL, &
+     &  "gradient_mod: size of dy should be (nx+1,ny)")
+  if(size(area,1) .NE. nx .OR. size(area,2) .NE. ny ) call mpp_error(FATAL, &
+     &  "gradient_mod: size of area should be (nx,ny)")
   if(size(vlon,1) .NE. 3 .OR. size(vlon,2) .NE. nx .OR. size(vlon,3) .NE. ny) &
           call mpp_error(FATAL, "gradient_mod: size of vlon should be (3,nx,ny)")
   if(size(vlat,1) .NE. 3 .OR. size(vlat,2) .NE. nx .OR. size(vlat,3) .NE. ny) &
@@ -119,13 +123,20 @@ subroutine calc_cubic_grid_info(xt, yt, xc, yc, dx, dy, area, edge_w, edge_e, ed
   nxp = nx+1
   nyp = ny+1
 
-  if(size(xt,1) .NE. nx+2 .OR. size(xt,2) .NE. ny+2 ) call mpp_error(FATAL, "gradient_mod: size of xt should be (nx+2,ny+2)")
-  if(size(yt,1) .NE. nx+2 .OR. size(yt,2) .NE. ny+2 ) call mpp_error(FATAL, "gradient_mod: size of yt should be (nx+2,ny+2)")
-  if(size(xc,1) .NE. nxp .OR. size(xc,2) .NE. nyp ) call mpp_error(FATAL, "gradient_mod: size of xc should be (nx+1,ny+1)")
-  if(size(yc,1) .NE. nxp .OR. size(yc,2) .NE. nyp ) call mpp_error(FATAL, "gradient_mod: size of yc should be (nx+1,ny+1)")
-  if(size(dx,1) .NE. nx .OR. size(dx,2) .NE. nyp ) call mpp_error(FATAL, "gradient_mod: size of dx should be (nx,ny+1)")
-  if(size(dy,1) .NE. nxp .OR. size(dy,2) .NE. ny ) call mpp_error(FATAL, "gradient_mod: size of dy should be (nx+1,ny)")
-  if(size(area,1) .NE. nx .OR. size(area,2) .NE. ny ) call mpp_error(FATAL, "gradient_mod: size of area should be (nx,ny)")
+  if(size(xt,1) .NE. nx+2 .OR. size(xt,2) .NE. ny+2 ) call mpp_error(FATAL, &
+     &  "gradient_mod: size of xt should be (nx+2,ny+2)")
+  if(size(yt,1) .NE. nx+2 .OR. size(yt,2) .NE. ny+2 ) call mpp_error(FATAL, &
+     &  "gradient_mod: size of yt should be (nx+2,ny+2)")
+  if(size(xc,1) .NE. nxp .OR. size(xc,2) .NE. nyp ) call mpp_error(FATAL, &
+     &  "gradient_mod: size of xc should be (nx+1,ny+1)")
+  if(size(yc,1) .NE. nxp .OR. size(yc,2) .NE. nyp ) call mpp_error(FATAL, &
+     &  "gradient_mod: size of yc should be (nx+1,ny+1)")
+  if(size(dx,1) .NE. nx .OR. size(dx,2) .NE. nyp ) call mpp_error(FATAL, &
+     &  "gradient_mod: size of dx should be (nx,ny+1)")
+  if(size(dy,1) .NE. nxp .OR. size(dy,2) .NE. ny ) call mpp_error(FATAL, &
+     &  "gradient_mod: size of dy should be (nx+1,ny)")
+  if(size(area,1) .NE. nx .OR. size(area,2) .NE. ny ) call mpp_error(FATAL, &
+     &  "gradient_mod: size of area should be (nx,ny)")
   if(size(vlon,1) .NE. 3 .OR. size(vlon,2) .NE. nx .OR. size(vlon,3) .NE. ny) &
           call mpp_error(FATAL, "gradient_mod: size of vlon should be (3,nx,ny)")
   if(size(vlat,1) .NE. 3 .OR. size(vlat,2) .NE. nx .OR. size(vlat,3) .NE. ny) &

--- a/mosaic/grid.F90
+++ b/mosaic/grid.F90
@@ -135,7 +135,9 @@ function get_grid_version()
     else if(field_exist(grid_file, 'ocn_mosaic_file') ) then
        grid_version = VERSION_2
     else
-       call mpp_error(FATAL, module_name//'/get_grid_version: Can''t determine the version of the grid spec: none of "x_T", "geolon_t", or "ocn_mosaic_file" exist in file "'//trim(grid_file)//'"')
+       call mpp_error(FATAL, module_name//&
+                    & '/get_grid_version: Can''t determine the version of the grid spec:'// &
+                    & ' none of "x_T", "geolon_t", or "ocn_mosaic_file" exist in file "'//trim(grid_file)//'"')
     endif
   endif
   get_grid_version = grid_version
@@ -207,7 +209,8 @@ subroutine get_grid_size_for_one_tile(component,tile,nx,ny)
      nx = nnx(tile); ny = nny(tile)
      deallocate(nnx,nny)
   else
-     call mpp_error(FATAL, 'get_grid_size: requested tile index '//trim(string(tile))//' is out of bounds (1:'//trim(string(ntiles))//')')
+     call mpp_error(FATAL, 'get_grid_size: requested tile index '// &
+                    & trim(string(tile))//' is out of bounds (1:'//trim(string(ntiles))//')')
   endif
 end subroutine get_grid_size_for_one_tile
 
@@ -234,7 +237,8 @@ subroutine get_grid_cell_area_SG(component, tile, cellarea, domain)
         call read_data(grid_file, 'AREA_'//trim(uppercase(component)),cellarea,&
             no_domain=.not.present(domain),domain=domain)
      case default
-        call mpp_error(FATAL, module_name//'/get_grid_cell_area: Illegal component name "'//trim(component)//'": must be one of ATM, LND, or OCN')
+        call mpp_error(FATAL, module_name//'/get_grid_cell_area: Illegal component name "'//trim(component) &
+                            & //'": must be one of ATM, LND, or OCN')
      end select
      ! convert area to m2
      cellarea = cellarea*4.*PI*radius**2
@@ -302,7 +306,8 @@ subroutine get_grid_comp_area_SG(component,tile,area,domain)
      case('LND')
         call read_data(grid_file,'AREA_LND',area,no_domain=.not.present(domain),domain=domain)
      case default
-        call mpp_error(FATAL, module_name//'/get_grid_comp_area: Illegal component name "'//trim(component)//'": must be one of ATM, LND, or OCN')
+        call mpp_error(FATAL, module_name// &
+              & '/get_grid_comp_area: Illegal component name "'//trim(component)//'": must be one of ATM, LND, or OCN')
      end select
   case(VERSION_2) ! mosaic gridspec
      select case (component)
@@ -319,7 +324,8 @@ subroutine get_grid_comp_area_SG(component,tile,area,domain)
         call read_data(grid_file, 'ocn_mosaic', mosaic_name)
         tile_name  = trim(mosaic_name)//'_tile'//char(tile+ichar('0'))
      case default
-        call mpp_error(FATAL, module_name//'/get_grid_comp_area: Illegal component name "'//trim(component)//'": must be one of ATM, LND, or OCN')
+        call mpp_error(FATAL, module_name// &
+              & '/get_grid_comp_area: Illegal component name "'//trim(component)//'": must be one of ATM, LND, or OCN')
      end select
      ! get the boundaries of the requested domain
      if(present(domain)) then
@@ -331,7 +337,8 @@ subroutine get_grid_comp_area_SG(component,tile,area,domain)
         js = 1 ; j0 = 0
      endif
      if (size(area,1)/=ie-is+1.or.size(area,2)/=je-js+1) &
-        call mpp_error(FATAL, module_name//'/get_grid_comp_area: size of the output argument "area" is not consistent with the domain')
+        call mpp_error(FATAL, module_name// &
+                       & '/get_grid_comp_area: size of the output argument "area" is not consistent with the domain')
 
      ! find the nest tile
      call read_data(grid_file, 'atm_mosaic', mosaic_name)
@@ -348,7 +355,8 @@ subroutine get_grid_comp_area_SG(component,tile,area,domain)
               num_nest_tile = num_nest_tile + 1
               nest_tile_name(num_nest_tile) = trim(mosaic_name)//'_tile'//char(n+ichar('0'))
            else if(trim(attvalue) .NE. "FALSE") then
-              call mpp_error(FATAL, module_name//'/get_grid_comp_area: value of global attribute nest_grid in file'// trim(tilefile)//' should be TRUE of FALSE')
+              call mpp_error(FATAL, module_name//'/get_grid_comp_area: value of global attribute nest_grid in file'// &
+                             &  trim(tilefile)//' should be TRUE of FALSE')
            endif
         end if
      end do
@@ -403,7 +411,8 @@ subroutine get_grid_comp_area_SG(component,tile,area,domain)
            deallocate(i1, j1, i2, j2, xgrid_area)
         enddo
         if (found_xgrid_files == 0) &
-           call mpp_error(FATAL, 'get_grid_comp_area: no xgrid files were found for component '//trim(component)//' (mosaic name is '//trim(mosaic_name)//')')
+           call mpp_error(FATAL, 'get_grid_comp_area: no xgrid files were found for component '// &
+                          & trim(component)//' (mosaic name is '//trim(mosaic_name)//')')
 
      endif
      deallocate(nest_tile_name)
@@ -468,11 +477,14 @@ subroutine get_grid_cell_vertices_1D(component, tile, glonb, glatb)
 
   call get_grid_size_for_one_tile(component, tile, nlon, nlat)
   if (size(glonb(:))/=nlon+1) &
-       call mpp_error (FATAL,  module_name//'/get_grid_cell_vertices_1D: Size of argument "glonb" is not consistent with the grid size')
+       call mpp_error (FATAL,  module_name// &
+                       & '/get_grid_cell_vertices_1D: Size of argument "glonb" is not consistent with the grid size')
   if (size(glatb(:))/=nlat+1) &
-       call mpp_error (FATAL, module_name//'/get_grid_cell_vertices_1D: Size of argument "glatb" is not consistent with the grid size')
+       call mpp_error (FATAL, module_name// &
+                       & '/get_grid_cell_vertices_1D: Size of argument "glatb" is not consistent with the grid size')
   if(trim(component) .NE. 'ATM' .AND. component .NE. 'LND' .AND. component .NE. 'OCN') then
-     call mpp_error(FATAL, module_name//'/get_grid_cell_vertices_1D: Illegal component name "'//trim(component)//'": must be one of ATM, LND, or OCN')
+     call mpp_error(FATAL, module_name//'/get_grid_cell_vertices_1D: Illegal component name "'// &
+                    & trim(component)//'": must be one of ATM, LND, or OCN')
   endif
 
   select case(get_grid_version())
@@ -565,11 +577,14 @@ subroutine get_grid_cell_vertices_2D(component, tile, lonb, latb, domain)
 
   ! verify that lonb and latb sizes are consistent with the size of domain
   if (size(lonb,1)/=ie-is+2.or.size(lonb,2)/=je-js+2) &
-       call mpp_error (FATAL, module_name//'/get_grid_cell_vertices: Size of argument "lonb" is not consistent with the domain size')
+       call mpp_error (FATAL, module_name// &
+                       & '/get_grid_cell_vertices: Size of argument "lonb" is not consistent with the domain size')
   if (size(latb,1)/=ie-is+2.or.size(latb,2)/=je-js+2) &
-       call mpp_error (FATAL, module_name//'/get_grid_cell_vertices: Size of argument "latb" is not consistent with the domain size')
+       call mpp_error (FATAL, module_name// &
+                       & '/get_grid_cell_vertices: Size of argument "latb" is not consistent with the domain size')
   if(trim(component) .NE. 'ATM' .AND. component .NE. 'LND' .AND. component .NE. 'OCN') then
-     call mpp_error(FATAL, module_name//'/get_grid_cell_vertices: Illegal component name "'//trim(component)//'": must be one of ATM, LND, or OCN')
+     call mpp_error(FATAL, module_name//'/get_grid_cell_vertices: Illegal component name "'// &
+                    & trim(component)//'": must be one of ATM, LND, or OCN')
   endif
 
   select case(get_grid_version())
@@ -736,11 +751,14 @@ subroutine get_grid_cell_centers_1D(component, tile, glon, glat)
 
   call get_grid_size_for_one_tile(component, tile, nlon, nlat)
   if (size(glon(:))/=nlon) &
-       call mpp_error (FATAL,  module_name//'/get_grid_cell_centers_1D: Size of argument "glon" is not consistent with the grid size')
+       call mpp_error (FATAL,  module_name// &
+                       & '/get_grid_cell_centers_1D: Size of argument "glon" is not consistent with the grid size')
   if (size(glat(:))/=nlat) &
-       call mpp_error (FATAL,  module_name//'/get_grid_cell_centers_1D: Size of argument "glat" is not consistent with the grid size')
+       call mpp_error (FATAL,  module_name// &
+                       & '/get_grid_cell_centers_1D: Size of argument "glat" is not consistent with the grid size')
   if(trim(component) .NE. 'ATM' .AND. component .NE. 'LND' .AND. component .NE. 'OCN') then
-     call mpp_error(FATAL, module_name//'/get_grid_cell_centers_1D: Illegal component name "'//trim(component)//'": must be one of ATM, LND, or OCN')
+     call mpp_error(FATAL, module_name//'/get_grid_cell_centers_1D: Illegal component name "'// &
+                    & trim(component)//'": must be one of ATM, LND, or OCN')
   endif
 
   select case(get_grid_version())
@@ -820,11 +838,14 @@ subroutine get_grid_cell_centers_2D(component, tile, lon, lat, domain)
 
   ! verify that lon and lat sizes are consistent with the size of domain
   if (size(lon,1)/=ie-is+1.or.size(lon,2)/=je-js+1) &
-       call mpp_error (FATAL, module_name//'/get_grid_cell_centers: Size of array "lon" is not consistent with the domain size')
+       call mpp_error (FATAL, module_name// &
+                       & '/get_grid_cell_centers: Size of array "lon" is not consistent with the domain size')
   if (size(lat,1)/=ie-is+1.or.size(lat,2)/=je-js+1) &
-       call mpp_error (FATAL, module_name//'/get_grid_cell_centers: Size of array "lat" is not consistent with the domain size')
+       call mpp_error (FATAL, module_name// &
+                       & '/get_grid_cell_centers: Size of array "lat" is not consistent with the domain size')
   if(trim(component) .NE. 'ATM' .AND. component .NE. 'LND' .AND. component .NE. 'OCN') then
-     call mpp_error(FATAL, module_name//'/get_grid_cell_vertices: Illegal component name "'//trim(component)//'": must be one of ATM, LND, or OCN')
+     call mpp_error(FATAL, module_name//'/get_grid_cell_vertices: Illegal component name "'// &
+                    & trim(component)//'": must be one of ATM, LND, or OCN')
   endif
 
   select case(get_grid_version())

--- a/mosaic2/grid2.F90
+++ b/mosaic2/grid2.F90
@@ -168,7 +168,8 @@ function get_great_circle_algorithm()
       if(trim(attvalue) == "TRUE") then
          get_great_circle_algorithm = .true.
       else if(trim(attvalue) .NE. "FALSE") then
-         call mpp_error(FATAL, module_name//'/get_great_circle_algorithm value of global attribute "great_circle_algorthm" in file'// &
+         call mpp_error(FATAL, module_name//&
+                   '/get_great_circle_algorithm value of global attribute "great_circle_algorthm" in file'// &
                    trim(grid_file)//' should be TRUE or FALSE')
       endif
    endif
@@ -229,8 +230,8 @@ function get_grid_version(fileobj)
     else if(variable_exists(fileobj, 'gridfiles') ) then
        get_grid_version = VERSION_3
     else
-       call mpp_error(FATAL, module_name//'/get_grid_version '//&
-            'Can''t determine the version of the grid spec: none of "x_T", "geolon_t", or "ocn_mosaic_file" exist in file "'//trim(grid_file)//'"')
+       call mpp_error(FATAL, module_name//'/get_grid_version Can''t determine the version of the grid spec:'// &
+                  & ' none of "x_T", "geolon_t", or "ocn_mosaic_file" exist in file "'//trim(grid_file)//'"')
     endif
   endif
 end function get_grid_version
@@ -531,7 +532,7 @@ subroutine get_grid_comp_area_SG(component,tile,area,domain)
                  num_nest_tile = num_nest_tile + 1
                  nest_tile_name(num_nest_tile) = trim(mosaic_name)//'_tile'//char(n+ichar('0'))
               else if(trim(attvalue) .NE. "FALSE") then
-                 call mpp_error(FATAL, module_name//'/get_grid_comp_area value of global attribute nest_grid in file'// &
+                 call mpp_error(FATAL,module_name//'/get_grid_comp_area value of global attribute nest_grid in file'//&
                       trim(tilefile)//' should be TRUE or FALSE')
               endif
            end if
@@ -677,7 +678,7 @@ subroutine get_grid_comp_area_SG(component,tile,area,domain)
                  num_nest_tile = num_nest_tile + 1
                  nest_tile_name(num_nest_tile) = trim(mosaic_name)//'_tile'//char(n+ichar('0'))
               else if(trim(attvalue) .NE. "FALSE") then
-                 call mpp_error(FATAL, module_name//'/get_grid_comp_area value of global attribute nest_grid in file'// &
+                 call mpp_error(FATAL,module_name//'/get_grid_comp_area value of global attribute nest_grid in file'//&
                       trim(tilefile)//' should be TRUE or FALSE')
               endif
            end if
@@ -908,7 +909,8 @@ subroutine get_grid_cell_vertices_2D(component, tile, lonb, latb, domain)
       valid_types = .true.
     end select
   end select
-  if(.not. valid_types) call mpp_error(FATAL, 'get_grid_cell_vertices_2D: invalid types, lonb/latb must be r4_kind or r8_kind')
+  if(.not. valid_types) call mpp_error(FATAL, &
+     &  'get_grid_cell_vertices_2D: invalid types, lonb/latb must be r4_kind or r8_kind')
 
 
   if (present(domain)) then

--- a/mpp/include/mpp_chksum_int.h
+++ b/mpp/include/mpp_chksum_int.h
@@ -63,7 +63,7 @@ function MPP_CHKSUM_INT_RMASK_( var, pelist, mask_val )
   if (mask_val == MPP_FILL_DOUBLE ) then !this is FMS variable field default fill
      ! we've packed an MPP_FILL_
      imask_val = MPP_FILL_INT
-  !!! Current NETCDF fill values (AKA MPP_FILL_*) designed towards CEILING(MPP_FILL_{FLOAT,DOUBLE},kind=4byte)=MPP_FILL_INT
+ !Current NETCDF fill values (AKA MPP_FILL_*) designed towards CEILING(MPP_FILL_{FLOAT,DOUBLE},kind=4byte)=MPP_FILL_INT
   else if ( CEILING(mask_val, i4_kind) == MPP_FILL_INT ) then
      ! we've also packed an MPP_FILL_
      imask_val = MPP_FILL_INT

--- a/mpp/include/mpp_comm_mpi.inc
+++ b/mpp/include/mpp_comm_mpi.inc
@@ -243,7 +243,8 @@ subroutine mpp_exit()
         write( out_unit,'(/a,i6,a)' ) 'Tabulating mpp_clock statistics across ', npes, ' PEs...'
         if( ANY(clocks(1:clock_num)%detailed) ) &
              write( out_unit,'(a)' )'   ... see mpp_clock.out.#### for details on individual PEs.'
-        write( out_unit,'(/32x,a)' ) '      hits          tmin          tmax          tavg          tstd  tfrac grain pemin pemax'
+        write( out_unit,'(/32x,a)' ) &
+                & '      hits          tmin          tmax          tavg          tstd  tfrac grain pemin pemax'
      end if
      write( log_unit,'(/37x,a)' ) 'time'
 

--- a/mpp/include/mpp_comm_nocomm.inc
+++ b/mpp/include/mpp_comm_nocomm.inc
@@ -181,7 +181,8 @@ subroutine mpp_exit()
         write( out_unit,'(/a,i6,a)' ) 'Tabulating mpp_clock statistics across ', npes, ' PEs...'
         if( ANY(clocks(1:clock_num)%detailed) ) &
              write( out_unit,'(a)' )'   ... see mpp_clock.out.#### for details on individual PEs.'
-        write( out_unit,'(/32x,a)' ) '      hits          tmin          tmax          tavg          tstd  tfrac grain pemin pemax'
+        write( out_unit,'(/32x,a)' ) &
+             & '      hits          tmin          tmax          tavg          tstd  tfrac grain pemin pemax'
      else
         write( out_unit,'(/37x,a)' ) 'time'
      end if

--- a/mpp/include/mpp_define_nest_domains.inc
+++ b/mpp/include/mpp_define_nest_domains.inc
@@ -101,7 +101,7 @@ subroutine mpp_define_nest_domains(nest_domain, domain, num_nest, nest_level, ti
                                               !! nest grid (monotonically increasing starting with 7),
                                               !! array containing tile number of the parent grid corresponding
                                               !! to the lower left corner of a given nest
-  integer,                    intent(in   ) :: istart_coarse(:), icount_coarse(:), jstart_coarse(:), jcount_coarse(:) !<start
+  integer, intent(in ) :: istart_coarse(:), icount_coarse(:), jstart_coarse(:), jcount_coarse(:) !<start
                                    !! array containing index in the parent grid of the lower left corner of a given
                                    !! nest, count: array containing span of the nest on the parent grid
   integer,                    intent(in   ) :: npes_nest_tile(:) !< array containing number of pes to allocated
@@ -136,17 +136,24 @@ subroutine mpp_define_nest_domains(nest_domain, domain, num_nest, nest_level, ti
 
   extra_halo_local = 0
   if(present(extra_halo)) then
-     if(extra_halo .NE. 0) call mpp_error(FATAL, "mpp_define_nest_domains.inc: only support extra_halo=0, contact developer")
+     if(extra_halo .NE. 0) call mpp_error(FATAL, &
+        &  "mpp_define_nest_domains.inc: only support extra_halo=0, contact developer")
      extra_halo_local = extra_halo
   endif
 
   !---make sure dimension size is correct
-  if(size(tile_fine(:)) .NE. num_nest) call mpp_error(FATAL, "mpp_define_nest_domains.inc: size(tile_fine) .NE. num_nest")
-  if(size(tile_coarse(:)) .NE. num_nest) call mpp_error(FATAL, "mpp_define_nest_domains.inc: size(tile_coarse) .NE. num_nest")
-  if(size(istart_coarse(:)) .NE. num_nest) call mpp_error(FATAL, "mpp_define_nest_domains.inc: size(istart_coarse) .NE. num_nest")
-  if(size(icount_coarse(:)) .NE. num_nest) call mpp_error(FATAL, "mpp_define_nest_domains.inc: size(icount_coarse) .NE. num_nest")
-  if(size(jstart_coarse(:)) .NE. num_nest) call mpp_error(FATAL, "mpp_define_nest_domains.inc: size(jstart_coarse) .NE. num_nest")
-  if(size(jcount_coarse(:)) .NE. num_nest) call mpp_error(FATAL, "mpp_define_nest_domains.inc: size(jcount_coarse) .NE. num_nest")
+  if(size(tile_fine(:)) .NE. num_nest) call mpp_error(FATAL, &
+     &  "mpp_define_nest_domains.inc: size(tile_fine) .NE. num_nest")
+  if(size(tile_coarse(:)) .NE. num_nest) call mpp_error(FATAL, &
+     &  "mpp_define_nest_domains.inc: size(tile_coarse) .NE. num_nest")
+  if(size(istart_coarse(:)) .NE. num_nest) call mpp_error(FATAL, &
+     &  "mpp_define_nest_domains.inc: size(istart_coarse) .NE. num_nest")
+  if(size(icount_coarse(:)) .NE. num_nest) call mpp_error(FATAL, &
+     &  "mpp_define_nest_domains.inc: size(icount_coarse) .NE. num_nest")
+  if(size(jstart_coarse(:)) .NE. num_nest) call mpp_error(FATAL, &
+     &  "mpp_define_nest_domains.inc: size(jstart_coarse) .NE. num_nest")
+  if(size(jcount_coarse(:)) .NE. num_nest) call mpp_error(FATAL, &
+     &  "mpp_define_nest_domains.inc: size(jcount_coarse) .NE. num_nest")
 
   do n = 1, num_nest
      if(istart_coarse(n) < 1) call mpp_error(FATAL, "mpp_define_nest_domains.inc: istart_coarse < 1")
@@ -162,14 +169,17 @@ subroutine mpp_define_nest_domains(nest_domain, domain, num_nest, nest_level, ti
   !--- make sure the nest level is monotonic and no jumping
   if(nest_level(1) .NE. 1)  call mpp_error(FATAL, "mpp_define_nest_domains.inc: nest_level(1) .NE. 1")
   do n = 2, num_nest
-     if(nest_level(n) < nest_level(n-1)) call mpp_error(FATAL, "mpp_define_nest_domains.inc: nest_level is not monotone increasing")
-     if(nest_level(n) > nest_level(n-1)+1) call mpp_error(FATAL, "mpp_define_nest_domains.inc: nest_level(n) > nest_level(n-1)+1")
+     if(nest_level(n) < nest_level(n-1)) call mpp_error(FATAL, &
+        &  "mpp_define_nest_domains.inc: nest_level is not monotone increasing")
+     if(nest_level(n) > nest_level(n-1)+1) call mpp_error(FATAL, &
+        &  "mpp_define_nest_domains.inc: nest_level(n) > nest_level(n-1)+1")
   enddo
   nlevels = nest_level(num_nest)
 
   !---make sure tile_fine and tile_nest are monotone increasing.
   do n = 2, num_nest
-     if(tile_fine(n) < tile_fine(n-1)) call  mpp_error(FATAL, "mpp_define_nest_domains.inc: tile_fine is not monotone increasing")
+     if(tile_fine(n) < tile_fine(n-1)) call  mpp_error(FATAL, &
+        &  "mpp_define_nest_domains.inc: tile_fine is not monotone increasing")
      if(tile_coarse(n) < tile_coarse(n-1)) call  mpp_error(FATAL, "mpp_define_nest_domains.inc: "// &
                                                            "tile_coarse is not monotone increasing")
   enddo
@@ -334,8 +344,10 @@ subroutine mpp_define_nest_domains(nest_domain, domain, num_nest, nest_level, ti
               nest_domain%nest(l)%jend_coarse(pos) = jend_coarse(n)
               if(l==1) then
                  my_tile_coarse = 1
-              else if((mpp_pe() .GE. pes(pe_start_pos(tile_fine(n))) .AND. mpp_pe() .LE. pes(pe_end_pos(tile_fine(n)))) .OR.  &
-                 (mpp_pe() .GE. pes(pe_start_pos(tile_coarse(n))) .AND. mpp_pe() .LE. pes(pe_end_pos(tile_coarse(n)))) ) then
+              else if( (mpp_pe() .GE. pes(pe_start_pos(tile_fine(n))) .AND. &
+                     &  mpp_pe() .LE. pes(pe_end_pos(tile_fine(n)))) .OR.  &
+                     & (mpp_pe() .GE. pes(pe_start_pos(tile_coarse(n))) .AND. &
+                     &  mpp_pe() .LE. pes(pe_end_pos(tile_coarse(n)))) ) then
                  my_tile_coarse = tile_coarse(n)
               endif
            endif
@@ -386,7 +398,8 @@ subroutine mpp_shift_nest_domains(nest_domain, domain, delta_i_coarse, delta_j_c
 
   extra_halo_local = 0
   if(present(extra_halo)) then
-     if(extra_halo .NE. 0) call mpp_error(FATAL, "shift mpp_define_nest_domains.inc: only support extra_halo=0, contact developer")
+     if(extra_halo .NE. 0) call mpp_error(FATAL, &
+        &  "shift mpp_define_nest_domains.inc: only support extra_halo=0, contact developer")
      extra_halo_local = extra_halo
   endif
 
@@ -394,8 +407,10 @@ subroutine mpp_shift_nest_domains(nest_domain, domain, delta_i_coarse, delta_j_c
   nlevels = nest_level(num_nest)
 
   !---make sure dimension size is correct
-  if(size(delta_i_coarse(:)) .NE. num_nest) call mpp_error(FATAL, "shift mpp_define_nest_domains.inc: size(delta_i_coarse) .NE. num_nest")
-  if(size(delta_j_coarse(:)) .NE. num_nest) call mpp_error(FATAL, "shift mpp_define_nest_domains.inc: size(delta_j_coarse) .NE. num_nest")
+  if(size(delta_i_coarse(:)) .NE. num_nest) call mpp_error(FATAL, &
+     &  "shift mpp_define_nest_domains.inc: size(delta_i_coarse) .NE. num_nest")
+  if(size(delta_j_coarse(:)) .NE. num_nest) call mpp_error(FATAL, &
+     &  "shift mpp_define_nest_domains.inc: size(delta_j_coarse) .NE. num_nest")
 
   ! Step through all nests and apply any modifications
   !  Should only need to modify {i,j}{start,end}_coarse
@@ -435,7 +450,8 @@ subroutine mpp_shift_nest_domains(nest_domain, domain, delta_i_coarse, delta_j_c
             call mpp_error(FATAL, "shift mpp_define_nest_domains.inc:pos .NE. nest_domain%nest(l)%num_nest")
 
         !  The nest may connect to different parent PEs after motion, so this must be recalculated
-        call define_nest_level_type(nest_domain%nest(l), nest_domain%nest(l)%x_refine, nest_domain%nest(l)%y_refine, extra_halo_local)
+        call define_nest_level_type(nest_domain%nest(l), nest_domain%nest(l)%x_refine, &
+                                   &  nest_domain%nest(l)%y_refine, extra_halo_local)
      endif
   enddo
 
@@ -863,7 +879,8 @@ subroutine compute_overlap_coarse_to_fine(nest_domain, overlap, extra_halo, posi
               je_coarse = je_coarse + nhalo
               !--- convert the index to coarse grid index.
               nconvert = convert_index_to_coarse(domain_coarse, 0, 0, tile_coarse, istart_coarse, iend_coarse, &
-                      jstart_coarse, jend_coarse, domain_coarse%ntiles, domain_coarse%tile_id(1), is_coarse, ie_coarse, &
+                      jstart_coarse, jend_coarse, domain_coarse%ntiles, domain_coarse%tile_id(1), is_coarse, &
+                                                                                             &  ie_coarse, &
                    js_coarse, je_coarse, is_convert2, ie_convert2, &
                    js_convert2, je_convert2, rotate2)
               do l = 1, nconvert
@@ -909,9 +926,8 @@ subroutine compute_overlap_coarse_to_fine(nest_domain, overlap, extra_halo, posi
               je_coarse = jstart_coarse
               !--- convert the index to coarse grid index.
               nconvert=convert_index_to_coarse(domain_coarse, 0, 0, tile_coarse, istart_coarse, iend_coarse, &
-                      jstart_coarse, jend_coarse, domain_coarse%ntiles, domain_coarse%tile_id(1), is_coarse, ie_coarse, &
-                   js_coarse, je_coarse, is_convert2, ie_convert2, &
-                   js_convert2, je_convert2, rotate2)
+                      & jstart_coarse, jend_coarse, domain_coarse%ntiles, domain_coarse%tile_id(1), is_coarse, &
+                      & ie_coarse, js_coarse, je_coarse, is_convert2, ie_convert2, js_convert2, je_convert2, rotate2)
               do l = 1, nconvert
                  is_coarse = max(isc_coarse, is_convert2(l))
                  ie_coarse = min(iec_coarse, ie_convert2(l))
@@ -947,9 +963,8 @@ subroutine compute_overlap_coarse_to_fine(nest_domain, overlap, extra_halo, posi
               je_coarse = je_coarse + nhalo
               !--- convert the index to coarse grid index.
               nconvert=convert_index_to_coarse(domain_coarse, 0, 0, tile_coarse, istart_coarse, iend_coarse, &
-                      jstart_coarse, jend_coarse, domain_coarse%ntiles, domain_coarse%tile_id(1), is_coarse, ie_coarse, &
-                   js_coarse, je_coarse, is_convert2, ie_convert2, &
-                   js_convert2, je_convert2, rotate2)
+                       & jstart_coarse, jend_coarse, domain_coarse%ntiles, domain_coarse%tile_id(1), is_coarse, &
+                       & ie_coarse, js_coarse, je_coarse, is_convert2, ie_convert2, js_convert2, je_convert2, rotate2)
               do l = 1, nconvert
                  is_coarse = max(isc_coarse, is_convert2(l))
                  ie_coarse = min(iec_coarse, ie_convert2(l))
@@ -984,9 +999,8 @@ subroutine compute_overlap_coarse_to_fine(nest_domain, overlap, extra_halo, posi
               je_coarse = jend_coarse + nhalo
               !--- convert the index to coarse grid index.
               nconvert=convert_index_to_coarse(domain_coarse, 0, 0, tile_coarse, istart_coarse, iend_coarse, &
-                      jstart_coarse, jend_coarse, domain_coarse%ntiles, domain_coarse%tile_id(1), is_coarse, ie_coarse, &
-                   js_coarse, je_coarse, is_convert2, ie_convert2, &
-                   js_convert2, je_convert2, rotate2)
+                       & jstart_coarse, jend_coarse, domain_coarse%ntiles, domain_coarse%tile_id(1), is_coarse, &
+                       & ie_coarse, js_coarse, je_coarse, is_convert2, ie_convert2, js_convert2, je_convert2, rotate2)
               do l = 1, nconvert
                  is_coarse = max(isc_coarse, is_convert2(l))
                  ie_coarse = min(iec_coarse, ie_convert2(l))
@@ -1296,8 +1310,8 @@ subroutine compute_overlap_fine_to_coarse(nest_domain, overlap, position, name)
            je_you = jstart_coarse + (jel_fine(n)-jstart_fine)/y_refine
            if(mod(jsl_fine(n)-jstart_fine, y_refine) .NE. 0 ) js_you = js_you + 1
            nconvert=convert_index_to_coarse(domain_coarse, ishift, jshift, tile_coarse, istart_coarse, iend_coarse, &
-                      jstart_coarse, jend_coarse, domain_coarse%ntiles, domain_coarse%tile_id(1), is_you, ie_you, js_you, je_you, &
-                      is_convert2, ie_convert2, js_convert2, je_convert2, rotate2)
+                      & jstart_coarse, jend_coarse, domain_coarse%ntiles, domain_coarse%tile_id(1), is_you, ie_you, &
+                      & js_you, je_you, is_convert2, ie_convert2, js_convert2, je_convert2, rotate2)
            do l = 1, nconvert
               is2 = max(is_convert2(l), isc_coarse)
               ie2 = min(ie_convert2(l), iec_coarse+ishift)
@@ -1540,7 +1554,7 @@ function search_C2F_nest_overlap(nest_domain, nest_level, extra_halo, position)
     character(len=128)                    :: name
 
     if(nest_level < 1 .OR. nest_level > nest_domain%num_level) call mpp_error(FATAL, &
-       "mpp_define_nest_domains.inc(search_C2F_nest_overlap): nest_level should be between 1 and nest_domain%num_level")
+      "mpp_define_nest_domains.inc(search_C2F_nest_overlap): nest_level should be between 1 and nest_domain%num_level")
 
     select case(position)
     case (CENTER)
@@ -1553,7 +1567,8 @@ function search_C2F_nest_overlap(nest_domain, nest_level, extra_halo, position)
     case (EAST)
        update_ref => nest_domain%nest(nest_level)%C2F_E
     case default
-       call mpp_error(FATAL,"mpp_define_nest_domains.inc(search_C2F_nest_overlap): position should be CENTER|CORNER|EAST|NORTH")
+       call mpp_error(FATAL, &
+                 & "mpp_define_nest_domains.inc(search_C2F_nest_overlap): position should be CENTER|CORNER|EAST|NORTH")
     end select
 
     search_C2F_nest_overlap => update_ref
@@ -1566,7 +1581,8 @@ function search_C2F_nest_overlap(nest_domain, nest_level, extra_halo, position)
        if(.NOT. ASSOCIATED(search_C2F_nest_overlap%next)) then
           allocate(search_C2F_nest_overlap%next)
           search_C2F_nest_overlap => search_C2F_nest_overlap%next
-          call compute_overlap_coarse_to_fine(nest_domain%nest(nest_level), search_C2F_nest_overlap, extra_halo, position, name)
+          call compute_overlap_coarse_to_fine(nest_domain%nest(nest_level), search_C2F_nest_overlap, &
+                                             &  extra_halo, position, name)
           exit
        else
           search_C2F_nest_overlap => search_C2F_nest_overlap%next
@@ -1587,7 +1603,7 @@ function search_C2F_nest_overlap(nest_domain, nest_level, extra_halo, position)
     type(nestSpec),         pointer       :: search_F2C_nest_overlap
 
     if(nest_level < 1 .OR. nest_level > nest_domain%num_level) call mpp_error(FATAL, &
-       "mpp_define_nest_domains.inc(search_F2C_nest_overlap): nest_level should be between 1 and nest_domain%num_level")
+      "mpp_define_nest_domains.inc(search_F2C_nest_overlap): nest_level should be between 1 and nest_domain%num_level")
 
     select case(position)
     case (CENTER)
@@ -1599,7 +1615,8 @@ function search_C2F_nest_overlap(nest_domain, nest_level, extra_halo, position)
     case (EAST)
        search_F2C_nest_overlap => nest_domain%nest(nest_level)%F2C_E
     case default
-       call mpp_error(FATAL,"mpp_define_nest_domains.inc(search_F2C_nest_overlap): position should be CENTER|CORNER|EAST|NORTH")
+       call mpp_error(FATAL, &
+                 & "mpp_define_nest_domains.inc(search_F2C_nest_overlap): position should be CENTER|CORNER|EAST|NORTH")
     end select
 
   end function search_F2C_nest_overlap
@@ -1759,7 +1776,8 @@ function search_C2F_nest_overlap(nest_domain, nest_level, extra_halo, position)
      type(nestSpec), pointer             :: update => NULL()
 
      if(nest_level < 1 .OR. nest_level > nest_domain%num_level) call mpp_error(FATAL, &
-       "mpp_define_nest_domains.inc(mpp_get_F2C_index_coarse): nest_level should be between 1 and nest_domain%num_level")
+         & "mpp_define_nest_domains.inc(mpp_get_F2C_index_coarse):"// &
+         & "nest_level should be between 1 and nest_domain%num_level")
 
 
      update_position = CENTER
@@ -1775,7 +1793,8 @@ function search_C2F_nest_overlap(nest_domain, nest_level, extra_halo, position)
      case (NORTH)
         update => nest_domain%nest(nest_level)%F2C_N
      case default
-        call mpp_error(FATAL, "mpp_define_nest_domains.inc(mpp_get_F2C_index_coarse): invalid option argument position")
+        call mpp_error(FATAL, &
+                       &  "mpp_define_nest_domains.inc(mpp_get_F2C_index_coarse): invalid option argument position")
      end select
      is_coarse = update%xbegin_c
      ie_coarse = update%xend_c
@@ -1913,7 +1932,8 @@ function search_C2F_nest_overlap(nest_domain, nest_level, extra_halo, position)
 
 
   !> This routine will convert the global coarse grid index to nest grid index.
-  function convert_index_to_nest(domain, ishift, jshift, tile_coarse, istart_coarse, iend_coarse, jstart_coarse, jend_coarse, &
+  function convert_index_to_nest(domain, ishift, jshift, tile_coarse, istart_coarse, iend_coarse, &
+                                &  jstart_coarse, jend_coarse, &
                        ntiles_coarse, tile_in, is_in, ie_in, js_in, je_in, is_out, ie_out, js_out, je_out, rotate_out)
     type(domain2D), intent(in) :: domain
     integer, intent(in)  :: ishift, jshift
@@ -2053,8 +2073,10 @@ function search_C2F_nest_overlap(nest_domain, nest_level, extra_halo, position)
 
   end function convert_index_to_nest
 
-  function convert_index_to_coarse(domain, ishift, jshift, tile_coarse, istart_coarse, iend_coarse, jstart_coarse, jend_coarse, &
-                             ntiles_coarse, tile_in, is_in, ie_in, js_in, je_in, is_out, ie_out, js_out, je_out, rotate_out)
+  function convert_index_to_coarse(domain, ishift, jshift, tile_coarse, istart_coarse, iend_coarse, &
+                                  &  jstart_coarse, jend_coarse, &
+                             ntiles_coarse, tile_in, is_in, ie_in, js_in, je_in, is_out, ie_out, js_out, &
+                                     &  je_out, rotate_out)
     type(domain2D), intent(in) :: domain
     integer, intent(in)  :: ishift, jshift
     integer, intent(in)  :: istart_coarse, iend_coarse, jstart_coarse, jend_coarse
@@ -2194,7 +2216,8 @@ function search_C2F_nest_overlap(nest_domain, nest_level, extra_halo, position)
   end function convert_index_to_coarse
 
 
-  subroutine convert_index_back(domain, ishift, jshift, rotate, is_in, ie_in, js_in, je_in, is_out, ie_out, js_out, je_out)
+  subroutine convert_index_back(domain, ishift, jshift, rotate, is_in, ie_in, js_in, je_in, is_out, ie_out, &
+                               &  js_out, je_out)
     type(domain2D), intent(in) :: domain
     integer, intent(in)  :: ishift, jshift
     integer, intent(in)  :: is_in, ie_in, js_in, je_in, rotate
@@ -2447,7 +2470,8 @@ function search_C2F_nest_overlap(nest_domain, nest_level, extra_halo, position)
      type(domain2d), pointer :: mpp_get_nest_coarse_domain
 
      if(nest_level < 1 .OR. nest_level > nest_domain%num_level) call mpp_error(FATAL, &
-       "mpp_define_nest_domains.inc(mpp_get_nest_coarse_domain): nest_level should be between 1 and nest_domain%num_level")
+        & "mpp_define_nest_domains.inc(mpp_get_nest_coarse_domain):"// &
+        & "nest_level should be between 1 and nest_domain%num_level")
 
      if(.not. nest_domain%nest(nest_level)%on_level) call mpp_error(FATAL, &
        "mpp_define_nest_domains.inc(mpp_get_nest_coarse_domain): nest_domain%nest(nest_level)%on_level is false")
@@ -2461,7 +2485,8 @@ function search_C2F_nest_overlap(nest_domain, nest_level, extra_halo, position)
      type(domain2d), pointer :: mpp_get_nest_fine_domain
 
      if(nest_level < 1 .OR. nest_level > nest_domain%num_level) call mpp_error(FATAL, &
-       "mpp_define_nest_domains.inc(mpp_get_nest_fine_domain): nest_level should be between 1 and nest_domain%num_level")
+       & "mpp_define_nest_domains.inc(mpp_get_nest_fine_domain):"// &
+       & "nest_level should be between 1 and nest_domain%num_level")
 
      if(.not. nest_domain%nest(nest_level)%on_level) call mpp_error(FATAL, &
        "mpp_define_nest_domains.inc(mpp_get_nest_fine_domain): nest_domain%nest(nest_level)%on_level is false")
@@ -2512,7 +2537,8 @@ function search_C2F_nest_overlap(nest_domain, nest_level, extra_halo, position)
      integer,                intent(in) :: nest_level
      integer,               intent(out) :: pelist(:)
      if(nest_level < 1 .OR. nest_level > nest_domain%num_level) call mpp_error(FATAL, &
-       "mpp_define_nest_domains.inc(mpp_get_nest_fine_pelist): nest_level should be between 1 and nest_domain%num_level")
+       & "mpp_define_nest_domains.inc(mpp_get_nest_fine_pelist):"// &
+       & "nest_level should be between 1 and nest_domain%num_level")
 
      if(size(pelist) .NE. size(nest_domain%nest(nest_level)%pelist_fine)) call mpp_error(FATAL, &
        "mpp_define_nest_domains.inc(mpp_get_nest_fine_pelist): size(pelist) "// &

--- a/mpp/include/mpp_define_nest_domains.inc
+++ b/mpp/include/mpp_define_nest_domains.inc
@@ -373,7 +373,7 @@ subroutine mpp_define_nest_domains(nest_domain, domain, num_nest, nest_level, ti
 
 end subroutine mpp_define_nest_domains
 
-!>  Based on mpp_define_nest_domains, but just resets positioning of nest 
+!>  Based on mpp_define_nest_domains, but just resets positioning of nest
 !>    Modifies the parent/coarse start and end indices of the nest location
 !!    Computes new overlaps of nest PEs on parent PEs
 !!    Ramstrom/HRD Moving Nest

--- a/mpp/include/mpp_define_nest_domains.inc
+++ b/mpp/include/mpp_define_nest_domains.inc
@@ -879,10 +879,8 @@ subroutine compute_overlap_coarse_to_fine(nest_domain, overlap, extra_halo, posi
               je_coarse = je_coarse + nhalo
               !--- convert the index to coarse grid index.
               nconvert = convert_index_to_coarse(domain_coarse, 0, 0, tile_coarse, istart_coarse, iend_coarse, &
-                      jstart_coarse, jend_coarse, domain_coarse%ntiles, domain_coarse%tile_id(1), is_coarse, &
-                                                                                             &  ie_coarse, &
-                   js_coarse, je_coarse, is_convert2, ie_convert2, &
-                   js_convert2, je_convert2, rotate2)
+                   & jstart_coarse, jend_coarse, domain_coarse%ntiles, domain_coarse%tile_id(1), is_coarse, ie_coarse,&
+                   & js_coarse, je_coarse, is_convert2, ie_convert2, js_convert2, je_convert2, rotate2)
               do l = 1, nconvert
                  is_coarse = max(isc_coarse, is_convert2(l))
                  ie_coarse = min(iec_coarse, ie_convert2(l))
@@ -1932,9 +1930,9 @@ function search_C2F_nest_overlap(nest_domain, nest_level, extra_halo, position)
 
 
   !> This routine will convert the global coarse grid index to nest grid index.
-  function convert_index_to_nest(domain, ishift, jshift, tile_coarse, istart_coarse, iend_coarse, &
-                                &  jstart_coarse, jend_coarse, &
-                       ntiles_coarse, tile_in, is_in, ie_in, js_in, je_in, is_out, ie_out, js_out, je_out, rotate_out)
+  function convert_index_to_nest(domain, ishift, jshift, tile_coarse, istart_coarse, iend_coarse, jstart_coarse, &
+                               & jend_coarse, ntiles_coarse, tile_in, is_in, ie_in, js_in, je_in, is_out, ie_out,&
+                               & js_out, je_out, rotate_out)
     type(domain2D), intent(in) :: domain
     integer, intent(in)  :: ishift, jshift
     integer, intent(in)  :: istart_coarse, iend_coarse, jstart_coarse, jend_coarse
@@ -2073,10 +2071,9 @@ function search_C2F_nest_overlap(nest_domain, nest_level, extra_halo, position)
 
   end function convert_index_to_nest
 
-  function convert_index_to_coarse(domain, ishift, jshift, tile_coarse, istart_coarse, iend_coarse, &
-                                  &  jstart_coarse, jend_coarse, &
-                             ntiles_coarse, tile_in, is_in, ie_in, js_in, je_in, is_out, ie_out, js_out, &
-                                     &  je_out, rotate_out)
+  function convert_index_to_coarse(domain, ishift, jshift, tile_coarse, istart_coarse, iend_coarse, jstart_coarse, &
+                                 & jend_coarse, ntiles_coarse, tile_in, is_in, ie_in, js_in, je_in, is_out, ie_out,&
+                                 & js_out, je_out, rotate_out)
     type(domain2D), intent(in) :: domain
     integer, intent(in)  :: ishift, jshift
     integer, intent(in)  :: istart_coarse, iend_coarse, jstart_coarse, jend_coarse

--- a/mpp/include/mpp_do_check.h
+++ b/mpp/include/mpp_do_check.h
@@ -233,7 +233,8 @@
                            print*,"Error from MPP_DO_CHECK on pe = ", mpp_pe(), ": field ", &
                                 trim(field_name), " at point (", i, ",", j, ",", k, ") = ", field(i,j,k), &
                                 " does not equal to the value = ", buffer(pos), " on pe ", check%recv(m)%pe
-                           call mpp_error(debug_update_level, "MPP_DO_CHECK: mismatch on the boundary for symmetry point")
+                           call mpp_error(debug_update_level, &
+                                          &  "MPP_DO_CHECK: mismatch on the boundary for symmetry point")
                            exit CHECK_LOOP
                         end if
                      end do

--- a/mpp/include/mpp_do_checkV.h
+++ b/mpp/include/mpp_do_checkV.h
@@ -470,7 +470,8 @@
                               print*,"Error from MPP_DO_CHECK_V on pe = ", mpp_pe(), ": y component of vector ", &
                                    trim(field_name), " at point (", i, ",", j, ",", k, ") = ", fieldy(i,j,k), &
                                    " does not equal to the value = ", buffer(pos), " on pe ", check_y%recv(ind_y)%pe
-                              call mpp_error(debug_update_level, "MPP_DO_CHECK_V: mismatch on the boundary for symmetry point")
+                              call mpp_error(debug_update_level, &
+                                             &  "MPP_DO_CHECK_V: mismatch on the boundary for symmetry point")
                               exit CHECK_LOOP
                            end if
                         end do
@@ -506,7 +507,8 @@
                               print*,"Error from MPP_DO_CHECK_V on pe = ", mpp_pe(), ": x-component of vector ", &
                                    trim(field_name), " at point (", i, ",", j, ",", k, ") = ", fieldx(i,j,k), &
                                    " does not equal to the value = ", buffer(pos), " on pe ", check_x%recv(ind_x)%pe
-                              call mpp_error(debug_update_level, "MPP_DO_CHECK_V: mismatch on the boundary for symmetry point")
+                              call mpp_error(debug_update_level, &
+                                             &  "MPP_DO_CHECK_V: mismatch on the boundary for symmetry point")
                               exit CHECK_LOOP
                            end if
                         end do

--- a/mpp/include/mpp_do_global_field.h
+++ b/mpp/include/mpp_do_global_field.h
@@ -77,8 +77,8 @@
       if(global_on_this_pe ) then
          if(size(local,3).NE.size(global,3) ) call mpp_error( FATAL, &
               'MPP_GLOBAL_FIELD: mismatch of third dimension size of global and local')
-         if( size(global,1).NE.(domain%x(tile)%global%size+ishift) .OR. size(global, &
-           & 2).NE.(domain%y(tile)%global%size+jshift))then
+         if( size(global,1).NE.(domain%x(tile)%global%size+ishift) .OR. &
+             size(global,2).NE.(domain%y(tile)%global%size+jshift))then
             if(xonly) then
                if(size(global,1).NE.(domain%x(tile)%global%size+ishift) .OR. &
                    size(global,2).NE.(domain%y(tile)%compute%size+jshift)) &
@@ -97,13 +97,13 @@
          endif
       endif
 
-      if( size(local,1).EQ.(domain%x(tile)%compute%size+ishift) .AND. size(local, &
-        & 2).EQ.(domain%y(tile)%compute%size+jshift) )then
+      if( size(local,1).EQ.(domain%x(tile)%compute%size+ishift) .AND. &
+          size(local,2).EQ.(domain%y(tile)%compute%size+jshift) )then
          !local is on compute domain
          ioff = -domain%x(tile)%compute%begin + 1
          joff = -domain%y(tile)%compute%begin + 1
-      else if( size(local,1).EQ.(domain%x(tile)%memory%size+ishift) .AND. size(local, &
-             & 2).EQ.(domain%y(tile)%memory%size+jshift) )then
+      else if( size(local,1).EQ.(domain%x(tile)%memory%size+ishift) .AND. &
+               size(local,2).EQ.(domain%y(tile)%memory%size+jshift) )then
          !local is on data domain
          ioff = -domain%x(tile)%data%begin + 1
          joff = -domain%y(tile)%data%begin + 1
@@ -339,8 +339,8 @@
       if(global_on_this_pe ) then
          if(size(local,3).NE.size(global,3) ) call mpp_error( FATAL, &
               'MPP_GLOBAL_FIELD: mismatch of third dimension size of global and local')
-         if( size(global,1).NE.(domain%x(tile)%global%size+ishift) .OR. size(global, &
-           & 2).NE.(domain%y(tile)%global%size+jshift))then
+         if( size(global,1).NE.(domain%x(tile)%global%size+ishift) .OR. &
+             size(global,2).NE.(domain%y(tile)%global%size+jshift))then
             if(xonly) then
                if(size(global,1).NE.(domain%x(tile)%global%size+ishift) .OR. &
                    size(global,2).NE.(domain%y(tile)%compute%size+jshift)) &
@@ -362,13 +362,13 @@
       ! NOTE: Since local is assumed to contiguously match the data domain, this
       !       is not a useful check.  But maybe someday we can support compute
       !       domains.
-      if( size(local,1).EQ.(domain%x(tile)%compute%size+ishift) .AND. size(local, &
-        & 2).EQ.(domain%y(tile)%compute%size+jshift) )then
+      if( size(local,1).EQ.(domain%x(tile)%compute%size+ishift) .AND. &
+          size(local,2).EQ.(domain%y(tile)%compute%size+jshift) )then
          !local is on compute domain
          ioff = -domain%x(tile)%compute%begin
          joff = -domain%y(tile)%compute%begin
-      else if( size(local,1).EQ.(domain%x(tile)%memory%size+ishift) .AND. size(local, &
-             & 2).EQ.(domain%y(tile)%memory%size+jshift) )then
+      else if( size(local,1).EQ.(domain%x(tile)%memory%size+ishift) .AND. &
+               size(local,2).EQ.(domain%y(tile)%memory%size+jshift) )then
          !local is on data domain
          ioff = -domain%x(tile)%data%begin
          joff = -domain%y(tile)%data%begin

--- a/mpp/include/mpp_do_global_field.h
+++ b/mpp/include/mpp_do_global_field.h
@@ -43,7 +43,8 @@
       if( stackuse.GT.mpp_domains_stack_size )then
           write( text, '(i8)' )stackuse
           call mpp_error( FATAL, &
-               'MPP_DO_GLOBAL_FIELD user stack overflow: call mpp_domains_set_stack_size('//trim(text)//') from all PEs.' )
+               'MPP_DO_GLOBAL_FIELD user stack overflow: call mpp_domains_set_stack_size('//trim(text)// &
+               & ') from all PEs.' )
       end if
       mpp_domains_stack_hwm = max( mpp_domains_stack_hwm, stackuse )
 
@@ -76,16 +77,19 @@
       if(global_on_this_pe ) then
          if(size(local,3).NE.size(global,3) ) call mpp_error( FATAL, &
               'MPP_GLOBAL_FIELD: mismatch of third dimension size of global and local')
-         if( size(global,1).NE.(domain%x(tile)%global%size+ishift) .OR. size(global,2).NE.(domain%y(tile)%global%size+jshift))then
+         if( size(global,1).NE.(domain%x(tile)%global%size+ishift) .OR. size(global, &
+           & 2).NE.(domain%y(tile)%global%size+jshift))then
             if(xonly) then
                if(size(global,1).NE.(domain%x(tile)%global%size+ishift) .OR. &
                    size(global,2).NE.(domain%y(tile)%compute%size+jshift)) &
-                  call mpp_error( FATAL, 'MPP_GLOBAL_FIELD: incoming arrays do not match domain for xonly global field.' )
+                  call mpp_error( FATAL, &
+                                 &  'MPP_GLOBAL_FIELD: incoming arrays do not match domain for xonly global field.' )
                jpos = -domain%y(tile)%compute%begin + 1
             else if(yonly) then
                if(size(global,1).NE.(domain%x(tile)%compute%size+ishift) .OR. &
                    size(global,2).NE.(domain%y(tile)%global%size+jshift)) &
-                  call mpp_error( FATAL, 'MPP_GLOBAL_FIELD: incoming arrays do not match domain for yonly global field.' )
+                  call mpp_error( FATAL, &
+                                 &  'MPP_GLOBAL_FIELD: incoming arrays do not match domain for yonly global field.' )
                ipos = -domain%x(tile)%compute%begin + 1
             else
                call mpp_error( FATAL, 'MPP_GLOBAL_FIELD: incoming arrays do not match domain.' )
@@ -93,16 +97,19 @@
          endif
       endif
 
-      if( size(local,1).EQ.(domain%x(tile)%compute%size+ishift) .AND. size(local,2).EQ.(domain%y(tile)%compute%size+jshift) )then
+      if( size(local,1).EQ.(domain%x(tile)%compute%size+ishift) .AND. size(local, &
+        & 2).EQ.(domain%y(tile)%compute%size+jshift) )then
          !local is on compute domain
          ioff = -domain%x(tile)%compute%begin + 1
          joff = -domain%y(tile)%compute%begin + 1
-      else if( size(local,1).EQ.(domain%x(tile)%memory%size+ishift) .AND. size(local,2).EQ.(domain%y(tile)%memory%size+jshift) )then
+      else if( size(local,1).EQ.(domain%x(tile)%memory%size+ishift) .AND. size(local, &
+             & 2).EQ.(domain%y(tile)%memory%size+jshift) )then
          !local is on data domain
          ioff = -domain%x(tile)%data%begin + 1
          joff = -domain%y(tile)%data%begin + 1
       else
-         call mpp_error( FATAL, 'MPP_GLOBAL_FIELD_: incoming field array must match either compute domain or memory domain.' )
+         call mpp_error( FATAL, &
+                       & 'MPP_GLOBAL_FIELD_: incoming field array must match either compute domain or memory domain.')
       end if
 
       ke  = size(local,3)
@@ -225,7 +232,7 @@
                do n = 1,nd-1
                   rpos = mod(domain%pos+n,nd)
                   if( domain%list(rpos)%tile_id(1) .NE. tile_id ) cycle
-                  nwords = (domain%list(rpos)%x(1)%compute%size+ishift) * (domain%list(rpos)%y(1)%compute%size+jshift) * ke
+                  nwords = (domain%list(rpos)%x(1)%compute%size+ishift)*(domain%list(rpos)%y(1)%compute%size+jshift)*ke
                   call mpp_recv(cremote(1), glen=nwords, from_pe=domain%list(rpos)%pe, tag=COMM_TAG_1 )
                   m = 0
                   is = domain%list(rpos)%x(1)%compute%begin; ie = domain%list(rpos)%x(1)%compute%end+ishift
@@ -250,7 +257,7 @@
             do n = 1,nd-1
                rpos = mod(domain%pos+n,nd)
                if( domain%list(rpos)%tile_id(1) .NE. tile_id ) cycle ! global field only within tile
-               nwords = (domain%list(rpos)%x(1)%compute%size+ishift) * (domain%list(rpos)%y(1)%compute%size+jshift) * ke
+               nwords = (domain%list(rpos)%x(1)%compute%size+ishift) * (domain%list(rpos)%y(1)%compute%size+jshift)*ke
                call mpp_recv( cremote(1), glen=nwords, from_pe=domain%list(rpos)%pe, tag=COMM_TAG_2 )
                m = 0
                is = domain%list(rpos)%x(1)%compute%begin; ie = domain%list(rpos)%x(1)%compute%end+ishift
@@ -332,16 +339,19 @@
       if(global_on_this_pe ) then
          if(size(local,3).NE.size(global,3) ) call mpp_error( FATAL, &
               'MPP_GLOBAL_FIELD: mismatch of third dimension size of global and local')
-         if( size(global,1).NE.(domain%x(tile)%global%size+ishift) .OR. size(global,2).NE.(domain%y(tile)%global%size+jshift))then
+         if( size(global,1).NE.(domain%x(tile)%global%size+ishift) .OR. size(global, &
+           & 2).NE.(domain%y(tile)%global%size+jshift))then
             if(xonly) then
                if(size(global,1).NE.(domain%x(tile)%global%size+ishift) .OR. &
                    size(global,2).NE.(domain%y(tile)%compute%size+jshift)) &
-                  call mpp_error( FATAL, 'MPP_GLOBAL_FIELD: incoming arrays do not match domain for xonly global field.' )
+                  call mpp_error( FATAL, &
+                                 &  'MPP_GLOBAL_FIELD: incoming arrays do not match domain for xonly global field.' )
                jpos = -domain%y(tile)%compute%begin + 1
             else if(yonly) then
                if(size(global,1).NE.(domain%x(tile)%compute%size+ishift) .OR. &
                    size(global,2).NE.(domain%y(tile)%global%size+jshift)) &
-                  call mpp_error( FATAL, 'MPP_GLOBAL_FIELD: incoming arrays do not match domain for yonly global field.' )
+                  call mpp_error( FATAL, &
+                                 &  'MPP_GLOBAL_FIELD: incoming arrays do not match domain for yonly global field.' )
                ipos = -domain%x(tile)%compute%begin + 1
             else
                call mpp_error( FATAL, 'MPP_GLOBAL_FIELD: incoming arrays do not match domain.' )
@@ -352,16 +362,19 @@
       ! NOTE: Since local is assumed to contiguously match the data domain, this
       !       is not a useful check.  But maybe someday we can support compute
       !       domains.
-      if( size(local,1).EQ.(domain%x(tile)%compute%size+ishift) .AND. size(local,2).EQ.(domain%y(tile)%compute%size+jshift) )then
+      if( size(local,1).EQ.(domain%x(tile)%compute%size+ishift) .AND. size(local, &
+        & 2).EQ.(domain%y(tile)%compute%size+jshift) )then
          !local is on compute domain
          ioff = -domain%x(tile)%compute%begin
          joff = -domain%y(tile)%compute%begin
-      else if( size(local,1).EQ.(domain%x(tile)%memory%size+ishift) .AND. size(local,2).EQ.(domain%y(tile)%memory%size+jshift) )then
+      else if( size(local,1).EQ.(domain%x(tile)%memory%size+ishift) .AND. size(local, &
+             & 2).EQ.(domain%y(tile)%memory%size+jshift) )then
          !local is on data domain
          ioff = -domain%x(tile)%data%begin
          joff = -domain%y(tile)%data%begin
       else
-         call mpp_error( FATAL, 'MPP_GLOBAL_FIELD_: incoming field array must match either compute domain or memory domain.' )
+         call mpp_error( FATAL, &
+                       & 'MPP_GLOBAL_FIELD_: incoming field array must match either compute domain or memory domain.' )
       end if
 
       ke  = size(local,3)

--- a/mpp/include/mpp_do_global_field_ad.h
+++ b/mpp/include/mpp_do_global_field_ad.h
@@ -45,7 +45,8 @@
       if( stackuse.GT.mpp_domains_stack_size )then
           write( text, '(i8)' )stackuse
           call mpp_error( FATAL, &
-               'MPP_DO_GLOBAL_FIELD user stack overflow: call mpp_domains_set_stack_size('//trim(text)//') from all PEs.' )
+               'MPP_DO_GLOBAL_FIELD user stack overflow: call mpp_domains_set_stack_size('//trim(text)// &
+               & ') from all PEs.' )
       end if
       mpp_domains_stack_hwm = max( mpp_domains_stack_hwm, stackuse )
 
@@ -78,16 +79,19 @@
       if(global_on_this_pe ) then
          if(size(local,3).NE.size(global,3) ) call mpp_error( FATAL, &
               'MPP_GLOBAL_FIELD: mismatch of third dimension size of global and local')
-         if( size(global,1).NE.(domain%x(tile)%global%size+ishift) .OR. size(global,2).NE.(domain%y(tile)%global%size+jshift))then
+         if( size(global,1).NE.(domain%x(tile)%global%size+ishift) .OR. size(global, &
+           & 2).NE.(domain%y(tile)%global%size+jshift))then
             if(xonly) then
                if(size(global,1).NE.(domain%x(tile)%global%size+ishift) .OR. &
                    size(global,2).NE.(domain%y(tile)%compute%size+jshift)) &
-                  call mpp_error( FATAL, 'MPP_GLOBAL_FIELD: incoming arrays do not match domain for xonly global field.' )
+                  call mpp_error( FATAL, &
+                                 &  'MPP_GLOBAL_FIELD: incoming arrays do not match domain for xonly global field.' )
                jpos = -domain%y(tile)%compute%begin + 1
             else if(yonly) then
                if(size(global,1).NE.(domain%x(tile)%compute%size+ishift) .OR. &
                    size(global,2).NE.(domain%y(tile)%global%size+jshift)) &
-                  call mpp_error( FATAL, 'MPP_GLOBAL_FIELD: incoming arrays do not match domain for yonly global field.' )
+                  call mpp_error( FATAL, &
+                                 &  'MPP_GLOBAL_FIELD: incoming arrays do not match domain for yonly global field.' )
                ipos = -domain%x(tile)%compute%begin + 1
             else
                call mpp_error( FATAL, 'MPP_GLOBAL_FIELD: incoming arrays do not match domain.' )
@@ -95,16 +99,19 @@
          endif
       endif
 
-      if( size(local,1).EQ.(domain%x(tile)%compute%size+ishift) .AND. size(local,2).EQ.(domain%y(tile)%compute%size+jshift) )then
+      if( size(local,1).EQ.(domain%x(tile)%compute%size+ishift) .AND. size(local, &
+        & 2).EQ.(domain%y(tile)%compute%size+jshift) )then
          !local is on compute domain
          ioff = -domain%x(tile)%compute%begin + 1
          joff = -domain%y(tile)%compute%begin + 1
-      else if( size(local,1).EQ.(domain%x(tile)%memory%size+ishift) .AND. size(local,2).EQ.(domain%y(tile)%memory%size+jshift) )then
+      else if( size(local,1).EQ.(domain%x(tile)%memory%size+ishift) .AND. size(local, &
+             & 2).EQ.(domain%y(tile)%memory%size+jshift) )then
          !local is on data domain
          ioff = -domain%x(tile)%data%begin + 1
          joff = -domain%y(tile)%data%begin + 1
       else
-         call mpp_error( FATAL, 'MPP_GLOBAL_FIELD_: incoming field array must match either compute domain or memory domain.' )
+         call mpp_error( FATAL, &
+                       & 'MPP_GLOBAL_FIELD_: incoming field array must match either compute domain or memory domain.')
       end if
 
       ke  = size(local,3)
@@ -187,7 +194,7 @@
                do n = 1,nd-1
                   rpos = mod(domain%pos+n,nd)
                   if( domain%list(rpos)%tile_id(1) .NE. tile_id ) cycle
-                  nwords = (domain%list(rpos)%x(1)%compute%size+ishift) * (domain%list(rpos)%y(1)%compute%size+jshift) * ke
+                  nwords = (domain%list(rpos)%x(1)%compute%size+ishift)*(domain%list(rpos)%y(1)%compute%size+jshift)*ke
                   m = 0
                   is = domain%list(rpos)%x(1)%compute%begin; ie = domain%list(rpos)%x(1)%compute%end+ishift
                   js = domain%list(rpos)%y(1)%compute%begin; je = domain%list(rpos)%y(1)%compute%end+jshift
@@ -209,7 +216,7 @@
             do n = 1,nd-1
                rpos = mod(domain%pos+n,nd)
                if( domain%list(rpos)%tile_id(1) .NE. tile_id ) cycle ! global field only within tile
-               nwords = (domain%list(rpos)%x(1)%compute%size+ishift) * (domain%list(rpos)%y(1)%compute%size+jshift) * ke
+               nwords = (domain%list(rpos)%x(1)%compute%size+ishift) * (domain%list(rpos)%y(1)%compute%size+jshift)*ke
                m = 0
                is = domain%list(rpos)%x(1)%compute%begin; ie = domain%list(rpos)%x(1)%compute%end+ishift
                js = domain%list(rpos)%y(1)%compute%begin; je = domain%list(rpos)%y(1)%compute%end+jshift

--- a/mpp/include/mpp_do_updateV.h
+++ b/mpp/include/mpp_do_updateV.h
@@ -902,7 +902,8 @@
                end select
             end if
          end if
-      else if( BTEST(domain%fold,SOUTH) .AND. (.NOT.BTEST(update_flags,SCALAR_BIT)) )then      ! ---southern boundary fold
+      else if( BTEST(domain%fold,SOUTH) .AND. (.NOT.BTEST(update_flags,SCALAR_BIT)) )then      ! ---southern
+                                                                                               !! boundary fold
          ! NOTE: symmetry is assumed for fold-south boundary
          j = domain%y(1)%global%begin
          if( domain%y(1)%data%begin.LE.j .AND. j.LE.domain%y(1)%data%end+shift )then !fold is within domain
@@ -996,7 +997,8 @@
                end select
             end if
          end if
-      else if( BTEST(domain%fold,WEST) .AND. (.NOT.BTEST(update_flags,SCALAR_BIT)) )then      ! ---eastern boundary fold
+      else if( BTEST(domain%fold,WEST) .AND. (.NOT.BTEST(update_flags,SCALAR_BIT)) )then      ! ---eastern
+                                                                                              !! boundary fold
          ! NOTE: symmetry is assumed for fold-west boundary
          i = domain%x(1)%global%begin
          if( domain%x(1)%data%begin.LE.i .AND. i.LE.domain%x(1)%data%end+shift )then !fold is within domain
@@ -1090,7 +1092,8 @@
                end select
             end if
          end if
-      else if( BTEST(domain%fold,EAST) .AND. (.NOT.BTEST(update_flags,SCALAR_BIT)) )then      ! ---eastern boundary fold
+      else if( BTEST(domain%fold,EAST) .AND. (.NOT.BTEST(update_flags,SCALAR_BIT)) )then      ! ---eastern
+                                                                                              !! boundary fold
          ! NOTE: symmetry is assumed for fold-west boundary
          i = domain%x(1)%global%end+shift
          if( domain%x(1)%data%begin.LE.i .AND. i.LE.domain%x(1)%data%end+shift )then !fold is within domain

--- a/mpp/include/mpp_do_updateV_ad.h
+++ b/mpp/include/mpp_do_updateV_ad.h
@@ -502,7 +502,8 @@
                end select
             end if
          end if
-      else if( BTEST(domain%fold,SOUTH) .AND. (.NOT.BTEST(update_flags,SCALAR_BIT)) )then      ! ---southern boundary fold
+      else if( BTEST(domain%fold,SOUTH) .AND. (.NOT.BTEST(update_flags,SCALAR_BIT)) )then      ! ---southern
+                                                                                               !! boundary fold
          ! NOTE: symmetry is assumed for fold-south boundary
          j = domain%y(1)%global%begin
          if( domain%y(1)%data%begin.LE.j .AND. j.LE.domain%y(1)%data%end+shift )then !fold is within domain
@@ -596,7 +597,8 @@
                end select
             end if
          end if
-      else if( BTEST(domain%fold,WEST) .AND. (.NOT.BTEST(update_flags,SCALAR_BIT)) )then      ! ---eastern boundary fold
+      else if( BTEST(domain%fold,WEST) .AND. (.NOT.BTEST(update_flags,SCALAR_BIT)) )then      ! ---eastern
+                                                                                              !! boundary fold
          ! NOTE: symmetry is assumed for fold-west boundary
          i = domain%x(1)%global%begin
          if( domain%x(1)%data%begin.LE.i .AND. i.LE.domain%x(1)%data%end+shift )then !fold is within domain
@@ -690,7 +692,8 @@
                end select
             end if
          end if
-      else if( BTEST(domain%fold,EAST) .AND. (.NOT.BTEST(update_flags,SCALAR_BIT)) )then      ! ---eastern boundary fold
+      else if( BTEST(domain%fold,EAST) .AND. (.NOT.BTEST(update_flags,SCALAR_BIT)) )then      ! ---eastern
+                                                                                              !! boundary fold
          ! NOTE: symmetry is assumed for fold-west boundary
          i = domain%x(1)%global%end+shift
          if( domain%x(1)%data%begin.LE.i .AND. i.LE.domain%x(1)%data%end+shift )then !fold is within domain

--- a/mpp/include/mpp_do_updateV_nonblock.h
+++ b/mpp/include/mpp_do_updateV_nonblock.h
@@ -741,7 +741,8 @@ subroutine MPP_COMPLETE_DO_UPDATE_3D_V_(id_update, f_addrsx, f_addrsy, domain, u
               if( is.GT.domain%x(1)%data%begin )then
 
                  if( 2*is-domain%x(1)%data%begin.GT.domain%x(1)%data%end+shift ) &
-                      call mpp_error( FATAL, 'MPP_COMPLETE_DO_UPDATE_V: folded-north BGRID_NE west edge ubound error.' )
+                      call mpp_error( FATAL, &
+                                     &  'MPP_COMPLETE_DO_UPDATE_V: folded-north BGRID_NE west edge ubound error.' )
                      do l=1,l_size
                         ptr_fieldx = f_addrsx(l, 1)
                         ptr_fieldy = f_addrsy(l, 1)
@@ -758,7 +759,8 @@ subroutine MPP_COMPLETE_DO_UPDATE_3D_V_(id_update, f_addrsx, f_addrsy, domain, u
               is = domain%x(1)%global%begin
               if( is.GT.domain%x(1)%data%begin )then
                  if( 2*is-domain%x(1)%data%begin-1.GT.domain%x(1)%data%end ) &
-                      call mpp_error( FATAL, 'MPP_COMPLETE_DO_UPDATE_V: folded-north CGRID_NE west edge ubound error.' )
+                      call mpp_error( FATAL, &
+                                     &  'MPP_COMPLETE_DO_UPDATE_V: folded-north CGRID_NE west edge ubound error.' )
                  do l=1,l_size
                     ptr_fieldy = f_addrsy(l, 1)
                     do k = 1,ke_list(l,tMe)
@@ -835,7 +837,8 @@ subroutine MPP_COMPLETE_DO_UPDATE_3D_V_(id_update, f_addrsx, f_addrsy, domain, u
               is = domain%x(1)%global%begin
               if( is.GT.domain%x(1)%data%begin )then
                  if( 2*is-domain%x(1)%data%begin.GT.domain%x(1)%data%end+shift ) &
-                      call mpp_error( FATAL, 'MPP_COMPLETE_DO_UPDATE_V: folded-south BGRID_NE west edge ubound error.' )
+                      call mpp_error( FATAL, &
+                                     &  'MPP_COMPLETE_DO_UPDATE_V: folded-south BGRID_NE west edge ubound error.' )
                  do l=1,l_size
                     ptr_fieldx = f_addrsx(l, 1)
                     ptr_fieldy = f_addrsy(l, 1)
@@ -851,7 +854,8 @@ subroutine MPP_COMPLETE_DO_UPDATE_3D_V_(id_update, f_addrsx, f_addrsy, domain, u
               is = domain%x(1)%global%begin
               if( is.GT.domain%x(1)%data%begin )then
                  if( 2*is-domain%x(1)%data%begin-1.GT.domain%x(1)%data%end ) &
-                      call mpp_error( FATAL, 'MPP_COMPLETE_DO_UPDATE_V: folded-south CGRID_NE west edge ubound error.' )
+                      call mpp_error( FATAL, &
+                                     &  'MPP_COMPLETE_DO_UPDATE_V: folded-south CGRID_NE west edge ubound error.' )
                  do l=1,l_size
                     ptr_fieldy = f_addrsy(l, 1)
                     do k = 1,ke_list(l,tMe)
@@ -929,7 +933,8 @@ subroutine MPP_COMPLETE_DO_UPDATE_3D_V_(id_update, f_addrsx, f_addrsy, domain, u
               if( js.GT.domain%y(1)%data%begin )then
 
                  if( 2*js-domain%y(1)%data%begin.GT.domain%y(1)%data%end+shift ) &
-                      call mpp_error( FATAL, 'MPP_COMPLETE_DO__UPDATE_V: folded-west BGRID_NE west edge ubound error.' )
+                      call mpp_error( FATAL, &
+                                     &  'MPP_COMPLETE_DO__UPDATE_V: folded-west BGRID_NE west edge ubound error.' )
                  do l=1,l_size
                     ptr_fieldx = f_addrsx(l, 1)
                     ptr_fieldy = f_addrsy(l, 1)
@@ -945,7 +950,8 @@ subroutine MPP_COMPLETE_DO_UPDATE_3D_V_(id_update, f_addrsx, f_addrsy, domain, u
               js = domain%y(1)%global%begin
               if( js.GT.domain%y(1)%data%begin )then
                  if( 2*js-domain%y(1)%data%begin-1.GT.domain%y(1)%data%end ) &
-                      call mpp_error( FATAL, 'MPP_COMPLETE_DO__UPDATE_V: folded-west CGRID_NE west edge ubound error.' )
+                      call mpp_error( FATAL, &
+                                     &  'MPP_COMPLETE_DO__UPDATE_V: folded-west CGRID_NE west edge ubound error.' )
                  do l=1,l_size
                     ptr_fieldx = f_addrsx(l, 1)
                     do k = 1,ke_list(l,tMe)
@@ -1023,7 +1029,8 @@ subroutine MPP_COMPLETE_DO_UPDATE_3D_V_(id_update, f_addrsx, f_addrsy, domain, u
               if( js.GT.domain%y(1)%data%begin )then
 
                  if( 2*js-domain%y(1)%data%begin.GT.domain%y(1)%data%end+shift ) &
-                      call mpp_error( FATAL, 'MPP_COMPLETE_DO__UPDATE_V: folded-east BGRID_NE west edge ubound error.' )
+                      call mpp_error( FATAL, &
+                                     &  'MPP_COMPLETE_DO__UPDATE_V: folded-east BGRID_NE west edge ubound error.' )
                  do l=1,l_size
                     ptr_fieldx = f_addrsx(l, 1)
                     ptr_fieldy = f_addrsy(l, 1)
@@ -1039,7 +1046,8 @@ subroutine MPP_COMPLETE_DO_UPDATE_3D_V_(id_update, f_addrsx, f_addrsy, domain, u
               js = domain%y(1)%global%begin
               if( js.GT.domain%y(1)%data%begin )then
                  if( 2*js-domain%y(1)%data%begin-1.GT.domain%y(1)%data%end ) &
-                      call mpp_error( FATAL, 'MPP_COMPLETE_DO__UPDATE_V: folded-east CGRID_NE west edge ubound error.' )
+                      call mpp_error( FATAL, &
+                                     &  'MPP_COMPLETE_DO__UPDATE_V: folded-east CGRID_NE west edge ubound error.' )
                  do l=1,l_size
                     ptr_fieldx = f_addrsx(l, 1)
                     do k = 1,ke_list(l,tMe)

--- a/mpp/include/mpp_do_update_nest.h
+++ b/mpp/include/mpp_do_update_nest.h
@@ -258,8 +258,8 @@ subroutine MPP_DO_UPDATE_NEST_FINE_3D_(f_addrs, nest_domain, update, d_type, ke,
 end subroutine MPP_DO_UPDATE_NEST_FINE_3D_
 
 #ifdef VECTOR_FIELD_
-subroutine MPP_DO_UPDATE_NEST_FINE_3D_V_(f_addrsx, f_addrsy, nest_domain, update_x, update_y, d_type, ke, wb_addrsx, wb_addrsy, &
-                                   eb_addrsx, eb_addrsy, sb_addrsx, sb_addrsy, nb_addrsx, nb_addrsy, flags)
+subroutine MPP_DO_UPDATE_NEST_FINE_3D_V_(f_addrsx, f_addrsy, nest_domain, update_x, update_y, d_type, ke, wb_addrsx, &
+                                   wb_addrsy, eb_addrsx, eb_addrsy, sb_addrsx, sb_addrsy, nb_addrsx, nb_addrsy, flags)
   integer(i8_kind),         intent(in) :: f_addrsx(:), f_addrsy(:)
   type(nest_level_type),      intent(in) :: nest_domain
   type(nestSpec),             intent(in) :: update_x, update_y
@@ -442,7 +442,8 @@ subroutine MPP_DO_UPDATE_NEST_FINE_3D_V_(f_addrsx, f_addrsy, nest_domain, update
                     end do
                  end do
               case default
-                 call mpp_error(FATAL, "MPP_DO_UPDATE_NEST_FINE_3D_V X: pack rotate must be ZERO, MINUS_NINETY or NINETY")
+                 call mpp_error(FATAL, &
+                                &  "MPP_DO_UPDATE_NEST_FINE_3D_V X: pack rotate must be ZERO, MINUS_NINETY or NINETY")
               end select
            endif
         end do ! do n = 1, update_x%send(ind_x)%count
@@ -507,7 +508,8 @@ subroutine MPP_DO_UPDATE_NEST_FINE_3D_V_(f_addrsx, f_addrsy, nest_domain, update
                     end do
                  endif
               case default
-                 call mpp_error(FATAL, "MPP_DO_UPDATE_NEST_FINE_3D_V Y: pack rotate must be ZERO, MINUS_NINETY or NINETY")
+                 call mpp_error(FATAL, &
+                                &  "MPP_DO_UPDATE_NEST_FINE_3D_V Y: pack rotate must be ZERO, MINUS_NINETY or NINETY")
               end select
            endif
         end do ! do n = 1, update_x%send(ind_x)%count

--- a/mpp/include/mpp_do_update_nonblock.h
+++ b/mpp/include/mpp_do_update_nonblock.h
@@ -17,7 +17,8 @@
 !* You should have received a copy of the GNU Lesser General Public
 !* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
 !***********************************************************************
-subroutine MPP_START_DO_UPDATE_3D_(id_update, f_addrs, domain, update, d_type, ke_max, ke_list, flags, reuse_id_update, name)
+subroutine MPP_START_DO_UPDATE_3D_(id_update, f_addrs, domain, update, d_type, ke_max, ke_list, flags, &
+                                  &  reuse_id_update, name)
   integer,                    intent(in) :: id_update
   integer(i8_kind),         intent(in) :: f_addrs(:,:)
   type(domain2D),             intent(in) :: domain

--- a/mpp/include/mpp_domains_comm.inc
+++ b/mpp/include/mpp_domains_comm.inc
@@ -66,7 +66,8 @@
                call mpp_error( FATAL, 'MPP_REDISTRIBUTE_INIT_COMM: mismatch between field_in and field_out.' )
           ke = ksize_out
       end if
-      if( ke == 0 )call mpp_error( FATAL, 'MPP_REDISTRIBUTE_INIT_COMM: either domain_in or domain_out must be native.' )
+      if( ke == 0 )call mpp_error( FATAL, &
+         &  'MPP_REDISTRIBUTE_INIT_COMM: either domain_in or domain_out must be native.' )
 !check sizes
       if( domain_in%pe /= NULL_PE )then
           if( isize_in /= domain_in%x(1)%data%size .OR. jsize_in /= domain_in%y(1)%data%size ) &
@@ -192,8 +193,9 @@
          mpp_domains_stack_hwm = max( mpp_domains_stack_hwm, msgsize )
          if( mpp_domains_stack_hwm.GT.mpp_domains_stack_size )then
              write( text,'(i8)' )mpp_domains_stack_hwm
-             call mpp_error( FATAL, 'MPP_REDISTRIBUTE_INIT_COMM: mpp_domains_stack overflow, call mpp_domains_set_stack_size(' &
-                  //trim(text)//') from all PEs.' )
+             call mpp_error( FATAL, &
+                  & 'MPP_REDISTRIBUTE_INIT_COMM: mpp_domains_stack overflow, call mpp_domains_set_stack_size(' &
+                  & //trim(text)//') from all PEs.' )
          end if
       end if
 
@@ -256,7 +258,8 @@
         ioff = -domain%x(1)%data%begin + 1
         joff = -domain%y(1)%data%begin + 1
       else
-        call mpp_error(FATAL,'MPP_GLOBAL_FIELD_INIT_COMM: incoming field array must match either compute domain or data domain.')
+        call mpp_error(FATAL, &
+                 & 'MPP_GLOBAL_FIELD_INIT_COMM: incoming field array must match either compute domain or data domain.')
       endif
 
     ! Create unique domain identifier
@@ -415,8 +418,9 @@
          mpp_domains_stack_hwm = max( mpp_domains_stack_hwm, msgsize )
          if( mpp_domains_stack_hwm.GT.mpp_domains_stack_size )then
              write( text,'(i8)' )mpp_domains_stack_hwm
-             call mpp_error( FATAL, 'MPP_GLOBAL_FIELD_INIT_COMM: mpp_domains_stack overflow, call mpp_domains_set_stack_size(' &
-                  //trim(text)//') from all PEs.' )
+             call mpp_error( FATAL, &
+                  & 'MPP_GLOBAL_FIELD_INIT_COMM: mpp_domains_stack overflow, call mpp_domains_set_stack_size(' &
+                  & //trim(text)//') from all PEs.' )
          end if
       end if
 

--- a/mpp/include/mpp_domains_define.inc
+++ b/mpp/include/mpp_domains_define.inc
@@ -214,12 +214,14 @@
     if(use_extent) then
        ibegin(0) = isg
        do ndiv = 0, ndivs-2
-          if(extent(ndiv) .LE. 0) call mpp_error( FATAL, 'mpp_compute_extent: domain extents must be positive definite.' )
+          if(extent(ndiv) .LE. 0) call mpp_error( FATAL, &
+             &  'mpp_compute_extent: domain extents must be positive definite.' )
           iend(ndiv) = ibegin(ndiv) + extent(ndiv) - 1
           ibegin(ndiv+1) = iend(ndiv) + 1
        enddo
        iend(ndivs-1) = ibegin(ndivs-1) + extent(ndivs-1) - 1
-       if(iend(ndivs-1) .NE. ieg) call mpp_error(FATAL, 'mpp_compute_extent: extent array limits do not match global domain.' )
+       if(iend(ndivs-1) .NE. ieg) call mpp_error(FATAL, &
+          &  'mpp_compute_extent: extent array limits do not match global domain.' )
     else
        do ndiv=0,ndivs-1
           !modified for mirror-symmetry
@@ -319,12 +321,14 @@
     integer              :: halosz, halobegin, haloend
     integer              :: errunit
 
-    if( .NOT.module_is_initialized )call mpp_error( FATAL, 'MPP_DEFINE_DOMAINS1D: You must first call mpp_domains_init.' )
+    if( .NOT.module_is_initialized )call mpp_error( FATAL, &
+       &  'MPP_DEFINE_DOMAINS1D: You must first call mpp_domains_init.' )
     if(size(global_indices(:)) .NE. 2) call mpp_error(FATAL,"mpp_define_domains1D: size of global_indices should be 2")
     !get global indices
     isg = global_indices(1)
     ieg = global_indices(2)
-    if( ndivs.GT.ieg-isg+1 )call mpp_error( FATAL, 'MPP_DEFINE_DOMAINS1D: more divisions requested than rows available.' )
+    if( ndivs.GT.ieg-isg+1 )call mpp_error( FATAL, &
+       &  'MPP_DEFINE_DOMAINS1D: more divisions requested than rows available.' )
     !get the list of PEs on which to assign domains; if pelist is absent use 0..npes-1
     if( PRESENT(pelist) )then
        if( .NOT.any(pelist.EQ.mpp_pe()) )then
@@ -369,7 +373,8 @@
     domain%goffset = 1
     domain%loffset = 1
     if( PRESENT(flags) )then
-       !NEW: obsolete flag global_compute_domain, since ndivs is non-optional and you cannot have global compute and ndivs.NE.1
+       !NEW: obsolete flag global_compute_domain, since ndivs is non-optional and you cannot
+       !have global compute and ndivs.NE.1
        compute_domain_is_global = ndivs.EQ.1
        !if compute domain is global, data domain must also be
        data_domain_is_global    = BTEST(flags,GLOBAL) .OR. compute_domain_is_global
@@ -488,9 +493,11 @@
        "mpp_domains_define.inc(mpp_define_io_domain): io_domain is already defined")
 
     if(mod(layout(1), io_layout(1)) .NE. 0) call mpp_error(FATAL, &
-       "mpp_domains_define.inc(mpp_define_io_domain): "//trim(domain%name)//" domain layout(1) must be divided by io_layout(1)")
+       "mpp_domains_define.inc(mpp_define_io_domain): "//trim(domain%name)// &
+                             & " domain layout(1) must be divided by io_layout(1)")
     if(mod(layout(2), io_layout(2)) .NE. 0) call mpp_error(FATAL, &
-       "mpp_domains_define.inc(mpp_define_io_domain): "//trim(domain%name)//" domain layout(2) must be divided by io_layout(2)")
+       "mpp_domains_define.inc(mpp_define_io_domain): "//trim(domain%name)// &
+                             & " domain layout(2) must be divided by io_layout(2)")
     if(size(domain%x(:)) > 1) call mpp_error(FATAL, &
        "mpp_domains_define.inc(mpp_define_io_domain): "//trim(domain%name)// &
        ": multiple tile per pe is not supported yet for this routine")
@@ -617,7 +624,8 @@
   subroutine mpp_define_domains2D( global_indices, layout, domain, pelist, xflags, yflags,    &
          xhalo, yhalo, xextent, yextent, maskmap, name, symmetry,  memory_size,               &
          whalo, ehalo, shalo, nhalo, is_mosaic, tile_count, tile_id, complete, x_cyclic_offset, y_cyclic_offset )
-    !define 2D data and computational domain on global rectilinear cartesian domain (isg:ieg,jsg:jeg) and assign them to PEs
+    !define 2D data and computational domain on global rectilinear cartesian domain (isg:ieg,jsg:jeg)
+    !and assign them to PEs
     integer,          intent(in)           :: global_indices(:) !<(/ isg, ieg, jsg, jeg /)
     integer,          intent(in)           :: layout(:)
     type(domain2D),   intent(inout)        :: domain
@@ -627,23 +635,31 @@
     logical,          intent(in), optional :: maskmap(0:,0:)
     character(len=*), intent(in), optional :: name
     logical,          intent(in), optional :: symmetry
-    logical,          intent(in), optional :: is_mosaic                  !< indicate if calling mpp_define_domains from mpp_define_mosaic.
+    logical,          intent(in), optional :: is_mosaic                  !< indicate if calling mpp_define_domains
+                                                                         !! from mpp_define_mosaic.
     integer,          intent(in), optional :: memory_size(:)
-    integer,          intent(in), optional :: whalo, ehalo, shalo, nhalo !< halo size for West, East, South and North direction.
+    integer,          intent(in), optional :: whalo, ehalo, shalo, nhalo !< halo size for West, East,
+                                                                         !! South and North direction.
                                                                          !< if whalo and ehalo is not present,
                                                                          !< will take the value of xhalo
                                                                          !< if shalo and nhalo is not present,
                                                                          !< will take the value of yhalo
-    integer, intent(in),          optional :: tile_count                 !< tile number on current pe, default value is 1
-                                                                         !< this is for the situation that multiple tiles on one processor.
+    integer, intent(in),          optional :: tile_count                 !< tile number on current pe,
+                                                                         !! default value is 1
+                                                                         !< this is for the
+                                                                         !< situation that
+                                                                         !multiple tiles on one processor
     integer, intent(in),          optional :: tile_id                    !< tile id
-    logical, intent(in),          optional :: complete                   !< true indicate mpp_define_domain is completed for mosaic definition.
+    logical, intent(in),          optional :: complete                   !< true indicate mpp_define_domain
+                                                                         !! is completed for mosaic definition.
     integer, intent(in),          optional :: x_cyclic_offset            !< offset for x-cyclic boundary condition,
                                                                          !< (0,j) = (ni, mod(j+x_cyclic_offset,nj))
-                                                                         !< (ni+1,j) = ( 1, mod(j+nj-x_cyclic_offset,nj) )
+                                                                         !< (ni+1,j) = ( 1,
+                                                                         !mod(j+nj-x_cyclic_offset,nj) )
     integer, intent(in),          optional :: y_cyclic_offset            !< offset for y-cyclic boundary condition
-                                                                         !< (i,0)    = (mod(i+y_cyclic_offset,ni), nj))
-                                                                         !< (i,nj+1) = (mod(mod(i+ni-y_cyclic_offset,ni), 1) )
+                                                                         !!(i,0)    = (mod(i+y_cyclic_offset,ni), nj))
+                                                                         !!(i,nj+1) =(mod(mod(i+ni-y_cyclic_offset,ni),
+                                                                         !! 1) )
 
     integer              :: i, j, m, n, xhalosz, yhalosz, memory_xsize, memory_ysize
     integer              :: whalosz, ehalosz, shalosz, nhalosz
@@ -665,7 +681,8 @@
     logical              :: send(8), recv(8)
 
     outunit = stdout()
-    if( .NOT.module_is_initialized )call mpp_error( FATAL, 'MPP_DEFINE_DOMAINS2D: You must first call mpp_domains_init.' )
+    if( .NOT.module_is_initialized )call mpp_error( FATAL, &
+       &  'MPP_DEFINE_DOMAINS2D: You must first call mpp_domains_init.' )
     if(PRESENT(name)) then
        if(len_trim(name) > NAME_LENGTH) call mpp_error(FATAL,  &
             "mpp_domains_define.inc(mpp_define_domains2D): the len_trim of optional argument name ="//trim(name)// &
@@ -674,7 +691,8 @@
     endif
     if(size(global_indices(:)) .NE. 4) call mpp_error(FATAL,   &
        "mpp_define_domains2D: size of global_indices should be 4 for "//trim(domain%name) )
-    if(size(layout(:)) .NE. 2) call mpp_error(FATAL,"mpp_define_domains2D: size of layout should be 2 for "//trim(domain%name) )
+    if(size(layout(:)) .NE. 2) call mpp_error(FATAL,"mpp_define_domains2D: size of layout should be 2 for "// &
+       & trim(domain%name) )
 
     ndivx = layout(1); ndivy = layout(2)
     isg = global_indices(1); ieg = global_indices(2); jsg = global_indices(3); jeg = global_indices(4)
@@ -712,7 +730,8 @@
     if(PRESENT(x_cyclic_offset)) x_offset = x_cyclic_offset
     if(PRESENT(y_cyclic_offset)) y_offset = y_cyclic_offset
     if(x_offset*y_offset .NE. 0) call mpp_error(FATAL, &
-       'MPP_DEFINE_DOMAINS2D: At least one of x_cyclic_offset and y_cyclic_offset must be zero for '//trim(domain%name))
+       'MPP_DEFINE_DOMAINS2D: At least one of x_cyclic_offset and y_cyclic_offset must be zero for '// &
+       & trim(domain%name))
 
     !--- x_cyclic_offset and y_cyclic_offset should no larger than the global grid size.
     if(abs(x_offset) > jeg-jsg+1) call mpp_error(FATAL, &
@@ -763,7 +782,8 @@
     mask = .TRUE.
     if( PRESENT(maskmap) )then
        if( size(maskmap,1).NE.ndivx .OR. size(maskmap,2).NE.ndivy ) &
-            call mpp_error( FATAL, 'MPP_DEFINE_DOMAINS2D: maskmap array does not match layout for '//trim(domain%name) )
+            call mpp_error( FATAL, 'MPP_DEFINE_DOMAINS2D: maskmap array does not match layout for '// &
+                           & trim(domain%name) )
        mask(:,:) = maskmap(:,:)
     end if
     !number of unmask domains in layout must equal number of PEs assigned
@@ -830,8 +850,10 @@
              domain%list(m)%x(tile)%compute%end   = iend(i)
              domain%list(m)%y(tile)%compute%begin = jbegin(j)
              domain%list(m)%y(tile)%compute%end   = jend(j)
-             domain%list(m)%x(tile)%compute%size  = domain%list(m)%x(tile)%compute%end - domain%list(m)%x(tile)%compute%begin + 1
-             domain%list(m)%y(tile)%compute%size  = domain%list(m)%y(tile)%compute%end - domain%list(m)%y(tile)%compute%begin + 1
+             domain%list(m)%x(tile)%compute%size  = domain%list(m)%x(tile)%compute%end &
+                                                  & - domain%list(m)%x(tile)%compute%begin + 1
+             domain%list(m)%y(tile)%compute%size  = domain%list(m)%y(tile)%compute%end &
+                                                  & - domain%list(m)%y(tile)%compute%begin + 1
              domain%list(m)%tile_id(tile)         = cur_tile_id
              domain%list(m)%x(tile)%pos           = i
              domain%list(m)%y(tile)%pos           = j
@@ -970,8 +992,8 @@
 
        if(nfold == 1) then
            if( x_offset .NE. 0 .OR. y_offset .NE. 0) call mpp_error(FATAL, &
-                  'MPP_DEFINE_DOMAINS2D: For the foled_north/folded_south/fold_east/folded_west boundary condition,  '// &
-                  'x_cyclic_offset and y_cyclic_offset must be zero for '//trim(domain%name))
+               'MPP_DEFINE_DOMAINS2D: For the foled_north/folded_south/fold_east/folded_west boundary condition,  '//&
+               'x_cyclic_offset and y_cyclic_offset must be zero for '//trim(domain%name))
        endif
        if( BTEST(domain%fold,SOUTH) .OR. BTEST(domain%fold,NORTH) )then
           if( domain%y(tile)%cyclic )call mpp_error( FATAL, &
@@ -979,7 +1001,8 @@
           if( modulo(domain%x(tile)%global%size,2).NE.0 ) &
                call mpp_error( FATAL, 'MPP_DEFINE_DOMAINS: number of points in X must be even ' // &
                   'when there is a fold in Y for '//trim(domain%name) )
-          !check if folded domain boundaries line up in X: compute domains lining up is a sufficient condition for symmetry
+          !check if folded domain boundaries line up in X: compute domains lining up is a sufficient
+          !condition for symmetry
           n = ndivx - 1
           do i = 0,n/2
              if( domain%x(tile)%list(i)%compute%size.NE.domain%x(tile)%list(n-i)%compute%size ) &
@@ -993,7 +1016,8 @@
           if( modulo(domain%y(tile)%global%size,2).NE.0 ) &
                call mpp_error( FATAL, 'MPP_DEFINE_DOMAINS: number of points in Y must be even '//&
                    'when there is a fold in X for '//trim(domain%name) )
-          !check if folded domain boundaries line up in Y: compute domains lining up is a sufficient condition for symmetry
+          !check if folded domain boundaries line up in Y: compute domains lining up is a sufficient
+          !condition for symmetry
           n = ndivy - 1
           do i = 0,n/2
              if( domain%y(tile)%list(i)%compute%size.NE.domain%y(tile)%list(n-i)%compute%size ) &
@@ -1091,7 +1115,8 @@
     !print out decomposition, this didn't consider maskmap.
     if( mpp_pe() .EQ. pes(0) .AND. PRESENT(name) )then
        write(*,*) trim(name)//' domain decomposition'
-       write(*,'(a,i4,a,i4,a,i4,a,i4)')'whalo = ', whalosz, ", ehalo = ", ehalosz, ", shalo = ", shalosz, ", nhalo = ", nhalosz
+       write(*,'(a,i4,a,i4,a,i4,a,i4)')'whalo = ', whalosz, ", ehalo = ", ehalosz, ", shalo = ", shalosz, ", &
+            &  nhalo = ", nhalosz
        write (*,110) (domain%x(1)%list(i)%compute%size, i= 0, layout(1)-1)
        write (*,120) (domain%y(1)%list(i)%compute%size, i= 0, layout(2)-1)
 110    format ('  X-AXIS = ',24i4,/,(11x,24i4))
@@ -1182,8 +1207,10 @@ end subroutine check_message_size
                                 istart1, iend1, jstart1, jend1, istart2, iend2, jstart2, jend2, pe_start, &
                                 pe_end, pelist, whalo, ehalo, shalo, nhalo, xextent, yextent,             &
                                 maskmap, name, memory_size, symmetry, xflags, yflags, tile_id )
-    integer,          intent(in)           :: global_indices(:,:)  ! The size of first indice is 4, (/ isg, ieg, jsg, jeg /)
-                                                                   ! The size of second indice is number of tiles in mosaic.
+    integer,          intent(in)           :: global_indices(:,:)  ! The size of first indice is 4, (/
+                                                                   !! isg, ieg, jsg, jeg /)
+                                                                   ! The size of second indice
+                                                                   ! is number of tiles in mosaic.
     integer,          intent(in)           :: layout(:,:)
     type(domain2D),   intent(inout)        :: domain
     integer,          intent(in)           :: num_tile             ! number of tiles in the mosaic
@@ -1258,8 +1285,10 @@ end subroutine check_message_size
     if(size(pe_start(:)) .NE. num_tile .OR. size(pe_end(:)) .NE. num_tile ) call mpp_error(FATAL, &
          'mpp_domains_define.inc: size of pe_start and/or pe_end is not equal num_tile')
     !--- make sure pe_start and pe_end is in the pelist.
-    if( ANY( pe_start < pes(0) ) ) call mpp_error(FATAL, 'mpp_domains_define.inc: not all the pe_start are in the pelist')
-    if( ANY( pe_end > pes(nlist-1)) ) call mpp_error(FATAL, 'mpp_domains_define.inc: not all the pe_end are in the pelist')
+    if( ANY( pe_start < pes(0) ) ) call mpp_error(FATAL, &
+       &  'mpp_domains_define.inc: not all the pe_start are in the pelist')
+    if( ANY( pe_end > pes(nlist-1)) ) call mpp_error(FATAL, &
+       &  'mpp_domains_define.inc: not all the pe_end are in the pelist')
 
     !--- calculate number of tiles on each pe.
     allocate( ntile_per_pe(0:nlist-1) )
@@ -1423,7 +1452,7 @@ end subroutine check_message_size
           call mpp_define_domains(global_indices(:,n), layout(:,n), domain, pelist=pelist_tile,                   &
                                   whalo=whalo, ehalo=ehalo, shalo=shalo, nhalo=nhalo, xextent=xext, yextent=yext, &
                                   maskmap=mask, name=name, symmetry=is_symmetry, memory_size = memory_size,       &
-                                  is_mosaic = .true., tile_count = tile_count(pe_start(n)), tile_id=tile_id_local(n),   &
+                                  is_mosaic = .true., tile_count = tile_count(pe_start(n)), tile_id=tile_id_local(n), &
                                   complete = n==num_tile)
        end if
        deallocate(mask, xext, yext, pelist_tile)
@@ -1454,8 +1483,10 @@ end subroutine check_message_size
        js1(n) = jstart1(n) + jsgList(t1) - 1; je1(n) = jend1(n) + jsgList(t1) - 1
        is2(n) = istart2(n) + isgList(t2) - 1; ie2(n) = iend2(n) + isgList(t2) - 1
        js2(n) = jstart2(n) + jsgList(t2) - 1; je2(n) = jend2(n) + jsgList(t2) - 1
-       call check_alignment( is1(n), ie1(n), js1(n), je1(n), isgList(t1), iegList(t1), jsgList(t1), jegList(t1), align1(n))
-       call check_alignment( is2(n), ie2(n), js2(n), je2(n), isgList(t2), iegList(t2), jsgList(t2), jegList(t2), align2(n))
+       call check_alignment( is1(n), ie1(n), js1(n), je1(n), isgList(t1), iegList(t1), jsgList(t1), &
+                           &  jegList(t1), align1(n))
+       call check_alignment( is2(n), ie2(n), js2(n), je2(n), isgList(t2), iegList(t2), jsgList(t2), &
+                           &  jegList(t2), align2(n))
        if( (align1(n) == WEST .or. align1(n) == EAST ) .NEQV. (align2(n) == WEST .or. align2(n) == EAST ) )&
              domain%rotated_ninety=.true.
     end do
@@ -1619,8 +1650,8 @@ end subroutine check_message_size
     tMe = 1; tNbr = 1
     folded_north = BTEST(domain%fold,NORTH)
     if( BTEST(domain%fold,SOUTH) .OR. BTEST(domain%fold,EAST) .OR. BTEST(domain%fold,WEST) ) then
-       call mpp_error(FATAL, "mpp_domains_define.inc(compute_overlaps): folded south, east or west boundary condition " // &
-            "is not supported, please use other version of compute_overlaps for "//trim(domain%name))
+       call mpp_error(FATAL,"mpp_domains_define.inc(compute_overlaps): folded south, east or west boundary condition "&
+            &//"is not supported, please use other version of compute_overlaps for "//trim(domain%name))
     endif
 
     nsend = 0
@@ -1859,7 +1890,7 @@ end subroutine check_message_size
              if(ie3 .GE. is3) call fill_overlap_send_nofold(overlap, domain, m, is3, ie3, js3, je3, &
                                     isc, iec, jsc, jec, isg, ieg, dir, ioff, domain%x(tMe)%cyclic, folded)
              if(ie2 .GE. is2) then
-                if(je2 == jeg .AND. jec == jeg .AND. folded_north .AND. (position == CORNER .OR. position == NORTH)) then
+                if(je2 == jeg .AND. jec == jeg .AND. folded_north.AND.(position == CORNER .OR. position == NORTH))then
                    call fill_overlap_send_fold(overlap, domain, m, is2, ie2, js2, je2, isc, iec, jsc, jec, &
                                     isg, ieg, dir, ishift, position, ioff, middle)
                 else
@@ -1940,7 +1971,7 @@ end subroutine check_message_size
                 end if
              end if
              if(x_cyclic_offset == 0 .AND. y_cyclic_offset == 0) then
-                if( je == jeg .AND. jec == jeg .AND. folded_north .AND. (position == CORNER .OR. position == NORTH)) then
+                if( je == jeg .AND. jec == jeg .AND. folded_north .AND.(position == CORNER .OR. position == NORTH))then
                    call fill_overlap_send_fold(overlap, domain, m, is, ie, js, je, isc, iec, jsc, jec, &
                         isg, ieg, dir, ishift, position, ioff, middle, domain%symmetry)
                 else
@@ -1953,7 +1984,7 @@ end subroutine check_message_size
              endif
 
              if(ie2 .GE. is2) then
-                if(je2 == jeg .AND. jec == jeg .AND. folded_north .AND. (position == CORNER .OR. position == NORTH)) then
+                if(je2 == jeg .AND. jec == jeg .AND. folded_north .AND.(position == CORNER .OR. position == NORTH))then
                    call fill_overlap_send_fold(overlap, domain, m, is2, ie2, js2, je2, isc, iec, jsc, jec, &
                                     isg, ieg, dir, ishift, position, ioff, middle, domain%symmetry)
                 else
@@ -2051,7 +2082,7 @@ end subroutine check_message_size
              if(ie3 .GE. is3) call fill_overlap_send_nofold(overlap, domain, m, is3, ie3, js3, je3, &
                                     isc, iec, jsc, jec, isg, ieg, dir, ioff, domain%x(tMe)%cyclic, folded)
              if(ie2 .GE. is2) then
-                if(je2 == jeg .AND. jec == jeg .AND. folded_north .AND. (position == CORNER .OR. position == NORTH)) then
+                if(je2 == jeg .AND. jec == jeg .AND. folded_north .AND.(position == CORNER .OR. position == NORTH))then
                    call fill_overlap_send_fold(overlap, domain, m, is2, ie2, js2, je2, isc, iec, jsc, jec, &
                                     isg, ieg, dir, ishift, position, ioff, middle)
                 else
@@ -2335,8 +2366,8 @@ end subroutine check_message_size
           if(je2 .GE. js2)call fill_overlap(overlap, domain, m, is, ie, js2, je2, isd, ied, jsd, jed, &
                isg, ieg, jsg, jeg, dir)
 
-          if(ie2 .GE. is2 .AND. je2 .GE. js2)call fill_overlap(overlap, domain, m, is2, ie2, js2, je2, isd, ied, jsd, jed, &
-               isg, ieg, jsg, jeg, dir)
+          if(ie2 .GE. is2 .AND. je2 .GE. js2)call fill_overlap(overlap, domain, m, is2, ie2, js2, je2, isd, ied, jsd, &
+               & jed, isg, ieg, jsg, jeg, dir)
 
 
           !recv_w
@@ -2415,8 +2446,8 @@ end subroutine check_message_size
                      isg, ieg, dir, ioff, domain%x(tMe)%cyclic, folded)
              endif
 
-             if(ie3 .GE. is3) call fill_overlap_recv_nofold(overlap, domain, m, is3, ie3, js3, je3, isd3, ied3, jsd3, jed3, &
-                     isg, ieg, dir, ioff, domain%x(tMe)%cyclic, folded)
+             if(ie3 .GE. is3) call fill_overlap_recv_nofold(overlap, domain, m, is3, ie3, js3, je3, isd3, ied3, jsd3, &
+                     & jed3, isg, ieg, dir, ioff, domain%x(tMe)%cyclic, folded)
 
              if(ie2 .GE. is2) then
                 if( jeg .GE. js2 .AND. jeg .LE. je2 .AND. jed2 == jeg .AND. folded_north &
@@ -2625,8 +2656,8 @@ end subroutine check_message_size
                 call fill_overlap_recv_nofold(overlap, domain, m, is, ie, js, je, isd, ied, jsd, jed, &
                      isg, ieg, dir, ioff, domain%x(tMe)%cyclic, folded)
              endif
-             if(ie3 .GE. is3) call fill_overlap_recv_nofold(overlap, domain, m, is3, ie3, js3, je3, isd3, ied3, jsd3, jed3, &
-                     isg, ieg, dir, ioff, domain%x(tMe)%cyclic, folded)
+             if(ie3 .GE. is3) call fill_overlap_recv_nofold(overlap, domain, m, is3, ie3, js3, je3, isd3, ied3, jsd3, &
+                     & jed3, isg, ieg, dir, ioff, domain%x(tMe)%cyclic, folded)
              if(ie2 .GE. is2) then
                 if(jeg .GE. js2 .AND. jeg .LE. je2 .AND. jed2 == jeg .AND. folded_north &
                      .AND. (position == CORNER .OR. position == NORTH)) then
@@ -3013,7 +3044,8 @@ end subroutine check_message_size
        check  => domain%check_N
     case default
        call mpp_error(FATAL, &
-        "mpp_domains_define.inc(compute_overlaps_fold_south): the value of position should be CENTER, EAST, CORNER or NORTH")
+        "mpp_domains_define.inc(compute_overlaps_fold_south): the value of position should be CENTER, EAST, &
+                               &  CORNER or NORTH")
     end select
 
     allocate(overlapList(MAXLIST) )
@@ -3173,7 +3205,8 @@ end subroutine check_message_size
              !--- when the south face is folded, some point at j=nj will be folded.
              !--- the position should be on CORNER or NORTH
              if( js == jsg .AND. (position == CORNER .OR. position == NORTH) &
-                  .AND. ( domain%list(m)%x(tNbr)%compute%begin == isg .OR. domain%list(m)%x(tNbr)%compute%begin-1 .GE. middle)) then
+                  .AND. ( domain%list(m)%x(tNbr)%compute%begin == isg .OR. &
+                        & domain%list(m)%x(tNbr)%compute%begin-1 .GE. middle)) then
                 call insert_update_overlap( overlap, domain%list(m)%pe, &
                                             is, ie, js+1, je, isc, iec, jsc, jec, dir)
                 is = domain%list(m)%x(tNbr)%compute%begin-whalo;    ie = domain%list(m)%x(tNbr)%compute%begin-1
@@ -3233,7 +3266,8 @@ end subroutine check_message_size
           !--- Now calculate the overlapping for fold-edge.
           !--- only position at NORTH and CORNER need to be considered
           if( ( position == NORTH .OR. position == CORNER) ) then
-             if( domain%y(tMe)%data%begin .LE. jsg .AND. jsg .LE. domain%y(tMe)%data%end+jshift )then !fold is within domain
+             if( domain%y(tMe)%data%begin .LE. jsg .AND. jsg .LE. domain%y(tMe)%data%end+jshift )then !fold
+                                                                                                    !! is within domain
                 dir = 3
                 !--- calculate the overlapping for sending
                 if( domain%x(tMe)%pos .LT. (size(domain%x(tMe)%list(:))+1)/2 )then
@@ -3502,7 +3536,8 @@ end subroutine check_message_size
           !--- for folded-south-edge, only need to consider to_pe's south(3) direction
           !--- only position at NORTH and CORNER need to be considered
           if( ( position == NORTH .OR. position == CORNER) ) then
-             if( domain%y(tMe)%data%begin .LE. jsg .AND. jsg .LE. domain%y(tMe)%data%end+jshift )then !fold is within domain
+             if( domain%y(tMe)%data%begin .LE. jsg .AND. jsg .LE. domain%y(tMe)%data%end+jshift )then !fold
+                                                                                                    !! is within domain
                 dir = 3
                 !--- calculating overlapping for receving on north
                 if( domain%x(tMe)%pos .GE. size(domain%x(tMe)%list(:))/2 )then
@@ -3650,7 +3685,8 @@ end subroutine check_message_size
        check  => domain%check_N
     case default
        call mpp_error(FATAL, &
-        "mpp_domains_define.inc(compute_overlaps_fold_west): the value of position should be CENTER, EAST, CORNER or NORTH")
+        "mpp_domains_define.inc(compute_overlaps_fold_west): the value of position should be CENTER, EAST, &
+                               &  CORNER or NORTH")
     end select
 
     !--- overlap is used to store the overlapping temporarily.
@@ -3728,7 +3764,8 @@ end subroutine check_message_size
              !--- when the west face is folded, the south halo points at
              !--- the position should be on CORNER or EAST
              if( is == isg .AND. (position == CORNER .OR. position == EAST) &
-                  .AND. ( domain%list(m)%y(tNbr)%compute%begin == jsg .OR. domain%list(m)%y(tNbr)%compute%begin-1 .GE. middle)) then
+                  .AND. ( domain%list(m)%y(tNbr)%compute%begin == jsg .OR. &
+                  & domain%list(m)%y(tNbr)%compute%begin-1 .GE. middle)) then
                 call insert_update_overlap( overlap, domain%list(m)%pe, &
                                             is+1, ie, js, je, isc, iec, jsc, jec, dir)
                 is = domain%list(m)%x(tNbr)%compute%begin; ie = is
@@ -3866,7 +3903,8 @@ end subroutine check_message_size
           !--- Now calculate the overlapping for fold-edge.
           !--- only position at EAST and CORNER need to be considered
           if( ( position == EAST .OR. position == CORNER) ) then
-             if( domain%x(tMe)%compute%begin-whalo .LE. isg .AND. isg .LE. domain%x(tMe)%data%end+ishift )then !fold is within domain
+             if( domain%x(tMe)%compute%begin-whalo .LE. isg .AND. isg .LE. domain%x(tMe)%data%end+ishift )then !fold
+                                                                                                    !! is within domain
                 dir = 5
                 !--- calculate the overlapping for sending
                 if( domain%y(tMe)%pos .LT. (size(domain%y(tMe)%list(:))+1)/2 )then
@@ -4128,7 +4166,8 @@ end subroutine check_message_size
           !--- for folded-south-edge, only need to consider to_pe's south(3) direction
           !--- only position at EAST and CORNER need to be considered
           if( ( position == EAST .OR. position == CORNER) ) then
-             if( domain%x(tMe)%data%begin .LE. isg .AND. isg .LE. domain%x(tMe)%data%end+ishift )then !fold is within domain
+             if( domain%x(tMe)%data%begin .LE. isg .AND. isg .LE. domain%x(tMe)%data%end+ishift )then !fold
+                                                                                                    !! is within domain
                 dir = 5
                 !--- calculating overlapping for receving on north
                 if( domain%y(tMe)%pos .GE. size(domain%y(tMe)%list(:))/2 )then
@@ -4265,7 +4304,8 @@ end subroutine check_message_size
        check  => domain%check_N
     case default
        call mpp_error(FATAL, &
-        "mpp_domains_define.inc(compute_overlaps_fold_east): the value of position should be CENTER, EAST, CORNER or NORTH")
+        "mpp_domains_define.inc(compute_overlaps_fold_east): the value of position should be CENTER, EAST, &
+                               &  CORNER or NORTH")
     end select
 
     !--- overlap is used to store the overlapping temporarily.
@@ -4377,7 +4417,7 @@ end subroutine check_message_size
                                             is, ie-1, js, je, isc, iec, jsc, jec, dir)
                 !--- consider at i = ieg for east edge.
                 !--- when the data is at corner and not symmetry, j = jsg -1 will get from cyclic condition
-                if(position == CORNER .AND. .NOT. domain%symmetry .AND. domain%list(m)%y(tNbr)%compute%begin == jsg) then
+                if(position == CORNER .AND. .NOT. domain%symmetry .AND. domain%list(m)%y(tNbr)%compute%begin==jsg)then
                    call insert_update_overlap(overlap, domain%list(m)%pe, &
                                               ie, ie, je, je, isc, iec, jsc, jec, dir, .true.)
                 end if
@@ -4489,7 +4529,8 @@ end subroutine check_message_size
           !--- Now calculate the overlapping for fold-edge.
           !--- only position at EAST and CORNER need to be considered
           if( ( position == EAST .OR. position == CORNER) ) then
-             if( domain%x(tMe)%data%begin .LE. ieg .AND. ieg .LE. domain%x(tMe)%data%end+ishift )then !fold is within domain
+             if( domain%x(tMe)%data%begin .LE. ieg .AND. ieg .LE. domain%x(tMe)%data%end+ishift )then !fold
+                                                                                                    !! is within domain
                 dir = 1
                 !--- calculate the overlapping for sending
                 if( domain%y(tMe)%pos .LT. (size(domain%y(tMe)%list(:))+1)/2 )then
@@ -4738,7 +4779,8 @@ end subroutine check_message_size
           !--- for folded-south-edge, only need to consider to_pe's south(3) direction
           !--- only position at EAST and CORNER need to be considered
           if( ( position == EAST .OR. position == CORNER) ) then
-             if( domain%x(tMe)%data%begin .LE. ieg .AND. ieg .LE. domain%x(tMe)%data%end+ishift )then !fold is within domain
+             if( domain%x(tMe)%data%begin .LE. ieg .AND. ieg .LE. domain%x(tMe)%data%end+ishift )then !fold
+                                                                                                    !! is within domain
                 dir = 1
                 !--- calculating overlapping for receving on north
                 if( domain%y(tMe)%pos .GE. size(domain%y(tMe)%list(:))/2 )then
@@ -4945,7 +4987,8 @@ end subroutine check_message_size
     integer                          :: nsend, nrecv, nsend_in, nrecv_in
 
     if( domain%fold .NE. 0) call mpp_error(FATAL, &
-         "mpp_domains_define.inc(set_overlaps): folded domain is not implemented for arbitrary halo update, contact developer")
+         "mpp_domains_define.inc(set_overlaps): folded domain is not implemented for arbitrary halo update, &
+                                &  contact developer")
 
     whalo_in = domain%whalo
     ehalo_in = domain%ehalo
@@ -4981,7 +5024,8 @@ end subroutine check_message_size
     do m = 1, nsend_in
        ptrIn  => overlap_in%send(m)
        if(ptrIn%count .LE. 0) call mpp_error(FATAL, &
-          "mpp_domains_define.inc(set_overlaps): number of overlap for send should be a positive number for"//trim(domain%name) )
+          "mpp_domains_define.inc(set_overlaps): number of overlap for send should be a positive number for"// &
+                                & trim(domain%name) )
        do n = 1, ptrIn%count
           dir = ptrIn%dir(n)
           rotation = ptrIn%rotation(n)
@@ -5285,14 +5329,22 @@ end subroutine check_message_size
        allocate(wCont(n)%refine1(num_contact), wCont(n)%refine2(num_contact) )
        allocate(sCont(n)%refine1(num_contact), sCont(n)%refine2(num_contact) )
        allocate(nCont(n)%refine1(num_contact), nCont(n)%refine2(num_contact) )
-       allocate(eCont(n)%is1(num_contact), eCont(n)%ie1(num_contact), eCont(n)%js1(num_contact), eCont(n)%je1(num_contact))
-       allocate(eCont(n)%is2(num_contact), eCont(n)%ie2(num_contact), eCont(n)%js2(num_contact), eCont(n)%je2(num_contact))
-       allocate(wCont(n)%is1(num_contact), wCont(n)%ie1(num_contact), wCont(n)%js1(num_contact), wCont(n)%je1(num_contact))
-       allocate(wCont(n)%is2(num_contact), wCont(n)%ie2(num_contact), wCont(n)%js2(num_contact), wCont(n)%je2(num_contact))
-       allocate(sCont(n)%is1(num_contact), sCont(n)%ie1(num_contact), sCont(n)%js1(num_contact), sCont(n)%je1(num_contact))
-       allocate(sCont(n)%is2(num_contact), sCont(n)%ie2(num_contact), sCont(n)%js2(num_contact), sCont(n)%je2(num_contact))
-       allocate(nCont(n)%is1(num_contact), nCont(n)%ie1(num_contact), nCont(n)%js1(num_contact), nCont(n)%je1(num_contact))
-       allocate(nCont(n)%is2(num_contact), nCont(n)%ie2(num_contact), nCont(n)%js2(num_contact), nCont(n)%je2(num_contact))
+       allocate(eCont(n)%is1(num_contact), eCont(n)%ie1(num_contact), eCont(n)%js1(num_contact), &
+               &  eCont(n)%je1(num_contact))
+       allocate(eCont(n)%is2(num_contact), eCont(n)%ie2(num_contact), eCont(n)%js2(num_contact), &
+               &  eCont(n)%je2(num_contact))
+       allocate(wCont(n)%is1(num_contact), wCont(n)%ie1(num_contact), wCont(n)%js1(num_contact), &
+               &  wCont(n)%je1(num_contact))
+       allocate(wCont(n)%is2(num_contact), wCont(n)%ie2(num_contact), wCont(n)%js2(num_contact), &
+               &  wCont(n)%je2(num_contact))
+       allocate(sCont(n)%is1(num_contact), sCont(n)%ie1(num_contact), sCont(n)%js1(num_contact), &
+               &  sCont(n)%je1(num_contact))
+       allocate(sCont(n)%is2(num_contact), sCont(n)%ie2(num_contact), sCont(n)%js2(num_contact), &
+               &  sCont(n)%je2(num_contact))
+       allocate(nCont(n)%is1(num_contact), nCont(n)%ie1(num_contact), nCont(n)%js1(num_contact), &
+               &  nCont(n)%je1(num_contact))
+       allocate(nCont(n)%is2(num_contact), nCont(n)%ie2(num_contact), nCont(n)%js2(num_contact), &
+               &  nCont(n)%je2(num_contact))
     end do
 
     !--- set up the east, south, west and north contact for each tile.
@@ -5565,7 +5617,8 @@ end subroutine check_message_size
                    is = max(isc1,isc2); ie = min(iec1,iec2)
                    js = max(jsc1,jsc2); je = min(jec1,jec2)
                    if(ie.GE.is .AND. je.GE.js )then
-                      if(.not. associated(overlapSend(m)%tileMe)) call allocate_update_overlap(overlapSend(m), MAXOVERLAP)
+                      if(.not. associated(overlapSend(m)%tileMe)) call allocate_update_overlap(overlapSend(m), &
+                        &  MAXOVERLAP)
                     call insert_overlap_type(overlapSend(m), domain%list(m)%pe, tMe, tNbr, &
                          is, ie, js, je, dir, rotateSend(n), .true. )
                    endif
@@ -5668,7 +5721,8 @@ end subroutine check_message_size
                    is = max(isd1,isd2); ie = min(ied1,ied2)
                    js = max(jsd1,jsd2); je = min(jed1,jed2)
                    if(ie.GE.is .AND. je.GE.js )then
-                      if(.not. associated(overlapRecv(m)%tileMe)) call allocate_update_overlap(overlapRecv(m), MAXOVERLAP)
+                      if(.not. associated(overlapRecv(m)%tileMe)) call allocate_update_overlap(overlapRecv(m), &
+                        &  MAXOVERLAP)
                     call insert_overlap_type(overlapRecv(m), domain%list(m)%pe, tMe, tNbr, &
                          is, ie, js, je, dir, rotateRecv(n), .true.)
                       count                              = overlapRecv(m)%count
@@ -5737,10 +5791,10 @@ end subroutine check_message_size
                          if(overlapSend(m)%tileMe(l) .NE. tMe) cycle
                          if(overlapSend(m)%tileNbr(l) .NE. tNbr) cycle
                          if(overlapSend(m)%dir(l) .NE. dirlist(n) ) cycle
-                       call insert_overlap_type(domain%update_T%send(nsend2), overlapSend(m)%pe,                     &
-                              overlapSend(m)%tileMe(l), overlapSend(m)%tileNbr(l), overlapSend(m)%is(l), overlapSend(m)%ie(l),  &
-                              overlapSend(m)%js(l), overlapSend(m)%je(l), overlapSend(m)%dir(l), overlapSend(m)%rotation(l),    &
-                            overlapSend(m)%from_contact(l)  )
+                       call insert_overlap_type(domain%update_T%send(nsend2), overlapSend(m)%pe, &
+                              overlapSend(m)%tileMe(l), overlapSend(m)%tileNbr(l), overlapSend(m)%is(l), &
+                              overlapSend(m)%ie(l), overlapSend(m)%js(l), overlapSend(m)%je(l), overlapSend(m)%dir(l),&
+                              overlapSend(m)%rotation(l), overlapSend(m)%from_contact(l)  )
                       end do
                    end do
                 end do
@@ -5804,9 +5858,9 @@ end subroutine check_message_size
                          if(overlapRecv(m)%tileNbr(l) .NE. tNbr) cycle
                          if(overlapRecv(m)%dir(l) .NE. dirlist(n) ) cycle
                        call insert_overlap_type(domain%update_T%recv(nrecv2), overlapRecv(m)%pe, &
-                              overlapRecv(m)%tileMe(l), overlapRecv(m)%tileNbr(l), overlapRecv(m)%is(l), overlapRecv(m)%ie(l),  &
-                              overlapRecv(m)%js(l), overlapRecv(m)%je(l), overlapRecv(m)%dir(l), overlapRecv(m)%rotation(l),    &
-                            overlapRecv(m)%from_contact(l))
+                              overlapRecv(m)%tileMe(l), overlapRecv(m)%tileNbr(l), overlapRecv(m)%is(l), &
+                              overlapRecv(m)%ie(l), overlapRecv(m)%js(l), overlapRecv(m)%je(l), overlapRecv(m)%dir(l),&
+                              overlapRecv(m)%rotation(l), overlapRecv(m)%from_contact(l))
                          count = domain%update_T%recv(nrecv2)%count
                       end do
                    end do
@@ -7490,7 +7544,8 @@ end subroutine mpp_modify_domain1D
 !   <INOUT NAME="domain_out" TYPE="type(domain2D)" > </INOUT>
 
 ! <PUBLICROUTINE>
-subroutine mpp_modify_domain2D(domain_in, domain_out, isc, iec, jsc, jec, isg, ieg, jsg, jeg, whalo, ehalo, shalo, nhalo)
+subroutine mpp_modify_domain2D(domain_in, domain_out, isc, iec, jsc, jec, isg, ieg, jsg, jeg, whalo, ehalo, &
+                              &  shalo, nhalo)
   ! </PUBLICROUTINE>
 type(domain2D), intent(in)    :: domain_in !< The source domain.
 type(domain2D), intent(inout) :: domain_out !< The returned domain.
@@ -7845,7 +7900,8 @@ end subroutine allocate_update_overlap
        overlap%count = overlap%count+1
        count = overlap%count
        if(count > MAXOVERLAP) call mpp_error(FATAL, &
-            "mpp_domains_define.inc(insert_update_overlap): number of overlap is greater than MAXOVERLAP, increase MAXOVERLAP")
+            "mpp_domains_define.inc(insert_update_overlap): number of overlap is greater than MAXOVERLAP, &
+                                   &  increase MAXOVERLAP")
        overlap%is(count) = is
        overlap%ie(count) = ie
        overlap%js(count) = js
@@ -7881,7 +7937,8 @@ subroutine insert_overlap_type(overlap, pe, tileMe, tileNbr, is, ie, js, je, dir
     overlap%count = overlap%count+1
     count = overlap%count
     if(count > MAXOVERLAP) call mpp_error(FATAL, &
-       "mpp_domains_define.inc(insert_overlap_type): number of overlap is greater than MAXOVERLAP, increase MAXOVERLAP")
+       "mpp_domains_define.inc(insert_overlap_type): number of overlap is greater than MAXOVERLAP, &
+                              &  increase MAXOVERLAP")
     overlap%tileMe      (count) = tileMe
     overlap%tileNbr     (count) = tileNbr
     overlap%is          (count) = is

--- a/mpp/include/mpp_domains_define.inc
+++ b/mpp/include/mpp_domains_define.inc
@@ -640,22 +640,20 @@
     integer,          intent(in), optional :: memory_size(:)
     integer,          intent(in), optional :: whalo, ehalo, shalo, nhalo !< halo size for West, East,
                                                                          !! South and North direction.
-                                                                         !< if whalo and ehalo is not present,
-                                                                         !< will take the value of xhalo
-                                                                         !< if shalo and nhalo is not present,
-                                                                         !< will take the value of yhalo
+                                                                         !! if whalo and ehalo is not present,
+                                                                         !! will take the value of xhalo
+                                                                         !! if shalo and nhalo is not present,
+                                                                         !! will take the value of yhalo
     integer, intent(in),          optional :: tile_count                 !< tile number on current pe,
-                                                                         !! default value is 1
-                                                                         !< this is for the
-                                                                         !< situation that
-                                                                         !multiple tiles on one processor
+                                                                         !! default value is 1.
+                                                                         !! this is for the situation that
+                                                                         !! multiple tiles on one processor
     integer, intent(in),          optional :: tile_id                    !< tile id
     logical, intent(in),          optional :: complete                   !< true indicate mpp_define_domain
                                                                          !! is completed for mosaic definition.
     integer, intent(in),          optional :: x_cyclic_offset            !< offset for x-cyclic boundary condition,
-                                                                         !< (0,j) = (ni, mod(j+x_cyclic_offset,nj))
-                                                                         !< (ni+1,j) = ( 1,
-                                                                         !mod(j+nj-x_cyclic_offset,nj) )
+                                                                         !! (0,j) = (ni, mod(j+x_cyclic_offset,nj))
+                                                                         !! (ni+1, j)=(1 ,mod(j+nj-x_cyclic_offset,nj))
     integer, intent(in),          optional :: y_cyclic_offset            !< offset for y-cyclic boundary condition
                                                                          !!(i,0)    = (mod(i+y_cyclic_offset,ni), nj))
                                                                          !!(i,nj+1) =(mod(mod(i+ni-y_cyclic_offset,ni),
@@ -1115,8 +1113,8 @@
     !print out decomposition, this didn't consider maskmap.
     if( mpp_pe() .EQ. pes(0) .AND. PRESENT(name) )then
        write(*,*) trim(name)//' domain decomposition'
-       write(*,'(a,i4,a,i4,a,i4,a,i4)')'whalo = ', whalosz, ", ehalo = ", ehalosz, ", shalo = ", shalosz, ", &
-            &  nhalo = ", nhalosz
+       write(*,'(a,i4,a,i4,a,i4,a,i4)')'whalo = ', whalosz, ", ehalo = ", ehalosz, ", shalo = ", shalosz, &
+                                     & ", nhalo = ", nhalosz
        write (*,110) (domain%x(1)%list(i)%compute%size, i= 0, layout(1)-1)
        write (*,120) (domain%y(1)%list(i)%compute%size, i= 0, layout(2)-1)
 110    format ('  X-AXIS = ',24i4,/,(11x,24i4))
@@ -1207,8 +1205,8 @@ end subroutine check_message_size
                                 istart1, iend1, jstart1, jend1, istart2, iend2, jstart2, jend2, pe_start, &
                                 pe_end, pelist, whalo, ehalo, shalo, nhalo, xextent, yextent,             &
                                 maskmap, name, memory_size, symmetry, xflags, yflags, tile_id )
-    integer,          intent(in)           :: global_indices(:,:)  ! The size of first indice is 4, (/
-                                                                   !! isg, ieg, jsg, jeg /)
+    integer,          intent(in)           :: global_indices(:,:)  ! The size of first indice is 4,
+                                                                   !! (/ isg, ieg, jsg, jeg /)
                                                                    ! The size of second indice
                                                                    ! is number of tiles in mosaic.
     integer,          intent(in)           :: layout(:,:)
@@ -3684,9 +3682,8 @@ end subroutine check_message_size
        update => domain%update_N
        check  => domain%check_N
     case default
-       call mpp_error(FATAL, &
-        "mpp_domains_define.inc(compute_overlaps_fold_west): the value of position should be CENTER, EAST, &
-                               &  CORNER or NORTH")
+       call mpp_error(FATAL, "mpp_domains_define.inc(compute_overlaps_fold_west):"//&
+                           & " the value of position should be CENTER, EAST, CORNER or NORTH")
     end select
 
     !--- overlap is used to store the overlapping temporarily.
@@ -4303,9 +4300,8 @@ end subroutine check_message_size
        update => domain%update_N
        check  => domain%check_N
     case default
-       call mpp_error(FATAL, &
-        "mpp_domains_define.inc(compute_overlaps_fold_east): the value of position should be CENTER, EAST, &
-                               &  CORNER or NORTH")
+       call mpp_error(FATAL, "mpp_domains_define.inc(compute_overlaps_fold_east):"// &
+                           & " the value of position should be CENTER, EAST, CORNER or NORTH")
     end select
 
     !--- overlap is used to store the overlapping temporarily.
@@ -4986,9 +4982,8 @@ end subroutine check_message_size
     type(overlap_type), pointer      :: ptrIn  => NULL()
     integer                          :: nsend, nrecv, nsend_in, nrecv_in
 
-    if( domain%fold .NE. 0) call mpp_error(FATAL, &
-         "mpp_domains_define.inc(set_overlaps): folded domain is not implemented for arbitrary halo update, &
-                                &  contact developer")
+    if( domain%fold .NE. 0) call mpp_error(FATAL, "mpp_domains_define.inc(set_overlaps):"// &
+                               & " folded domain is not implemented for arbitrary halo update, contact developer")
 
     whalo_in = domain%whalo
     ehalo_in = domain%ehalo
@@ -5023,9 +5018,8 @@ end subroutine check_message_size
     !--- setting up overlap.
     do m = 1, nsend_in
        ptrIn  => overlap_in%send(m)
-       if(ptrIn%count .LE. 0) call mpp_error(FATAL, &
-          "mpp_domains_define.inc(set_overlaps): number of overlap for send should be a positive number for"// &
-                                & trim(domain%name) )
+       if(ptrIn%count .LE. 0) call mpp_error(FATAL, "mpp_domains_define.inc(set_overlaps):"// &
+                              " number of overlap for send should be a positive number for"//trim(domain%name) )
        do n = 1, ptrIn%count
           dir = ptrIn%dir(n)
           rotation = ptrIn%rotation(n)
@@ -7899,9 +7893,8 @@ end subroutine allocate_update_overlap
        endif
        overlap%count = overlap%count+1
        count = overlap%count
-       if(count > MAXOVERLAP) call mpp_error(FATAL, &
-            "mpp_domains_define.inc(insert_update_overlap): number of overlap is greater than MAXOVERLAP, &
-                                   &  increase MAXOVERLAP")
+       if(count > MAXOVERLAP) call mpp_error(FATAL, "mpp_domains_define.inc(insert_update_overlap):"//&
+                              & " number of overlap is greater than MAXOVERLAP, increase MAXOVERLAP")
        overlap%is(count) = is
        overlap%ie(count) = ie
        overlap%js(count) = js
@@ -7936,9 +7929,8 @@ subroutine insert_overlap_type(overlap, pe, tileMe, tileNbr, is, ie, js, je, dir
     endif
     overlap%count = overlap%count+1
     count = overlap%count
-    if(count > MAXOVERLAP) call mpp_error(FATAL, &
-       "mpp_domains_define.inc(insert_overlap_type): number of overlap is greater than MAXOVERLAP, &
-                              &  increase MAXOVERLAP")
+    if(count > MAXOVERLAP) call mpp_error(FATAL, "mpp_domains_define.inc(insert_overlap_type):"//&
+                           & " number of overlap is greater than MAXOVERLAP, increase MAXOVERLAP")
     overlap%tileMe      (count) = tileMe
     overlap%tileNbr     (count) = tileNbr
     overlap%is          (count) = is

--- a/mpp/include/mpp_domains_misc.inc
+++ b/mpp/include/mpp_domains_misc.inc
@@ -343,7 +343,8 @@ end subroutine init_nonblock_type
   else if((size(field_in,1) .eq. ieg-isg+1+2*xhalo) .and. (size(field_in,2) .eq. jeg-jsg+1+2*yhalo)) then
      field2(is:ie,js:je) = field_in(is-isd+1:ie-isd+1,js-jsd+1:je-jsd+1)
   else
-     print*, 'on pe ', pe, 'domain: ', isc, iec, jsc, jec, isd, ied, jsd, jed, 'size of field: ', size(field_in,1), size(field_in,2)
+     print*, 'on pe ', pe, 'domain: ', isc, iec, jsc, jec, isd, ied, jsd, jed, 'size of field: ', size(field_in,1), &
+             & size(field_in,2)
      call mpp_error(FATAL,'mpp_check_field: '//trim(mesg)//':field is not on compute, data or global domain')
   endif
 
@@ -772,7 +773,8 @@ end subroutine init_nonblock_type
                 exit
              endif
           enddo
-          if(ind == 0) call mpp_error( FATAL, 'MPP_BROADCAST_DOMAIN_NEST_FINE:native is true, but tile_id is found in tile_nest')
+          if(ind == 0) call mpp_error( FATAL, &
+             &  'MPP_BROADCAST_DOMAIN_NEST_FINE:native is true, but tile_id is found in tile_nest')
           nestsize(ind) = size(domain%list(:))
       end if
       call mpp_max(nestsize, num_nest)

--- a/mpp/include/mpp_domains_util.inc
+++ b/mpp/include/mpp_domains_util.inc
@@ -318,10 +318,12 @@
     integer :: i      !< For loops
 
     call mpp_get_global_domain(domain, xbegin=xbegin, xend=xend, ybegin=ybegin, yend=yend, xsize=xsize, ysize=ysize)
-    call mpp_set_global_domain (domain, 2*xbegin-1, 2*xend+1, 2*ybegin-1, 2*yend+1, 2*(xend-xbegin)+3, 2*(yend-ybegin)+3)
+    call mpp_set_global_domain (domain, 2*xbegin-1, 2*xend+1, 2*ybegin-1, 2*yend+1, 2*(xend-xbegin)+3, &
+                               &  2*(yend-ybegin)+3)
 
     call mpp_get_compute_domain(domain, xbegin=xbegin, xend=xend, ybegin=ybegin, yend=yend, xsize=xsize, ysize=ysize)
-    call mpp_set_compute_domain (domain, 2*xbegin-1, 2*xend+1, 2*ybegin-1, 2*yend+1, 2*(xend-xbegin)+3, 2*(yend-ybegin)+3)
+    call mpp_set_compute_domain (domain, 2*xbegin-1, 2*xend+1, 2*ybegin-1, 2*yend+1, 2*(xend-xbegin)+3, &
+                                &  2*(yend-ybegin)+3)
 
     call mpp_get_data_domain(domain, xbegin=xbegin, xend=xend, ybegin=ybegin, yend=yend, xsize=xsize, ysize=ysize)
     call mpp_set_data_domain (domain, 2*xbegin-1, 2*xend+1, 2*ybegin-1, 2*yend+1, 2*(xend-xbegin)+3, 2*(yend-ybegin)+3)
@@ -633,10 +635,12 @@ subroutine mpp_get_domain_extents1D(domain, xextent, yextent)
 
    if(domain%ntiles .NE. 1) call mpp_error(FATAL,"mpp_domains_util.inc(mpp_get_domain_extents1D): "// &
        "ntiles is more than 1, please use mpp_get_domain_extents2D")
-   if(size(xextent) .NE. size(domain%x(1)%list(:)))  call mpp_error(FATAL,"mpp_domains_util.inc(mpp_get_domain_extents1D): "// &
-       "size(xextent) does not equal to size(domain%x(1)%list(:)))")
-   if(size(yextent) .NE. size(domain%y(1)%list(:)))  call mpp_error(FATAL,"mpp_domains_util.inc(mpp_get_domain_extents1D): "// &
-       "size(yextent) does not equal to size(domain%y(1)%list(:)))")
+   if(size(xextent) .NE. size(domain%x(1)%list(:)))  call mpp_error(FATAL, &
+       & "mpp_domains_util.inc(mpp_get_domain_extents1D): "// &
+       & "size(xextent) does not equal to size(domain%x(1)%list(:)))")
+   if(size(yextent) .NE. size(domain%y(1)%list(:)))  call mpp_error(FATAL, &
+       & "mpp_domains_util.inc(mpp_get_domain_extents1D): "// &
+       & "size(yextent) does not equal to size(domain%y(1)%list(:)))")
    do n = 0, size(domain%x(1)%list(:))-1
       xextent(n) = domain%x(1)%list(n)%compute%size
    enddo
@@ -1430,7 +1434,8 @@ end subroutine mpp_get_tile_compute_domains
     count = overlap%count
     if(size(is(:)) .NE. count .OR. size(ie (:)) .NE. count .OR. size(js (:)) .NE. count .OR.  &
        size(je(:)) .NE. count .OR. size(dir(:)) .NE. count .OR. size(rot(:)) .NE. count ) &
-       call mpp_error( FATAL, "mpp_domains_mod(mpp_get_overlap): size mismatch between number of overlap and array size")
+       call mpp_error( FATAL, &
+                      &  "mpp_domains_mod(mpp_get_overlap): size mismatch between number of overlap and array size")
 
     is  = overlap%is      (1:count)
     ie  = overlap%ie      (1:count)

--- a/mpp/include/mpp_global_field_ug.h
+++ b/mpp/include/mpp_global_field_ug.h
@@ -58,7 +58,8 @@
       if( stackuse.GT.mpp_domains_stack_size )then
           write( text, '(i8)' )stackuse
           call mpp_error( FATAL, &
-               'MPP_DO_GLOBAL_FIELD_UG user stack overflow: call mpp_domains_set_stack_size('//trim(text)//') from all PEs.' )
+               'MPP_DO_GLOBAL_FIELD_UG user stack overflow: call mpp_domains_set_stack_size('//trim(text)// &
+               & ') from all PEs.' )
       end if
       mpp_domains_stack_hwm = max( mpp_domains_stack_hwm, stackuse )
 

--- a/mpp/include/mpp_global_reduce.h
+++ b/mpp/include/mpp_global_reduce.h
@@ -59,12 +59,14 @@
 !field is on compute domain
         ioff = isc
         joff = jsc
-    else if( size(field,1).EQ.domain%x(1)%memory%size+ishift .AND. size(field,2).EQ.domain%y(1)%memory%size+jshift )then
+    else if( size(field,1).EQ.domain%x(1)%memory%size+ishift .AND. size(field, &
+           & 2).EQ.domain%y(1)%memory%size+jshift )then
 !field is on data domain
         ioff = domain%x(1)%data%begin
         joff = domain%y(1)%data%begin
     else
-        call mpp_error( FATAL, 'MPP_GLOBAL_REDUCE_: incoming field array must match either compute domain or data domain.' )
+        call mpp_error( FATAL, &
+                       &  'MPP_GLOBAL_REDUCE_: incoming field array must match either compute domain or data domain.' )
     end if
 
 !get your local max/min

--- a/mpp/include/mpp_global_reduce.h
+++ b/mpp/include/mpp_global_reduce.h
@@ -59,8 +59,7 @@
 !field is on compute domain
         ioff = isc
         joff = jsc
-    else if( size(field,1).EQ.domain%x(1)%memory%size+ishift .AND. size(field, &
-           & 2).EQ.domain%y(1)%memory%size+jshift )then
+    else if( size(field,1).EQ.domain%x(1)%memory%size+ishift .AND. size(field,2).EQ.domain%y(1)%memory%size+jshift)then
 !field is on data domain
         ioff = domain%x(1)%data%begin
         joff = domain%y(1)%data%begin

--- a/mpp/include/mpp_global_sum.h
+++ b/mpp/include/mpp_global_sum.h
@@ -43,16 +43,19 @@
 
     call mpp_get_domain_shift(domain, ishift, jshift, position)
 
-    if( size(field,1).EQ.domain%x(tile)%compute%size+ishift .AND. size(field,2).EQ.domain%y(tile)%compute%size+jshift )then
+    if( size(field,1).EQ.domain%x(tile)%compute%size+ishift .AND. size(field, &
+      & 2).EQ.domain%y(tile)%compute%size+jshift )then
 !field is on compute domain
         ioff = -domain%x(tile)%compute%begin + 1
         joff = -domain%y(tile)%compute%begin + 1
-    else if( size(field,1).EQ.domain%x(tile)%memory%size+ishift .AND. size(field,2).EQ.domain%y(tile)%memory%size+jshift )then
+    else if( size(field,1).EQ.domain%x(tile)%memory%size+ishift .AND. size(field, &
+           & 2).EQ.domain%y(tile)%memory%size+jshift )then
 !field is on data domain
         ioff = -domain%x(tile)%data%begin + 1
         joff = -domain%y(tile)%data%begin + 1
     else
-        call mpp_error( FATAL, 'MPP_GLOBAL_SUM_: incoming field array must match either compute domain or data domain.' )
+        call mpp_error( FATAL, &
+                       &  'MPP_GLOBAL_SUM_: incoming field array must match either compute domain or data domain.' )
     end if
 
     if(domain%ntiles > MAX_TILES)  call mpp_error( FATAL,  &
@@ -108,7 +111,8 @@
              do list = 1, nlist - 1
                 m = mod( domain%pos+nlist-list, nlist )
                 if( domain%list(m)%pe == domain%list(m)%tile_root_pe ) then
-                    call mpp_recv( nbrgsum(1), glen=size(domain%list(m)%x(:)), from_pe=domain%list(m)%pe, tag=COMM_TAG_1)
+                    call mpp_recv( nbrgsum(1), glen=size(domain%list(m)%x(:)), from_pe=domain%list(m)%pe, &
+                                 &  tag=COMM_TAG_1)
                     do n = 1, size(domain%list(m)%x(:))
                        gsum(domain%list(m)%tile_id(n)) = nbrgsum(n)
                     end do
@@ -137,7 +141,8 @@
           MPP_GLOBAL_SUM_ = mpp_reproducing_sum(field2D, overflow_check=overflow_check)
        endif
 #else
-        call mpp_error( FATAL, 'MPP_GLOBAL_SUM_: BITWISE_EFP_SUM is only implemented for real number, contact developer')
+        call mpp_error( FATAL, &
+                       &  'MPP_GLOBAL_SUM_: BITWISE_EFP_SUM is only implemented for real number, contact developer')
 #endif
     else  !this is not bitwise-exact across different PE counts
        ioffset = domain%x(tile)%loffset*ishift; joffset = domain%y(tile)%loffset*jshift

--- a/mpp/include/mpp_global_sum.h
+++ b/mpp/include/mpp_global_sum.h
@@ -43,13 +43,13 @@
 
     call mpp_get_domain_shift(domain, ishift, jshift, position)
 
-    if( size(field,1).EQ.domain%x(tile)%compute%size+ishift .AND. size(field, &
-      & 2).EQ.domain%y(tile)%compute%size+jshift )then
+    if( size(field,1).EQ.domain%x(tile)%compute%size+ishift .AND. &
+      & size(field,2).EQ.domain%y(tile)%compute%size+jshift )then
 !field is on compute domain
         ioff = -domain%x(tile)%compute%begin + 1
         joff = -domain%y(tile)%compute%begin + 1
-    else if( size(field,1).EQ.domain%x(tile)%memory%size+ishift .AND. size(field, &
-           & 2).EQ.domain%y(tile)%memory%size+jshift )then
+    else if( size(field,1).EQ.domain%x(tile)%memory%size+ishift .AND. &
+           & size(field,2).EQ.domain%y(tile)%memory%size+jshift )then
 !field is on data domain
         ioff = -domain%x(tile)%data%begin + 1
         joff = -domain%y(tile)%data%begin + 1

--- a/mpp/include/mpp_global_sum_ad.h
+++ b/mpp/include/mpp_global_sum_ad.h
@@ -48,16 +48,19 @@ subroutine MPP_GLOBAL_SUM_AD_( domain, field, gsum_, flags, position, tile_count
 
     call mpp_get_domain_shift(domain, ishift, jshift, position)
 
-    if( size(field,1).EQ.domain%x(tile)%compute%size+ishift .AND. size(field,2).EQ.domain%y(tile)%compute%size+jshift )then
+    if( size(field,1).EQ.domain%x(tile)%compute%size+ishift .AND. size(field, &
+      & 2).EQ.domain%y(tile)%compute%size+jshift )then
 !field is on compute domain
         ioff = -domain%x(tile)%compute%begin + 1
         joff = -domain%y(tile)%compute%begin + 1
-    else if( size(field,1).EQ.domain%x(tile)%memory%size+ishift .AND. size(field,2).EQ.domain%y(tile)%memory%size+jshift )then
+    else if( size(field,1).EQ.domain%x(tile)%memory%size+ishift .AND. size(field, &
+           & 2).EQ.domain%y(tile)%memory%size+jshift )then
 !field is on data domain
         ioff = -domain%x(tile)%data%begin + 1
         joff = -domain%y(tile)%data%begin + 1
     else
-        call mpp_error( FATAL, 'MPP_GLOBAL_SUM_: incoming field array must match either compute domain or data domain.' )
+        call mpp_error( FATAL, &
+                       &  'MPP_GLOBAL_SUM_: incoming field array must match either compute domain or data domain.' )
     end if
 
     if(domain%ntiles > MAX_TILES)  call mpp_error( FATAL,  &
@@ -137,7 +140,8 @@ subroutine MPP_GLOBAL_SUM_AD_( domain, field, gsum_, flags, position, tile_count
           end do
        end do
 #else
-        call mpp_error( FATAL, 'MPP_GLOBAL_SUM_: BITWISE_EFP_SUM is only implemented for real number, contact developer')
+        call mpp_error( FATAL, &
+                       &  'MPP_GLOBAL_SUM_: BITWISE_EFP_SUM is only implemented for real number, contact developer')
 #endif
     else  !this is not bitwise-exact across different PE counts
        ioffset = domain%x(tile)%loffset*ishift; joffset = domain%y(tile)%loffset*jshift

--- a/mpp/include/mpp_global_sum_ad.h
+++ b/mpp/include/mpp_global_sum_ad.h
@@ -48,13 +48,13 @@ subroutine MPP_GLOBAL_SUM_AD_( domain, field, gsum_, flags, position, tile_count
 
     call mpp_get_domain_shift(domain, ishift, jshift, position)
 
-    if( size(field,1).EQ.domain%x(tile)%compute%size+ishift .AND. size(field, &
-      & 2).EQ.domain%y(tile)%compute%size+jshift )then
+    if( size(field,1).EQ.domain%x(tile)%compute%size+ishift .AND. &
+      & size(field,2).EQ.domain%y(tile)%compute%size+jshift )then
 !field is on compute domain
         ioff = -domain%x(tile)%compute%begin + 1
         joff = -domain%y(tile)%compute%begin + 1
-    else if( size(field,1).EQ.domain%x(tile)%memory%size+ishift .AND. size(field, &
-           & 2).EQ.domain%y(tile)%memory%size+jshift )then
+    else if( size(field,1).EQ.domain%x(tile)%memory%size+ishift .AND. &
+           & size(field,2).EQ.domain%y(tile)%memory%size+jshift )then
 !field is on data domain
         ioff = -domain%x(tile)%data%begin + 1
         joff = -domain%y(tile)%data%begin + 1

--- a/mpp/include/mpp_group_update.h
+++ b/mpp/include/mpp_group_update.h
@@ -970,9 +970,11 @@ subroutine MPP_RESET_GROUP_UPDATE_FIELD_2D_V_(group, fieldx, fieldy)
   if(group%reset_index_v > group%nvector) &
      call mpp_error(FATAL, "MPP_RESET_GROUP_UPDATE_FIELD_2D_V_: group%reset_index_v > group%nvector")
   if(size(fieldx,1) .NE. group%isize_x .OR. size(fieldx,2) .NE. group%jsize_x .OR. group%ksize_v .NE. 1) &
-     call mpp_error(FATAL, "MPP_RESET_GROUP_UPDATE_FIELD_2D_V_: size of fieldx does not match the size stored in group")
+     call mpp_error(FATAL, &
+                    &  "MPP_RESET_GROUP_UPDATE_FIELD_2D_V_: size of fieldx does not match the size stored in group")
   if(size(fieldy,1) .NE. group%isize_y .OR. size(fieldy,2) .NE. group%jsize_y ) &
-     call mpp_error(FATAL, "MPP_RESET_GROUP_UPDATE_FIELD_2D_V_: size of fieldy does not match the size stored in group")
+     call mpp_error(FATAL, &
+                    &  "MPP_RESET_GROUP_UPDATE_FIELD_2D_V_: size of fieldy does not match the size stored in group")
 
   group%addrs_x(group%reset_index_v) = LOC(fieldx)
   group%addrs_y(group%reset_index_v) = LOC(fieldy)
@@ -990,9 +992,11 @@ subroutine MPP_RESET_GROUP_UPDATE_FIELD_3D_V_(group, fieldx, fieldy)
   if(group%reset_index_v > group%nvector) &
      call mpp_error(FATAL, "MPP_RESET_GROUP_UPDATE_FIELD_3D_V_: group%reset_index_v > group%nvector")
   if(size(fieldx,1) .NE. group%isize_x .OR. size(fieldx,2) .NE. group%jsize_x .OR. size(fieldx,3) .NE. group%ksize_v) &
-     call mpp_error(FATAL, "MPP_RESET_GROUP_UPDATE_FIELD_3D_V_: size of fieldx does not match the size stored in group")
+     call mpp_error(FATAL, &
+                    &  "MPP_RESET_GROUP_UPDATE_FIELD_3D_V_: size of fieldx does not match the size stored in group")
   if(size(fieldy,1) .NE. group%isize_y .OR. size(fieldy,2) .NE. group%jsize_y .OR. size(fieldy,3) .NE. group%ksize_v) &
-     call mpp_error(FATAL, "MPP_RESET_GROUP_UPDATE_FIELD_3D_V_: size of fieldy does not match the size stored in group")
+     call mpp_error(FATAL, &
+                    &  "MPP_RESET_GROUP_UPDATE_FIELD_3D_V_: size of fieldy does not match the size stored in group")
 
   group%addrs_x(group%reset_index_v) = LOC(fieldx)
   group%addrs_y(group%reset_index_v) = LOC(fieldy)
@@ -1011,10 +1015,12 @@ subroutine MPP_RESET_GROUP_UPDATE_FIELD_4D_V_(group, fieldx, fieldy)
      call mpp_error(FATAL, "MPP_RESET_GROUP_UPDATE_FIELD_4D_V_: group%reset_index_v > group%nvector")
   if(size(fieldx,1) .NE. group%isize_x .OR. size(fieldx,2) .NE. group%jsize_x .OR. &
               size(fieldx,3)*size(fieldx,4) .NE. group%ksize_v) &
-     call mpp_error(FATAL, "MPP_RESET_GROUP_UPDATE_FIELD_4D_V_: size of fieldx does not match the size stored in group")
+     call mpp_error(FATAL, &
+                    &  "MPP_RESET_GROUP_UPDATE_FIELD_4D_V_: size of fieldx does not match the size stored in group")
   if(size(fieldy,1) .NE. group%isize_y .OR. size(fieldy,2) .NE. group%jsize_y .OR. &
               size(fieldy,3)*size(fieldy,4) .NE. group%ksize_v) &
-     call mpp_error(FATAL, "MPP_RESET_GROUP_UPDATE_FIELD_4D_V_: size of fieldy does not match the size stored in group")
+     call mpp_error(FATAL, &
+                    &  "MPP_RESET_GROUP_UPDATE_FIELD_4D_V_: size of fieldy does not match the size stored in group")
 
   group%addrs_x(group%reset_index_v) = LOC(fieldx)
   group%addrs_y(group%reset_index_v) = LOC(fieldy)

--- a/mpp/include/mpp_io_connect.inc
+++ b/mpp/include/mpp_io_connect.inc
@@ -232,7 +232,8 @@
       if( PRESENT(form) )form_flag = form
 #ifndef use_netCDF
       if( form_flag.EQ.MPP_NETCDF ) &
-           call mpp_error( FATAL, 'MPP_OPEN: To open a file with form=MPP_NETCDF, you must compile mpp_io with -Duse_netCDF.' )
+           call mpp_error( FATAL, &
+                         & 'MPP_OPEN: To open a file with form=MPP_NETCDF, you must compile mpp_io with -Duse_netCDF.')
 #endif
       access_flag = MPP_SEQUENTIAL
       if( PRESENT(access) )access_flag = access
@@ -421,8 +422,8 @@
          endif
       endif
       mpp_file(unit)%name = text
-      if( verbose )print '(a,2i6,x,a,5i5)', 'MPP_OPEN: PE, unit, filename, action, format, access, threading, fileset=', &
-           pe, unit, trim(mpp_file(unit)%name), action_flag, form_flag, access_flag, threading_flag, fileset_flag
+      if(verbose) print '(a,2i6,x,a,5i5)','MPP_OPEN: PE, unit, filename, action, format, access, threading, fileset=',&
+           & pe, unit, trim(mpp_file(unit)%name), action_flag, form_flag, access_flag, threading_flag, fileset_flag
 
 !action: read, write, overwrite, append: act and pos are ignored by netCDF
       if( action_flag.EQ.MPP_RDONLY )then
@@ -452,9 +453,11 @@
               acc = 'SEQUENTIAL'
           else if( access_flag.EQ.MPP_DIRECT )then
               acc = 'DIRECT'
-              if( form_flag.EQ.MPP_ASCII )call mpp_error( FATAL, 'MPP_OPEN: formatted direct access I/O is prohibited.' )
+              if( form_flag.EQ.MPP_ASCII )call mpp_error( FATAL, &
+                 &  'MPP_OPEN: formatted direct access I/O is prohibited.' )
               if( .NOT.PRESENT(recl) ) &
-                   call mpp_error( FATAL, 'MPP_OPEN: recl (record length in bytes) must be specified with access=MPP_DIRECT.' )
+                   call mpp_error( FATAL, &
+                                 & 'MPP_OPEN: recl (record length in bytes) must be specified with access=MPP_DIRECT.')
               mpp_file(unit)%record = 1
               records_per_pe = 1 !each PE writes 1 record per mpp_write
           else
@@ -467,7 +470,8 @@
 !fileset: MULTI or SINGLE (only for multi-threaded I/O
           if( fileset_flag.EQ.MPP_SINGLE )then
               if( form_flag.EQ.MPP_NETCDF .AND. act.EQ.'WRITE' ) &
-                   call mpp_error( FATAL, 'MPP_OPEN: netCDF currently does not support single-file multi-threaded output.' )
+                   call mpp_error( FATAL, &
+                                  &  'MPP_OPEN: netCDF currently does not support single-file multi-threaded output.' )
 
           else if( fileset_flag.NE.MPP_MULTI )then
               call mpp_error( FATAL, 'MPP_OPEN: fileset must be one of MPP_MULTI or MPP_SINGLE.' )
@@ -557,13 +561,15 @@
               if(debug) write(*,*) 'Blocksize for create of ', trim(mpp_file(unit)%name),' is ', fsize
               error = NF__CREATE( trim(mpp_file(unit)%name),NF_CLOBBER, inital, fsize, mpp_file(unit)%ncid )
               call netcdf_err( error, mpp_file(unit) )
-              action_flag = MPP_WRONLY !after setting clobber, there is no further distinction btwn MPP_WRONLY and MPP_OVERWR
+              action_flag = MPP_WRONLY !after setting clobber, there is no further distinction btwn MPP_WRONLY
+                                       !! and MPP_OVERWR
               if( verbose )print '(a,i6,i16)', 'MPP_OPEN: overwrite netCDF file: pe, ncid=', pe, mpp_file(unit)%ncid
           else if( action_flag.EQ.MPP_APPEND )then
               inquire(file=trim(mpp_file(unit)%name),EXIST=exists)
               if (.NOT.exists) call mpp_error(FATAL,'MPP_OPEN:'&
                    &//trim(mpp_file(unit)%name)//' does not exist.')
-              error=NF__OPEN(trim(mpp_file(unit)%name),NF_WRITE,fsize,mpp_file(unit)%ncid);call netcdf_err(error,mpp_file(unit))
+              error=NF__OPEN(trim(mpp_file(unit)%name),NF_WRITE,fsize,mpp_file(unit)%ncid)
+              call netcdf_err(error, mpp_file(unit))
 !get the current time level of the file: writes to this file will be at next time level
               error = NF_INQ_UNLIMDIM( mpp_file(unit)%ncid, unlim%did )
               if( error.EQ.NF_NOERR )then
@@ -580,7 +586,8 @@
                inquire(file=trim(mpp_file(unit)%name),EXIST=exists)
               if (.NOT.exists) call mpp_error(FATAL,'MPP_OPEN:'&
                    &//trim(mpp_file(unit)%name)//' does not exist.')
-              error=NF__OPEN(trim(mpp_file(unit)%name),NF_NOWRITE,fsize,mpp_file(unit)%ncid);call netcdf_err(error,mpp_file(unit))
+              error=NF__OPEN(trim(mpp_file(unit)%name),NF_NOWRITE,fsize,mpp_file(unit)%ncid)
+              call netcdf_err(error, mpp_file(unit))
               if( verbose )print '(a,i6,i16,i4)', 'MPP_OPEN: opening existing netCDF file: pe, ncid, time_axis_id=',&
                    pe, mpp_file(unit)%ncid, mpp_file(unit)%id
               mpp_file(unit)%format=form_flag ! need this for mpp_read
@@ -590,20 +597,24 @@
 #elif use_LARGEFILE
           if( action_flag.EQ.MPP_WRONLY )then
               if(debug) write(*,*) 'Blocksize for create of ', trim(mpp_file(unit)%name),' is ', fsize
-              error = NF__CREATE( trim(mpp_file(unit)%name),IOR(NF_64BIT_OFFSET,NF_NOCLOBBER),inital,fsize,mpp_file(unit)%ncid )
+              error = NF__CREATE( trim(mpp_file(unit)%name),IOR(NF_64BIT_OFFSET,NF_NOCLOBBER),inital,fsize, &
+                                & mpp_file(unit)%ncid )
               call netcdf_err( error, mpp_file(unit) )
               if( verbose )print '(a,i6,i16)', 'MPP_OPEN: new netCDF file: pe, ncid=', pe, mpp_file(unit)%ncid
           else if( action_flag.EQ.MPP_OVERWR )then
               if(debug) write(*,*) 'Blocksize for create of ', trim(mpp_file(unit)%name),' is ', fsize
-              error = NF__CREATE( trim(mpp_file(unit)%name),IOR(NF_64BIT_OFFSET,NF_CLOBBER), inital, fsize, mpp_file(unit)%ncid )
+              error = NF__CREATE( trim(mpp_file(unit)%name),IOR(NF_64BIT_OFFSET,NF_CLOBBER), inital, fsize, &
+                                & mpp_file(unit)%ncid )
               call netcdf_err( error, mpp_file(unit) )
-              action_flag = MPP_WRONLY !after setting clobber, there is no further distinction btwn MPP_WRONLY and MPP_OVERWR
+              action_flag = MPP_WRONLY !after setting clobber, there is no further distinction btwn MPP_WRONLY
+                                       !! and MPP_OVERWR
               if( verbose )print '(a,i6,i16)', 'MPP_OPEN: overwrite netCDF file: pe, ncid=', pe, mpp_file(unit)%ncid
           else if( action_flag.EQ.MPP_APPEND )then
               inquire(file=trim(mpp_file(unit)%name),EXIST=exists)
               if (.NOT.exists) call mpp_error(FATAL,'MPP_OPEN:'&
                    &//trim(mpp_file(unit)%name)//' does not exist.')
-              error=NF__OPEN(trim(mpp_file(unit)%name),NF_WRITE,fsize,mpp_file(unit)%ncid);call netcdf_err(error, mpp_file(unit))
+              error=NF__OPEN(trim(mpp_file(unit)%name),NF_WRITE,fsize,mpp_file(unit)%ncid)
+              call netcdf_err(error, mpp_file(unit))
 !get the current time level of the file: writes to this file will be at next time level
               error = NF_INQ_UNLIMDIM( mpp_file(unit)%ncid, unlim%did )
               if( error.EQ.NF_NOERR )then
@@ -620,7 +631,8 @@
                inquire(file=trim(mpp_file(unit)%name),EXIST=exists)
               if (.NOT.exists) call mpp_error(FATAL,'MPP_OPEN:'&
                    &//trim(mpp_file(unit)%name)//' does not exist.')
-              error=NF__OPEN(trim(mpp_file(unit)%name),NF_NOWRITE,fsize,mpp_file(unit)%ncid);call netcdf_err(error,mpp_file(unit))
+              error=NF__OPEN(trim(mpp_file(unit)%name),NF_NOWRITE,fsize,mpp_file(unit)%ncid)
+              call netcdf_err(error, mpp_file(unit))
               if( verbose )print '(a,i6,i16,i4)', 'MPP_OPEN: opening existing netCDF file: pe, ncid, time_axis_id=',&
                    pe, mpp_file(unit)%ncid, mpp_file(unit)%id
               mpp_file(unit)%format=form_flag ! need this for mpp_read
@@ -630,20 +642,24 @@
 #else
           if( action_flag.EQ.MPP_WRONLY )then
               if(debug) write(*,*) 'Blocksize for create of ', trim(mpp_file(unit)%name),' is ', fsize
-              error=NF__CREATE( trim(mpp_file(unit)%name), IOR(NF_NETCDF4,NF_CLASSIC_MODEL), inital, fsize, mpp_file(unit)%ncid )
+              error=NF__CREATE( trim(mpp_file(unit)%name), IOR(NF_NETCDF4,NF_CLASSIC_MODEL), inital, fsize, &
+                              & mpp_file(unit)%ncid )
               call netcdf_err( error, mpp_file(unit) )
               if( verbose )print '(a,i6,i16)', 'MPP_OPEN: new netCDF file: pe, ncid=', pe, mpp_file(unit)%ncid
           else if( action_flag.EQ.MPP_OVERWR )then
               if(debug) write(*,*) 'Blocksize for create of ', trim(mpp_file(unit)%name),' is ', fsize
-              error=NF__CREATE( trim(mpp_file(unit)%name), IOR(NF_NETCDF4,NF_CLASSIC_MODEL), inital, fsize, mpp_file(unit)%ncid )
+              error=NF__CREATE( trim(mpp_file(unit)%name), IOR(NF_NETCDF4,NF_CLASSIC_MODEL), inital, fsize, &
+                              & mpp_file(unit)%ncid )
               call netcdf_err( error, mpp_file(unit) )
-              action_flag = MPP_WRONLY !after setting clobber, there is no further distinction btwn MPP_WRONLY and MPP_OVERWR
+              action_flag = MPP_WRONLY !after setting clobber, there is no further distinction btwn MPP_WRONLY
+                                       !! and MPP_OVERWR
               if( verbose )print '(a,i6,i16)', 'MPP_OPEN: overwrite netCDF file: pe, ncid=', pe, mpp_file(unit)%ncid
           else if( action_flag.EQ.MPP_APPEND )then
               inquire(file=trim(mpp_file(unit)%name),EXIST=exists)
               if (.NOT.exists) call mpp_error(FATAL,'MPP_OPEN:'&
                    &//trim(mpp_file(unit)%name)//' does not exist.')
-              error=NF__OPEN(trim(mpp_file(unit)%name),NF_WRITE,fsize,mpp_file(unit)%ncid);call netcdf_err(error,mpp_file(unit))
+              error=NF__OPEN(trim(mpp_file(unit)%name),NF_WRITE,fsize,mpp_file(unit)%ncid)
+              call netcdf_err(error,mpp_file(unit))
 !get the current time level of the file: writes to this file will be at next time level
               error = NF_INQ_UNLIMDIM( mpp_file(unit)%ncid, unlim%did )
               if( error.EQ.NF_NOERR )then
@@ -660,7 +676,8 @@
                inquire(file=trim(mpp_file(unit)%name),EXIST=exists)
               if (.NOT.exists) call mpp_error(FATAL,'MPP_OPEN:'&
                    &//trim(mpp_file(unit)%name)//' does not exist.')
-              error=NF__OPEN(trim(mpp_file(unit)%name),NF_NOWRITE,fsize,mpp_file(unit)%ncid);call netcdf_err(error,mpp_file(unit))
+              error=NF__OPEN(trim(mpp_file(unit)%name),NF_NOWRITE,fsize,mpp_file(unit)%ncid)
+              call netcdf_err(error,mpp_file(unit))
               if( verbose )print '(a,i6,i16,i4)', 'MPP_OPEN: opening existing netCDF file: pe, ncid, time_axis_id=',&
                    pe, mpp_file(unit)%ncid, mpp_file(unit)%id
               mpp_file(unit)%format=form_flag ! need this for mpp_read
@@ -683,13 +700,14 @@
           end if
           inquire( file=trim(mpp_file(unit)%name), EXIST=exists )
           if( exists .AND. action_flag.EQ.MPP_WRONLY ) &
-               call mpp_error( WARNING, 'MPP_OPEN: File '//trim(mpp_file(unit)%name)//' opened WRONLY already exists!' )
+               call mpp_error( WARNING, 'MPP_OPEN: File '//trim(mpp_file(unit)%name)//' opened WRONLY already exists!')
           if( action_flag.EQ.MPP_OVERWR )action_flag = MPP_WRONLY
 !perform the OPEN here
           ios = 0
           if( PRESENT(recl) )then
               if( verbose )print '(2(x,a,i6),5(x,a),a,i8)', 'MPP_OPEN: PE=', pe, &
-                   'unit=', unit, trim(mpp_file(unit)%name), 'attributes=', trim(acc), trim(for), trim(act), ' RECL=', recl
+                   'unit=', unit, trim(mpp_file(unit)%name), 'attributes=', trim(acc), trim(for), trim(act), &
+                                      &  ' RECL=', recl
               open( unit, file=trim(mpp_file(unit)%name), access=acc, form=for, action=act, recl=recl,iostat=ios )
           else
               if( verbose )print '(2(x,a,i6),6(x,a))',      'MPP_OPEN: PE=', pe, &
@@ -716,7 +734,8 @@
       if( PRESENT(nohdrs) )mpp_file(unit)%nohdrs = nohdrs
 
       if( action_flag.EQ.MPP_WRONLY )then
-          if( form_flag.NE.MPP_NETCDF .AND. access_flag.EQ.MPP_DIRECT )call mpp_write_meta( unit, 'record_length', ival=recl )
+          if( form_flag.NE.MPP_NETCDF .AND. access_flag.EQ.MPP_DIRECT )call mpp_write_meta( unit, &
+            &  'record_length', ival=recl )
 !actual file name
           call mpp_write_meta( unit, 'filename', cval=mpp_file(unit)%name)
 !MPP_IO package version

--- a/mpp/include/mpp_io_misc.inc
+++ b/mpp/include/mpp_io_misc.inc
@@ -95,7 +95,8 @@
 
 ! determine the pack_size
       pack_size = size(transfer(doubledata, realarray))
-      if( pack_size .NE. 1 .AND. pack_size .NE. 2) call mpp_error(FATAL,'mpp_io_mod(mpp_io_init): pack_size should be 1 or 2')
+      if( pack_size .NE. 1 .AND. pack_size .NE. 2) call mpp_error(FATAL, &
+         & 'mpp_io_mod(mpp_io_init): pack_size should be 1 or 2')
 
 !initialize default_field
       default_field%name = 'noname'
@@ -137,7 +138,8 @@
 !up to MAXUNITS fortran units and MAXUNITS netCDF units are supported
 !file attributes (opened, format, access, threading, fileset) are saved against the unit number
 !external handles to netCDF units are saved from maxunits+1:2*maxunits
-      allocate( mpp_file(NULLUNIT:2*maxunits) ) !starts at NULLUNIT=-1, used by non-participant PEs in single-threaded I/O
+      allocate( mpp_file(NULLUNIT:2*maxunits) ) !starts at NULLUNIT=-1, used by non-participant PEs in
+                                                !! single-threaded I/O
       mpp_file(:)%name   = ' '
       mpp_file(:)%action    = -1
       mpp_file(:)%format    = -1
@@ -275,7 +277,8 @@
       if( .NOT.module_is_initialized )call mpp_error( FATAL, 'MPP_FLUSH: must first call mpp_io_init.' )
       if( .NOT.mpp_file(unit)%write_on_this_pe) return
       if( .NOT.mpp_file(unit)%opened ) call mpp_error( FATAL, 'MPP_FLUSH: invalid unit number.' )
-      if( .NOT.mpp_file(unit)%initialized )call mpp_error( FATAL, 'MPP_FLUSH: cannot flush a file during writing of metadata.' )
+      if( .NOT.mpp_file(unit)%initialized )call mpp_error( FATAL, &
+         &  'MPP_FLUSH: cannot flush a file during writing of metadata.' )
 
       if( mpp_file(unit)%format.EQ.MPP_NETCDF )then
 #ifdef use_netCDF

--- a/mpp/include/mpp_io_read.inc
+++ b/mpp/include/mpp_io_read.inc
@@ -361,7 +361,8 @@
             call mpp_error( FATAL, 'MPP_READ: ndim of text field should be at most 2')
          end select
 
-         if( verbose )print '(a,2i6,i6,12i4)', 'mpp_read_text: PE, unit, nwords, start, axsiz=', pe, unit, len(data), start, axsiz
+         if( verbose )print '(a,2i6,i6,12i4)', 'mpp_read_text: PE, unit, nwords, start, axsiz=', pe, unit, &
+           &  len(data), start, axsiz
 
           select case (field%type)
              case(NF_CHAR)
@@ -489,8 +490,10 @@
 ! assign global attributes
 !
         do i=1,natt
-           error=NF_INQ_ATTNAME(ncid,NF_GLOBAL,i,name);call netcdf_err( error, mpp_file(unit), string=' Global attribute error.' )
-           error=NF_INQ_ATT(ncid,NF_GLOBAL,trim(name),type,len);call netcdf_err( error, mpp_file(unit), string=' Attribute='//name )
+           error=NF_INQ_ATTNAME(ncid,NF_GLOBAL,i,name)
+           call netcdf_err( error, mpp_file(unit), string=' Global attribute error.' )
+           error=NF_INQ_ATT(ncid,NF_GLOBAL,trim(name),type,len);call netcdf_err( error, mpp_file(unit), &
+                            string=' Attribute='//name )
            mpp_file(unit)%Att(i)%name = name
            mpp_file(unit)%Att(i)%len = len
            mpp_file(unit)%Att(i)%type = type
@@ -516,13 +519,15 @@
                  allocate(mpp_file(unit)%Att(i)%fatt(len), STAT=istat)
                  if ( istat .ne. 0 ) then
                     write(text,'(A)') istat
-                    call mpp_error(FATAL, "mpp_io_mod(mpp_read_meta): Unable to allocate mpp_file%Att%fatt, NF_SHORT case.  "//&
+                    call mpp_error(FATAL, &
+                         & "mpp_io_mod(mpp_read_meta): Unable to allocate mpp_file%Att%fatt, NF_SHORT case.  "//&
                          & "STAT = "//trim(text))
                  end if
                  allocate(i2vals(len), STAT=istat)
                  if ( istat .ne. 0 ) then
                     write(text,'(A)') istat
-                    call mpp_error(FATAL, "mpp_io_mod(mpp_read_meta): Unable to allocate temporary array i2vals.  STAT = "&
+                    call mpp_error(FATAL, &
+                         & "mpp_io_mod(mpp_read_meta): Unable to allocate temporary array i2vals.  STAT = "&
                          & //trim(text))
                  end if
                  error=NF_GET_ATT_INT2(ncid,NF_GLOBAL,name,i2vals)
@@ -534,13 +539,15 @@
                  allocate(mpp_file(unit)%Att(i)%fatt(len), STAT=istat)
                  if ( istat .ne. 0 ) then
                     write(text,'(A)') istat
-                    call mpp_error(FATAL, "mpp_io_mod(mpp_read_meta): Unable to allocate mpp_file%Att%fatt, NF_INT case.  "//&
+                    call mpp_error(FATAL, &
+                         & "mpp_io_mod(mpp_read_meta): Unable to allocate mpp_file%Att%fatt, NF_INT case.  "//&
                          & "STAT = "//trim(text))
                  end if
                  allocate(ivals(len), STAT=istat)
                  if ( istat .ne. 0 ) then
                     write(text,'(A)') istat
-                    call mpp_error(FATAL, "mpp_io_mod(mpp_read_meta): Unable to allocate temporary array ivals.  STAT = "&
+                    call mpp_error(FATAL, &
+                         & "mpp_io_mod(mpp_read_meta): Unable to allocate temporary array ivals.  STAT = "&
                          & //trim(text))
                  end if
                  error=NF_GET_ATT_INT(ncid,NF_GLOBAL,name,ivals)
@@ -554,13 +561,15 @@
                  allocate(mpp_file(unit)%Att(i)%fatt(len), STAT=istat)
                  if ( istat .ne. 0 ) then
                     write(text,'(A)') istat
-                    call mpp_error(FATAL, "mpp_io_mod(mpp_read_meta): Unable to allocate mpp_file%Att%fatt, NF_FLOAT case.  "//&
+                    call mpp_error(FATAL, &
+                         & "mpp_io_mod(mpp_read_meta): Unable to allocate mpp_file%Att%fatt, NF_FLOAT case.  "//&
                          & "STAT = "//trim(text))
                  end if
                  allocate(rvals(len), STAT=istat)
                  if ( istat .ne. 0 ) then
                     write(text,'(A)') istat
-                    call mpp_error(FATAL, "mpp_io_mod(mpp_read_meta): Unable to allocate temporary array rvals.  STAT = "&
+                    call mpp_error(FATAL, &
+                         & "mpp_io_mod(mpp_read_meta): Unable to allocate temporary array rvals.  STAT = "&
                          & //trim(text))
                  end if
                  error=NF_GET_ATT_REAL(ncid,NF_GLOBAL,name,rvals)
@@ -572,13 +581,15 @@
                  allocate(mpp_file(unit)%Att(i)%fatt(len), STAT=istat)
                  if ( istat .ne. 0 ) then
                     write(text,'(A)') istat
-                    call mpp_error(FATAL, "mpp_io_mod(mpp_read_meta): Unable to allocate mpp_file%Att%fatt, NF_DOUBLE case.  "//&
+                    call mpp_error(FATAL, &
+                         & "mpp_io_mod(mpp_read_meta): Unable to allocate mpp_file%Att%fatt, NF_DOUBLE case.  "//&
                          & "STAT = "//trim(text))
                  end if
                  allocate(r8vals(len), STAT=istat)
                  if ( istat .ne. 0 ) then
                     write(text,'(A)') istat
-                    call mpp_error(FATAL, "mpp_io_mod(mpp_read_meta): Unable to allocate temporary array r8vals.  STAT = "&
+                    call mpp_error(FATAL, &
+                         & "mpp_io_mod(mpp_read_meta): Unable to allocate temporary array r8vals.  STAT = "&
                          & //trim(text))
                  end if
                  error=NF_GET_ATT_DOUBLE(ncid,NF_GLOBAL,name,r8vals)
@@ -638,16 +649,19 @@
                     allocate(mpp_file(unit)%Axis(dimid)%data(len), STAT=istat)
                     if ( istat .ne. 0 ) then
                        write(text,'(A)') istat
-                       call mpp_error(FATAL, "mpp_io_mod(mpp_read_meta): Unable to allocate mpp_file%Axis%data, NF_INT case.  "//&
+                       call mpp_error(FATAL, &
+                            & "mpp_io_mod(mpp_read_meta): Unable to allocate mpp_file%Axis%data, NF_INT case.  "//&
                             & "STAT = "//trim(text))
                     end if
                     allocate(ivals(len), STAT=istat)
                     if ( istat .ne. 0 ) then
                        write(text,'(A)') istat
-                       call mpp_error(FATAL, "mpp_io_mod(mpp_read_meta): Unable to allocate temporary array ivals.  STAT = "&
+                       call mpp_error(FATAL, &
+                            & "mpp_io_mod(mpp_read_meta): Unable to allocate temporary array ivals.  STAT = "&
                             & //trim(text))
                     end if
-                    error = NF_GET_VAR_INT(ncid,i,ivals);call netcdf_err( error, mpp_file(unit), mpp_file(unit)%Axis(dimid) )
+                    error = NF_GET_VAR_INT(ncid,i,ivals)
+                    call netcdf_err( error, mpp_file(unit), mpp_file(unit)%Axis(dimid) )
                     mpp_file(unit)%Axis(dimid)%data(1:len)=ivals(1:len)
                     deallocate(ivals)
                  case (NF_FLOAT)
@@ -661,10 +675,12 @@
                     allocate(rvals(len), STAT=istat)
                     if ( istat .ne. 0 ) then
                        write(text,'(A)') istat
-                       call mpp_error(FATAL, "mpp_io_mod(mpp_read_meta): Unable to allocate temporary array rvals.  STAT = "&
+                       call mpp_error(FATAL, &
+                            & "mpp_io_mod(mpp_read_meta): Unable to allocate temporary array rvals.  STAT = "&
                             & //trim(text))
                     end if
-                    error = NF_GET_VAR_REAL(ncid,i,rvals);call netcdf_err( error, mpp_file(unit), mpp_file(unit)%Axis(dimid) )
+                    error = NF_GET_VAR_REAL(ncid,i,rvals)
+                    call netcdf_err( error, mpp_file(unit), mpp_file(unit)%Axis(dimid) )
                     mpp_file(unit)%Axis(dimid)%data(1:len)=rvals(1:len)
                     deallocate(rvals)
                  case (NF_DOUBLE)
@@ -678,10 +694,12 @@
                     allocate(r8vals(len), STAT=istat)
                     if ( istat .ne. 0 ) then
                        write(text,'(A)') istat
-                       call mpp_error(FATAL, "mpp_io_mod(mpp_read_meta): Unable to allocate temporary array r8vals.  STAT = "&
+                       call mpp_error(FATAL, &
+                            & "mpp_io_mod(mpp_read_meta): Unable to allocate temporary array r8vals.  STAT = "&
                             & //trim(text))
                     end if
-                    error = NF_GET_VAR_DOUBLE(ncid,i,r8vals);call netcdf_err( error, mpp_file(unit), mpp_file(unit)%Axis(dimid) )
+                    error = NF_GET_VAR_DOUBLE(ncid,i,r8vals)
+                    call netcdf_err( error, mpp_file(unit), mpp_file(unit)%Axis(dimid) )
                     mpp_file(unit)%Axis(dimid)%data(1:len) = r8vals(1:len)
                     deallocate(r8vals)
                  case default
@@ -693,7 +711,8 @@
                     allocate(mpp_file(unit)%time_values(len), STAT=istat)
                     if ( istat .ne. 0 ) then
                        write(text,'(A)') istat
-                       call mpp_error(FATAL, "mpp_io_mod(mpp_read_meta): Unable to allocate mpp_file%time_valuse.  STAT = "&
+                       call mpp_error(FATAL, &
+                            & "mpp_io_mod(mpp_read_meta): Unable to allocate mpp_file%time_valuse.  STAT = "&
                             & //trim(text))
                     end if
                     select case (type)
@@ -701,7 +720,8 @@
                        allocate(rvals(len), STAT=istat)
                        if ( istat .ne. 0 ) then
                           write(text,'(A)') istat
-                          call mpp_error(FATAL, "mpp_io_mod(mpp_read_meta): Unable to allocate temporary array rvals.  STAT = "&
+                          call mpp_error(FATAL, &
+                               & "mpp_io_mod(mpp_read_meta): Unable to allocate temporary array rvals.  STAT = "&
                                & //trim(text))
                        end if
                        !z1l read from root pe and broadcast to other processor.
@@ -717,7 +737,8 @@
                        allocate(r8vals(len), STAT=istat)
                        if ( istat .ne. 0 ) then
                           write(text,'(A)') istat
-                          call mpp_error(FATAL, "mpp_io_mod(mpp_read_meta): Unable to allocate temporary array r8vals.  STAT = "&
+                          call mpp_error(FATAL, &
+                            & "mpp_io_mod(mpp_read_meta): Unable to allocate temporary array r8vals.  STAT = "&
                             & //trim(text))
                        end if
                        !z1l read from root pe and broadcast to other processor.
@@ -765,7 +786,8 @@
                     allocate(mpp_file(unit)%Axis(dimid)%Att(j)%fatt(len), STAT=istat)
                     if ( istat .ne. 0 ) then
                        write(text,'(A)') istat
-                       call mpp_error(FATAL, "mpp_io_mod(mpp_read_meta): Unable to allocate mpp_file%Axis%Att%fatt, "//&
+                       call mpp_error(FATAL, &
+                            & "mpp_io_mod(mpp_read_meta): Unable to allocate mpp_file%Axis%Att%fatt, "//&
                             & "NF_SHORT CASE.  STAT = "//trim(text))
                     end if
                     allocate(i2vals(len), STAT=istat)
@@ -1007,7 +1029,8 @@
 
            if( .not.isdim )then
 ! for non-dimension variables
-              nv=nv+1; if( nv.GT.mpp_file(unit)%nvar )call mpp_error( FATAL, 'variable index exceeds number of defined variables' )
+              nv=nv+1; if( nv.GT.mpp_file(unit)%nvar )call mpp_error( FATAL, &
+                          &  'variable index exceeds number of defined variables' )
               mpp_file(unit)%Var(nv)%type = type
               mpp_file(unit)%Var(nv)%id = i
               mpp_file(unit)%Var(nv)%name = name
@@ -1038,7 +1061,8 @@
               do j=1,nvdims
                  if(dimids(j).eq.mpp_file(unit)%recdimid  .and. mpp_file(unit)%time_level/=-1)then
                     mpp_file(unit)%Var(nv)%time_axis_index = j   !dimids(j). z1l: Should be j.
-                                                                 !This will cause problem when appending to existed file.
+                                                                 !This will cause problem when
+                                                                 !appending to existed file.
                     mpp_file(unit)%Var(nv)%size(j)=1    ! dimid length set to 1 here for consistency w/ mpp_write
                  else
                     mpp_file(unit)%Var(nv)%size(j)=mpp_file(unit)%Axis(dimids(j))%len
@@ -1052,7 +1076,8 @@
               enddo
 
               do j=1,nvatts
-                 error=NF_INQ_ATTNAME(ncid,i,j,attname);call netcdf_err( error, mpp_file(unit), field=mpp_file(unit)%Var(nv) )
+                 error=NF_INQ_ATTNAME(ncid,i,j,attname)
+                 call netcdf_err( error, mpp_file(unit), field=mpp_file(unit)%Var(nv) )
                  error=NF_INQ_ATT(ncid,i,attname,type,len)
                  call netcdf_err( error, mpp_file(unit),field= mpp_file(unit)%Var(nv), string=' Attribute='//attname )
                  mpp_file(unit)%Var(nv)%Att(j)%name = trim(attname)
@@ -1063,7 +1088,8 @@
                    case (NF_CHAR)
                      if (len.gt.512) call mpp_error(FATAL,'VAR ATT too long')
                      error=NF_GET_ATT_TEXT(ncid,i,trim(attname),mpp_file(unit)%Var(nv)%Att(j)%catt(1:len))
-                     call netcdf_err( error, mpp_file(unit), field=mpp_file(unit)%var(nv), attr=mpp_file(unit)%var(nv)%att(j) )
+                     call netcdf_err( error, mpp_file(unit), field=mpp_file(unit)%var(nv), &
+                                    & attr=mpp_file(unit)%var(nv)%att(j) )
                      if (verbose .and. pe == 0 )&
                            print *, 'Var ',nv,' ATT ',trim(attname),' ',mpp_file(unit)%Var(nv)%Att(j)%catt(1:len)
 ! store integers as float internally
@@ -1071,17 +1097,20 @@
                      allocate(mpp_file(unit)%Var(nv)%Att(j)%fatt(len), STAT=istat)
                      if ( istat .ne. 0 ) then
                         write(text,'(A)') istat
-                        call mpp_error(FATAL, "mpp_io_mod(mpp_read_meta): Unable to allocate mpp_file%Var%Att%fatt, "//&
+                        call mpp_error(FATAL, &
+                             & "mpp_io_mod(mpp_read_meta): Unable to allocate mpp_file%Var%Att%fatt, "//&
                              & "NF_SHORT CASE.  STAT = "//trim(text))
                      end if
                      allocate(i2vals(len), STAT=istat)
                      if ( istat .ne. 0 ) then
                         write(text,'(A)') istat
-                        call mpp_error(FATAL, "mpp_io_mod(mpp_read_meta): Unable to allocate temporary array i2vals.  STAT = "&
+                        call mpp_error(FATAL, &
+                             & "mpp_io_mod(mpp_read_meta): Unable to allocate temporary array i2vals.  STAT = "&
                              & //trim(text))
                      end if
                      error=NF_GET_ATT_INT2(ncid,i,trim(attname),i2vals)
-                     call netcdf_err( error, mpp_file(unit), field=mpp_file(unit)%var(nv), attr=mpp_file(unit)%var(nv)%att(j) )
+                     call netcdf_err( error, mpp_file(unit), field=mpp_file(unit)%var(nv), &
+                                    & attr=mpp_file(unit)%var(nv)%att(j) )
                      mpp_file(unit)%Var(nv)%Att(j)%fatt(1:len)= i2vals(1:len)
                      if( verbose  .and. pe == 0 )&
                           print *, 'Var ',nv,' ATT ',trim(attname),' ',mpp_file(unit)%Var(nv)%Att(j)%fatt
@@ -1090,7 +1119,8 @@
                      allocate(mpp_file(unit)%Var(nv)%Att(j)%fatt(len), STAT=istat)
                      if ( istat .ne. 0 ) then
                         write(text,'(A)') istat
-                        call mpp_error(FATAL, "mpp_io_mod(mpp_read_meta): Unable to allocate mpp_file%Var%Att%fatt, "//&
+                        call mpp_error(FATAL, &
+                             & "mpp_io_mod(mpp_read_meta): Unable to allocate mpp_file%Var%Att%fatt, "//&
                              & "NF_INT CASE.  STAT = "//trim(text))
                      end if
                      allocate(ivals(len), STAT=istat)
@@ -1133,7 +1163,7 @@
                      allocate(mpp_file(unit)%Var(nv)%Att(j)%fatt(len), STAT=istat)
                      if ( istat .ne. 0 ) then
                         write(text,'(A)') istat
-                        call mpp_error(FATAL, "mpp_io_mod(mpp_read_meta): Unable to allocate mpp_file%Var%Att%fatt, "//&
+                        call mpp_error(FATAL,"mpp_io_mod(mpp_read_meta): Unable to allocate mpp_file%Var%Att%fatt, "//&
                              & "NF_DOUBLE CASE.  STAT = "//trim(text))
                      end if
                      allocate(r8vals(len), STAT=istat)

--- a/mpp/include/mpp_io_read.inc
+++ b/mpp/include/mpp_io_read.inc
@@ -1029,8 +1029,8 @@
 
            if( .not.isdim )then
 ! for non-dimension variables
-              nv=nv+1; if( nv.GT.mpp_file(unit)%nvar )call mpp_error( FATAL, &
-                          &  'variable index exceeds number of defined variables' )
+              nv=nv+1
+              if( nv.GT.mpp_file(unit)%nvar )call mpp_error(FATAL,'variable index exceeds number of defined variables')
               mpp_file(unit)%Var(nv)%type = type
               mpp_file(unit)%Var(nv)%id = i
               mpp_file(unit)%Var(nv)%name = name

--- a/mpp/include/mpp_io_unstructured_read.inc
+++ b/mpp/include/mpp_io_unstructured_read.inc
@@ -43,15 +43,18 @@ subroutine mpp_io_unstructured_read_r8_1D(funit, &
     integer(i4_kind),intent(in),optional              :: tindex    !<Time level index for a NetCDF file.
     integer(i4_kind),dimension(:),intent(in),optional :: start     !<Corner indices for a NetCDF file.
     integer(i4_kind),dimension(:),intent(in),optional :: nread     !<Edge lengths for a NetCDF file.
-    integer(i4_kind),intent(in),optional              :: threading !<Flag telling whether one or multiple ranks will read the file.
+    integer(i4_kind),intent(in),optional              :: threading !<Flag telling whether one or multiple
+                                                                   !! ranks will read the file.
 
    !Local variables
-    integer(i4_kind)                          :: threading_flag !<Flag telling whether one or multiple ranks will read the file.  This defaults to MPP_SINGLE.
+    integer(i4_kind)                          :: threading_flag !<Flag telling whether one or multiple
+                                                             !! ranks will read the file.  This defaults to MPP_SINGLE.
     type(domainUG),pointer                     :: io_domain      !<Pointer to the unstructured I/O domain.
     integer(i4_kind)                          :: io_domain_npes !<The total number of ranks in an I/O domain pelist.
     integer(i4_kind),dimension(:),allocatable :: pelist         !<A pelist.
     integer(i4_kind)                          :: p              !<Loop variable.
-    logical(l4_kind)                          :: compute_chksum !<Flag telling whether or not a check-sum of the read-in data is calculated.
+    logical(l4_kind)                          :: compute_chksum !<Flag telling whether or not a check-sum
+                                                                !! of the read-in data is calculated.
     integer(i8_kind)                         :: chk            !<Calculated check-sum for the read in data.
 
    !Start the mpp timer.
@@ -222,15 +225,18 @@ subroutine mpp_io_unstructured_read_r8_2D(funit, &
     integer(i4_kind),intent(in),optional              :: tindex    !<Time level index for a NetCDF file.
     integer(i4_kind),dimension(:),intent(in),optional :: start     !<Corner indices for a NetCDF file.
     integer(i4_kind),dimension(:),intent(in),optional :: nread     !<Edge lengths for a NetCDF file.
-    integer(i4_kind),intent(in),optional              :: threading !<Flag telling whether one or multiple ranks will read the file.
+    integer(i4_kind),intent(in),optional              :: threading !<Flag telling whether one or multiple
+                                                                   !! ranks will read the file.
 
    !Local variables
-    integer(i4_kind)                          :: threading_flag !<Flag telling whether one or multiple ranks will read the file.  This defaults to MPP_SINGLE.
+    integer(i4_kind)                          :: threading_flag !<Flag telling whether one or multiple
+                                                             !! ranks will read the file.  This defaults to MPP_SINGLE.
     type(domainUG),pointer                     :: io_domain      !<Pointer to the unstructured I/O domain.
     integer(i4_kind)                          :: io_domain_npes !<The total number of ranks in an I/O domain pelist.
     integer(i4_kind),dimension(:),allocatable :: pelist         !<A pelist.
     integer(i4_kind)                          :: p              !<Loop variable.
-    logical(l4_kind)                          :: compute_chksum !<Flag telling whether or not a check-sum of the read-in data is calculated.
+    logical(l4_kind)                          :: compute_chksum !<Flag telling whether or not a check-sum
+                                                                !! of the read-in data is calculated.
     integer(i8_kind)                         :: chk            !<Calculated check-sum for the read in data.
 
    !Start the mpp timer.
@@ -401,15 +407,18 @@ subroutine mpp_io_unstructured_read_r8_3D(funit, &
     integer(i4_kind),intent(in),optional              :: tindex    !<Time level index for a NetCDF file.
     integer(i4_kind),dimension(:),intent(in),optional :: start     !<Corner indices for a NetCDF file.
     integer(i4_kind),dimension(:),intent(in),optional :: nread     !<Edge lengths for a NetCDF file.
-    integer(i4_kind),intent(in),optional              :: threading !<Flag telling whether one or multiple ranks will read the file.
+    integer(i4_kind),intent(in),optional              :: threading !<Flag telling whether one or multiple
+                                                                   !! ranks will read the file.
 
    !Local variables
-    integer(i4_kind)                          :: threading_flag !<Flag telling whether one or multiple ranks will read the file.  This defaults to MPP_SINGLE.
+    integer(i4_kind)                          :: threading_flag !<Flag telling whether one or multiple
+                                                             !! ranks will read the file.  This defaults to MPP_SINGLE.
     type(domainUG),pointer                     :: io_domain      !<Pointer to the unstructured I/O domain.
     integer(i4_kind)                          :: io_domain_npes !<The total number of ranks in an I/O domain pelist.
     integer(i4_kind),dimension(:),allocatable :: pelist         !<A pelist.
     integer(i4_kind)                          :: p              !<Loop variable.
-    logical(l4_kind)                          :: compute_chksum !<Flag telling whether or not a check-sum of the read-in data is calculated.
+    logical(l4_kind)                          :: compute_chksum !<Flag telling whether or not a check-sum
+                                                                !! of the read-in data is calculated.
     integer(i8_kind)                         :: chk            !<Calculated check-sum for the read in data.
 
    !Start the mpp timer.
@@ -584,15 +593,18 @@ subroutine mpp_io_unstructured_read_r4_1D(funit, &
     integer(i4_kind),intent(in),optional              :: tindex    !<Time level index for a NetCDF file.
     integer(i4_kind),dimension(:),intent(in),optional :: start     !<Corner indices for a NetCDF file.
     integer(i4_kind),dimension(:),intent(in),optional :: nread     !<Edge lengths for a NetCDF file.
-    integer(i4_kind),intent(in),optional              :: threading !<Flag telling whether one or multiple ranks will read the file.
+    integer(i4_kind),intent(in),optional              :: threading !<Flag telling whether one or multiple
+                                                                   !! ranks will read the file.
 
    !Local variables
-    integer(i4_kind)                          :: threading_flag !<Flag telling whether one or multiple ranks will read the file.  This defaults to MPP_SINGLE.
+    integer(i4_kind)                          :: threading_flag !<Flag telling whether one or multiple
+                                                             !! ranks will read the file.  This defaults to MPP_SINGLE.
     type(domainUG),pointer                     :: io_domain      !<Pointer to the unstructured I/O domain.
     integer(i4_kind)                          :: io_domain_npes !<The total number of ranks in an I/O domain pelist.
     integer(i4_kind),dimension(:),allocatable :: pelist         !<A pelist.
     integer(i4_kind)                          :: p              !<Loop variable.
-    logical(l4_kind)                          :: compute_chksum !<Flag telling whether or not a check-sum of the read-in data is calculated.
+    logical(l4_kind)                          :: compute_chksum !<Flag telling whether or not a check-sum
+                                                                !! of the read-in data is calculated.
     integer(i8_kind)                         :: chk            !<Calculated check-sum for the read in data.
 
    !Start the mpp timer.
@@ -763,15 +775,18 @@ subroutine mpp_io_unstructured_read_r4_2D(funit, &
     integer(i4_kind),intent(in),optional              :: tindex    !<Time level index for a NetCDF file.
     integer(i4_kind),dimension(:),intent(in),optional :: start     !<Corner indices for a NetCDF file.
     integer(i4_kind),dimension(:),intent(in),optional :: nread     !<Edge lengths for a NetCDF file.
-    integer(i4_kind),intent(in),optional              :: threading !<Flag telling whether one or multiple ranks will read the file.
+    integer(i4_kind),intent(in),optional              :: threading !<Flag telling whether one or multiple
+                                                                   !! ranks will read the file.
 
    !Local variables
-    integer(i4_kind)                          :: threading_flag !<Flag telling whether one or multiple ranks will read the file.  This defaults to MPP_SINGLE.
+    integer(i4_kind)                          :: threading_flag !<Flag telling whether one or multiple
+                                                             !! ranks will read the file.  This defaults to MPP_SINGLE.
     type(domainUG),pointer                     :: io_domain      !<Pointer to the unstructured I/O domain.
     integer(i4_kind)                          :: io_domain_npes !<The total number of ranks in an I/O domain pelist.
     integer(i4_kind),dimension(:),allocatable :: pelist         !<A pelist.
     integer(i4_kind)                          :: p              !<Loop variable.
-    logical(l4_kind)                          :: compute_chksum !<Flag telling whether or not a check-sum of the read-in data is calculated.
+    logical(l4_kind)                          :: compute_chksum !<Flag telling whether or not a check-sum
+                                                                !! of the read-in data is calculated.
     integer(i8_kind)                         :: chk            !<Calculated check-sum for the read in data.
 
    !Start the mpp timer.
@@ -942,15 +957,18 @@ subroutine mpp_io_unstructured_read_r4_3D(funit, &
     integer(i4_kind),intent(in),optional              :: tindex    !<Time level index for a NetCDF file.
     integer(i4_kind),dimension(:),intent(in),optional :: start     !<Corner indices for a NetCDF file.
     integer(i4_kind),dimension(:),intent(in),optional :: nread     !<Edge lengths for a NetCDF file.
-    integer(i4_kind),intent(in),optional              :: threading !<Flag telling whether one or multiple ranks will read the file.
+    integer(i4_kind),intent(in),optional              :: threading !<Flag telling whether one or multiple
+                                                                   !! ranks will read the file.
 
    !Local variables
-    integer(i4_kind)                          :: threading_flag !<Flag telling whether one or multiple ranks will read the file.  This defaults to MPP_SINGLE.
+    integer(i4_kind)                          :: threading_flag !<Flag telling whether one or multiple
+                                                             !! ranks will read the file.  This defaults to MPP_SINGLE.
     type(domainUG),pointer                     :: io_domain      !<Pointer to the unstructured I/O domain.
     integer(i4_kind)                          :: io_domain_npes !<The total number of ranks in an I/O domain pelist.
     integer(i4_kind),dimension(:),allocatable :: pelist         !<A pelist.
     integer(i4_kind)                          :: p              !<Loop variable.
-    logical(l4_kind)                          :: compute_chksum !<Flag telling whether or not a check-sum of the read-in data is calculated.
+    logical(l4_kind)                          :: compute_chksum !<Flag telling whether or not a check-sum
+                                                                !! of the read-in data is calculated.
     integer(i8_kind)                         :: chk            !<Calculated check-sum for the read in data.
 
    !Start the mpp timer.

--- a/mpp/include/mpp_io_unstructured_write.inc
+++ b/mpp/include/mpp_io_unstructured_write.inc
@@ -35,12 +35,16 @@ subroutine mpp_io_unstructured_write_r8_1D(funit, &
                                            default_data)
 
    !Inputs/outputs
-    integer(i4_kind),intent(in)                   :: funit        !<A file unit for the to which the data will be written
+    integer(i4_kind),intent(in)                   :: funit        !<A file unit for the to which the
+                                                                  !! data will be written
     type(fieldtype),intent(inout)                 :: field        !<A field whose data will be written
-    type(domainUG),intent(inout)                  :: domain       !<An unstructured mpp domain associatd with the inputted file
+    type(domainUG),intent(inout)                  :: domain       !<An unstructured mpp domain associatd
+                                                                  !! with the inputted file
     real(KIND=r8_kind),dimension(:),intent(inout) :: fdata        !<The data that will be written to the file
-    integer,dimension(:),intent(in)               :: nelems_io    !<Number of grid points in the compressed dimension for each rank (correct
-                                                                  !!sizes only exist for the root rank of I/O domain pelist)
+    integer,dimension(:),intent(in)               :: nelems_io    !<Number of grid points in the compressed
+                                                                  !! dimension for each rank (correct
+                                                                  !!sizes only exist for the
+                                                                  !!root rank of I/O domain pelist)
     real(KIND=r8_kind),intent(in),optional        :: tstamp       !<A time value
     real(KIND=r8_kind),intent(in), optional       :: default_data !<Fill value for the inputted field
 
@@ -49,10 +53,13 @@ subroutine mpp_io_unstructured_write_r8_1D(funit, &
     type(domainUG),pointer                      :: io_domain      !<Pointer to the unstructured I/O domain
     integer(i4_kind)                            :: io_domain_npes !<The total number of ranks in an I/O domain pelist
     integer(i4_kind),dimension(:),allocatable   :: pelist         !<A pelist
-    integer(i4_kind)                            :: nelems         !<Total number of data points (sum(nelems_io)) to be written
+    integer(i4_kind)                            :: nelems         !<Total number of data points (sum(nelems_io))
+                                                                  !! to be written
                                                                   !!by the root rank of the pelist
-    real(KIND=r8_kind),dimension(:),allocatable :: rbuff          !<Buffer used to gather the data onto the root rank of the pelist
-    real(KIND=r8_kind),dimension(:),allocatable :: cdata          !<Array used to write the data to the file after the gather is performed
+    real(KIND=r8_kind),dimension(:),allocatable :: rbuff          !<Buffer used to gather the data onto
+                                                                  !! the root rank of the pelist
+    real(KIND=r8_kind),dimension(:),allocatable :: cdata          !<Array used to write the data to the
+                                                                  !! file after the gather is performed
     integer(i4_kind)                            :: i              !<Loop variable
 
    !Start the mpp timer.
@@ -163,12 +170,16 @@ subroutine mpp_io_unstructured_write_r8_2D(funit, &
                                            default_data)
 
    !Inputs/outputs
-    integer(i4_kind),intent(in)                     :: funit        !<A file unit for the to which the data will be written
+    integer(i4_kind),intent(in)                     :: funit        !<A file unit for the to which the
+                                                                    !! data will be written
     type(fieldtype),intent(inout)                   :: field        !<A field whose data will be written
-    type(domainUG),intent(inout)                    :: domain       !<An unstructured mpp domain associatd with the inputted file
+    type(domainUG),intent(inout)                    :: domain       !<An unstructured mpp domain associatd
+                                                                    !! with the inputted file
     real(KIND=r8_kind),dimension(:,:),intent(inout) :: fdata        !<The data that will be written to the file
-    integer,dimension(:),intent(in)                 :: nelems_io    !<Number of grid points in the compressed dimension for each rank
-                                                                    !!(correct sizes only exist for the root rank of I/O domain pelist)
+    integer,dimension(:),intent(in)                 :: nelems_io    !<Number of grid points in the compressed
+                                                                    !! dimension for each rank
+                                                                    !!(correct sizes only exist
+                                                                    !!for the root rank of I/O domain pelist)
     real(KIND=r8_kind),intent(in),optional          :: tstamp       !<A time value
     real(KIND=r8_kind),intent(in), optional         :: default_data !<Fill value for the inputted field
 
@@ -177,15 +188,23 @@ subroutine mpp_io_unstructured_write_r8_2D(funit, &
     type(domainUG),pointer                        :: io_domain      !<Pointer to the unstructured I/O domain
     integer(i4_kind)                              :: io_domain_npes !<The total number of ranks in an I/O domain pelist
     integer(i4_kind),dimension(:),allocatable     :: pelist         !<A pelist
-    integer(i4_kind)                              :: dim_size_1     !<Number of data points in the first dimension (size(fdata,1))
-    integer(i4_kind)                              :: dim_size_2     !<Number of data points in the second dimension (size(fdata,2))
-    real(KIND=r8_kind),dimension(:),allocatable   :: sbuff          !<Buffer used to gather the data onto the root rank of the pelist
-    integer(i4_kind)                              :: nelems         !<Total number of data points (sum(nelems_io)) to be written
+    integer(i4_kind)                              :: dim_size_1     !<Number of data points in the first
+                                                                    !! dimension (size(fdata,1))
+    integer(i4_kind)                              :: dim_size_2     !<Number of data points in the second
+                                                                    !! dimension (size(fdata,2))
+    real(KIND=r8_kind),dimension(:),allocatable   :: sbuff          !<Buffer used to gather the data
+                                                                    !! onto the root rank of the pelist
+    integer(i4_kind)                              :: nelems         !<Total number of data points (sum(nelems_io))
+                                                                    !! to be written
                                                                     !!by the root rank of the pelist
-    real(KIND=r8_kind),dimension(:),allocatable   :: rbuff          !<Buffer used to gather the data onto the root rank of the pelist
-    real(KIND=r8_kind),dimension(:,:),allocatable :: cdata          !<Array used to write the data to the file after the gather is performed
-    integer(i4_kind)                              :: offset_r       !<Offset for rbuff used to reorder data before netCDF write
-    integer(i4_kind)                              :: offset_c       !<Offset for cdata used to reorder data before netCDF write
+    real(KIND=r8_kind),dimension(:),allocatable   :: rbuff          !<Buffer used to gather the data
+                                                                    !! onto the root rank of the pelist
+    real(KIND=r8_kind),dimension(:,:),allocatable :: cdata          !<Array used to write the data to
+                                                                    !! the file after the gather is performed
+    integer(i4_kind)                              :: offset_r       !<Offset for rbuff used to reorder
+                                                                    !! data before netCDF write
+    integer(i4_kind)                              :: offset_c       !<Offset for cdata used to reorder
+                                                                    !! data before netCDF write
     integer(i4_kind)                              :: i              !<Loop variable
     integer(i4_kind)                              :: j              !<Loop variable
     integer(i4_kind)                              :: k              !<Loop variable
@@ -322,30 +341,45 @@ subroutine mpp_io_unstructured_write_r8_3D(funit, &
                                            default_data)
 
    !Inputs/outputs
-    integer(i4_kind),intent(in)                       :: funit        !<A file unit for the to which the data will be written
+    integer(i4_kind),intent(in)                       :: funit        !<A file unit for the to which
+                                                                      !! the data will be written
     type(fieldtype),intent(inout)                     :: field        !<A field whose data will be written
-    type(domainUG),intent(inout)                      :: domain       !<An unstructured mpp domain associatd with the inputted file
+    type(domainUG),intent(inout)                      :: domain       !<An unstructured mpp domain associatd
+                                                                      !! with the inputted file
     real(KIND=r8_kind),dimension(:,:,:),intent(inout) :: fdata        !<The data that will be written to the file
-    integer,dimension(:),intent(in)                   :: nelems_io    !<Number of grid points in the compressed dimension for each rank
-                                                                      !!(correct sizes only exist for the root rank of I/O domain pelist)
+    integer,dimension(:),intent(in)                   :: nelems_io    !<Number of grid points in the
+                                                                      !! compressed dimension for each rank
+                                                                      !!(correct sizes only
+                                                                      !!exist for the root rank of I/O domain pelist)
     real(KIND=r8_kind),intent(in),optional            :: tstamp       !<A time value
     real(KIND=r8_kind),intent(in), optional           :: default_data !<Fill value for the inputted field
 
    !Local variables
-    real(KIND=r8_kind)                              :: fill           !<Fill value for the inputted field (defaults: zero)
+    real(KIND=r8_kind)                              :: fill           !<Fill value for the inputted field
+                                                                      !! (defaults: zero)
     type(domainUG),pointer                          :: io_domain      !<Pointer to the unstructured I/O domain
-    integer(i4_kind)                                :: io_domain_npes !<The total number of ranks in an I/O domain pelist
+    integer(i4_kind)                                :: io_domain_npes !<The total number of ranks in
+                                                                      !! an I/O domain pelist
     integer(i4_kind),dimension(:),allocatable       :: pelist         !<A pelist
-    integer(i4_kind)                                :: dim_size_1     !<Number of data points in the first dimension (size(fdata,1))
-    integer(i4_kind)                                :: dim_size_2     !<Number of data points in the second dimension (size(fdata,2))
-    integer(i4_kind)                                :: dim_size_3     !<Number of data points in the second dimension (size(fdata,3))
-    real(KIND=r8_kind),dimension(:),allocatable     :: sbuff          !<Buffer used to gather the data onto the root rank of the pelist
-    integer(i4_kind)                                :: nelems         !<Total number of data points (sum(nelems_io)) to be written
+    integer(i4_kind)                                :: dim_size_1     !<Number of data points in the
+                                                                      !! first dimension (size(fdata,1))
+    integer(i4_kind)                                :: dim_size_2     !<Number of data points in the
+                                                                      !! second dimension (size(fdata,2))
+    integer(i4_kind)                                :: dim_size_3     !<Number of data points in the
+                                                                      !! second dimension (size(fdata,3))
+    real(KIND=r8_kind),dimension(:),allocatable     :: sbuff          !<Buffer used to gather the data
+                                                                      !! onto the root rank of the pelist
+    integer(i4_kind)                                :: nelems         !<Total number of data points (sum(nelems_io))
+                                                                      !! to be written
                                                                       !!by the root rank of the pelist
-    real(KIND=r8_kind),dimension(:),allocatable     :: rbuff          !<Buffer used to gather the data onto the root rank of the pelist
-    real(KIND=r8_kind),dimension(:,:,:),allocatable :: cdata          !<Array used to write the data to the file after the gather is performed
-    integer(i4_kind)                                :: offset_r       !<Offset for rbuff used to reorder data before netCDF write
-    integer(i4_kind)                                :: offset_c       !<Offset for cdata used to reorder data before netCDF write
+    real(KIND=r8_kind),dimension(:),allocatable     :: rbuff          !<Buffer used to gather the data
+                                                                      !! onto the root rank of the pelist
+    real(KIND=r8_kind),dimension(:,:,:),allocatable :: cdata          !<Array used to write the data
+                                                                      !! to the file after the gather is performed
+    integer(i4_kind)                                :: offset_r       !<Offset for rbuff used to reorder
+                                                                      !! data before netCDF write
+    integer(i4_kind)                                :: offset_c       !<Offset for cdata used to reorder
+                                                                      !! data before netCDF write
     integer(i4_kind)                                :: i              !<Loop variable
     integer(i4_kind)                                :: j              !<Loop variable
     integer(i4_kind)                                :: k              !<Loop variable
@@ -491,12 +525,17 @@ subroutine mpp_io_unstructured_write_r8_4D(funit, &
                                            default_data)
 
    !Inputs/outputs
-    integer(i4_kind),intent(in)                         :: funit        !<A file unit for the to which the data will be written
+    integer(i4_kind),intent(in)                         :: funit        !<A file unit for the to which
+                                                                        !! the data will be written
     type(fieldtype),intent(inout)                       :: field        !<A field whose data will be written
-    type(domainUG),intent(inout)                        :: domain       !<An unstructured mpp domain associatd with the inputted file
+    type(domainUG),intent(inout)                        :: domain       !<An unstructured mpp domain
+                                                                        !! associatd with the inputted file
     real(KIND=r8_kind),dimension(:,:,:,:),intent(inout) :: fdata        !<The data that will be written to the file
-    integer,dimension(:),intent(in),optional            :: nelems_io_in !<Number of grid points in the unstructured dimension for each rank
-                                                                        !!(correct sizes only exist for the root rank of I/O domain pelist)
+    integer,dimension(:),intent(in),optional            :: nelems_io_in !<Number of grid points in the
+                                                                        !! unstructured dimension for each rank
+                                                                        !!(correct sizes only
+                                                                        !!(cexist for the root
+                                                                        !!rank of I/O domain pelist
     real(KIND=r8_kind),intent(in),optional              :: tstamp       !<A time value
     real(KIND=r8_kind),intent(in), optional             :: default_data !<Fill value for the inputted field
 
@@ -505,17 +544,27 @@ subroutine mpp_io_unstructured_write_r8_4D(funit, &
     type(domainUG),pointer                      :: io_domain        !<Pointer to the unstructured I/O domain
     integer(i4_kind)                            :: io_domain_npes   !<The total number of ranks in an I/O domain pelist
     integer(i4_kind),dimension(:),allocatable   :: pelist           !<A pelist
-    integer(i4_kind),dimension(:),allocatable   :: nelems_io        !<Number of grid points in the unstructured dimension for each rank
-    integer(i4_kind)                            :: compute_size     !<Size of the unstructured compute domain for the current rank
-    integer(i4_kind)                            :: size_fdata_dim_2 !<Number of data points in a non-unstructured dimension (size(fdata,2))
-    integer(i4_kind)                            :: size_fdata_dim_3 !<Number of data points in a non-unstructured dimension (size(fdata,3))
-    integer(i4_kind)                            :: size_fdata_dim_4 !<Number of data points in a non-unstructured dimension (size(fdata,3))
-    integer(i4_kind)                            :: mynelems         !<Number of data points in the unstructured dimension (size(fdata,1))
-    real(KIND=r8_kind),dimension(:),allocatable :: sbuff            !<Buffer used to gather the data onto the root rank of the pelist
-    integer(i4_kind)                            :: nelems           !<Total number of data points (sum(nelems_io)) to be written
+    integer(i4_kind),dimension(:),allocatable   :: nelems_io        !<Number of grid points in the unstructured
+                                                                    !! dimension for each rank
+    integer(i4_kind)                            :: compute_size     !<Size of the unstructured compute
+                                                                    !! domain for the current rank
+    integer(i4_kind)                            :: size_fdata_dim_2 !<Number of data points in a non-unstructured
+                                                                    !! dimension (size(fdata,2))
+    integer(i4_kind)                            :: size_fdata_dim_3 !<Number of data points in a non-unstructured
+                                                                    !! dimension (size(fdata,3))
+    integer(i4_kind)                            :: size_fdata_dim_4 !<Number of data points in a non-unstructured
+                                                                    !! dimension (size(fdata,3))
+    integer(i4_kind)                            :: mynelems         !<Number of data points in the unstructured
+                                                                    !! dimension (size(fdata,1))
+    real(KIND=r8_kind),dimension(:),allocatable :: sbuff            !<Buffer used to gather the data
+                                                                    !! onto the root rank of the pelist
+    integer(i4_kind)                            :: nelems           !<Total number of data points (sum(nelems_io))
+                                                                    !! to be written
                                                                     !!by the root rank of the pelist
-    real(KIND=r8_kind),dimension(:),allocatable :: rbuff            !<Buffer to gather the data onto root rank of pelist
-    real(KIND=r8_kind),dimension(:,:,:,:),allocatable :: cdata      !<Array  to write the data to file after gather is performed
+    real(KIND=r8_kind),dimension(:),allocatable :: rbuff            !<Buffer to gather the data onto
+                                                                    !! root rank of pelist
+    real(KIND=r8_kind),dimension(:,:,:,:),allocatable :: cdata      !<Array  to write the data to file
+                                                                    !! after gather is performed
     integer(i4_kind)                            :: i                !<Loop variable
     integer(i4_kind)                            :: j                !<Loop variable
     integer(i4_kind)                            :: k                !<Loop variable
@@ -682,12 +731,16 @@ subroutine mpp_io_unstructured_write_r4_1D(funit, &
                                            default_data)
 
    !Inputs/outputs
-    integer(i4_kind),intent(in)                   :: funit        !<A file unit for the to which the data will be written
+    integer(i4_kind),intent(in)                   :: funit        !<A file unit for the to which the
+                                                                  !! data will be written
     type(fieldtype),intent(inout)                 :: field        !<A field whose data will be written
-    type(domainUG),intent(inout)                  :: domain       !<An unstructured mpp domain associatd with the inputted file
+    type(domainUG),intent(inout)                  :: domain       !<An unstructured mpp domain associatd
+                                                                  !! with the inputted file
     real(KIND=r4_kind),dimension(:),intent(inout) :: fdata        !<The data that will be written to the file
-    integer,dimension(:),intent(in)               :: nelems_io    !<Number of grid points in the compressed dimension for each rank (correct
-                                                                  !!sizes only exist for the root rank of I/O domain pelist)
+    integer,dimension(:),intent(in)               :: nelems_io    !<Number of grid points in the compressed
+                                                                  !! dimension for each rank (correct
+                                                                  !!sizes only exist for the
+                                                                  !!root rank of I/O domain pelist)
     real(KIND=r4_kind),intent(in),optional        :: tstamp       !<A time value
     real(KIND=r4_kind),intent(in), optional       :: default_data !<Fill value for the inputted field
 
@@ -696,10 +749,13 @@ subroutine mpp_io_unstructured_write_r4_1D(funit, &
     type(domainUG),pointer                      :: io_domain      !<Pointer to the unstructured I/O domain
     integer(i4_kind)                            :: io_domain_npes !<The total number of ranks in an I/O domain pelist
     integer(i4_kind),dimension(:),allocatable   :: pelist         !<A pelist
-    integer(i4_kind)                            :: nelems         !<Total number of data points (sum(nelems_io)) to be written
+    integer(i4_kind)                            :: nelems         !<Total number of data points (sum(nelems_io))
+                                                                  !! to be written
                                                                   !!by the root rank of the pelist
-    real(KIND=r4_kind),dimension(:),allocatable :: rbuff          !<Buffer used to gather the data onto the root rank of the pelist
-    real(KIND=r4_kind),dimension(:),allocatable :: cdata          !<Array used to write the data to the file after the gather is performed
+    real(KIND=r4_kind),dimension(:),allocatable :: rbuff          !<Buffer used to gather the data onto
+                                                                  !! the root rank of the pelist
+    real(KIND=r4_kind),dimension(:),allocatable :: cdata          !<Array used to write the data to the
+                                                                  !! file after the gather is performed
     integer(i4_kind)                            :: i              !<Loop variable
 
    !Start the mpp timer.
@@ -810,12 +866,16 @@ subroutine mpp_io_unstructured_write_r4_2D(funit, &
                                            default_data)
 
    !Inputs/outputs
-    integer(i4_kind),intent(in)                     :: funit        !<A file unit for the to which the data will be written
+    integer(i4_kind),intent(in)                     :: funit        !<A file unit for the to which the
+                                                                    !! data will be written
     type(fieldtype),intent(inout)                   :: field        !<A field whose data will be written
-    type(domainUG),intent(inout)                    :: domain       !<An unstructured mpp domain associatd with the inputted file
+    type(domainUG),intent(inout)                    :: domain       !<An unstructured mpp domain associatd
+                                                                    !! with the inputted file
     real(KIND=r4_kind),dimension(:,:),intent(inout) :: fdata        !<The data that will be written to the file
-    integer,dimension(:),intent(in)                 :: nelems_io    !<Number of grid points in the compressed dimension for each rank
-                                                                    !!(correct sizes only exist for the root rank of I/O domain pelist)
+    integer,dimension(:),intent(in)                 :: nelems_io    !<Number of grid points in the compressed
+                                                                    !! dimension for each rank
+                                                                    !!(correct sizes only exist
+                                                                    !!for the root rank of I/O domain pelist)
     real(KIND=r4_kind),intent(in),optional          :: tstamp       !<A time value
     real(KIND=r4_kind),intent(in), optional         :: default_data !<Fill value for the inputted field
 
@@ -824,15 +884,23 @@ subroutine mpp_io_unstructured_write_r4_2D(funit, &
     type(domainUG),pointer                        :: io_domain      !<Pointer to the unstructured I/O domain
     integer(i4_kind)                              :: io_domain_npes !<The total number of ranks in an I/O domain pelist
     integer(i4_kind),dimension(:),allocatable     :: pelist         !<A pelist
-    integer(i4_kind)                              :: dim_size_1     !<Number of data points in the first dimension (size(fdata,1))
-    integer(i4_kind)                              :: dim_size_2     !<Number of data points in the second dimension (size(fdata,2))
-    real(KIND=r4_kind),dimension(:),allocatable   :: sbuff          !<Buffer used to gather the data onto the root rank of the pelist
-    integer(i4_kind)                              :: nelems         !<Total number of data points (sum(nelems_io)) to be written
+    integer(i4_kind)                              :: dim_size_1     !<Number of data points in the first
+                                                                    !! dimension (size(fdata,1))
+    integer(i4_kind)                              :: dim_size_2     !<Number of data points in the second
+                                                                    !! dimension (size(fdata,2))
+    real(KIND=r4_kind),dimension(:),allocatable   :: sbuff          !<Buffer used to gather the data
+                                                                    !! onto the root rank of the pelist
+    integer(i4_kind)                              :: nelems         !<Total number of data points (sum(nelems_io))
+                                                                    !! to be written
                                                                     !!by the root rank of the pelist
-    real(KIND=r4_kind),dimension(:),allocatable   :: rbuff          !<Buffer used to gather the data onto the root rank of the pelist
-    real(KIND=r4_kind),dimension(:,:),allocatable :: cdata          !<Array used to write the data to the file after the gather is performed
-    integer(i4_kind)                              :: offset_r       !<Offset for rbuff used to reorder data before netCDF write
-    integer(i4_kind)                              :: offset_c       !<Offset for cdata used to reorder data before netCDF write
+    real(KIND=r4_kind),dimension(:),allocatable   :: rbuff          !<Buffer used to gather the data
+                                                                    !! onto the root rank of the pelist
+    real(KIND=r4_kind),dimension(:,:),allocatable :: cdata          !<Array used to write the data to
+                                                                    !! the file after the gather is performed
+    integer(i4_kind)                              :: offset_r       !<Offset for rbuff used to reorder
+                                                                    !! data before netCDF write
+    integer(i4_kind)                              :: offset_c       !<Offset for cdata used to reorder
+                                                                    !! data before netCDF write
     integer(i4_kind)                              :: i              !<Loop variable
     integer(i4_kind)                              :: j              !<Loop variable
     integer(i4_kind)                              :: k              !<Loop variable
@@ -969,30 +1037,45 @@ subroutine mpp_io_unstructured_write_r4_3D(funit, &
                                            default_data)
 
    !Inputs/outputs
-    integer(i4_kind),intent(in)                       :: funit        !<A file unit for the to which the data will be written
+    integer(i4_kind),intent(in)                       :: funit        !<A file unit for the to which
+                                                                      !! the data will be written
     type(fieldtype),intent(inout)                     :: field        !<A field whose data will be written
-    type(domainUG),intent(inout)                      :: domain       !<An unstructured mpp domain associatd with the inputted file
+    type(domainUG),intent(inout)                      :: domain       !<An unstructured mpp domain associatd
+                                                                      !! with the inputted file
     real(KIND=r4_kind),dimension(:,:,:),intent(inout) :: fdata        !<The data that will be written to the file
-    integer,dimension(:),intent(in)                   :: nelems_io    !<Number of grid points in the compressed dimension for each rank
-                                                                      !!(correct sizes only exist for the root rank of I/O domain pelist)
+    integer,dimension(:),intent(in)                   :: nelems_io    !<Number of grid points in the
+                                                                      !! compressed dimension for each rank
+                                                                      !!(correct sizes only
+                                                                      !!exist for the root rank of I/O domain pelist)
     real(KIND=r4_kind),intent(in),optional            :: tstamp       !<A time value
     real(KIND=r4_kind),intent(in), optional           :: default_data !<Fill value for the inputted field
 
    !Local variables
-    real(KIND=r4_kind)                              :: fill           !<Fill value for the inputted field (defaults: zero)
+    real(KIND=r4_kind)                              :: fill           !<Fill value for the inputted field
+                                                                      !! (defaults: zero)
     type(domainUG),pointer                          :: io_domain      !<Pointer to the unstructured I/O domain
-    integer(i4_kind)                                :: io_domain_npes !<The total number of ranks in an I/O domain pelist
+    integer(i4_kind)                                :: io_domain_npes !<The total number of ranks in
+                                                                      !! an I/O domain pelist
     integer(i4_kind),dimension(:),allocatable       :: pelist         !<A pelist
-    integer(i4_kind)                                :: dim_size_1     !<Number of data points in the first dimension (size(fdata,1))
-    integer(i4_kind)                                :: dim_size_2     !<Number of data points in the second dimension (size(fdata,2))
-    integer(i4_kind)                                :: dim_size_3     !<Number of data points in the second dimension (size(fdata,3))
-    real(KIND=r4_kind),dimension(:),allocatable     :: sbuff          !<Buffer used to gather the data onto the root rank of the pelist
-    integer(i4_kind)                                :: nelems         !<Total number of data points (sum(nelems_io)) to be written
+    integer(i4_kind)                                :: dim_size_1     !<Number of data points in the
+                                                                      !! first dimension (size(fdata,1))
+    integer(i4_kind)                                :: dim_size_2     !<Number of data points in the
+                                                                      !! second dimension (size(fdata,2))
+    integer(i4_kind)                                :: dim_size_3     !<Number of data points in the
+                                                                      !! second dimension (size(fdata,3))
+    real(KIND=r4_kind),dimension(:),allocatable     :: sbuff          !<Buffer used to gather the data
+                                                                      !! onto the root rank of the pelist
+    integer(i4_kind)                                :: nelems         !<Total number of data points (sum(nelems_io))
+                                                                      !! to be written
                                                                       !!by the root rank of the pelist
-    real(KIND=r4_kind),dimension(:),allocatable     :: rbuff          !<Buffer used to gather the data onto the root rank of the pelist
-    real(KIND=r4_kind),dimension(:,:,:),allocatable :: cdata          !<Array used to write the data to the file after the gather is performed
-    integer(i4_kind)                                :: offset_r       !<Offset for rbuff used to reorder data before netCDF write
-    integer(i4_kind)                                :: offset_c       !<Offset for cdata used to reorder data before netCDF write
+    real(KIND=r4_kind),dimension(:),allocatable     :: rbuff          !<Buffer used to gather the data
+                                                                      !! onto the root rank of the pelist
+    real(KIND=r4_kind),dimension(:,:,:),allocatable :: cdata          !<Array used to write the data
+                                                                      !! to the file after the gather is performed
+    integer(i4_kind)                                :: offset_r       !<Offset for rbuff used to reorder
+                                                                      !! data before netCDF write
+    integer(i4_kind)                                :: offset_c       !<Offset for cdata used to reorder
+                                                                      !! data before netCDF write
     integer(i4_kind)                                :: i              !<Loop variable
     integer(i4_kind)                                :: j              !<Loop variable
     integer(i4_kind)                                :: k              !<Loop variable
@@ -1138,12 +1221,17 @@ subroutine mpp_io_unstructured_write_r4_4D(funit, &
                                            default_data)
 
    !Inputs/outputs
-    integer(i4_kind),intent(in)                         :: funit        !<A file unit for the to which the data will be written
+    integer(i4_kind),intent(in)                         :: funit        !<A file unit for the to which
+                                                                        !! the data will be written
     type(fieldtype),intent(inout)                       :: field        !<A field whose data will be written
-    type(domainUG),intent(inout)                        :: domain       !<An unstructured mpp domain associatd with the inputted file
+    type(domainUG),intent(inout)                        :: domain       !<An unstructured mpp domain
+                                                                        !! associatd with the inputted file
     real(KIND=r4_kind),dimension(:,:,:,:),intent(inout) :: fdata        !<The data that will be written to the file
-    integer,dimension(:),intent(in),optional            :: nelems_io_in !<Number of grid points in the unstructured dimension for each rank
-                                                                        !!(correct sizes only exist for the root rank of I/O domain pelist)
+    integer,dimension(:),intent(in),optional            :: nelems_io_in !<Number of grid points in the
+                                                                        !! unstructured dimension for each rank
+                                                                        !!(correct sizes only
+                                                                        !!(cexist for the root
+                                                                        !!rank of I/O domain pelist
     real(KIND=r4_kind),intent(in),optional              :: tstamp       !<A time value
     real(KIND=r4_kind),intent(in), optional             :: default_data !<Fill value for the inputted field
 
@@ -1152,17 +1240,27 @@ subroutine mpp_io_unstructured_write_r4_4D(funit, &
     type(domainUG),pointer                      :: io_domain        !<Pointer to the unstructured I/O domain
     integer(i4_kind)                            :: io_domain_npes   !<The total number of ranks in an I/O domain pelist
     integer(i4_kind),dimension(:),allocatable   :: pelist           !<A pelist
-    integer(i4_kind),dimension(:),allocatable   :: nelems_io        !<Number of grid points in the unstructured dimension for each rank
-    integer(i4_kind)                            :: compute_size     !<Size of the unstructured compute domain for the current rank
-    integer(i4_kind)                            :: size_fdata_dim_2 !<Number of data points in a non-unstructured dimension (size(fdata,2))
-    integer(i4_kind)                            :: size_fdata_dim_3 !<Number of data points in a non-unstructured dimension (size(fdata,3))
-    integer(i4_kind)                            :: size_fdata_dim_4 !<Number of data points in a non-unstructured dimension (size(fdata,3))
-    integer(i4_kind)                            :: mynelems         !<Number of data points in the unstructured dimension (size(fdata,1))
-    real(KIND=r4_kind),dimension(:),allocatable :: sbuff            !<Buffer used to gather the data onto the root rank of the pelist
-    integer(i4_kind)                            :: nelems           !<Total number of data points (sum(nelems_io)) to be written
+    integer(i4_kind),dimension(:),allocatable   :: nelems_io        !<Number of grid points in the unstructured
+                                                                    !! dimension for each rank
+    integer(i4_kind)                            :: compute_size     !<Size of the unstructured compute
+                                                                    !! domain for the current rank
+    integer(i4_kind)                            :: size_fdata_dim_2 !<Number of data points in a non-unstructured
+                                                                    !! dimension (size(fdata,2))
+    integer(i4_kind)                            :: size_fdata_dim_3 !<Number of data points in a non-unstructured
+                                                                    !! dimension (size(fdata,3))
+    integer(i4_kind)                            :: size_fdata_dim_4 !<Number of data points in a non-unstructured
+                                                                    !! dimension (size(fdata,3))
+    integer(i4_kind)                            :: mynelems         !<Number of data points in the unstructured
+                                                                    !! dimension (size(fdata,1))
+    real(KIND=r4_kind),dimension(:),allocatable :: sbuff            !<Buffer used to gather the data
+                                                                    !! onto the root rank of the pelist
+    integer(i4_kind)                            :: nelems           !<Total number of data points (sum(nelems_io))
+                                                                    !! to be written
                                                                     !!by the root rank of the pelist
-    real(KIND=r4_kind),dimension(:),allocatable :: rbuff            !<Buffer to gather the data onto root rank of pelist
-    real(KIND=r4_kind),dimension(:,:,:,:),allocatable :: cdata      !<Array  to write the data to file after gather is performed
+    real(KIND=r4_kind),dimension(:),allocatable :: rbuff            !<Buffer to gather the data onto
+                                                                    !! root rank of pelist
+    real(KIND=r4_kind),dimension(:,:,:,:),allocatable :: cdata      !<Array  to write the data to file
+                                                                    !! after gather is performed
     integer(i4_kind)                            :: i                !<Loop variable
     integer(i4_kind)                            :: j                !<Loop variable
     integer(i4_kind)                            :: k                !<Loop variable

--- a/mpp/include/mpp_io_util.inc
+++ b/mpp/include/mpp_io_util.inc
@@ -168,7 +168,8 @@
        checksum = 0
        check_exist = mpp_find_att(field%Att(:),"checksum")
        if ( check_exist >= 0 ) then
-         if(size(checksum(:)) >size(field%checksum(:))) call mpp_error(FATAL,"size(checksum(:)) >size(field%checksum(:))")
+         if(size(checksum(:)) >size(field%checksum(:))) call mpp_error(FATAL, &
+            & "size(checksum(:)) >size(field%checksum(:))")
          checksum = field%checksum(1:size(checksum(:)))
        endif
      endif

--- a/mpp/include/mpp_io_write.inc
+++ b/mpp/include/mpp_io_write.inc
@@ -95,7 +95,7 @@
 !! space axis, otherwise it is a time axis with an unlimited dimension.
 !! Only one time axis is allowed per file.
 !! @code{.F90}
-!!  subroutine mpp_write_meta_field( unit, field, axes, name, units, longname 
+!!  subroutine mpp_write_meta_field( unit, field, axes, name, units, longname
 !!                                   standard_name, min, max, missing, fill, scale, add, pack)
 !!     integer, intent(in) :: unit
 !!     type(fieldtype), intent(out) :: field

--- a/mpp/include/mpp_io_write.inc
+++ b/mpp/include/mpp_io_write.inc
@@ -356,11 +356,13 @@
 
 
 
-    subroutine mpp_write_meta_axis_r1d( unit, axis, name, units, longname, cartesian, sense, domain, data, min, calendar)
+    subroutine mpp_write_meta_axis_r1d( unit, axis, name, units, longname, cartesian, sense, domain, data, min, &
+                                      &  calendar)
 !load the values in an axistype (still need to call mpp_write)
 !write metadata attributes for axis
 !it is declared intent(inout) so you can nullify pointers in the incoming object if needed
-!the f90 standard doesn't guarantee that intent(out) on a type guarantees that its pointer components will be unassociated
+!the f90 standard doesn't guarantee that intent(out) on a type guarantees that its pointer
+!components will be unassociated
       integer,          intent(in)           :: unit
       type(axistype),   intent(inout)        :: axis
       character(len=*), intent(in)           :: name, units, longname
@@ -532,7 +534,8 @@
           call mpp_write_meta( unit, axis%id, 'domain_decomposition', ival=(/isg,ieg,is,ie/))
           axis%natt = axis%natt + 1
       end if
-      if( verbose )print '(a,2i6,x,a,2i3)', 'MPP_WRITE_META: Wrote axis metadata, pe, unit, axis%name, axis%id, axis%did=', &
+      if( verbose )print '(a,2i6,x,a,2i3)', &
+           'MPP_WRITE_META: Wrote axis metadata, pe, unit, axis%name, axis%id, axis%did=', &
            pe, unit, trim(axis%name), axis%id, axis%did
 
       mpp_file(unit)%ndim = max(1,mpp_file(unit)%ndim + 1)
@@ -545,7 +548,8 @@
 !load the values in an axistype (still need to call mpp_write)
 !write metadata attributes for axis
 !it is declared intent(inout) so you can nullify pointers in the incoming object if needed
-!the f90 standard doesn't guarantee that intent(out) on a type guarantees that its pointer components will be unassociated
+!the f90 standard doesn't guarantee that intent(out) on a type guarantees that its pointer
+!components will be unassociated
       integer,          intent(in)           :: unit
       type(axistype),   intent(inout)        :: axis
       character(len=*), intent(in)           :: name, units, longname
@@ -603,7 +607,8 @@
         call mpp_write_meta( unit, axis%id, 'valid_min', ival=min)
         axis%natt = axis%natt + 1
       endif
-      if( verbose )print '(a,2i6,x,a,2i3)', 'MPP_WRITE_META: Wrote axis metadata, pe, unit, axis%name, axis%id, axis%did=', &
+      if( verbose )print '(a,2i6,x,a,2i3)', &
+           'MPP_WRITE_META: Wrote axis metadata, pe, unit, axis%name, axis%id, axis%did=', &
            pe, unit, trim(axis%name), axis%id, axis%did
 
       mpp_file(unit)%ndim = max(1,mpp_file(unit)%ndim + 1)
@@ -617,7 +622,8 @@
 !load the values in an axistype (still need to call mpp_write)
 !write metadata attributes for axis
 !it is declared intent(inout) so you can nullify pointers in the incoming object if needed
-!the f90 standard doesn't guarantee that intent(out) on a type guarantees that its pointer components will be unassociated
+!the f90 standard doesn't guarantee that intent(out) on a type guarantees that its pointer
+!components will be unassociated
       integer,          intent(in)           :: unit
       type(axistype),   intent(inout)        :: axis
       character(len=*), intent(in)           :: name
@@ -790,17 +796,17 @@
               case(0)
                   error = NF_DEF_VAR( mpp_file(unit)%ncid, field%name, NF_INT, size(field%axes(:)), axis_id, field%id )
               case(1)
-                  error = NF_DEF_VAR( mpp_file(unit)%ncid, field%name, NF_DOUBLE, size(field%axes(:)), axis_id, field%id )
+                  error = NF_DEF_VAR( mpp_file(unit)%ncid, field%name, NF_DOUBLE, size(field%axes(:)),axis_id,field%id)
               case(2)
-                  error = NF_DEF_VAR( mpp_file(unit)%ncid, field%name, NF_FLOAT,  size(field%axes(:)), axis_id, field%id )
+                  error = NF_DEF_VAR( mpp_file(unit)%ncid, field%name, NF_FLOAT,  size(field%axes(:)),axis_id,field%id)
               case(4)
                   if( .NOT.PRESENT(scale) .OR. .NOT.PRESENT(add) ) &
                        call mpp_error( FATAL, 'MPP_WRITE_META_FIELD: scale and add must be supplied when pack=4.' )
-                  error = NF_DEF_VAR( mpp_file(unit)%ncid, field%name, NF_SHORT,  size(field%axes(:)), axis_id, field%id )
+                  error = NF_DEF_VAR( mpp_file(unit)%ncid, field%name, NF_SHORT,  size(field%axes(:)),axis_id,field%id)
               case(8)
                   if( .NOT.PRESENT(scale) .OR. .NOT.PRESENT(add) ) &
                        call mpp_error( FATAL, 'MPP_WRITE_META_FIELD: scale and add must be supplied when pack=8.' )
-                  error = NF_DEF_VAR( mpp_file(unit)%ncid, field%name, NF_BYTE,   size(field%axes(:)), axis_id, field%id )
+                  error = NF_DEF_VAR( mpp_file(unit)%ncid, field%name, NF_BYTE,   size(field%axes(:)),axis_id,field%id)
               case default
                   call mpp_error( FATAL, 'MPP_WRITE_META_FIELD: only legal packing values are 1,2,4,8.' )
           end select
@@ -816,7 +822,8 @@
       else
           varnum = varnum + 1
           field%id = varnum
-          if( PRESENT(pack) )call mpp_error( WARNING, 'MPP_WRITE_META: Packing is currently available only on netCDF files.' )
+          if( PRESENT(pack) )call mpp_error( WARNING, &
+             &  'MPP_WRITE_META: Packing is currently available only on netCDF files.' )
 !write field def
           write( text, '(a,i4,a)' )'FIELD ', field%id, ' name'
           call write_attribute( unit, trim(text), cval=field%name )
@@ -1446,7 +1453,8 @@
          .AND. axis%domain.NE.NULL_DOMAIN1D )then
           call mpp_write_meta( unit, axis%id, 'domain_decomposition', ival=(/isg,ieg,is,ie/) )
       end if
-      if( verbose )print '(a,2i6,x,a,2i3)', 'MPP_WRITE_META: Wrote axis metadata, pe, unit, axis%name, axis%id, axis%did=', &
+      if( verbose )print '(a,2i6,x,a,2i3)', &
+           'MPP_WRITE_META: Wrote axis metadata, pe, unit, axis%name, axis%id, axis%did=', &
            pe, unit, trim(axis%name), axis%id, axis%did
 #else
       call mpp_error( FATAL, 'MPP_READ currently requires use_netCDF option' )

--- a/mpp/include/mpp_read_2Ddecomp.h
+++ b/mpp/include/mpp_read_2Ddecomp.h
@@ -223,7 +223,8 @@
               end if
           end if
       endif
-      if( verbose )print '(a,2i6,i6,12i4)', 'READ_RECORD: PE, unit, nwords, start, axsiz=', pe, unit, nwords, start, axsiz
+      if( verbose )print '(a,2i6,i6,12i4)', 'READ_RECORD: PE, unit, nwords, start, axsiz=', pe, unit, nwords, &
+        &  start, axsiz
 
       call READ_RECORD_CORE_(unit, field, nwords, data, start, axsiz)
 

--- a/mpp/include/mpp_read_compressed.h
+++ b/mpp/include/mpp_read_compressed.h
@@ -67,7 +67,8 @@
         allocate(pelist(npes))
         call mpp_get_pelist(io_domain,pelist)
 
-        if(mpp_pe() == pelist(1)) call READ_RECORD_(unit,field,size(data(:,:)),data,tindex,start_in=start, axsiz_in=nread)
+        if(mpp_pe() == pelist(1)) call READ_RECORD_(unit,field,size(data(:,:)),data,tindex,start_in=start, &
+          &  axsiz_in=nread)
 
         !--- z1l replace mpp_broadcast with mpp_send/mpp_recv to avoid hang in calling MPI_COMM_CREATE
         !---     because size(pelist) might be different for different rank.
@@ -160,7 +161,8 @@
          allocate(pelist(npes))
          call mpp_get_pelist(io_domain,pelist)
 
-         if(mpp_pe() == pelist(1)) call READ_RECORD_(unit,field,size(data(:,:,:)),data,tindex,start_in=start, axsiz_in=nread)
+         if(mpp_pe() == pelist(1)) call READ_RECORD_(unit,field,size(data(:,:,:)),data,tindex,start_in=start, &
+           &  axsiz_in=nread)
 
          !--- z1l replace mpp_broadcast with mpp_send/mpp_recv to avoid hang in calling MPI_COMM_CREATE
          !---  because size(pelist) might be different for different rank.

--- a/mpp/include/mpp_sum_nocomm.h
+++ b/mpp/include/mpp_sum_nocomm.h
@@ -19,7 +19,8 @@
     subroutine MPP_SUM_( a, length, pelist )
 !sums array a over the PEs in pelist (all PEs if this argument is omitted)
 !result is also automatically broadcast: all PEs have the sum in a at the end
-!we are using f77-style call: array passed by address and not descriptor; further, the f90 conformance check is avoided.
+!we are using f77-style call: array passed by address and not descriptor; further, the f90
+!conformance check is avoided.
       integer, intent(in) :: length
       integer, intent(in), optional :: pelist(:)
       MPP_TYPE_, intent(inout) :: a(*)

--- a/mpp/include/mpp_transmit_mpi.h
+++ b/mpp/include/mpp_transmit_mpi.h
@@ -22,7 +22,8 @@
 !                                                                             !
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-    subroutine MPP_TRANSMIT_( put_data, put_len, to_pe, get_data, get_len, from_pe, block, tag, recv_request, send_request )
+    subroutine MPP_TRANSMIT_( put_data, put_len, to_pe, get_data, get_len, from_pe, block, tag, recv_request, &
+                            &  send_request )
 !a message-passing routine intended to be reminiscent equally of both MPI and SHMEM
 
 !put_data and get_data are contiguous MPP_TYPE_ arrays
@@ -37,7 +38,8 @@
 !      ALL_PES: broadcast and collect operations (collect not yet implemented)
 
 !ideally we would not pass length, but this f77-style call performs better (arrays passed by address, not descriptor)
-!further, this permits <length> contiguous words from an array of any rank to be passed (avoiding f90 rank conformance check)
+!further, this permits <length> contiguous words from an array of any rank to be passed (avoiding
+!f90 rank conformance check)
 
 !caller is responsible for completion checks (mpp_sync_self) before and after
 
@@ -62,7 +64,8 @@
       if( debug )then
           call SYSTEM_CLOCK(tick)
           write( stdout_unit,'(a,i18,a,i6,a,2i6,2i8)' )&
-               'T=',tick, ' PE=',pe, ' MPP_TRANSMIT begin: to_pe, from_pe, put_len, get_len=', to_pe, from_pe, put_len, get_len
+               'T=',tick, ' PE=',pe, ' MPP_TRANSMIT begin: to_pe, from_pe, put_len, get_len=', to_pe, from_pe, &
+                       &  put_len, get_len
       end if
 
       comm_tag = DEFAULT_TAG
@@ -151,7 +154,8 @@
       if( debug )then
           call SYSTEM_CLOCK(tick)
           write( stdout_unit,'(a,i18,a,i6,a,2i6,2i8)' )&
-               'T=',tick, ' PE=',pe, ' MPP_TRANSMIT end: to_pe, from_pe, put_len, get_len=', to_pe, from_pe, put_len, get_len
+               'T=',tick, ' PE=',pe, ' MPP_TRANSMIT end: to_pe, from_pe, put_len, get_len=', to_pe, from_pe, &
+                       &  put_len, get_len
       end if
       return
     end subroutine MPP_TRANSMIT_

--- a/mpp/include/mpp_transmit_nocomm.h
+++ b/mpp/include/mpp_transmit_nocomm.h
@@ -22,7 +22,8 @@
 !                                                                             !
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-    subroutine MPP_TRANSMIT_( put_data, put_len, to_pe, get_data, get_len, from_pe, block, tag, recv_request, send_request )
+    subroutine MPP_TRANSMIT_( put_data, put_len, to_pe, get_data, get_len, from_pe, block, tag, recv_request, &
+                            &  send_request )
 !a message-passing routine intended to be reminiscent equally of both MPI and SHMEM
 
 !put_data and get_data are contiguous MPP_TYPE_ arrays
@@ -37,7 +38,8 @@
 !      ALL_PES: broadcast and collect operations (collect not yet implemented)
 
 !ideally we would not pass length, but this f77-style call performs better (arrays passed by address, not descriptor)
-!further, this permits <length> contiguous words from an array of any rank to be passed (avoiding f90 rank conformance check)
+!further, this permits <length> contiguous words from an array of any rank to be passed (avoiding
+!f90 rank conformance check)
 
 !caller is responsible for completion checks (mpp_sync_self) before and after
 
@@ -62,7 +64,8 @@
       if( debug )then
           call SYSTEM_CLOCK(tick)
           write( outunit,'(a,i18,a,i5,a,2i5,2i8)' )&
-               'T=',tick, ' PE=',pe, ' MPP_TRANSMIT begin: to_pe, from_pe, put_len, get_len=', to_pe, from_pe, put_len, get_len
+               'T=',tick, ' PE=',pe, ' MPP_TRANSMIT begin: to_pe, from_pe, put_len, get_len=', to_pe, from_pe, &
+                       &  put_len, get_len
       end if
 
 !do put first and then get
@@ -125,7 +128,8 @@
       if( debug )then
           call SYSTEM_CLOCK(tick)
           write( outunit,'(a,i18,a,i5,a,2i5,2i8)' )&
-               'T=',tick, ' PE=',pe, ' MPP_TRANSMIT end: to_pe, from_pe, put_len, get_len=', to_pe, from_pe, put_len, get_len
+               'T=',tick, ' PE=',pe, ' MPP_TRANSMIT end: to_pe, from_pe, put_len, get_len=', to_pe, from_pe, &
+                       &  put_len, get_len
       end if
       return
     end subroutine MPP_TRANSMIT_

--- a/mpp/include/mpp_unstruct_domain.inc
+++ b/mpp/include/mpp_unstruct_domain.inc
@@ -22,13 +22,15 @@
 !> @brief Routines for defining and managing unstructured grids
 
   !#####################################################################
-  subroutine mpp_define_unstruct_domain(UG_domain, SG_domain, npts_tile, grid_nlev, ndivs, npes_io_group, grid_index, name)
+  subroutine mpp_define_unstruct_domain(UG_domain, SG_domain, npts_tile, grid_nlev, ndivs, npes_io_group, &
+                                       &  grid_index, name)
      type(domainUG),   intent(inout) :: UG_domain
      type(domain2d), target,     intent(in) :: SG_domain
      integer,                    intent(in) :: npts_tile(:) ! number of unstructured points on each tile
      integer,                    intent(in) :: grid_nlev(:) ! number of levels in each unstructured grid.
      integer,                    intent(in) :: ndivs
-     integer,                    intent(in) :: npes_io_group  ! number of processors in a io group. Only pe with same tile_id
+     integer,                    intent(in) :: npes_io_group  ! number of processors in a io group. Only
+                                                              !! pe with same tile_id
                                                               ! in the same group
      integer,                    intent(in) :: grid_index(:)
      character(len=*), optional, intent(in) :: name
@@ -46,10 +48,12 @@
      UG_domain%ntiles = ntiles
 
      !--- total number of points must be no less than ndivs
-     if(sum(npts_tile)<ndivs) call mpp_error(FATAL, "mpp_define_unstruct_domain: total number of points is less than ndivs")
+     if(sum(npts_tile)<ndivs) call mpp_error(FATAL, &
+        &  "mpp_define_unstruct_domain: total number of points is less than ndivs")
      !--- We are assuming nlev on each grid is at least one.
      do n = 1, size(grid_nlev(:))
-        if(grid_nlev(n) < 1) call mpp_error(FATAL, "mpp_define_unstruct_domain: grid_nlev at some point is less than 1")
+        if(grid_nlev(n) < 1) call mpp_error(FATAL, &
+           &  "mpp_define_unstruct_domain: grid_nlev at some point is less than 1")
      enddo
 
      !-- costs for each tile.

--- a/mpp/include/mpp_update_domains2D.h
+++ b/mpp/include/mpp_update_domains2D.h
@@ -154,7 +154,8 @@
                   call mpp_do_check(f_addrs(1:l_size,1:ntile), domain, check, d_type, ke, flags, name )
                endif
             endif
-            update => search_update_overlap(domain, update_whalo, update_ehalo, update_shalo, update_nhalo, update_position)
+            update => search_update_overlap(domain, update_whalo, update_ehalo, update_shalo, update_nhalo, &
+                                           &  update_position)
 
             !call mpp_do_update( f_addrs(1:l_size,1:ntile), domain, update, d_type, ke, &
             !                    b_addrs(1:l_size,1:ntile), bsize, flags)
@@ -214,7 +215,8 @@
       return
     end subroutine MPP_UPDATE_DOMAINS_5D_
 
-    subroutine MPP_REDISTRIBUTE_2D_( domain_in, field_in, domain_out, field_out, complete, free, list_size, dc_handle, position )
+    subroutine MPP_REDISTRIBUTE_2D_( domain_in, field_in, domain_out, field_out, complete, free, list_size, &
+                                   &  dc_handle, position )
       type(domain2D), intent(in) :: domain_in, domain_out
       MPP_TYPE_, intent(in)  :: field_in (:,:)
       MPP_TYPE_, intent(out) :: field_out(:,:)
@@ -231,13 +233,15 @@
       ptr_out = 0
       if(domain_in%initialized) ptr_in  = LOC(field_in )
       if(domain_out%initialized) ptr_out = LOC(field_out)
-      call mpp_redistribute( domain_in, field3D_in, domain_out, field3D_out, complete, free, list_size, dc_handle, position )
+      call mpp_redistribute( domain_in, field3D_in, domain_out, field3D_out, complete, free, list_size, &
+                           &  dc_handle, position )
 
       return
     end subroutine MPP_REDISTRIBUTE_2D_
 
 
-    subroutine MPP_REDISTRIBUTE_3D_( domain_in, field_in, domain_out, field_out, complete, free, list_size, dc_handle, position )
+    subroutine MPP_REDISTRIBUTE_3D_( domain_in, field_in, domain_out, field_out, complete, free, list_size, &
+                                   &  dc_handle, position )
       type(domain2D), intent(in) :: domain_in, domain_out
       MPP_TYPE_, intent(in)  :: field_in (:,:,:)
       MPP_TYPE_, intent(out) :: field_out(:,:,:)
@@ -310,7 +314,8 @@
             endif
             if(set_mismatch)then
                write( text,'(i2)' ) l_size
-               call mpp_error(FATAL,'MPP_REDISTRIBUTE_3D: Incompatible field at count '//text//' for group redistribute.' )
+               call mpp_error(FATAL,'MPP_REDISTRIBUTE_3D: Incompatible field at count '// &
+                              & text//' for group redistribute.' )
             endif
          endif
          if(do_redist)then
@@ -331,7 +336,8 @@
     end subroutine MPP_REDISTRIBUTE_3D_
 
 
-    subroutine MPP_REDISTRIBUTE_4D_( domain_in, field_in, domain_out, field_out, complete, free, list_size, dc_handle, position )
+    subroutine MPP_REDISTRIBUTE_4D_( domain_in, field_in, domain_out, field_out, complete, free, list_size, &
+                                   &  dc_handle, position )
       type(domain2D), intent(in) :: domain_in, domain_out
       MPP_TYPE_, intent(in)  :: field_in (:,:,:,:)
       MPP_TYPE_, intent(out) :: field_out(:,:,:,:)
@@ -348,20 +354,24 @@
       ptr_out = 0
       if(domain_in%initialized) ptr_in  = LOC(field_in )
       if(domain_out%initialized) ptr_out = LOC(field_out)
-      call mpp_redistribute( domain_in, field3D_in, domain_out, field3D_out, complete, free, list_size, dc_handle, position  )
+      call mpp_redistribute( domain_in, field3D_in, domain_out, field3D_out, complete, free, list_size, &
+                           &  dc_handle, position  )
 
       return
     end subroutine MPP_REDISTRIBUTE_4D_
 
-    subroutine MPP_REDISTRIBUTE_5D_( domain_in, field_in, domain_out, field_out, complete, free, list_size, dc_handle, position )
+    subroutine MPP_REDISTRIBUTE_5D_( domain_in, field_in, domain_out, field_out, complete, free, list_size, &
+                                   &  dc_handle, position )
       type(domain2D), intent(in) :: domain_in, domain_out
       MPP_TYPE_, intent(in)  :: field_in (:,:,:,:,:)
       MPP_TYPE_, intent(out) :: field_out(:,:,:,:,:)
       logical, intent(in), optional :: complete, free
       integer, intent(in), optional :: list_size
       integer, intent(in), optional :: position
-      MPP_TYPE_ :: field3D_in (size(field_in, 1),size(field_in, 2),size(field_in ,3)*size(field_in ,4)*size(field_in ,5))
-      MPP_TYPE_ :: field3D_out(size(field_out,1),size(field_out,2),size(field_out,3)*size(field_out,4)*size(field_out,5))
+      MPP_TYPE_ :: field3D_in (size(field_in, 1),size(field_in, 2),size(field_in ,3)*size(field_in , &
+                              & 4)*size(field_in ,5))
+      MPP_TYPE_ :: field3D_out(size(field_out,1),size(field_out,2),size(field_out,3)*size(field_out, &
+                              & 4)*size(field_out,5))
 
       type(DomainCommunicator2D),pointer,optional :: dc_handle
       pointer( ptr_in,  field3D_in  )
@@ -371,7 +381,8 @@
       ptr_out = 0
       if(domain_in%initialized) ptr_in  = LOC(field_in )
       if(domain_out%initialized) ptr_out = LOC(field_out)
-      call mpp_redistribute( domain_in, field3D_in, domain_out, field3D_out, complete, free, list_size, dc_handle, position  )
+      call mpp_redistribute( domain_in, field3D_in, domain_out, field3D_out, complete, free, list_size, &
+                           &  dc_handle, position  )
 
       return
     end subroutine MPP_REDISTRIBUTE_5D_
@@ -558,8 +569,10 @@
                    end if
                 endif
             endif
-            updatex => search_update_overlap(domain, update_whalo, update_ehalo, update_shalo, update_nhalo, position_x)
-            updatey => search_update_overlap(domain, update_whalo, update_ehalo, update_shalo, update_nhalo, position_y)
+            updatex => search_update_overlap(domain, update_whalo, update_ehalo, update_shalo, update_nhalo, &
+                                            &  position_x)
+            updatey => search_update_overlap(domain, update_whalo, update_ehalo, update_shalo, update_nhalo, &
+                                            &  position_y)
             if(exchange_uv) then
                call mpp_do_update(f_addrsx(1:l_size,1:ntile),f_addrsy(1:l_size,1:ntile), domain, updatey, updatex, &
                     d_type,ke, grid_offset_type, flags)

--- a/mpp/include/mpp_update_domains2D.h
+++ b/mpp/include/mpp_update_domains2D.h
@@ -368,10 +368,10 @@
       logical, intent(in), optional :: complete, free
       integer, intent(in), optional :: list_size
       integer, intent(in), optional :: position
-      MPP_TYPE_ :: field3D_in (size(field_in, 1),size(field_in, 2),size(field_in ,3)*size(field_in , &
-                              & 4)*size(field_in ,5))
-      MPP_TYPE_ :: field3D_out(size(field_out,1),size(field_out,2),size(field_out,3)*size(field_out, &
-                              & 4)*size(field_out,5))
+      MPP_TYPE_ :: field3D_in (size(field_in, 1),size(field_in, 2), &
+                             & size(field_in ,3)*size(field_in,4)*size(field_in ,5))
+      MPP_TYPE_ :: field3D_out(size(field_out,1),size(field_out,2), &
+                             & size(field_out,3)*size(field_out,4)*size(field_out,5))
 
       type(DomainCommunicator2D),pointer,optional :: dc_handle
       pointer( ptr_in,  field3D_in  )

--- a/mpp/include/mpp_update_domains2D_ad.h
+++ b/mpp/include/mpp_update_domains2D_ad.h
@@ -154,7 +154,8 @@
                   call mpp_do_check(f_addrs(1:l_size,1:ntile), domain, check, d_type, ke, flags, name )
                endif
             endif
-            update => search_update_overlap(domain, update_whalo, update_ehalo, update_shalo, update_nhalo, update_position)
+            update => search_update_overlap(domain, update_whalo, update_ehalo, update_shalo, update_nhalo, &
+                                           &  update_position)
 
             !call mpp_do_update( f_addrs(1:l_size,1:ntile), domain, update, d_type, ke, &
             !                    b_addrs(1:l_size,1:ntile), bsize, flags)
@@ -361,7 +362,8 @@
          set_mismatch = set_mismatch .OR. (update_nhalo /= nhalosz)
          if(set_mismatch)then
             write( text,'(i2)' ) list
-            call mpp_error(FATAL,'MPP_UPDATE_AD_3D_V: Incompatible field at count '//text//' for group vector update.' )
+            call mpp_error(FATAL,'MPP_UPDATE_AD_3D_V: Incompatible field at count '// &
+                           & text//' for group vector update.' )
          end if
       end if
       if(is_complete) then
@@ -397,8 +399,10 @@
                    end if
                 endif
             endif
-            updatex => search_update_overlap(domain, update_whalo, update_ehalo, update_shalo, update_nhalo, position_x)
-            updatey => search_update_overlap(domain, update_whalo, update_ehalo, update_shalo, update_nhalo, position_y)
+            updatex => search_update_overlap(domain, update_whalo, update_ehalo, update_shalo, update_nhalo, &
+                                            &  position_x)
+            updatey => search_update_overlap(domain, update_whalo, update_ehalo, update_shalo, update_nhalo, &
+                                            &  position_y)
             if(exchange_uv) then
                call mpp_do_update_ad(f_addrsx(1:l_size,1:ntile),f_addrsy(1:l_size,1:ntile), domain, updatey, updatex, &
                     d_type,ke, grid_offset_type, flags)

--- a/mpp/include/mpp_update_domains2D_nonblock.h
+++ b/mpp/include/mpp_update_domains2D_nonblock.h
@@ -122,7 +122,8 @@ function MPP_START_UPDATE_DOMAINS_3D_( field, domain, flags, position, &
   if(max_ntile>1) then
      if(ntile>MAX_TILES) then
         write( text,'(i2)' ) MAX_TILES
-        call mpp_error(FATAL,'MPP_START_UPDATE_DOMAINS_3D: MAX_TILES='//text//' is less than number of tiles on this pe.' )
+        call mpp_error(FATAL,'MPP_START_UPDATE_DOMAINS_3D: MAX_TILES='// &
+                       & text//' is less than number of tiles on this pe.' )
      endif
      if(.NOT. present(tile_count) ) call mpp_error(FATAL, "MPP_UPDATE_3D: "// &
           "optional argument tile_count should be present when number of tiles on this pe is more than 1")
@@ -196,7 +197,8 @@ function MPP_START_UPDATE_DOMAINS_3D_( field, domain, flags, position, &
              nonblock_data(current_id)%update_shalo .NE. update_shalo .OR. &
              nonblock_data(current_id)%update_nhalo .NE. update_nhalo .OR. &
              nonblock_data(current_id)%update_position .NE. update_position ) then
-           call mpp_error(FATAL,'MPP_START_UPDATE_DOMAINS: mismatch for optional argument for field '//trim(field_name) )
+           call mpp_error(FATAL,'MPP_START_UPDATE_DOMAINS: mismatch for optional argument for field '// &
+                          & trim(field_name) )
         endif
      else
         reuse_id_update = .false.
@@ -221,7 +223,8 @@ function MPP_START_UPDATE_DOMAINS_3D_( field, domain, flags, position, &
 
      ke_max = maxval(ke_list(1:l_size,1:ntile))
      if( domain_update_is_needed(domain, update_whalo, update_ehalo, update_shalo, update_nhalo) )then
-        update => search_update_overlap(domain, update_whalo, update_ehalo, update_shalo, update_nhalo, update_position)
+        update => search_update_overlap(domain, update_whalo, update_ehalo, update_shalo, update_nhalo, &
+                                       &  update_position)
         call mpp_start_do_update(current_id, f_addrs(1:l_size,1:ntile), domain, update, d_type, &
                                  ke_max, ke_list(1:l_size,1:ntile), update_flags, reuse_id_update, field_name )
      endif
@@ -378,7 +381,8 @@ subroutine MPP_COMPLETE_UPDATE_DOMAINS_3D_( id_update, field, domain, flags, pos
   if(max_ntile>1) then
      if(ntile>MAX_TILES) then
         write( text,'(i2)' ) MAX_TILES
-        call mpp_error(FATAL,'MPP_COMPLETE_UPDATE_DOMAINS_3D: MAX_TILES='//text//' is less than number of tiles on this pe.' )
+        call mpp_error(FATAL,'MPP_COMPLETE_UPDATE_DOMAINS_3D: MAX_TILES='// &
+                       & text//' is less than number of tiles on this pe.' )
      endif
      if(.NOT. present(tile_count) ) call mpp_error(FATAL, "MPP_UPDATE_3D: "// &
           "optional argument tile_count should be present when number of tiles on this pe is more than 1")
@@ -402,18 +406,24 @@ subroutine MPP_COMPLETE_UPDATE_DOMAINS_3D_( id_update, field, domain, flags, pos
   ke_list(list,tile) = size(field,3)
 
   !check to make sure the consistency of halo size, position and flags.
-  if( nonblock_data(id_update)%update_flags .NE. update_flags ) call mpp_error(FATAL, "MPP_COMPLETE_UPDATE_DOMAINS_3D: "// &
-       "mismatch of optional argument flag between MPP_COMPLETE_UPDATE_DOMAINS and MPP_START_UPDATE_DOMAINS")
-  if( nonblock_data(id_update)%update_whalo .NE. update_whalo ) call mpp_error(FATAL, "MPP_COMPLETE_UPDATE_DOMAINS_3D: "// &
-       "mismatch of optional argument whalo between MPP_COMPLETE_UPDATE_DOMAINS and MPP_START_UPDATE_DOMAINS")
-  if( nonblock_data(id_update)%update_ehalo .NE. update_ehalo ) call mpp_error(FATAL, "MPP_COMPLETE_UPDATE_DOMAINS_3D: "// &
-       "mismatch of optional argument ehalo between MPP_COMPLETE_UPDATE_DOMAINS and MPP_START_UPDATE_DOMAINS")
-  if( nonblock_data(id_update)%update_shalo .NE. update_shalo ) call mpp_error(FATAL, "MPP_COMPLETE_UPDATE_DOMAINS_3D: "// &
-       "mismatch of optional argument shalo between MPP_COMPLETE_UPDATE_DOMAINS and MPP_START_UPDATE_DOMAINS")
-  if( nonblock_data(id_update)%update_nhalo .NE. update_nhalo ) call mpp_error(FATAL, "MPP_COMPLETE_UPDATE_DOMAINS_3D: "// &
-       "mismatch of optional argument nhalo between MPP_COMPLETE_UPDATE_DOMAINS and MPP_START_UPDATE_DOMAINS")
-  if( nonblock_data(id_update)%update_position .NE. update_position ) call mpp_error(FATAL, "MPP_COMPLETE_UPDATE_DOMAINS_3D: "// &
-       "mismatch of optional argument position between MPP_COMPLETE_UPDATE_DOMAINS and MPP_START_UPDATE_DOMAINS")
+  if( nonblock_data(id_update)%update_flags .NE. update_flags ) &
+       call mpp_error(FATAL, "MPP_COMPLETE_UPDATE_DOMAINS_3D: "// &
+               "mismatch of optional argument flag between MPP_COMPLETE_UPDATE_DOMAINS and MPP_START_UPDATE_DOMAINS")
+  if( nonblock_data(id_update)%update_whalo .NE. update_whalo ) &
+       call mpp_error(FATAL, "MPP_COMPLETE_UPDATE_DOMAINS_3D: "// &
+               "mismatch of optional argument whalo between MPP_COMPLETE_UPDATE_DOMAINS and MPP_START_UPDATE_DOMAINS")
+  if( nonblock_data(id_update)%update_ehalo .NE. update_ehalo ) &
+       call mpp_error(FATAL, "MPP_COMPLETE_UPDATE_DOMAINS_3D: "// &
+               "mismatch of optional argument ehalo between MPP_COMPLETE_UPDATE_DOMAINS and MPP_START_UPDATE_DOMAINS")
+  if( nonblock_data(id_update)%update_shalo .NE. update_shalo ) &
+       call mpp_error(FATAL, "MPP_COMPLETE_UPDATE_DOMAINS_3D: "// &
+               "mismatch of optional argument shalo between MPP_COMPLETE_UPDATE_DOMAINS and MPP_START_UPDATE_DOMAINS")
+  if( nonblock_data(id_update)%update_nhalo .NE. update_nhalo ) &
+       call mpp_error(FATAL, "MPP_COMPLETE_UPDATE_DOMAINS_3D: "// &
+               "mismatch of optional argument nhalo between MPP_COMPLETE_UPDATE_DOMAINS and MPP_START_UPDATE_DOMAINS")
+  if( nonblock_data(id_update)%update_position .NE. update_position ) &
+       call mpp_error(FATAL, "MPP_COMPLETE_UPDATE_DOMAINS_3D: "// &
+             "mismatch of optional argument position between MPP_COMPLETE_UPDATE_DOMAINS and MPP_START_UPDATE_DOMAINS")
 
   if(is_complete) then
      l_size = list
@@ -421,11 +431,13 @@ subroutine MPP_COMPLETE_UPDATE_DOMAINS_3D_( id_update, field, domain, flags, pos
   end if
 
   if(do_update) then
-     if(l_size .NE. nonblock_data(id_update)%nfields) call mpp_error(FATAL, "MPP_COMPLETE_UPDATE_DOMAINS_3D: "// &
+     if(l_size .NE. nonblock_data(id_update)%nfields) &
+        call mpp_error(FATAL, "MPP_COMPLETE_UPDATE_DOMAINS_3D: "// &
              "mismatch of number of fields between mpp_start_update_domains and mpp_complete_update_domains")
      num_update = num_update - 1
      if( domain_update_is_needed(domain, update_whalo, update_ehalo, update_shalo, update_nhalo) ) then
-        update => search_update_overlap(domain, update_whalo, update_ehalo, update_shalo, update_nhalo, update_position)
+        update => search_update_overlap(domain, update_whalo, update_ehalo, update_shalo, update_nhalo, &
+                                       &  update_position)
         ke_max = maxval(ke_list(1:l_size,1:ntile))
         call mpp_complete_do_update(id_update, f_addrs(1:l_size,1:ntile), domain, update, d_type, &
                                     ke_max, ke_list(1:l_size,1:ntile), update_flags)
@@ -606,7 +618,8 @@ function MPP_START_UPDATE_DOMAINS_3D_V_( fieldx, fieldy, domain, flags, gridtype
   if(max_ntile>1) then
      if(ntile>MAX_TILES) then
         write( text,'(i2)' ) MAX_TILES
-        call mpp_error(FATAL,'MPP_START_UPDATE_DOMAINS_V: MAX_TILES='//text//' is less than number of tiles on this pe.' )
+        call mpp_error(FATAL,'MPP_START_UPDATE_DOMAINS_V: MAX_TILES='// &
+                       & text//' is less than number of tiles on this pe.' )
      endif
      if(.NOT. present(tile_count) ) call mpp_error(FATAL, "MPP_UPDATE_3D_V: "// &
           "optional argument tile_count should be present when number of tiles on some pe is more than 1")
@@ -655,7 +668,8 @@ function MPP_START_UPDATE_DOMAINS_3D_V_( fieldx, fieldy, domain, flags, gridtype
      set_mismatch = set_mismatch .OR. (update_nhalo /= nhalosz)
      if(set_mismatch)then
         write( text,'(i2)' ) list
-        call mpp_error(FATAL,'MPP_START_UPDATE_DOMAINS_V: Incompatible field at count '//text//' for group vector update.' )
+        call mpp_error(FATAL,'MPP_START_UPDATE_DOMAINS_V: Incompatible field at count '// &
+                       & text//' for group vector update.' )
      end if
   end if
   if(is_complete) then
@@ -681,14 +695,16 @@ function MPP_START_UPDATE_DOMAINS_3D_V_( fieldx, fieldy, domain, flags, gridtype
              nonblock_data(current_id)%update_shalo .NE. update_shalo .OR. &
              nonblock_data(current_id)%update_nhalo .NE. update_nhalo .OR. &
              nonblock_data(current_id)%update_gridtype .NE. grid_offset_type ) then
-           call mpp_error(FATAL,'MPP_START_UPDATE_DOMAINS_V: mismatch for optional argument for field '//trim(field_name) )
+           call mpp_error(FATAL,'MPP_START_UPDATE_DOMAINS_V: mismatch for optional argument for field '// &
+                          & trim(field_name) )
         endif
      else
         reuse_id_update = .false.
         current_id_update = current_id_update + 1
         current_id = current_id_update
         if( current_id_update > MAX_NONBLOCK_UPDATE ) then
-           write( text,'(a,i8,a,i8)' ) 'num_fields =', current_id_update, ' greater than MAX_NONBLOCK_UPDATE =', MAX_NONBLOCK_UPDATE
+           write( text,'(a,i8,a,i8)' ) 'num_fields =', current_id_update, &
+                &  ' greater than MAX_NONBLOCK_UPDATE =', MAX_NONBLOCK_UPDATE
            call mpp_error(FATAL,'MPP_START_UPDATE_DOMAINS_V: '//trim(text))
         endif
         nonblock_data(current_id)%update_flags = update_flags
@@ -904,19 +920,24 @@ subroutine MPP_COMPLETE_UPDATE_DOMAINS_3D_V_( id_update, fieldx, fieldy, domain,
   end if
 
   !check to make sure the consistency of halo size, position and flags.
-  if( nonblock_data(id_update)%update_flags .NE. update_flags ) call mpp_error(FATAL, "MPP_COMPLETE_UPDATE_DOMAINS_3D_V: "// &
-       "mismatch of optional argument flag between MPP_COMPLETE_UPDATE_DOMAINS and MPP_START_UPDATE_DOMAINS")
-  if( nonblock_data(id_update)%update_whalo .NE. update_whalo ) call mpp_error(FATAL, "MPP_COMPLETE_UPDATE_DOMAINS_3D_V: "// &
-       "mismatch of optional argument whalo between MPP_COMPLETE_UPDATE_DOMAINS and MPP_START_UPDATE_DOMAINS")
-  if( nonblock_data(id_update)%update_ehalo .NE. update_ehalo ) call mpp_error(FATAL, "MPP_COMPLETE_UPDATE_DOMAINS_3D_V: "// &
-       "mismatch of optional argument ehalo between MPP_COMPLETE_UPDATE_DOMAINS and MPP_START_UPDATE_DOMAINS")
-  if( nonblock_data(id_update)%update_shalo .NE. update_shalo ) call mpp_error(FATAL, "MPP_COMPLETE_UPDATE_DOMAINS_3D_V: "// &
-       "mismatch of optional argument shalo between MPP_COMPLETE_UPDATE_DOMAINS and MPP_START_UPDATE_DOMAINS")
-  if( nonblock_data(id_update)%update_nhalo .NE. update_nhalo ) call mpp_error(FATAL, "MPP_COMPLETE_UPDATE_DOMAINS_3D_V: "// &
-       "mismatch of optional argument nhalo between MPP_COMPLETE_UPDATE_DOMAINS and MPP_START_UPDATE_DOMAINS")
+  if( nonblock_data(id_update)%update_flags .NE. update_flags ) &
+       call mpp_error(FATAL, "MPP_COMPLETE_UPDATE_DOMAINS_3D_V: "// &
+               "mismatch of optional argument flag between MPP_COMPLETE_UPDATE_DOMAINS and MPP_START_UPDATE_DOMAINS")
+  if( nonblock_data(id_update)%update_whalo .NE. update_whalo ) &
+       call mpp_error(FATAL, "MPP_COMPLETE_UPDATE_DOMAINS_3D_V: "// &
+               "mismatch of optional argument whalo between MPP_COMPLETE_UPDATE_DOMAINS and MPP_START_UPDATE_DOMAINS")
+  if( nonblock_data(id_update)%update_ehalo .NE. update_ehalo ) &
+       call mpp_error(FATAL, "MPP_COMPLETE_UPDATE_DOMAINS_3D_V: "// &
+               "mismatch of optional argument ehalo between MPP_COMPLETE_UPDATE_DOMAINS and MPP_START_UPDATE_DOMAINS")
+  if( nonblock_data(id_update)%update_shalo .NE. update_shalo ) &
+       call mpp_error(FATAL, "MPP_COMPLETE_UPDATE_DOMAINS_3D_V: "// &
+               "mismatch of optional argument shalo between MPP_COMPLETE_UPDATE_DOMAINS and MPP_START_UPDATE_DOMAINS")
+  if( nonblock_data(id_update)%update_nhalo .NE. update_nhalo ) &
+       call mpp_error(FATAL, "MPP_COMPLETE_UPDATE_DOMAINS_3D_V: "// &
+               "mismatch of optional argument nhalo between MPP_COMPLETE_UPDATE_DOMAINS and MPP_START_UPDATE_DOMAINS")
   if( nonblock_data(id_update)%update_gridtype .NE. grid_offset_type ) &
         call mpp_error(FATAL, "MPP_COMPLETE_UPDATE_DOMAINS_3D_V: "// &
-       "mismatch of optional argument gridtype between MPP_COMPLETE_UPDATE_DOMAINS and MPP_START_UPDATE_DOMAINS")
+             "mismatch of optional argument gridtype between MPP_COMPLETE_UPDATE_DOMAINS and MPP_START_UPDATE_DOMAINS")
 
   max_ntile = domain%max_ntile_pe
   ntile = size(domain%x(:))

--- a/mpp/include/mpp_update_domains2D_nonblock.h
+++ b/mpp/include/mpp_update_domains2D_nonblock.h
@@ -937,7 +937,7 @@ subroutine MPP_COMPLETE_UPDATE_DOMAINS_3D_V_( id_update, fieldx, fieldy, domain,
                "mismatch of optional argument nhalo between MPP_COMPLETE_UPDATE_DOMAINS and MPP_START_UPDATE_DOMAINS")
   if( nonblock_data(id_update)%update_gridtype .NE. grid_offset_type ) &
         call mpp_error(FATAL, "MPP_COMPLETE_UPDATE_DOMAINS_3D_V: "// &
-             "mismatch of optional argument gridtype between MPP_COMPLETE_UPDATE_DOMAINS and MPP_START_UPDATE_DOMAINS")
+       "mismatch of optional argument gridtype between MPP_COMPLETE_UPDATE_DOMAINS and MPP_START_UPDATE_DOMAINS")
 
   max_ntile = domain%max_ntile_pe
   ntile = size(domain%x(:))

--- a/mpp/include/mpp_update_nest_domains.h
+++ b/mpp/include/mpp_update_nest_domains.h
@@ -149,7 +149,8 @@ subroutine MPP_UPDATE_NEST_FINE_3D_(field, nest_domain, wbuffer, sbuffer, ebuffe
 
    !---check data is on data domain or compute domain
    if( nest_domain%nest(nest_level)%is_coarse_pe ) then
-      call mpp_get_data_domain(nest_domain%nest(nest_level)%domain_coarse, xbegin, xend, ybegin, yend, position=update_position)
+      call mpp_get_data_domain(nest_domain%nest(nest_level)%domain_coarse, xbegin, xend, ybegin, yend, &
+                              &  position=update_position)
       if(isize .NE. xend-xbegin+1 .OR. jsize .NE. yend-ybegin+1) then
          call mpp_get_compute_domain(nest_domain%nest(nest_level)%domain_coarse, xbegin, xend, ybegin, yend, &
                                      position=update_position)
@@ -324,7 +325,8 @@ end subroutine MPP_UPDATE_NEST_FINE_2D_V_
 subroutine MPP_UPDATE_NEST_FINE_3D_V_(fieldx, fieldy, nest_domain, wbufferx, wbuffery, sbufferx, sbuffery, &
                                       ebufferx, ebuffery, nbufferx, nbuffery, nest_level, &
                                       flags, gridtype, complete, extra_halo, name, tile_count)
-    MPP_TYPE_,             intent(in)      :: fieldx(:,:,:), fieldy(:,:,:) !< field x and y components on the model grid
+    MPP_TYPE_,             intent(in)      :: fieldx(:,:,:), fieldy(:,:,:) !< field x and y components
+                                                                           !! on the model grid
     type(nest_domain_type), intent(inout)  :: nest_domain !< Holds the information to pass data
                                                           !! between fine and coarse grid.
     MPP_TYPE_,             intent(inout)   :: wbufferx(:,:,:), wbuffery(:,:,:) !< west side buffer x and y  components
@@ -515,25 +517,33 @@ subroutine MPP_UPDATE_NEST_FINE_3D_V_(fieldx, fieldy, nest_domain, wbufferx, wbu
 
       if(nest_domain%nest(nest_level)%is_fine_pe) then
          call check_data_size("MPP_UPDATE_NEST_FINE_3D_V", "wbufferx", wbufferszx, "updatex", &
-                              (updatex%west%ie_you-updatex%west%is_you+1)*(updatex%west%je_you-updatex%west%js_you+1)*ksize )
+                              (updatex%west%ie_you-updatex%west%is_you+1)*(updatex%west%je_you-updatex%west%js_you+1) &
+                              *ksize )
          call check_data_size("MPP_UPDATE_NEST_FINE_3D_V", "wbuffery", wbufferszy, "updatey", &
-                              (updatey%west%ie_you-updatey%west%is_you+1)*(updatey%west%je_you-updatey%west%js_you+1)*ksize )
+                              (updatey%west%ie_you-updatey%west%is_you+1)*(updatey%west%je_you-updatey%west%js_you+1) &
+                              *ksize )
          call check_data_size("MPP_UPDATE_NEST_FINE_3D_V", "ebufferx", ebufferszx, "updatex", &
-                              (updatex%east%ie_you-updatex%east%is_you+1)*(updatex%east%je_you-updatex%east%js_you+1)*ksize )
+                              (updatex%east%ie_you-updatex%east%is_you+1)*(updatex%east%je_you-updatex%east%js_you+1) &
+                              *ksize )
          call check_data_size("MPP_UPDATE_NEST_FINE_3D_V", "ebuffery", ebufferszy, "updatey", &
-                              (updatey%east%ie_you-updatey%east%is_you+1)*(updatey%east%je_you-updatey%east%js_you+1)*ksize )
+                              (updatey%east%ie_you-updatey%east%is_you+1)*(updatey%east%je_you-updatey%east%js_you+1) &
+                              *ksize )
          call check_data_size("MPP_UPDATE_NEST_FINE_3D_V", "sbufferx", sbufferszx, "updatex", &
-                              (updatex%south%ie_you-updatex%south%is_you+1)*(updatex%south%je_you-updatex%south%js_you+1)*ksize )
+                              (updatex%south%ie_you-updatex%south%is_you+1) &
+                              * (updatex%south%je_you-updatex%south%js_you+1)*ksize )
          call check_data_size("MPP_UPDATE_NEST_FINE_3D_V", "sbuffery", sbufferszy, "updatey", &
-                              (updatey%south%ie_you-updatey%south%is_you+1)*(updatey%south%je_you-updatey%south%js_you+1)*ksize )
+                              (updatey%south%ie_you-updatey%south%is_you+1) &
+                              * (updatey%south%je_you-updatey%south%js_you+1)*ksize )
          call check_data_size("MPP_UPDATE_NEST_FINE_3D_V", "nbufferx", nbufferszx, "updatex", &
-                              (updatex%north%ie_you-updatex%north%is_you+1)*(updatex%north%je_you-updatex%north%js_you+1)*ksize )
+                              (updatex%north%ie_you-updatex%north%is_you+1) &
+                              * (updatex%north%je_you-updatex%north%js_you+1)*ksize )
          call check_data_size("MPP_UPDATE_NEST_FINE_3D_V", "nbuffery", nbufferszy, "updatey", &
-                              (updatey%north%ie_you-updatey%north%is_you+1)*(updatey%north%je_you-updatey%north%js_you+1)*ksize )
+                              (updatey%north%ie_you-updatey%north%is_you+1) &
+                              * (updatey%north%je_you-updatey%north%js_you+1)*ksize )
       endif
 
-      call mpp_do_update_nest_fine(f_addrsx(1:l_size), f_addrsy(1:l_size), nest_domain%nest(nest_level), updatex, updatey, &
-            d_type, ksize, wb_addrsx(1:l_size), wb_addrsy(1:l_size), eb_addrsx(1:l_size), eb_addrsy(1:l_size),  &
+      call mpp_do_update_nest_fine(f_addrsx(1:l_size), f_addrsy(1:l_size), nest_domain%nest(nest_level), updatex, &
+            updatey, d_type, ksize, wb_addrsx(1:l_size), wb_addrsy(1:l_size), eb_addrsx(1:l_size),eb_addrsy(1:l_size),&
             sb_addrsx(1:l_size), sb_addrsy(1:l_size), nb_addrsx(1:l_size), nb_addrsy(1:l_size), update_flags )
 
    endif
@@ -547,13 +557,17 @@ subroutine MPP_UPDATE_NEST_FINE_4D_V_(fieldx, fieldy, nest_domain, wbufferx, wbu
     MPP_TYPE_,             intent(in)      :: fieldx(:,:,:,:), fieldy(:,:,:,:) !< field x and y
                                                                      !! components on the model grid
     type(nest_domain_type), intent(inout)  :: nest_domain
-    MPP_TYPE_,             intent(inout)   :: wbufferx(:,:,:,:), wbuffery(:,:,:,:) !< west side buffer x and y  components
+    MPP_TYPE_,             intent(inout)   :: wbufferx(:,:,:,:), wbuffery(:,:,:,:) !< west side buffer
+                                                                                   !! x and y  components
                                                                  !! to be filled with data on coarse grid.
-    MPP_TYPE_,             intent(inout)   :: ebufferx(:,:,:,:), ebuffery(:,:,:,:) !< east side buffer x and y  components
+    MPP_TYPE_,             intent(inout)   :: ebufferx(:,:,:,:), ebuffery(:,:,:,:) !< east side buffer
+                                                                                   !! x and y  components
                                                                  !! to be filled with data on coarse grid.
-    MPP_TYPE_,             intent(inout)   :: sbufferx(:,:,:,:), sbuffery(:,:,:,:) !< south side buffer x and y  components
+    MPP_TYPE_,             intent(inout)   :: sbufferx(:,:,:,:), sbuffery(:,:,:,:) !< south side buffer
+                                                                                   !! x and y  components
                                                                  !! to be filled with data on coarse grid.
-    MPP_TYPE_,             intent(inout)   :: nbufferx(:,:,:,:), nbuffery(:,:,:,:) !< north side buffer x and y  components
+    MPP_TYPE_,             intent(inout)   :: nbufferx(:,:,:,:), nbuffery(:,:,:,:) !< north side buffer
+                                                                                   !! x and y  components
                                                                  !! to be filled with data on coarse grid.
     integer,          intent(in)           :: nest_level !< level of the nest (> 1 implies a telescoping nest)
     integer,          intent(in), optional :: flags !< Specify the direction of fine grid halo buffer to be filled.
@@ -607,7 +621,8 @@ end subroutine MPP_UPDATE_NEST_FINE_4D_V_
 
 #endif
 
-subroutine MPP_UPDATE_NEST_COARSE_2D_(field_in, nest_domain, field_out, nest_level, complete, position, name, tile_count)
+subroutine MPP_UPDATE_NEST_COARSE_2D_(field_in, nest_domain, field_out, nest_level, complete, position, name, &
+                                     &  tile_count)
       MPP_TYPE_,             intent(in)      :: field_in(:,:) !< field on the model grid
       type(nest_domain_type), intent(inout)  :: nest_domain !< Holds the information to pass data
                                                             !! between fine and coarse grid.
@@ -627,7 +642,8 @@ subroutine MPP_UPDATE_NEST_COARSE_2D_(field_in, nest_domain, field_out, nest_lev
       pointer( ptr_out, field3D_out)
       ptr_in = LOC(field_in)
       ptr_out = LOC(field_out)
-      call mpp_update_nest_coarse( field3D_in, nest_domain, field3D_out, nest_level, complete, position, name, tile_count)
+      call mpp_update_nest_coarse( field3D_in, nest_domain, field3D_out, nest_level, complete, position, name, &
+                                 &  tile_count)
 
       return
 
@@ -637,7 +653,8 @@ end subroutine MPP_UPDATE_NEST_COARSE_2D_
 
 !--- field_in is the data on fine grid pelist to be passed to coarse grid pelist.
 !--- field_in and field_out are all on the coarse grid. field_in is remapped from fine grid to coarse grid.
-subroutine MPP_UPDATE_NEST_COARSE_3D_(field_in, nest_domain, field_out, nest_level, complete, position, name, tile_count)
+subroutine MPP_UPDATE_NEST_COARSE_3D_(field_in, nest_domain, field_out, nest_level, complete, position, name, &
+                                     &  tile_count)
    MPP_TYPE_,             intent(in)      :: field_in(:,:,:) !< field on the model grid
    type(nest_domain_type), intent(inout)  :: nest_domain !< Holds the information to pass data
                                                             !! between fine and coarse grid.
@@ -745,7 +762,8 @@ subroutine MPP_UPDATE_NEST_COARSE_3D_(field_in, nest_domain, field_out, nest_lev
 end subroutine MPP_UPDATE_NEST_COARSE_3D_
 
 !###############################################################################
-subroutine MPP_UPDATE_NEST_COARSE_4D_(field_in, nest_domain, field_out, nest_level, complete, position, name, tile_count)
+subroutine MPP_UPDATE_NEST_COARSE_4D_(field_in, nest_domain, field_out, nest_level, complete, position, name, &
+                                     &  tile_count)
       MPP_TYPE_,             intent(in)      :: field_in(:,:,:,:) !< field on the model grid
       type(nest_domain_type), intent(inout)  :: nest_domain !< Holds the information to pass data
                                                             !! between fine and coarse grid.
@@ -764,7 +782,8 @@ subroutine MPP_UPDATE_NEST_COARSE_4D_(field_in, nest_domain, field_out, nest_lev
       pointer( ptr_out, field3D_out )
       ptr_in = LOC(field_in)
       ptr_out = LOC(field_out)
-      call mpp_update_nest_coarse( field3D_in, nest_domain, field3D_out, nest_level, complete, position, name, tile_count)
+      call mpp_update_nest_coarse( field3D_in, nest_domain, field3D_out, nest_level, complete, position, name, &
+                                 &  tile_count)
 
       return
 
@@ -781,7 +800,8 @@ subroutine MPP_UPDATE_NEST_COARSE_2D_V_(fieldx_in, fieldy_in, nest_domain, field
    MPP_TYPE_,             intent(in)      :: fieldy_in(:,:) !< y component of field on the model grid
    type(nest_domain_type), intent(inout)  :: nest_domain !< Holds the information to pass data
                                                          !! between fine and coarse grid.
-   integer,          intent(in), optional :: flags, gridtype !< Specify the direction of fine grid halo buffer to be filled.
+   integer,          intent(in), optional :: flags, gridtype !< Specify the direction of fine grid halo
+                                                             !! buffer to be filled.
                                                     !! Default value is XUPDATE+YUPDATE.
    MPP_TYPE_,             intent(inout)   :: fieldx_out(:,:) !< x component of field_out to be
                                                              !! filled with data on coarse grid
@@ -821,7 +841,8 @@ subroutine MPP_UPDATE_NEST_COARSE_3D_V_(fieldx_in, fieldy_in, nest_domain, field
    MPP_TYPE_,             intent(in)      :: fieldy_in(:,:,:) !< y component of field on the model grid
    type(nest_domain_type), intent(inout)  :: nest_domain !< Holds the information to pass data
                                                          !! between fine and coarse grid.
-   integer,          intent(in), optional :: flags, gridtype !< Specify the direction of fine grid halo buffer to be filled.
+   integer,          intent(in), optional :: flags, gridtype !< Specify the direction of fine grid halo
+                                                             !! buffer to be filled.
                                                     !! Default value is XUPDATE+YUPDATE.
    MPP_TYPE_,             intent(inout)   :: fieldx_out(:,:,:) !< x component of field_out to be
                                                                !! filled with data on coarse grid
@@ -992,8 +1013,9 @@ subroutine MPP_UPDATE_NEST_COARSE_3D_V_(fieldx_in, fieldy_in, nest_domain, field
          endif
       endif
 
-      call mpp_do_update_nest_coarse(fin_addrsx(1:l_size), fin_addrsy(1:l_size), fout_addrsx(1:l_size), fout_addrsy(1:l_size), &
-                                     nest_domain, nest_domain%nest(nest_level), updatex, updatey, d_type, ksize, update_flags)
+      call mpp_do_update_nest_coarse(fin_addrsx(1:l_size), fin_addrsy(1:l_size), fout_addrsx(1:l_size), &
+                                     fout_addrsy(1:l_size), nest_domain, nest_domain%nest(nest_level), updatex, &
+                                     updatey, d_type, ksize, update_flags)
    endif
 
 end subroutine MPP_UPDATE_NEST_COARSE_3D_V_
@@ -1004,7 +1026,8 @@ subroutine MPP_UPDATE_NEST_COARSE_4D_V_(fieldx_in, fieldy_in, nest_domain, field
    MPP_TYPE_,             intent(in)      :: fieldy_in(:,:,:,:) !< y component field on the model grid
    type(nest_domain_type), intent(inout)  :: nest_domain !< Holds the information to pass data
                                                          !! between fine and coarse grid.
-   integer,          intent(in), optional :: flags, gridtype !< Specify the direction of fine grid halo buffer to be filled.
+   integer,          intent(in), optional :: flags, gridtype !< Specify the direction of fine grid halo
+                                                             !! buffer to be filled.
                                                     !! Default value is XUPDATE+YUPDATE.
    MPP_TYPE_,             intent(inout)   :: fieldx_out(:,:,:,:) !< x component of field_out to be
                                                                  !! filled with data on coarse grid

--- a/mpp/include/mpp_util.inc
+++ b/mpp/include/mpp_util.inc
@@ -887,7 +887,8 @@ end function rarray_to_char
     delta = end_tick - clocks(id)%tick
     if( delta.LT.0 )then
        errunit = stderr()
-       write( errunit,* )'pe, id, start_tick, end_tick, delta, max_ticks=', pe, id, clocks(id)%tick, end_tick, delta, max_ticks
+       write( errunit,* )'pe, id, start_tick, end_tick, delta, max_ticks=', pe, id, clocks(id)%tick, end_tick, &
+            &  delta, max_ticks
        delta = delta + max_ticks + 1
        call mpp_error( WARNING, 'MPP_CLOCK_END: Clock rollover, assumed single roll.' )
     end if
@@ -927,13 +928,15 @@ end function rarray_to_char
 
     if( .not. mpp_record_timing_data )return
     if( .not.debug .or. (current_clock.EQ.0) )return
-    if( current_clock.LT.0 .OR. current_clock.GT.clock_num )call mpp_error( FATAL, 'MPP_CLOCK_BEGIN: invalid current_clock.' )
+    if( current_clock.LT.0 .OR. current_clock.GT.clock_num )call mpp_error( FATAL, &
+       &  'MPP_CLOCK_BEGIN: invalid current_clock.' )
     if( .NOT.clocks(current_clock)%detailed )return
     call SYSTEM_CLOCK(end_tick)
     n = clocks(current_clock)%events(event_id)%calls + 1
 
     if( n.EQ.MAX_EVENTS )call mpp_error( WARNING, &
-         'MPP_CLOCK: events exceed MAX_EVENTS, ignore detailed profiling data for clock '//trim(clocks(current_clock)%name) )
+         'MPP_CLOCK: events exceed MAX_EVENTS, ignore detailed profiling data for clock '// &
+         & trim(clocks(current_clock)%name) )
     if( n.GT.MAX_EVENTS )return
 
     clocks(current_clock)%events(event_id)%calls = n
@@ -1088,7 +1091,8 @@ end function rarray_to_char
     integer,save :: i
     logical      :: l_open
 
-    call mpp_error(WARNING,'get_unit is deprecated and will be removed in a future release, please use the Fortran intrinsic newunit')
+    call mpp_error(WARNING, 'get_unit is deprecated and will be removed in a future release,'&
+                          & //' please use the Fortran intrinsic newunit')
     do i=10,99
        inquire(unit=i,opened=l_open)
        if(.not.l_open)exit
@@ -1411,8 +1415,8 @@ end function rarray_to_char
                 end if
                 if ( len_trim(str_tmp) == LENGTH ) then
                    write(UNIT=text, FMT='(I5)') length
-                   call mpp_error(FATAL, 'get_ascii_file_num_lines: Length of output string ('//trim(text)//' is too small.&
-                        & Increase the LENGTH value.')
+                   call mpp_error(FATAL, 'get_ascii_file_num_lines: Length of output string ('//trim(text)//&
+                                       & ' is too small. Increase the LENGTH value.')
                 end if
                 num_lines = num_lines + 1
              end do
@@ -1481,8 +1485,8 @@ end function rarray_to_char
                 end if
                 if ( len_trim(str_tmp) == LENGTH ) then
                    write(UNIT=text, FMT='(I5)') length
-                   call mpp_error(FATAL, 'get_ascii_file_num_lines: Length of output string ('//trim(text)//' is too small.&
-                        & Increase the LENGTH value.')
+                   call mpp_error(FATAL, 'get_ascii_file_num_lines: Length of output string ('//trim(text)//&
+                                       & ' is too small. Increase the LENGTH value.')
                 end if
                 if (len_trim(str_tmp) > max_length) max_length = len_trim(str_tmp)
                 num_lines = num_lines + 1
@@ -1564,7 +1568,8 @@ end function rarray_to_char
 
           if ( status .ne. 0 ) then
              write (UNIT=text, FMT='(I5)') status
-             call mpp_error(FATAL, 'READ_ASCII_FILE: Error opening file: '//trim(FILENAME)//'.  (IOSTAT = '//trim(text)//')')
+             call mpp_error(FATAL, 'READ_ASCII_FILE: Error opening file: '// &
+                            & trim(FILENAME)//'.  (IOSTAT = '//trim(text)//')')
           else
 
              if ( num_lines .gt. 0 ) then
@@ -1589,7 +1594,8 @@ end function rarray_to_char
                       endif
                       if ( status .gt. 0 ) then
                          write (UNIT=text, FMT='(I5)') pnum_lines
-                         call mpp_error(FATAL, 'READ_ASCII_FILE: Error reading line '//trim(text)//' in file '//trim(FILENAME)//'.')
+                         call mpp_error(FATAL, 'READ_ASCII_FILE: Error reading line '// &
+                                        & trim(text)//' in file '//trim(FILENAME)//'.')
                       end if
                       if(pnum_lines > num_lines) then
                          call mpp_error(FATAL, 'READ_ASCII_FILE: number of lines in file '//trim(FILENAME)// &
@@ -1597,8 +1603,8 @@ end function rarray_to_char
                       end if
                       if ( len_trim(str_tmp) == LENGTH ) then
                          write(UNIT=text, FMT='(I5)') length
-                         call mpp_error(FATAL, 'READ_ASCII_FILE: Length of output string ('//trim(text)//' is too small.&
-                              & Increase the LENGTH value.')
+                         call mpp_error(FATAL, 'READ_ASCII_FILE: Length of output string ('//trim(text)// &
+                                             & ' is too small. Increase the LENGTH value.')
                       end if
                       Content(pnum_lines) = str_tmp
                       pnum_lines = pnum_lines + 1

--- a/mpp/include/mpp_write_2Ddecomp.h
+++ b/mpp/include/mpp_write_2Ddecomp.h
@@ -130,7 +130,8 @@
 !write time information if new time
           if( newtime )then
               if( KIND(time).EQ.r8_kind )then
-                  error = NF_PUT_VAR1_DOUBLE( mpp_file(unit)%ncid, mpp_file(unit)%id, mpp_file(unit:unit)%time_level, time )
+                  error = NF_PUT_VAR1_DOUBLE( mpp_file(unit)%ncid, mpp_file(unit)%id, mpp_file(unit:unit)%time_level,&
+                                            & time )
               else if( KIND(time).EQ.r4_kind )then
                  error = NF90_PUT_VAR ( mpp_file(unit)%ncid, mpp_file(unit)%id, time)
               end if

--- a/mpp/include/mpp_write_compressed.h
+++ b/mpp/include/mpp_write_compressed.h
@@ -95,7 +95,8 @@
       allocate(nz_gather(npes))
       call mpp_gather((/nz/), nz_gather, pelist)
       if ( mpp_file(unit)%write_on_this_pe.and.maxloc(nz_gather,1).ne.minloc(nz_gather,1) ) then
-         call mpp_error( FATAL, 'MPP_WRITE_COMPRESSED_2D_: size(data,2) must be consistent across all PEs in io_domain' )
+         call mpp_error( FATAL, &
+                        &  'MPP_WRITE_COMPRESSED_2D_: size(data,2) must be consistent across all PEs in io_domain' )
       end if
       deallocate(nz_gather)
 

--- a/mpp/include/mpp_write_unlimited_axis.h
+++ b/mpp/include/mpp_write_unlimited_axis.h
@@ -31,11 +31,13 @@
 
       call mpp_clock_begin(mpp_write_clock)
 
-      if( .NOT.module_is_initialized )call mpp_error( FATAL, 'MPP_WRITE_UNLIMITED_AXIS_1D_: must first call mpp_io_init.' )
+      if( .NOT.module_is_initialized )call mpp_error( FATAL, &
+         &  'MPP_WRITE_UNLIMITED_AXIS_1D_: must first call mpp_io_init.' )
       if( .NOT.mpp_file(unit)%valid )call mpp_error( FATAL, 'MPP_WRITE_UNLIMITED_AXIS_1D_: invalid unit number.' )
 
       io_domain=>mpp_get_io_domain(domain)
-      if (.not. ASSOCIATED(io_domain)) call mpp_error( FATAL, 'MPP_WRITE_UNLIMITED_AXIS_1D_: io_domain must be defined.' )
+      if (.not. ASSOCIATED(io_domain)) call mpp_error( FATAL, &
+          &  'MPP_WRITE_UNLIMITED_AXIS_1D_: io_domain must be defined.' )
       npes = mpp_get_domain_npes(io_domain)
       allocate(pelist(npes))
       call mpp_get_pelist(io_domain,pelist)

--- a/mpp/mpp.F90
+++ b/mpp/mpp.F90
@@ -1116,7 +1116,8 @@ private
   !! Integer checksums on FP data use the F90 <TT>TRANSFER()</TT>
   !! intrinsic.
   !!
-  !! The <LINK SRC="http://www.gfdl.noaa.gov/fms-cgi-bin/cvsweb.cgi/FMS/shared/chksum/chksum.html">serial checksum module</LINK> is superseded
+  !! The <LINK SRC="http://www.gfdl.noaa.gov/fms-cgi-bin/cvsweb.cgi/FMS/shared/chksum/chksum.html">serial
+  !! checksum module</LINK> is superseded
   !! by this function, and is no longer being actively maintained. This
   !! provides identical results on a single-processor job, and to perform
   !! serial checksums on a single processor of a parallel job, you only
@@ -1210,7 +1211,8 @@ private
 !***********************************************************************
   integer, parameter   :: PESET_MAX = 10000
   integer              :: current_peset_max = 32
-  type(communicator), allocatable :: peset(:) !< Will be allocated starting from 0, 0 is a dummy used to hold single-PE "self" communicator
+  type(communicator), allocatable :: peset(:) !< Will be allocated starting from 0, 0 is a dummy used
+                                              !! to hold single-PE "self" communicator
   logical              :: module_is_initialized = .false.
   logical              :: debug = .false.
   integer              :: npes=1, root_pe=0, pe=0

--- a/mpp/mpp_domains.F90
+++ b/mpp/mpp_domains.F90
@@ -346,7 +346,8 @@ module mpp_domains_mod
      integer,         pointer :: dir(:)          => NULL() !< direction ( value 1,2,3,4 = E,S,W,N)
      integer,         pointer :: rotation(:)     => NULL() !< rotation angle.
      integer,         pointer :: index(:)        => NULL() !< for refinement
-     logical,         pointer :: from_contact(:) => NULL() !< indicate if the overlap is computed from define_contact_overlap
+     logical,         pointer :: from_contact(:) => NULL() !< indicate if the overlap is computed from
+                                                           !! define_contact_overlap
   end type overlap_type
 
   !> Private type for overlap specifications
@@ -402,17 +403,24 @@ module mpp_domains_mod
      type(domain1D),     pointer :: y(:)          => NULL() !< y-direction domain decomposition
      type(domain2D_spec),pointer :: list(:)       => NULL() !< domain decomposition on pe list
      type(tile_type),    pointer :: tileList(:)   => NULL() !< store tile information
-     type(overlapSpec),  pointer :: check_C       => NULL() !< send and recv information for boundary consistency check of C-cell
-     type(overlapSpec),  pointer :: check_E       => NULL() !< send and recv information for boundary consistency check of E-cell
-     type(overlapSpec),  pointer :: check_N       => NULL() !< send and recv information for boundary consistency check of N-cell
-     type(overlapSpec),  pointer :: bound_C       => NULL() !< send information for getting boundary value for symmetry domain.
-     type(overlapSpec),  pointer :: bound_E       => NULL() !< send information for getting boundary value for symmetry domain.
-     type(overlapSpec),  pointer :: bound_N       => NULL() !< send information for getting boundary value for symmetry domain.
+     type(overlapSpec),  pointer :: check_C       => NULL() !< send and recv information for boundary
+                                                            !! consistency check of C-cell
+     type(overlapSpec),  pointer :: check_E       => NULL() !< send and recv information for boundary
+                                                            !! consistency check of E-cell
+     type(overlapSpec),  pointer :: check_N       => NULL() !< send and recv information for boundary
+                                                            !! consistency check of N-cell
+     type(overlapSpec),  pointer :: bound_C       => NULL() !< send information for getting boundary
+                                                            !! value for symmetry domain.
+     type(overlapSpec),  pointer :: bound_E       => NULL() !< send information for getting boundary
+                                                            !! value for symmetry domain.
+     type(overlapSpec),  pointer :: bound_N       => NULL() !< send information for getting boundary
+                                                            !! value for symmetry domain.
      type(overlapSpec),  pointer :: update_T      => NULL() !< send and recv information for halo update of T-cell.
      type(overlapSpec),  pointer :: update_E      => NULL() !< send and recv information for halo update of E-cell.
      type(overlapSpec),  pointer :: update_C      => NULL() !< send and recv information for halo update of C-cell.
      type(overlapSpec),  pointer :: update_N      => NULL() !< send and recv information for halo update of N-cell.
-     type(domain2d),     pointer :: io_domain     => NULL() !< domain for IO, will be set through calling mpp_set_io_domain ( this will be changed).
+     type(domain2d),     pointer :: io_domain     => NULL() !< domain for IO, will be set through calling
+                                                            !! mpp_set_io_domain ( this will be changed).
   END TYPE domain2D
 
   !> Type used to represent the contact between tiles.
@@ -690,7 +698,8 @@ module mpp_domains_mod
   !     Not sure why static d_comm fails during deallocation of derived type members; allocatable works
   !     type(DomainCommunicator2D),dimension(MAX_FIELDS),save,target    :: d_comm !< domain communicators
   type(DomainCommunicator2D),dimension(:),allocatable,save,target :: d_comm  !< domain communicators
-  integer,                   dimension(-1:MAX_FIELDS),save           :: d_comm_idx=-9999 !< index of d_comm associated with sorted addresses
+  integer,                   dimension(-1:MAX_FIELDS),save           :: d_comm_idx=-9999 !< index of
+                                                                             !! d_comm associated with sorted addresses
   integer,                   dimension(MAX_FIELDS),save           :: dc_salvage=-9999 !< freed indices of d_comm
   integer,                                         save           :: dc_sort_len=0 !< length sorted comm keys
 !! (=num active communicators)

--- a/mpp/mpp_io.F90
+++ b/mpp/mpp_io.F90
@@ -188,8 +188,8 @@
 !!
 !!   A set of <I>attributes</I> for each variable is also available. The
 !!   variable definitions and attribute information is written/read by calling
-!!   <LINK SRC="#mpp_write_meta">mpp_write_meta</LINK> or <LINK SRC="#mpp_read_meta">mpp_read_meta</LINK>. A typical calling
-!!   sequence for writing data might be:
+!!   <LINK SRC="#mpp_write_meta">mpp_write_meta</LINK> or <LINK SRC="#mpp_read_meta">mpp_read_meta</LINK>. A typical
+!!   calling sequence for writing data might be:
 !!
 !!   <PRE>
 !!   ...
@@ -291,7 +291,9 @@
 !!   <TT>mpp_get_atts</TT> returns all global attributes for
 !!   the file in the derived type <TT>atttype(natt)</TT>.
 !!   <TT>mpp_get_vars</TT> returns variable types
-!!   (<TT>fieldtype(nvar)</TT>).  Since the record dimension data are not allocated for calls to <LINK SRC="#mpp_write">mpp_write</LINK>, a separate call to  <TT>mpp_get_times</TT> is required to access record dimension data.  Subsequent calls to
+!!   (<TT>fieldtype(nvar)</TT>).  Since the record dimension data are not allocated for calls to
+!!   <LINK SRC="#mpp_write">mpp_write</LINK>, a separate call to  <TT>mpp_get_times</TT> is required to access record
+!!   dimension data.  Subsequent calls to
 !!   <TT>mpp_read</TT> return the field data arrays corresponding to
 !!   the fieldtype.  The <TT>domain</TT> type is an optional
 !!   argument.  If <TT>domain</TT> is omitted, the incoming field

--- a/parser/yaml_parser.F90
+++ b/parser/yaml_parser.F90
@@ -221,8 +221,10 @@ subroutine get_key_name(file_id, key_id, key_name)
    integer, intent(in) :: file_id !< File id of the yaml file to search
    character(len=*), intent(out) :: key_name
 
-   if (.not. is_valid_file_id(file_id)) call mpp_error(FATAL, "The file id in your get_key_name call is invalid! Check your call.")
-   if (.not. is_valid_key_id(file_id, key_id)) call mpp_error(FATAL, "The key id in your get_key_name call is invalid! Check your call.")
+   if (.not. is_valid_file_id(file_id)) call mpp_error(FATAL, &
+       &  "The file id in your get_key_name call is invalid! Check your call.")
+   if (.not. is_valid_key_id(file_id, key_id)) call mpp_error(FATAL, &
+       &  "The key id in your get_key_name call is invalid! Check your call.")
 
    key_name = fms_c2f_string(get_key(file_id, key_id))
 
@@ -234,8 +236,10 @@ subroutine get_key_value(file_id, key_id, key_value)
    integer, intent(in) :: file_id !< File id of the yaml file to search
    character(len=*), intent(out) :: key_value
 
-   if (.not. is_valid_file_id(file_id)) call mpp_error(FATAL, "The file id in your get_key_value call is invalid! Check your call.")
-   if (.not. is_valid_key_id(file_id, key_id)) call mpp_error(FATAL, "The key id in your get_key_value call is invalid! Check your call.")
+   if (.not. is_valid_file_id(file_id)) call mpp_error(FATAL, &
+       &  "The file id in your get_key_value call is invalid! Check your call.")
+   if (.not. is_valid_key_id(file_id, key_id)) call mpp_error(FATAL, &
+       &  "The key id in your get_key_value call is invalid! Check your call.")
 
    key_value = fms_c2f_string(get_value(file_id, key_id))
 
@@ -261,8 +265,10 @@ subroutine get_value_from_key_0d(file_id, block_id, key_name, key_value, is_opti
    optional = .false.
    if (present(is_optional)) optional = is_optional
 
-   if (.not. is_valid_file_id(file_id)) call mpp_error(FATAL, "The file id in your get_value_from_key call is invalid! Check your call.")
-   if (.not. is_valid_block_id(file_id, block_id)) call mpp_error(FATAL, "The block id in your get_value_from_key call is invalid! Check your call.")
+   if (.not. is_valid_file_id(file_id)) call mpp_error(FATAL, &
+       &  "The file id in your get_value_from_key call is invalid! Check your call.")
+   if (.not. is_valid_block_id(file_id, block_id)) call mpp_error(FATAL, &
+       &  "The block id in your get_value_from_key call is invalid! Check your call.")
 
    c_buffer = get_value_from_key_wrap(file_id, block_id, trim(key_name)//c_null_char, sucess)
    if (sucess == 1) then
@@ -271,16 +277,20 @@ subroutine get_value_from_key_0d(file_id, block_id, key_name, key_value, is_opti
      select type (key_value)
        type is (integer(kind=i4_kind))
           read(buffer,*, iostat=err_unit) key_value
-          if (err_unit .ne. 0) call mpp_error(FATAL, "Key:"//trim(key_name)//" Error converting '"//trim(buffer)//"' to i4")
+          if (err_unit .ne. 0) call mpp_error(FATAL, "Key:"// &
+              & trim(key_name)//" Error converting '"//trim(buffer)//"' to i4")
        type is (integer(kind=i8_kind))
           read(buffer,*, iostat=err_unit) key_value
-          if (err_unit .ne. 0) call mpp_error(FATAL, "Key:"//trim(key_name)//" Error converting '"//trim(buffer)//"' to i8")
+          if (err_unit .ne. 0) call mpp_error(FATAL, "Key:"// &
+              & trim(key_name)//" Error converting '"//trim(buffer)//"' to i8")
        type is (real(kind=r4_kind))
           read(buffer,*, iostat=err_unit) key_value
-          if (err_unit .ne. 0) call mpp_error(FATAL, "Key:"//trim(key_name)//" Error converting '"//trim(buffer)//"' to r4")
+          if (err_unit .ne. 0) call mpp_error(FATAL, "Key:"// &
+              & trim(key_name)//" Error converting '"//trim(buffer)//"' to r4")
        type is (real(kind=r8_kind))
           read(buffer,*, iostat=err_unit) key_value
-          if (err_unit .ne. 0) call mpp_error(FATAL, "Key:"//trim(key_name)//" Error converting '"//trim(buffer)//"' to r8")
+          if (err_unit .ne. 0) call mpp_error(FATAL, "Key:"// &
+              & trim(key_name)//" Error converting '"//trim(buffer)//"' to r8")
        type is (character(len=*))
           call string_copy(key_value, buffer)
      class default
@@ -313,8 +323,10 @@ subroutine get_value_from_key_1d(file_id, block_id, key_name, key_value, is_opti
    optional=.false.
    if (present(is_optional)) optional = is_optional
 
-   if (.not. is_valid_file_id(file_id)) call mpp_error(FATAL, "The file id in your get_value_from_key call is invalid! Check your call.")
-   if (.not. is_valid_block_id(file_id, block_id)) call mpp_error(FATAL, "The block id in your get_value_from_key call is invalid! Check your call.")
+   if (.not. is_valid_file_id(file_id)) call mpp_error(FATAL, &
+       &  "The file id in your get_value_from_key call is invalid! Check your call.")
+   if (.not. is_valid_block_id(file_id, block_id)) call mpp_error(FATAL, &
+       &  "The block id in your get_value_from_key call is invalid! Check your call.")
 
    c_buffer = get_value_from_key_wrap(file_id, block_id, trim(key_name)//c_null_char, sucess)
    if (sucess == 1) then
@@ -323,16 +335,20 @@ subroutine get_value_from_key_1d(file_id, block_id, key_name, key_value, is_opti
      select type (key_value)
        type is (integer(kind=i4_kind))
           read(buffer,*, iostat=err_unit) key_value
-          if (err_unit .ne. 0) call mpp_error(FATAL, "Key:"//trim(key_name)//" Error converting '"//trim(buffer)//"' to i4")
+          if (err_unit .ne. 0) call mpp_error(FATAL, "Key:"// &
+              & trim(key_name)//" Error converting '"//trim(buffer)//"' to i4")
        type is (integer(kind=i8_kind))
           read(buffer,*, iostat=err_unit) key_value
-          if (err_unit .ne. 0) call mpp_error(FATAL, "Key:"//trim(key_name)//" Error converting '"//trim(buffer)//"' to i8")
+          if (err_unit .ne. 0) call mpp_error(FATAL, "Key:"// &
+              & trim(key_name)//" Error converting '"//trim(buffer)//"' to i8")
        type is (real(kind=r4_kind))
           read(buffer,*, iostat=err_unit) key_value
-          if (err_unit .ne. 0) call mpp_error(FATAL, "Key:"//trim(key_name)//" Error converting '"//trim(buffer)//"' to r4")
+          if (err_unit .ne. 0) call mpp_error(FATAL, "Key:"// &
+              & trim(key_name)//" Error converting '"//trim(buffer)//"' to r4")
        type is (real(kind=r8_kind))
           read(buffer,*, iostat=err_unit) key_value
-          if (err_unit .ne. 0) call mpp_error(FATAL, "Key:"//trim(key_name)//" Error converting '"//trim(buffer)//"' to r8")
+          if (err_unit .ne. 0) call mpp_error(FATAL, "Key:"// &
+              & trim(key_name)//" Error converting '"//trim(buffer)//"' to r8")
        type is (character(len=*))
           call mpp_error(FATAL, "get_value_from_key 1d string variables are not supported. Contact developers")
      class default
@@ -355,12 +371,14 @@ function get_num_blocks(file_id, block_name, parent_block_id) &
     integer, intent(in), optional :: parent_block_id !< Id of the parent block
     integer :: nblocks
 
-    if (.not. is_valid_file_id(file_id)) call mpp_error(FATAL, "The file id in your get_num_blocks call is invalid! Check your call.")
+    if (.not. is_valid_file_id(file_id)) call mpp_error(FATAL, &
+        &  "The file id in your get_num_blocks call is invalid! Check your call.")
 
     if (.not. present(parent_block_id)) then
        nblocks=get_num_blocks_all(file_id, trim(block_name)//c_null_char)
     else
-       if (.not. is_valid_block_id(file_id, parent_block_id)) call mpp_error(FATAL, "The parent_block id in your get_num_blocks call is invalid! Check your call.")
+       if (.not. is_valid_block_id(file_id, parent_block_id)) call mpp_error(FATAL, &
+           &  "The parent_block id in your get_num_blocks call is invalid! Check your call.")
        nblocks=get_num_blocks_child(file_id, trim(block_name)//c_null_char, parent_block_id)
     endif
 end function get_num_blocks
@@ -376,7 +394,8 @@ subroutine get_block_ids(file_id, block_name, block_ids, parent_block_id)
     integer :: nblocks_id
     integer :: nblocks
 
-    if (.not. is_valid_file_id(file_id)) call mpp_error(FATAL, "The file id in your get_block_ids call is invalid! Check your call.")
+    if (.not. is_valid_file_id(file_id)) call mpp_error(FATAL, &
+        &  "The file id in your get_block_ids call is invalid! Check your call.")
 
     nblocks_id = size(block_ids)
     nblocks = get_num_blocks(file_id, block_name, parent_block_id)
@@ -385,7 +404,8 @@ subroutine get_block_ids(file_id, block_name, block_ids, parent_block_id)
     if (.not. present(parent_block_id)) then
        call get_block_ids_all(file_id, trim(block_name)//c_null_char, block_ids)
     else
-       if (.not. is_valid_block_id(file_id, parent_block_id)) call mpp_error(FATAL, "The parent_block id in your get_block_ids call is invalid! Check your call.")
+       if (.not. is_valid_block_id(file_id, parent_block_id)) call mpp_error(FATAL, &
+           &  "The parent_block id in your get_block_ids call is invalid! Check your call.")
        call get_block_ids_child(file_id, trim(block_name)//c_null_char, block_ids, parent_block_id)
     endif
 end subroutine get_block_ids
@@ -398,8 +418,10 @@ function get_nkeys(file_id, block_id) &
    integer, intent(in) :: block_id !< Id of the parent_block
    integer :: nkeys
 
-    if (.not. is_valid_file_id(file_id)) call mpp_error(FATAL, "The file id in your get_nkeys call is invalid! Check your call.")
-    if (.not. is_valid_block_id(file_id, block_id)) call mpp_error(FATAL, "The block id in your get_nkeys call is invalid! Check your call.")
+    if (.not. is_valid_file_id(file_id)) call mpp_error(FATAL, &
+        &  "The file id in your get_nkeys call is invalid! Check your call.")
+    if (.not. is_valid_block_id(file_id, block_id)) call mpp_error(FATAL, &
+        &  "The block id in your get_nkeys call is invalid! Check your call.")
 
     nkeys = get_nkeys_binding(file_id, block_id)
 end function get_nkeys
@@ -413,8 +435,10 @@ subroutine get_key_ids (file_id, block_id, key_ids)
    integer :: nkey_ids !< Size of key_ids
    integer :: nkeys !< Actual number of keys
 
-   if (.not. is_valid_file_id(file_id)) call mpp_error(FATAL, "The file id in your get_key_ids call is invalid! Check your call.")
-   if (.not. is_valid_block_id(file_id, block_id)) call mpp_error(FATAL, "The block id in your get_key_ids call is invalid! Check your call.")
+   if (.not. is_valid_file_id(file_id)) call mpp_error(FATAL, &
+       &  "The file id in your get_key_ids call is invalid! Check your call.")
+   if (.not. is_valid_block_id(file_id, block_id)) call mpp_error(FATAL, &
+       &  "The block id in your get_key_ids call is invalid! Check your call.")
 
    nkey_ids = size(key_ids)
    nkeys = get_nkeys(file_id, block_id)

--- a/parser/yaml_parser_binding.c
+++ b/parser/yaml_parser_binding.c
@@ -103,7 +103,7 @@ char *get_value_from_key_wrap(int *file_id, int *block_id, char *key_name, int *
 {
   int i;              /* For loops */
   int j = *file_id;   /* To minimize the typing :) */
- 
+
   *sucess = 0;          /* Flag indicating if the search was sucessful */
 
   for ( i = 1; i <= my_files.files[j].nkeys; i++ )
@@ -262,7 +262,7 @@ bool open_and_parse_file_wrap(char *filename, int *file_id)
     {
     case YAML_KEY_TOKEN:
        {
-        is_key = true; 
+        is_key = true;
         break;
        }
     case YAML_VALUE_TOKEN:

--- a/sat_vapor_pres/sat_vapor_pres.F90
+++ b/sat_vapor_pres/sat_vapor_pres.F90
@@ -2728,7 +2728,8 @@ subroutine show_all_bad_0d ( temp )
  do i=1,size(temp,1)
    ind = int(dtinv*(temp(i,j,k)-tmin+teps))
    if (ind < 0 .or. ind > nlim) then
-     write(unit,'(a,e10.3,a,i4,a,i4,a,i4,a,i6)') 'Bad temperature=',temp(i,j,k),'  at i=',i,' j=',j,' k=',k,' pe=',mpp_pe()
+     write(unit,'(a,e10.3,a,i4,a,i4,a,i4,a,i6)') 'Bad temperature=',temp(i,j,k),'  at i=',i,' j=',j,' k=',k, &
+          & ' pe=',mpp_pe()
    endif
  enddo
  enddo

--- a/supported_interfaces.md
+++ b/supported_interfaces.md
@@ -2,7 +2,7 @@
 # Supported Public Interfaces for FMS
 
 List of supported public interfaces and associated types meant for external use through the 'fms' module.
-Additional information for this module and others can be found in the Doxygen generated documentation. 
+Additional information for this module and others can be found in the Doxygen generated documentation.
 
 ### affinity
 ##### Interfaces

--- a/test_fms/coupler/test_coupler_2d.F90
+++ b/test_fms/coupler/test_coupler_2d.F90
@@ -89,8 +89,8 @@ endif
 
 !> Write the file with new io
 call set_up_coupler_type(bc_type, data_grid, appendix="new", to_read=.false.)
-call coupler_type_register_restarts(bc_type, bc_rest_files, num_rest_files, domain, to_read=.false., ocean_restart=.false., &
-                                    & directory="RESTART/")
+call coupler_type_register_restarts(bc_type, bc_rest_files, num_rest_files, domain, to_read=.false., &
+                                   & ocean_restart=.false., directory="RESTART/")
 
 do i = 1, bc_type%num_bcs
    call write_restart(bc_rest_files(i))
@@ -99,8 +99,8 @@ enddo
 
 !< Now read the file back!
 call set_up_coupler_type(bc_type_read, data_grid, appendix="new", to_read=.true.)
-call coupler_type_register_restarts(bc_type_read, bc_rest_files, num_rest_files, domain, to_read=.true., ocean_restart=.false.,&
-                                    & directory="RESTART/")
+call coupler_type_register_restarts(bc_type_read, bc_rest_files, num_rest_files, domain, to_read=.true., &
+                                  & ocean_restart=.false., directory="RESTART/")
 
 do i = 1, bc_type_read%num_bcs
    call read_restart(bc_rest_files(i))
@@ -201,8 +201,8 @@ subroutine compare_answers(bc_type_read, bc_type)
    do i=1, bc_type%num_bcs
       do j = 1, bc_type%bc(i)%num_fields
          if (sum(bc_type%bc(i)%field(j)%values) .ne. sum(bc_type_read%bc(i)%field(j)%values)) then
-             call mpp_error(FATAL, "test_coupler_2d: Answers do not match for: "//trim(bc_type%bc(i)%ice_restart_file)//&
-                            &" var: "//trim(bc_type%bc(i)%field(j)%name))
+             call mpp_error(FATAL, "test_coupler_2d: Answers do not match for: "//trim(bc_type%bc(i)%ice_restart_file)&
+                            & //" var: "//trim(bc_type%bc(i)%field(j)%name))
          endif
       end do
    end do

--- a/test_fms/coupler/test_coupler_3d.F90
+++ b/test_fms/coupler/test_coupler_3d.F90
@@ -94,8 +94,8 @@ endif
 
 !> Write the file with new io
 call set_up_coupler_type(bc_type, data_grid, appendix="new", to_read=.false.)
-call coupler_type_register_restarts(bc_type, bc_rest_files, num_rest_files, domain, to_read=.false., ocean_restart=.false., &
-                                    & directory="RESTART/")
+call coupler_type_register_restarts(bc_type, bc_rest_files, num_rest_files, domain, to_read=.false., &
+                                  & ocean_restart=.false., directory="RESTART/")
 
 do i = 1, bc_type%num_bcs
    call write_restart(bc_rest_files(i))
@@ -104,8 +104,8 @@ enddo
 
 !< Now read the file back!
 call set_up_coupler_type(bc_type_read, data_grid, appendix="new", to_read=.true.)
-call coupler_type_register_restarts(bc_type_read, bc_rest_files, num_rest_files, domain, to_read=.true., ocean_restart=.false.,&
-                                    & directory="RESTART/")
+call coupler_type_register_restarts(bc_type_read, bc_rest_files, num_rest_files, domain, to_read=.true., &
+                                  & ocean_restart=.false., directory="RESTART/")
 
 do i = 1, bc_type_read%num_bcs
    call read_restart(bc_rest_files(i))
@@ -208,8 +208,8 @@ subroutine compare_answers(bc_type_read, bc_type)
    do i=1, bc_type%num_bcs
       do j = 1, bc_type%bc(i)%num_fields
          if (sum(bc_type%bc(i)%field(j)%values) .ne. sum(bc_type_read%bc(i)%field(j)%values)) then
-             call mpp_error(FATAL, "test_coupler_3d: Answers do not match for: "//trim(bc_type%bc(i)%ice_restart_file)//&
-                            &" var: "//trim(bc_type%bc(i)%field(j)%name))
+             call mpp_error(FATAL, "test_coupler_3d: Answers do not match for: "//trim(bc_type%bc(i)%ice_restart_file)&
+                            & //" var: "//trim(bc_type%bc(i)%field(j)%name))
          endif
       end do
    end do

--- a/test_fms/data_override/test_data_override.F90
+++ b/test_fms/data_override/test_data_override.F90
@@ -44,7 +44,8 @@ program test
   ! Input data and path_names file for this program is in:
   ! /archive/pjp/unit_tests/test_data_override/lima/exp1
  use           mpp_mod, only: input_nml_file, stdout, mpp_chksum
- use   mpp_domains_mod, only: domain2d, mpp_define_domains, mpp_define_io_domain, mpp_get_compute_domain, mpp_define_layout
+ use   mpp_domains_mod, only: domain2d, mpp_define_domains, mpp_define_io_domain, mpp_get_compute_domain, &
+                           &  mpp_define_layout
  use           fms_mod, only: fms_init, fms_end, mpp_npes, file_exist, check_nml_error
  use           fms_mod, only: error_mesg, FATAL, file_exist, field_exist, field_size
  use  fms_affinity_mod, only: fms_affinity_set
@@ -141,7 +142,8 @@ program test
     call read_data(grid_file, 'ocn_mosaic_file', solo_mosaic_file)
     solo_mosaic_file = 'INPUT/'//trim(solo_mosaic_file)
     call field_size(solo_mosaic_file, 'gridfiles', siz)
-    if( siz(2) .NE. 1) call error_mesg('test_data_override', 'only support single tile mosaic, contact developer', FATAL)
+    if( siz(2) .NE. 1) &
+       call error_mesg('test_data_override', 'only support single tile mosaic, contact developer', FATAL)
     call read_data(solo_mosaic_file, 'gridfiles', tile_file)
     tile_file = 'INPUT/'//trim(tile_file)
     call field_size(tile_file, 'area', siz)
@@ -308,7 +310,7 @@ enddo
 
 contains
 
-!=================================================================================================================================
+!======================================================================================================================
  subroutine get_grid
    real, allocatable, dimension(:,:,:) :: lon_vert_glo, lat_vert_glo
    real, allocatable, dimension(:,:)   :: lon_global, lat_global
@@ -441,7 +443,8 @@ contains
           write(outunit,*)'NOTE from test_unstruct_update ==> For Mosaic "', trim(type), &
                '", each tile will be distributed over ', npes_per_tile, ' processors.'
        else
-          call mpp_error(NOTE,'test_unstruct_update: npes should be multiple of ntiles No test is done for '//trim(type))
+          call mpp_error(NOTE,'test_unstruct_update: npes should be multiple of ntiles No test is done for '// &
+                         & trim(type))
           return
        endif
        if(layout_cubic(1)*layout_cubic(2) == npes_per_tile) then
@@ -533,7 +536,8 @@ contains
     allocate(ntiles_grid(ntotal_land))
     ntiles_grid = 1
    !--- define the unstructured grid domain
-    call mpp_define_unstruct_domain(UG_domain, SG_domain, npts_tile, ntiles_grid, mpp_npes(), 1, grid_index, name="LAND unstruct")
+    call mpp_define_unstruct_domain(UG_domain, SG_domain, npts_tile, ntiles_grid, mpp_npes(), 1, grid_index, &
+                                   &  name="LAND unstruct")
     call mpp_get_UG_compute_domain(UG_domain, istart, iend)
 
     !--- figure out lmask according to grid_index
@@ -819,5 +823,5 @@ contains
 
   end subroutine define_cubic_mosaic
 
-!=================================================================================================================================
+!======================================================================================================================
  end program test

--- a/test_fms/diag_manager/test_diag_manager.F90
+++ b/test_fms/diag_manager/test_diag_manager.F90
@@ -200,9 +200,12 @@
 !#output files
 !"unstructured_diag_test", 2, "days", 2, "days", "time",
 !#output variables
-!"UG_unit_test", "unstructured_real_scalar_field_data", "rsf_diag_1", "unstructured_diag_test", "all", .TRUE., "none", 1,
-!"UG_unit_test", "unstructured_real_1D_field_data", "unstructured_real_1D_field_data", "unstructured_diag_test", "all", .TRUE., "none", 1,
-!"UG_unit_test", "unstructured_real_2D_field_data", "unstructured_real_2D_field_data", "unstructured_diag_test", "all", .TRUE., "none", 1,
+!"UG_unit_test", "unstructured_real_scalar_field_data", "rsf_diag_1", "unstructured_diag_test", "all", .TRUE., "none",
+! 1,
+!"UG_unit_test", "unstructured_real_1D_field_data", "unstructured_real_1D_field_data", "unstructured_diag_test", 
+!"all", .TRUE., "none", 1,
+!"UG_unit_test", "unstructured_real_2D_field_data", "unstructured_real_2D_field_data", "unstructured_diag_test",
+!"all", .TRUE., "none", 1,
 !"UG_unit_test", "lon", "grid_xt", "unstructured_diag_test", "all", .TRUE., "none", 1,
 !"UG_unit_test", "lat", "grid_yt", "unstructured_diag_test", "all", .TRUE., "none", 1,
 !--------------------------------------------------------------------------------------------------
@@ -291,28 +294,32 @@ PROGRAM test
   INTEGER :: id_nv, id_nv_init
 
 !!!!!! Stuff for unstrctured grid
-    integer(kind=i4_kind)              :: nx = 8                               !<Total number of grid points in the x-dimension (longitude?)
-    integer(kind=i4_kind)              :: ny = 8                               !<Total number of grid points in the y-dimension (latitude?)
-    integer(kind=i4_kind)              :: nz = 2                               !<Total number of grid points in the z-dimension (height)
+    integer(kind=i4_kind)              :: nx = 8                               !<Total number of grid points in the
+                                                                               !! x-dimension (longitude?)
+    integer(kind=i4_kind)              :: ny = 8           !<Total number of grid points in the y-dimension (latitude?)
+    integer(kind=i4_kind)              :: nz = 2           !<Total number of grid points in the z-dimension (height)
     integer(kind=i4_kind)              :: nt = 2                               !<Total number of time grid points.
     integer(kind=i4_kind)              :: io_tile_factor = 1                   !< The IO tile factor
     integer(kind=i4_kind)              :: halo = 2                             !<Number of grid points in the halo???
-    integer(kind=i4_kind)              :: ntiles_x = 1                         !<Number of tiles in the x-direction (A 2D grid of tiles is used in this test.)
-    integer(kind=i4_kind)              :: ntiles_y = 2                         !<Number of tiles in the y-direction (A 2D grid of tiles is used in this test.)
-    integer(kind=i4_kind)              :: total_num_tiles                      !<The total number of tiles for the run (= ntiles_x*ntiles_y)
-    integer(kind=i4_kind)              :: stackmax = 1500000                   !<Default size to which the mpp stack will be set.
-    integer(kind=i4_kind)              :: stackmaxd = 500000                   !<Default size to which the mpp_domains stack will be set.
+    integer(kind=i4_kind)              :: ntiles_x = 1     !<Number of tiles in the x-direction
+                                                           !! (A 2D grid of tiles is used in this test.)
+    integer(kind=i4_kind)              :: ntiles_y = 2     !<Number of tiles in the y-direction (A 2D grid of tiles is
+                                                           !! used in this test.)
+    integer(kind=i4_kind)              :: total_num_tiles  !<The total number of tiles for the run (=ntiles_x*ntiles_y)
+    integer(kind=i4_kind)              :: stackmax = 1500000 !<Default size to which the mpp stack will be set.
+    integer(kind=i4_kind)              :: stackmaxd = 500000 !<Default size to which the mpp_domains stack will be set.
     logical(kind=l4_kind)              :: debug = .false.                      !<Flag to print debugging information.
     character(len=64)              :: test_file = "test_unstructured_grid" !<Base filename for the unit tests.
     character(len=64)              :: iospec = '-F cachea'                 !<Something cray related ???
-    integer(kind=i4_kind)              :: pack_size = 1                        !<(Number of bits in real(kind=r8_kind))/(Number of bits in real)
-    integer(kind=i4_kind)              :: npes                                 !<Total number of ranks in the current pelist.
+    integer(kind=i4_kind)              :: pack_size = 1    !<(Number of bits in real(kind=r8_kind))/(Number of bits
+                                                           !! in real)
+    integer(kind=i4_kind)              :: npes             !<Total number of ranks in the current pelist.
     integer(kind=i4_kind)              :: io_status                            !<Namelist read error code.
-    real(kind=r8_kind)              :: doubledata = 0.0                     !<Used to determine pack_size.  This must be kind=r8_kind.
-    real                           :: realdata = 0.0                       !<Used to determine pack_size.  Do not specify a kind parameter.
+    real(kind=r8_kind)              :: doubledata = 0.0    !<Used to determine pack_size.  This must be kind=r8_kind.
+    real                           :: realdata = 0.0   !<Used to determine pack_size.  Do not specify a kind parameter.
     integer(kind=i4_kind)              :: funit = 7                            !<File unit.
-    logical(kind=l4_kind)              :: fopened                              !<Flag telling if a file is already open.
-    type(time_type)                :: diag_time                            !<
+    logical(kind=l4_kind)              :: fopened      !<Flag telling if a file is already open.
+    type(time_type)                :: diag_time
 
     integer(kind=i4_kind)              :: output_unit=6
 !!!!!!
@@ -366,8 +373,8 @@ PROGRAM test
   ! Check the status of reading the diag_manager_nml
   IF ( check_nml_error(IOSTAT=ierr, NML_NAME='DIAG_MANAGER_NML') < 0 ) THEN
      IF ( mpp_pe() == mpp_root_pe() ) THEN
-        CALL error_mesg('diag_manager_mod::diag_manager_init', 'TEST_DIAG_MANAGER_NML not found in input.nml.  Using defaults.',&
-             & WARNING)
+        CALL error_mesg('diag_manager_mod::diag_manager_init', &
+               & 'TEST_DIAG_MANAGER_NML not found in input.nml.  Using defaults.', WARNING)
      END IF
   END IF
   WRITE (log_unit,test_diag_manager_nml)
@@ -459,14 +466,16 @@ SELECT CASE ( test_number ) ! Closes just before the CONTAINS block.
   ALLOCATE(pfull(nlev), bk(nlev), phalf(nlev+1))
 
   ALLOCATE(lon1(is1:ie1), lat1(js1:je1), lonb1(is1:ie1+1), latb1(js1:je1+1))
-  CALL compute_grid(nlon1, nlat1, is1, ie1, js1, je1, lon_global1, lat_global1, lonb_global1, latb_global1, lon1, lat1, lonb1, latb1)
+  CALL compute_grid(nlon1, nlat1, is1, ie1, js1, je1, lon_global1, lat_global1, lonb_global1, latb_global1, lon1, &
+                  & lat1, lonb1, latb1)
   CALL mpp_define_domains((/1,nlon2,1,nlat2/), layout, Domain2, name='test_diag_manager')
   CALL mpp_get_compute_domain(Domain2, is2, ie2, js2, je2)
   CALL mpp_define_io_domain(Domain1, io_layout)
   CALL mpp_define_io_domain(Domain2, io_layout)
 
   ALLOCATE(lon2(is2:ie2), lat2(js2:je2), lonb2(is2:ie2+1), latb2(js2:je2+1))
-  CALL compute_grid(nlon2, nlat2, is2, ie2, js2, je2, lon_global2, lat_global2, lonb_global2, latb_global2, lon2, lat2, lonb2, latb2)
+  CALL compute_grid(nlon2, nlat2, is2, ie2, js2, je2, lon_global2, lat_global2, lonb_global2, latb_global2, lon2, &
+                  & lat2, lonb2, latb2)
   dp = surf_press/nlev
   DO k=1, nlev+1
      phalf(k) = dp*(k-1)
@@ -504,11 +513,15 @@ SELECT CASE ( test_number ) ! Closes just before the CONTAINS block.
   dat2h(:,:,2) = -dat2h(:,:,1)
   dat2_2d = dat2(:,:,1)
 
-  id_lonb1 = diag_axis_init('lonb1', RAD_TO_DEG*lonb_global1, 'degrees_E', 'x', long_name='longitude edges', Domain2=Domain1)
-  id_latb1 = diag_axis_init('latb1', RAD_TO_DEG*latb_global1, 'degrees_N', 'y', long_name='latitude edges',  Domain2=Domain1)
+  id_lonb1 = diag_axis_init('lonb1', RAD_TO_DEG*lonb_global1, 'degrees_E', 'x', long_name='longitude edges', &
+                          & Domain2=Domain1)
+  id_latb1 = diag_axis_init('latb1', RAD_TO_DEG*latb_global1, 'degrees_N', 'y', long_name='latitude edges',  &
+                          & Domain2=Domain1)
 
-  id_lon1  = diag_axis_init('lon1',  RAD_TO_DEG*lon_global1, 'degrees_E','x',long_name='longitude',Domain2=Domain1,edges=id_lonb1)
-  id_lat1  = diag_axis_init('lat1',  RAD_TO_DEG*lat_global1, 'degrees_N','y',long_name='latitude', Domain2=Domain1,edges=id_latb1)
+  id_lon1  = diag_axis_init('lon1',  RAD_TO_DEG*lon_global1, 'degrees_E','x',long_name='longitude',Domain2=Domain1, &
+                          & edges=id_lonb1)
+  id_lat1  = diag_axis_init('lat1',  RAD_TO_DEG*lat_global1, 'degrees_N','y',long_name='latitude', Domain2=Domain1, &
+                          & edges=id_latb1)
 
   id_phalf= diag_axis_init('phalf', phalf, 'Pa', 'z', long_name='half pressure level', direction=-1)
   id_pfull= diag_axis_init('pfull', pfull, 'Pa', 'z', long_name='full pressure level', direction=-1, edges=id_phalf)
@@ -551,18 +564,20 @@ SELECT CASE ( test_number ) ! Closes just before the CONTAINS block.
      ! Test 16 tests the filename appendix
      CALL set_filename_appendix('g01')
   END IF
-  id_dat1 = register_diag_field('test_diag_manager_mod', 'dat1', (/id_lon1,id_lat1,id_pfull/), Time, 'sample data', 'K')
+  id_dat1 = register_diag_field('test_diag_manager_mod', 'dat1', (/id_lon1,id_lat1,id_pfull/), Time, 'sample data','K')
   IF ( test_number == 18 ) THEN
      CALL diag_field_add_attribute(id_dat1, 'real_att', 2.3)
      CALL diag_field_add_attribute(id_dat1, 'cell_methods', 'area: mean')
      CALL diag_field_add_attribute(id_dat1, 'cell_methods', 'lon: mean')
   END IF
   IF ( test_number == 18 .OR. test_number == 19 ) THEN
-     id_dat2 = register_diag_field('test_diag_manager_mod', 'dat2', (/id_lon1,id_lat1,id_pfull/), Time, 'sample data', 'K')
+     id_dat2 = register_diag_field('test_diag_manager_mod', 'dat2', (/id_lon1,id_lat1,id_pfull/), Time, &
+                                 & 'sample data', 'K')
      CALL diag_field_add_attribute(id_dat2, 'interp_method', 'none')
      CALL diag_field_add_attribute(id_dat2, 'int_att', (/ 1, 2 /) )
   ELSE
-     id_dat2 = register_diag_field('test_diag_manager_mod', 'dat2', (/id_lon2,id_lat2,id_pfull/), Time, 'sample data', 'K')
+     id_dat2 = register_diag_field('test_diag_manager_mod', 'dat2', (/id_lon2,id_lat2,id_pfull/), Time, &
+                                 & 'sample data', 'K')
   END IF
   id_sol_con = register_diag_field ('test_diag_manager_mod', 'solar_constant', Time, &
                   'solar constant', 'watts/m2')
@@ -615,7 +630,7 @@ SELECT CASE ( test_number ) ! Closes just before the CONTAINS block.
      END IF
   END IF
 
-  IF ( test_number == 16 .OR. test_number == 17 .OR. test_number == 18 .OR. test_number == 21 .OR. test_number == 22 ) THEN
+  IF(test_number == 16 .OR. test_number == 17 .OR. test_number == 18 .OR. test_number == 21 .OR. test_number == 22)THEN
      is_in = 1
      js_in = 1
      ie_in = nlon
@@ -623,13 +638,17 @@ SELECT CASE ( test_number ) ! Closes just before the CONTAINS block.
 
      IF ( id_dat1 > 0 ) used = send_data(id_dat1, dat1, Time, err_msg=err_msg)
      IF ( id_dat2 > 0 ) used = send_data(id_dat2, dat1, Time, err_msg=err_msg)
-     IF ( id_dat2h > 0 ) used = send_data(id_dat2h, dat2h, Time, is_in=is_in, js_in=js_in, ie_in=ie_in, je_in=je_in, err_msg=err_msg)
-     IF ( id_dat2h_2 > 0 ) used = send_data(id_dat2h_2, dat2h, Time, is_in=is_in, js_in=js_in, ie_in=ie_in, je_in=je_in, err_msg=err_msg)
+     IF ( id_dat2h > 0 ) used = send_data(id_dat2h, dat2h, Time, is_in=is_in, js_in=js_in, ie_in=ie_in, je_in=je_in, &
+                                        & err_msg=err_msg)
+     IF ( id_dat2h_2 > 0 ) used = send_data(id_dat2h_2, dat2h, Time, is_in=is_in, js_in=js_in, ie_in=ie_in, &
+                                          & je_in=je_in, err_msg=err_msg)
      Time = Time + set_time(0,1)
      IF ( id_dat1 > 0 ) used = send_data(id_dat1, dat1, Time, err_msg=err_msg)
      IF ( id_dat2 > 0 ) used = send_data(id_dat2, dat1, Time, err_msg=err_msg)
-     IF ( id_dat2h > 0 ) used = send_data(id_dat2h, dat2h, Time, is_in=is_in, js_in=js_in, ie_in=ie_in, je_in=je_in, err_msg=err_msg)
-     IF ( id_dat2h_2 > 0 ) used = send_data(id_dat2h_2, dat2h, Time, is_in=is_in, js_in=js_in, ie_in=ie_in, je_in=je_in, err_msg=err_msg)
+     IF ( id_dat2h > 0 ) used = send_data(id_dat2h, dat2h, Time, is_in=is_in, js_in=js_in, ie_in=ie_in, je_in=je_in, &
+                                        & err_msg=err_msg)
+     IF ( id_dat2h_2 > 0 ) used = send_data(id_dat2h_2, dat2h, Time, is_in=is_in, js_in=js_in, ie_in=ie_in, &
+                                          & je_in=je_in, err_msg=err_msg)
   END IF
 
   !-- The following is used to test openMP
@@ -665,7 +684,7 @@ SELECT CASE ( test_number ) ! Closes just before the CONTAINS block.
 
 
   IF ( test_number == 14 ) THEN
-     id_dat2_2d = register_diag_field('test_mod', 'dat2', (/id_lon2,id_lat2/), Time, 'sample data', 'K', err_msg=err_msg)
+     id_dat2_2d = register_diag_field('test_mod', 'dat2', (/id_lon2,id_lat2/), Time, 'sample data','K',err_msg=err_msg)
      IF ( err_msg /= '' ) THEN
         WRITE (out_unit,'(a)') 'test14 successful. err_msg='//TRIM(err_msg)
      ELSE
@@ -680,7 +699,8 @@ SELECT CASE ( test_number ) ! Closes just before the CONTAINS block.
   IF ( test_number == 13 ) THEN
      IF ( id_dat2_2d > 0 ) used=send_data(id_dat2_2d, dat2(:,:,1), Time, err_msg=err_msg)
      IF ( err_msg == '' ) THEN
-        WRITE (out_unit,'(a)') 'test13: successful if a WARNING message appears that refers to output interval greater than runlength'
+        WRITE (out_unit,'(a)') &
+              & 'test13: successful if a WARNING message appears that refers to output interval greater than runlength'
      ELSE
         WRITE (out_unit,'(a)') 'test13 fails: err_msg='//TRIM(err_msg)
      END IF
@@ -695,7 +715,8 @@ SELECT CASE ( test_number ) ! Closes just before the CONTAINS block.
      ie_in = ie2-is2+1+hi
      je_in = je2-js2+1+hj
 
-     IF ( id_dat2 > 0 ) used=send_data(id_dat2, dat2h, Time, is_in=is_in, js_in=js_in, ie_in=ie_in, je_in=je_in, err_msg=err_msg)
+     IF ( id_dat2 > 0 ) used=send_data(id_dat2, dat2h, Time, is_in=is_in, js_in=js_in, ie_in=ie_in, je_in=je_in, &
+                                     & err_msg=err_msg)
      IF ( err_msg == '' ) THEN
         WRITE (out_unit,'(a)') 'test11.1 successful.'
      ELSE
@@ -1002,7 +1023,8 @@ END SELECT ! End of case handling opened for test 12.
 
 CONTAINS
 
-  SUBROUTINE compute_grid(nlon, nlat, is, ie, js, je, lon_global, lat_global, lonb_global, latb_global, lon, lat, lonb, latb)
+  SUBROUTINE compute_grid(nlon, nlat, is, ie, js, je, lon_global, lat_global, lonb_global, latb_global, lon, lat, &
+                        & lonb, latb)
     INTEGER, INTENT(in) :: nlon, nlat, is, ie, js, je
     REAL, INTENT(out), DIMENSION(:) :: lon_global, lat_global, lonb_global, latb_global, lon, lat, lonb, latb
 
@@ -1061,80 +1083,132 @@ CONTAINS
         integer(kind=i4_kind),intent(in)  :: ny                 !<The number of grid points in the y-direction.
         integer(kind=i4_kind),intent(in)  :: nz                 !<The number of grid points in the z-direction.
         integer(kind=i4_kind),intent(in)  :: npes               !<The total number of ranks used in this test.
-        integer(kind=i4_kind),intent(in)  :: num_domain_tiles_x !<The total number of domain tiles in the x-dimension for the 2D structured domain in this test.
-        integer(kind=i4_kind),intent(in)  :: num_domain_tiles_y !<The total number of domain tiles in the y-dimension for the 2D structured domain in this test.
+        integer(kind=i4_kind),intent(in)  :: num_domain_tiles_x !<The total number of domain tiles in the x-dimension
+                                                                !! for the 2D structured domain in this test.
+        integer(kind=i4_kind),intent(in)  :: num_domain_tiles_y !<The total number of domain tiles in the y-dimension
+                                                                !! for the 2D structured domain in this test.
         type(time_type),intent(inout) :: diag_time          !<Time for diag_manager.
         integer(kind=i4_kind),intent(in)  :: io_tile_factor     !<I/O tile factor.  See below.
 
        !Local variables
-        integer(kind=i4_kind)                              :: num_domain_tiles                           !<The total number of domain tiles for the 2D structured domain in this test.
-        integer(kind=i4_kind)                              :: npes_per_domain_tile                       !<The number of ranks per domain tile for the 2D structured domain.
-        integer(kind=i4_kind)                              :: my_domain_tile_id                          !<The 2D structured domain tile id for the current rank.
-        logical(kind=l4_kind)                              :: is_domain_tile_root                        !<Flag telling if the current rank is the root rank of its associated 2D structured domain tile.
-        integer(kind=i4_kind),dimension(2)                 :: layout_for_full_domain                     !<Rank layout (2D grid) for the full 2D structured domain. Example: 16 ranks -> (16,1) or (8,2) or (4,4) or (2,8) or (1,16)
-        integer(kind=i4_kind),dimension(:),allocatable     :: pe_start                                   !<Array holding the smallest rank id assigned to each 2D structured domain tile.
-        integer(kind=i4_kind),dimension(:),allocatable     :: pe_end                                     !<Array holding the largest rank id assigned to each 2D structured domain tile.
-        integer(kind=i4_kind)                              :: x_grid_points_per_domain_tile              !<The number of grid points in the x-dimension on each 2D structured domain tile.
-        integer(kind=i4_kind)                              :: y_grid_points_per_domain_tile              !<The number of grid points in the y-dimension on each 2D structured domain tile.
-        integer(kind=i4_kind),dimension(:,:),allocatable   :: global_indices                             !<Required to define the 2D structured domain.
-        integer(kind=i4_kind),dimension(:,:),allocatable   :: layout2D                                   !<Required to define the 2D structured domain.
-        type(domain2D)                                 :: domain_2D                                  !<A structured 2D domain.
+        integer(kind=i4_kind)                              :: num_domain_tiles !<The total number of domain tiles for
+                                                                              !! the 2D structured domain in this test.
+        integer(kind=i4_kind)                              :: npes_per_domain_tile !<The number of ranks per domain
+                                                                                  !! tile for the 2D structured domain.
+        integer(kind=i4_kind)                              :: my_domain_tile_id !<The 2D structured domain tile id for
+                                                                                !! the current rank.
+        logical(kind=l4_kind)                              :: is_domain_tile_root !<Flag telling if the current rank
+                                                       !! is the root rank of its associated 2D structured domain tile.
+        integer(kind=i4_kind),dimension(2)                 :: layout_for_full_domain !<Rank layout (2D grid) for the
+                                                   !! full 2D structured domain.
+                                                   !! Example: 16 ranks -> (16,1) or (8,2) or (4,4) or (2,8) or (1,16)
+        integer(kind=i4_kind),dimension(:),allocatable     :: pe_start !<Array holding the smallest rank id assigned 
+                                                                       !! to each 2D structured domain tile.
+        integer(kind=i4_kind),dimension(:),allocatable     :: pe_end !<Array holding the largest rank id assigned to
+                                                                     !! each 2D structured domain tile.
+        integer(kind=i4_kind)                              :: x_grid_points_per_domain_tile !<The number of grid
+                                                        !! points in the x-dimension on each 2D structured domain tile.
+        integer(kind=i4_kind)                              :: y_grid_points_per_domain_tile !<The number of grid
+                                                        !! points in the y-dimension on each 2D structured domain tile.
+        integer(kind=i4_kind),dimension(:,:),allocatable   :: global_indices !<Required to define the 2D structured
+                                                                             !! domain.
+        integer(kind=i4_kind),dimension(:,:),allocatable   :: layout2D !<Required to define the 2D structured domain.
+        type(domain2D)                                 :: domain_2D !<A structured 2D domain.
         logical(kind=l4_kind),dimension(:,:,:),allocatable :: land_mask                                  !<A toy mask.
-        integer(kind=i4_kind),dimension(:),allocatable     :: num_non_masked_grid_points_per_domain_tile !<Total number of non-masked grid points on each 2D structured domain tile.
-        integer(kind=i4_kind)                              :: mask_counter                               !<Counting variable.
-        integer(kind=i4_kind)                              :: num_non_masked_grid_points                 !<Total number of non-masked grid points for the 2D structured domain.
-        integer(kind=i4_kind),dimension(:),allocatable     :: num_land_tiles_per_non_masked_grid_point   !<Number of land tiles per non-masked grid point for the 2D structured domain.
-        integer(kind=i4_kind)                              :: num_ranks_using_unstructured_grid          !<Number of ranks using the unstructured domain.
-        integer(kind=i4_kind),dimension(:),allocatable     :: unstructured_grid_point_index_map          !<Array that maps indices between the 2D structured and unstructured domains.
-        type(domainUG)                                 :: domain_ug                                  !<An unstructured mpp domain.
-        integer(kind=i4_kind),dimension(:),allocatable     :: unstructured_axis_data                     !<Data that is registered to the restart file for the unstructured axis.
-        integer(kind=i4_kind)                              :: unstructured_axis_data_size                !<Size of the unstructured axis data array.
-        character(len=256)                             :: unstructured_axis_name                     !<Name for the unstructured axis.
-        real,dimension(:),allocatable                  :: x_axis_data                                !<Data for the x-axis that is registered to the restart file.
-        real,dimension(:),allocatable                  :: y_axis_data                                !<Data for the y-axis that is registered to the restart file.
-        real,dimension(:),allocatable                  :: z_axis_data                                !<Data for the z-axis that is registered to the restart file.
-        real                                           :: unstructured_real_scalar_field_data_ref    !<Reference test data for an unstructured real scalar field.
-        real,dimension(:),allocatable                  :: unstructured_real_1D_field_data_ref        !<Reference test data for an unstructured real 1D field.
-        real,dimension(:,:),allocatable                :: unstructured_real_2D_field_data_ref        !<Reference test data for an unstructured real 2D field.
-        real,dimension(:,:,:),allocatable              :: unstructured_real_3D_field_data_ref        !<Reference test data for an unstructured real 3D field.
-        integer                                        :: unstructured_int_scalar_field_data_ref     !<Reference test data for an unstructured integer scalar field.
-        integer,dimension(:),allocatable               :: unstructured_int_1D_field_data_ref         !<Reference test data for an unstructured integer 1D field.
-        integer,dimension(:,:),allocatable             :: unstructured_int_2D_field_data_ref         !<Reference test data for an unstructured integer 2D field.
-        character(len=256)                             :: unstructured_real_scalar_field_name        !<Name for an unstructured real scalar field.
-        real                                           :: unstructured_real_scalar_field_data        !<Data for an unstructured real scalar field.
-        character(len=256)                             :: unstructured_real_1D_field_name            !<Name for an unstructured real 1D field.
-        real,dimension(:),allocatable                  :: unstructured_real_1D_field_data            !<Data for an unstructured real 1D field.
-        character(len=256)                             :: unstructured_real_2D_field_name            !<Name for an unstructured real 2D field.
-        real,dimension(:,:),allocatable                :: unstructured_real_2D_field_data            !<Data for an unstructured real 2D field.
-        character(len=256)                             :: unstructured_real_3D_field_name            !<Name for an unstructured real 3D field.
-        real,dimension(:,:,:),allocatable              :: unstructured_real_3D_field_data            !<Data for an unstructured real 3D field.
-        character(len=256)                             :: unstructured_int_scalar_field_name         !<Name for an unstructured integer scalar field.
-        integer                                        :: unstructured_int_scalar_field_data         !<Data for an unstructured integer scalar field.
-        character(len=256)                             :: unstructured_int_1D_field_name             !<Name for an unstructured integer 1D field.
-        integer,dimension(:),allocatable               :: unstructured_int_1D_field_data             !<Data for an unstructured integer 1D field.
-        character(len=256)                             :: unstructured_int_2D_field_name             !<Name for an unstructured integer 2D field.
-        character(len=100)                             :: unstructured_1d_alt                       !<Name of the unstrucutred 1D field if L>1
-        integer,dimension(:,:),allocatable             :: unstructured_int_2D_field_data             !<Data for an unstructured integer 2D field.
-       integer(kind=i4_kind),allocatable,dimension(:)      :: unstructured_axis_diag_id                  !<Id returned for the unstructured axis by diag_axis_init.
-       integer(kind=i4_kind)                               :: x_axis_diag_id                             !<Id returned for the x-axis by diag_axis_init.
-       integer(kind=i4_kind)                              :: y_axis_diag_id                             !<Id returned for the y-axis by diag_axis_init.
-       integer(kind=i4_kind)                              :: z_axis_diag_id                             !<Id returned for the z-axis by diag_axis_init.
+        integer(kind=i4_kind),dimension(:),allocatable     :: num_non_masked_grid_points_per_domain_tile !<Total number
+                                                        !! of non-masked grid points on each 2D structured domain tile.
+        integer(kind=i4_kind)                              :: mask_counter !<Counting variable.
+        integer(kind=i4_kind)                              :: num_non_masked_grid_points !<Total number of non-masked
+                                                                          !! grid points for the 2D structured domain.
+        integer(kind=i4_kind),dimension(:),allocatable     :: num_land_tiles_per_non_masked_grid_point   !<Number of
+                                                 !! land tiles per non-masked grid point for the 2D structured domain.
+        integer(kind=i4_kind)                              :: num_ranks_using_unstructured_grid !<Number of ranks
+                                                                                 !! using the unstructured domain.
+        integer(kind=i4_kind),dimension(:),allocatable     :: unstructured_grid_point_index_map !<Array that maps
+                                                      !! indices between the 2D structured and unstructured domains.
+        type(domainUG)                                 :: domain_ug !<An unstructured mpp domain.
+        integer(kind=i4_kind),dimension(:),allocatable     :: unstructured_axis_data !<Data that is registered to the
+                                                                             !! restart file for the unstructured axis.
+        integer(kind=i4_kind)                              :: unstructured_axis_data_size !<Size of the unstructured
+                                                                                          !! axis data array.
+        character(len=256)                             :: unstructured_axis_name !<Name for the unstructured axis.
+        real,dimension(:),allocatable                  :: x_axis_data !<Data for the x-axis that is registered to the
+                                                                      !! restart file.
+        real,dimension(:),allocatable                  :: y_axis_data !<Data for the y-axis that is registered to the
+                                                                      !! restart file.
+        real,dimension(:),allocatable                  :: z_axis_data !<Data for the z-axis that is registered to the
+                                                                      !! restart file.
+        real                                           :: unstructured_real_scalar_field_data_ref !<Reference test
+                                                                      !! data for an unstructured real scalar field.
+        real,dimension(:),allocatable                  :: unstructured_real_1D_field_data_ref !<Reference
+                                                                        !! test data for an unstructured real 1D field.
+        real,dimension(:,:),allocatable                :: unstructured_real_2D_field_data_ref !<Reference
+                                                                        !! test data for an unstructured real 2D field.
+        real,dimension(:,:,:),allocatable              :: unstructured_real_3D_field_data_ref !<Reference
+                                                                        !! test data for an unstructured real 3D field.
+        integer                                        :: unstructured_int_scalar_field_data_ref !<Reference
+                                                                 !! test data for an unstructured integer scalar field.
+        integer,dimension(:),allocatable               :: unstructured_int_1D_field_data_ref !<Reference
+                                                                     !! test data for an unstructured integer 1D field.
+        integer,dimension(:,:),allocatable             :: unstructured_int_2D_field_data_ref !<Reference
+                                                                     !! test data for an unstructured integer 2D field.
+        character(len=256)                             :: unstructured_real_scalar_field_name !<Name
+                                                                              !! for an unstructured real scalar field.
+        real                                           :: unstructured_real_scalar_field_data !<Data
+                                                                              !! for an unstructured real scalar field.
+        character(len=256)                             :: unstructured_real_1D_field_name !<Name for
+                                                                                      !! an unstructured real 1D field.
+        real,dimension(:),allocatable                  :: unstructured_real_1D_field_data !<Data for
+                                                                                      !! an unstructured real 1D field.
+        character(len=256)                             :: unstructured_real_2D_field_name !<Name for
+                                                                                      !! an unstructured real 2D field.
+        real,dimension(:,:),allocatable                :: unstructured_real_2D_field_data !<Data for
+                                                                                      !! an unstructured real 2D field.
+        character(len=256)                             :: unstructured_real_3D_field_name !<Name for
+                                                                                      !! an unstructured real 3D field.
+        real,dimension(:,:,:),allocatable              :: unstructured_real_3D_field_data !<Data for
+                                                                                      !! an unstructured real 3D field.
+        character(len=256)                             :: unstructured_int_scalar_field_name !<Name for
+                                                                               !! an unstructured integer scalar field.
+        integer                                        :: unstructured_int_scalar_field_data !<Data for
+                                                                               !! an unstructured integer scalar field.
+        character(len=256)                             :: unstructured_int_1D_field_name !<Name for an
+                                                                                      !! unstructured integer 1D field.
+        integer,dimension(:),allocatable               :: unstructured_int_1D_field_data !<Data for an
+                                                                                      !! unstructured integer 1D field.
+        character(len=256)                             :: unstructured_int_2D_field_name !<Name for an
+                                                                                      !! unstructured integer 2D field.
+        character(len=100)                             :: unstructured_1d_alt!<Name of the unstructured 1D field if L>1
+        integer,dimension(:,:),allocatable             :: unstructured_int_2D_field_data !<Data for an
+                                                                                      !! unstructured integer 2D field.
+       integer(kind=i4_kind),allocatable,dimension(:)      :: unstructured_axis_diag_id !<Id returned
+                                                                        !! for the unstructured axis by diag_axis_init.
+       integer(kind=i4_kind)                               :: x_axis_diag_id !<Id returned for the x-axis
+                                                                             !! by diag_axis_init.
+       integer(kind=i4_kind)                              :: y_axis_diag_id !<Id returned for the y-axis
+                                                                            !! by diag_axis_init.
+       integer(kind=i4_kind)                              :: z_axis_diag_id !<Id returned for the z-axis
+                                                                            !! by diag_axis_init.
        real,allocatable,dimension(:) :: lat, lon
        integer(kind=i4_kind)             :: idlat
        integer(kind=i4_kind)                              :: idlon
-       integer(kind=i4_kind)                              :: rsf_diag_id                                !<Id returned for a real scalar field associated with the unstructured grid by
-                                !!register_diag_field.
-       integer(kind=i4_kind),allocatable,dimension(:)     :: rsf_diag_1d_id                             !<Id returned for a real 1D array  field associated with the unstructured grid by                                                                                                     !!register_diag_field.
-       integer(kind=i4_kind)                              :: rsf_diag_2d_id                             !<Id returned for a real 2D array  field associated with the unstructured grid by                                                                                                     !!register_diag_field.
-        integer(kind=i4_kind)                              :: num_diag_time_steps                        !<Number of timesteps (to simulate the model running).
-        type(time_type)                                :: diag_time_start                            !<Starting time for the test.
-        type(time_type)                                :: diag_time_step                             !<Time step for the test.
-        logical(kind=l4_kind)                              :: used                                       !<Return value from send data.
+       integer(kind=i4_kind)                              :: rsf_diag_id !<Id returned for a real scalar field 
+                                                                         !! associated with the unstructured grid by
+                                                                         !! register_diag_field.
+       integer(kind=i4_kind),allocatable,dimension(:)     :: rsf_diag_1d_id !<Id returned for a real 1D array field
+                                                      !! associated with the unstructured grid by register_diag_field.
+       integer(kind=i4_kind)                              :: rsf_diag_2d_id !<Id returned for a real 2D array field
+                                                      !! associated with the unstructured grid by register_diag_field.
+        integer(kind=i4_kind)                              :: num_diag_time_steps !<Number of timesteps
+                                                                                  !! (to simulate the model running).
+        type(time_type)                                :: diag_time_start !<Starting time for the test.
+        type(time_type)                                :: diag_time_step !<Time step for the test.
+        logical(kind=l4_kind)                              :: used !<Return value from send data.
 
-        integer(kind=i4_kind)                              :: i                                          !<Loop variable.
-        integer(kind=i4_kind)                              :: j                                          !<Loop variable.
-        integer(kind=i4_kind)                              :: k,l=1                                          !<Loop variable.
-        integer(kind=i4_kind)                              :: p                                          !<Counting variable.
+        integer(kind=i4_kind)                              :: i !<Loop variable.
+        integer(kind=i4_kind)                              :: j !<Loop variable.
+        integer(kind=i4_kind)                              :: k,l=1 !<Loop variable.
+        integer(kind=i4_kind)                              :: p !<Counting variable.
 
        !Needed to define the 2D structured domain but never used.
         integer(kind=i4_kind)              :: ncontacts
@@ -1454,13 +1528,15 @@ allocate(rsf_diag_1d_id(1))
         unstructured_real_scalar_field_data_ref = 1234.5678*real(l)
 
        !real 1D field.
-        if (.not.allocated(unstructured_real_1D_field_data_ref)) allocate(unstructured_real_1D_field_data_ref(unstructured_axis_data_size))
+        if (.not.allocated(unstructured_real_1D_field_data_ref)) &
+              & allocate(unstructured_real_1D_field_data_ref(unstructured_axis_data_size))
         do i = 1,unstructured_axis_data_size
             unstructured_real_1D_field_data_ref(i) = real(i) *real(i)+0.1*(mpp_pe()+1)
         enddo
 
        !real 2D field.
-        if (.not.allocated(unstructured_real_2D_field_data_ref)) allocate(unstructured_real_2D_field_data_ref(unstructured_axis_data_size,nz))
+        if (.not.allocated(unstructured_real_2D_field_data_ref)) &
+              & allocate(unstructured_real_2D_field_data_ref(unstructured_axis_data_size,nz))
         do j = 1,nz
             do i = 1,unstructured_axis_data_size
                 unstructured_real_2D_field_data_ref(i,j) = real(j)+0.1*(mpp_pe()+1.0)
@@ -1471,7 +1547,8 @@ allocate(rsf_diag_1d_id(1))
         enddo
 
        !real 3D field.
-!       if(.not.allocated(unstructured_real_3D_field_data_ref) allocate(unstructured_real_3D_field_data_ref(unstructured_axis_data_size,nz,cc_axis_size))
+!       if(.not.allocated(unstructured_real_3D_field_data_ref) 
+!             allocate(unstructured_real_3D_field_data_ref(unstructured_axis_data_size,nz,cc_axis_size))
 !       do k = 1,cc_axis_size
 !           do j = 1,nz
 !               do i = 1,unstructured_axis_data_size
@@ -1487,13 +1564,15 @@ allocate(rsf_diag_1d_id(1))
         unstructured_int_scalar_field_data_ref = 7654321*L
 
        !integer 1D field.
-        if (.not.allocated(unstructured_int_1D_field_data_ref)) allocate(unstructured_int_1D_field_data_ref(unstructured_axis_data_size))
+        if (.not.allocated(unstructured_int_1D_field_data_ref)) &
+              & allocate(unstructured_int_1D_field_data_ref(unstructured_axis_data_size))
         do i = 1,unstructured_axis_data_size
             unstructured_int_1D_field_data_ref(i) = i - 8*l
         enddo
 
        !integer 2D field.
-        if (.not.allocated(unstructured_int_2D_field_data_ref)) allocate(unstructured_int_2D_field_data_ref(unstructured_axis_data_size,nz))
+        if (.not.allocated(unstructured_int_2D_field_data_ref)) &
+              & allocate(unstructured_int_2D_field_data_ref(unstructured_axis_data_size,nz))
         do j = 1,nz
             do i = 1,unstructured_axis_data_size
                 unstructured_int_2D_field_data_ref(i,j) = -1*((j-1)*unstructured_axis_data_size+i) + 2*L
@@ -1562,13 +1641,15 @@ ENDIF !L.ne.1
        !Add a real 1D field to the restart file.  This field is of the form:
        !field = field(unstructured).
         unstructured_real_1D_field_name = "unstructured_real_1D_field_1"
-        if (.not.allocated(unstructured_real_1D_field_data)) allocate(unstructured_real_1D_field_data(unstructured_axis_data_size))
+        if (.not.allocated(unstructured_real_1D_field_data)) &
+              & allocate(unstructured_real_1D_field_data(unstructured_axis_data_size))
         unstructured_real_1D_field_data = unstructured_real_1D_field_data_ref
 
        !Add a real 2D field to the restart file.  This field is of the form:
        !field = field(unstructured,z).
         unstructured_real_2D_field_name = "unstructured_real_2D_field_1"
-       if (.not.allocated(unstructured_real_2D_field_data)) allocate(unstructured_real_2D_field_data(unstructured_axis_data_size,nz))
+       if (.not.allocated(unstructured_real_2D_field_data)) &
+              & allocate(unstructured_real_2D_field_data(unstructured_axis_data_size,nz))
        unstructured_real_2D_field_data = unstructured_real_2D_field_data_ref
 !       allocate(unstructured_real_2D_field_data(unstructured_axis_data_size,nx))
 !       unstructured_real_2D_field_data = 1
@@ -1576,7 +1657,8 @@ ENDIF !L.ne.1
        !Add a real 3D field to the restart file.  This field is of the form:
        !field = field(unstructured,z,cc).
 !       unstructured_real_3D_field_name = "unstructured_real_3D_field_1"
-!       if (.not.allocated(unstructured_real_3D_field_data)) allocate(unstructured_real_3D_field_data(unstructured_axis_data_size,nz,cc_axis_size))
+!       if (.not.allocated(unstructured_real_3D_field_data)) &
+!              & allocate(unstructured_real_3D_field_data(unstructured_axis_data_size,nz,cc_axis_size))
 !       unstructured_real_3D_field_data = unstructured_real_3D_field_data_ref
 
        !Add an integer scalar field to the restart file.
@@ -1586,13 +1668,15 @@ ENDIF !L.ne.1
        !Add an integer 1D field to the restart file.  This field is of the
        !from: field = field(unstructured).
         unstructured_int_1D_field_name = "unstructured_int_1D_field_1"
-        if (.not.allocated(unstructured_int_1D_field_data)) allocate(unstructured_int_1D_field_data(unstructured_axis_data_size))
+        if (.not.allocated(unstructured_int_1D_field_data)) &
+              & allocate(unstructured_int_1D_field_data(unstructured_axis_data_size))
         unstructured_int_1D_field_data = unstructured_int_1D_field_data_ref
 
        !Add an integer 2D field to the restart file.  This field is of the
        !form: field = field(unstructured,z).
         unstructured_int_2D_field_name = "unstructured_int_2D_field_1"
-        if (.not.allocated(unstructured_int_2D_field_data)) allocate(unstructured_int_2D_field_data(unstructured_axis_data_size,nz))
+        if (.not.allocated(unstructured_int_2D_field_data)) &
+              & allocate(unstructured_int_2D_field_data(unstructured_axis_data_size,nz))
         unstructured_int_2D_field_data = unstructured_int_2D_field_data_ref
 
        !Simulate the model timesteps, so that diagnostics may be written

--- a/test_fms/diag_manager/test_diag_manager.F90
+++ b/test_fms/diag_manager/test_diag_manager.F90
@@ -202,7 +202,7 @@
 !#output variables
 !"UG_unit_test", "unstructured_real_scalar_field_data", "rsf_diag_1", "unstructured_diag_test", "all", .TRUE., "none",
 ! 1,
-!"UG_unit_test", "unstructured_real_1D_field_data", "unstructured_real_1D_field_data", "unstructured_diag_test", 
+!"UG_unit_test", "unstructured_real_1D_field_data", "unstructured_real_1D_field_data", "unstructured_diag_test",
 !"all", .TRUE., "none", 1,
 !"UG_unit_test", "unstructured_real_2D_field_data", "unstructured_real_2D_field_data", "unstructured_diag_test",
 !"all", .TRUE., "none", 1,
@@ -1102,7 +1102,7 @@ CONTAINS
         integer(kind=i4_kind),dimension(2)                 :: layout_for_full_domain !<Rank layout (2D grid) for the
                                                    !! full 2D structured domain.
                                                    !! Example: 16 ranks -> (16,1) or (8,2) or (4,4) or (2,8) or (1,16)
-        integer(kind=i4_kind),dimension(:),allocatable     :: pe_start !<Array holding the smallest rank id assigned 
+        integer(kind=i4_kind),dimension(:),allocatable     :: pe_start !<Array holding the smallest rank id assigned
                                                                        !! to each 2D structured domain tile.
         integer(kind=i4_kind),dimension(:),allocatable     :: pe_end !<Array holding the largest rank id assigned to
                                                                      !! each 2D structured domain tile.
@@ -1192,7 +1192,7 @@ CONTAINS
        real,allocatable,dimension(:) :: lat, lon
        integer(kind=i4_kind)             :: idlat
        integer(kind=i4_kind)                              :: idlon
-       integer(kind=i4_kind)                              :: rsf_diag_id !<Id returned for a real scalar field 
+       integer(kind=i4_kind)                              :: rsf_diag_id !<Id returned for a real scalar field
                                                                          !! associated with the unstructured grid by
                                                                          !! register_diag_field.
        integer(kind=i4_kind),allocatable,dimension(:)     :: rsf_diag_1d_id !<Id returned for a real 1D array field
@@ -1547,7 +1547,7 @@ allocate(rsf_diag_1d_id(1))
         enddo
 
        !real 3D field.
-!       if(.not.allocated(unstructured_real_3D_field_data_ref) 
+!       if(.not.allocated(unstructured_real_3D_field_data_ref)
 !             allocate(unstructured_real_3D_field_data_ref(unstructured_axis_data_size,nz,cc_axis_size))
 !       do k = 1,cc_axis_size
 !           do j = 1,nz

--- a/test_fms/exchange/test_xgrid.F90
+++ b/test_fms/exchange/test_xgrid.F90
@@ -535,8 +535,8 @@ implicit none
           "test_xgrid: atm_input_file should have a different name from atm_output_file")
      allocate(siz(4))
      call get_variable_size(atminputfileobj, atm_field_name, siz)
-     if(siz(1) .NE. nxa .OR. siz(2) .NE. nya ) call mpp_error(FATAL,"test_xgrid: x- and y-size of field "//trim(atm_field_name) &
-            //" in file "//trim(atm_input_file) //" does not compabile with the grid size" )
+     if(siz(1) .NE. nxa .OR. siz(2) .NE. nya ) call mpp_error(FATAL,"test_xgrid: x- and y-size of field "// &
+            & trim(atm_field_name)//" in file "//trim(atm_input_file) //" does not compabile with the grid size" )
      if(siz(3) > 1) call mpp_error(FATAL,"test_xgrid: number of vertical level of field "//trim(atm_field_name) &
             //" in file "//trim(atm_input_file) //" should be no larger than 1")
      deallocate(siz)
@@ -669,7 +669,8 @@ implicit none
      deallocate(atm_data_out_1, atm_data_out_2, atm_data_out_3)
      deallocate(x_1, x_2)
   else
-     write(out_unit,*) "NOTE from test_xgrid ==> file "//trim(atm_input_file)//" does not exist, no check is done for real(r8_kind) data sets."
+     write(out_unit,*) "NOTE from test_xgrid ==> file "//trim(atm_input_file)// &
+         & " does not exist, no check is done for real(r8_kind) data sets."
   end if
 
   runoff_input_file_exist = open_file(runoffinputfileobj, runoff_input_file, "read", lnd_domain)
@@ -681,8 +682,8 @@ implicit none
           "test_xgrid: runoff_input_file should have a different name from runoff_output_file")
      call get_variable_size(runoffinputfileobj, runoff_field_name, siz )
      deallocate(siz)
-     if(siz(1) .NE. nxl .OR. siz(2) .NE. nyl ) call mpp_error(FATAL,"test_xgrid: x- and y-size of field "//trim(runoff_field_name) &
-            //" in file "//trim(runoff_input_file) //" does not compabile with the grid size" )
+     if(siz(1) .NE. nxl .OR. siz(2) .NE. nyl ) call mpp_error(FATAL,"test_xgrid: x- and y-size of field "// &
+            & trim(runoff_field_name)//" in file "//trim(runoff_input_file) //" does not compabile with the grid size")
      if(siz(3) > 1) call mpp_error(FATAL,"test_xgrid: number of vertical level of field "//trim(runoff_field_name) &
             //" in file "//trim(runoff_input_file) //" should be no larger than 1")
 
@@ -716,7 +717,8 @@ implicit none
      write(out_unit,*) "the global area sum of runoff input data is                    : ", sum_runoff_in
      write(out_unit,*) "the global area sum of runoff output data is                   : ", sum_runoff_out
   else
-     write(out_unit,*) "NOTE from test_xgrid ==> file "//trim(runoff_input_file)//" does not exist, no check is done for real(r8_kind) data sets."
+     write(out_unit,*) "NOTE from test_xgrid ==> file "//trim(runoff_input_file)// &
+         & " does not exist, no check is done for real(r8_kind) data sets."
   end if
 
   ! when num_iter is greater than 0, create random number as input to test the performance of xgrid_mod.
@@ -869,7 +871,8 @@ contains
        call set_frac_area(ice_frac, 'OCN', Xmap_ug)
     endif
 
-!    call setup_xmap(Xmap_runoff_ug, (/ 'LND', 'OCN'/), (/ Lnd_domain, Ice_domain/), grid_file, lnd_ug_domain=UG_domain )
+!    call setup_xmap(Xmap_runoff_ug, (/ 'LND', 'OCN'/), (/ Lnd_domain, Ice_domain/), grid_file,
+!    lnd_ug_domain=UG_domain )
     allocate(atm_data_ug(isc_atm:iec_atm, jsc_atm:jec_atm   ) )
     allocate(atm_data_ug_1(isc_atm:iec_atm, jsc_atm:jec_atm   ) )
     allocate(atm_data_ug_2(isc_atm:iec_atm, jsc_atm:jec_atm   ) )

--- a/test_fms/fms/test_fms.F90
+++ b/test_fms/fms/test_fms.F90
@@ -1,7 +1,7 @@
 module test_fms_mod
  use, intrinsic :: iso_c_binding
 
-        interface 
+        interface
                 function strPoint () bind(C,name="strPoint") result(Cstring)
                    use, intrinsic :: iso_c_binding
                         type (c_ptr) :: Cstring !< String returned from this function "100"
@@ -70,8 +70,8 @@ program test_fms
  endif
 
 
- 
+
 
  call fms_end()
- 
+
 end program test_fms

--- a/test_fms/fms2_io/test_bc_restart.F90
+++ b/test_fms/fms2_io/test_bc_restart.F90
@@ -56,7 +56,8 @@ call fms2_io_init
 nlon = 144
 nlat = 144
 
-call mpp_define_domains( (/1,nlon,1,nlat/), layout, atm%Domain, xhalo=3, yhalo=3, symmetry=.true., name='test_bc_restart')
+call mpp_define_domains( (/1,nlon,1,nlat/), layout, atm%Domain, xhalo=3, yhalo=3, symmetry=.true., &
+                       &  name='test_bc_restart')
 call mpp_get_data_domain(atm%domain, isd, ied, jsd, jed )
 
 allocate(atm%var2d(isd:ied,jsd:jed))

--- a/test_fms/fms2_io/test_global_att.F90
+++ b/test_fms/fms2_io/test_global_att.F90
@@ -95,21 +95,25 @@ else
 endif
 
 !< Compares the values read with the expected values
-if (buf_r8_kind /= real(7., kind=r8_kind)) call mpp_error(FATAL, "test_global_att-"//trim(my_format(i))//": error reading buf_r8_kind")
+if (buf_r8_kind /= real(7., kind=r8_kind)) call mpp_error(FATAL, "test_global_att-"// &
+    & trim(my_format(i))//": error reading buf_r8_kind")
 if (buf_r8_kind_1d(1) /= real(7., kind=r8_kind) .or. buf_r8_kind_1d(2) /= real(9., kind=r8_kind)) &
      call mpp_error(FATAL, "test_global_att-"//trim(my_format(i))//": error reading buf_r8_kind_1d")
 
-if (buf_r4_kind /= real(4., kind=r4_kind)) call mpp_error(FATAL, "test_global_att-"//trim(my_format(i))//": error reading buf_r4_kind")
+if (buf_r4_kind /= real(4., kind=r4_kind)) call mpp_error(FATAL, "test_global_att-"// &
+    & trim(my_format(i))//": error reading buf_r4_kind")
 if (buf_r4_kind_1d(1) /= real(4., kind=r4_kind) .or. buf_r4_kind_1d(2) /= real(6., kind=r4_kind)) &
     call mpp_error(FATAL, "test_global_att-"//trim(my_format(i))//": error reading buf_r4_kind_1d")
 
-if (buf_i4_kind /= int(3, kind=i4_kind)) call mpp_error(FATAL, "test_global_att-"//trim(my_format(i))//": error reading buf_i4_kind")
+if (buf_i4_kind /= int(3, kind=i4_kind)) call mpp_error(FATAL, "test_global_att-"// &
+    & trim(my_format(i))//": error reading buf_i4_kind")
 if (buf_i4_kind_1d(1) /= int(3, kind=i4_kind) .or. buf_i4_kind_1d(2) /= int(5, kind=i4_kind)) &
     call mpp_error(FATAL, "test_global_att-"//trim(my_format(i))//": error reading buf_i4_kind_1d")
 
 !< int8 is only supported with the "netcdf4" type
 if(i .eq. 3) then
-   if (buf_i8_kind /= int(2, kind=i8_kind)) call mpp_error(FATAL, "test_global_att-"//trim(my_format(i))//": error reading buf_i8_kind")
+   if (buf_i8_kind /= int(2, kind=i8_kind)) call mpp_error(FATAL, "test_global_att-"// &
+       & trim(my_format(i))//": error reading buf_i8_kind")
    if (buf_i8_kind_1d(1) /= int(2, kind=i8_kind) .or. buf_i8_kind_1d(2) /= int(4, kind=i8_kind)) &
        & call mpp_error(FATAL, "test_global_att-"//trim(my_format(i))//": error reading buf_i8_kind_1d")
 endif

--- a/test_fms/monin_obukhov/test_monin_obukhov.F90
+++ b/test_fms/monin_obukhov/test_monin_obukhov.F90
@@ -19,7 +19,8 @@
 
 program test_monin_obukhov
 
-  use monin_obukhov_inter, only: monin_obukhov_drag_1d, monin_obukhov_stable_mix, monin_obukhov_diff, monin_obukhov_profile_1d
+  use monin_obukhov_inter, only: monin_obukhov_drag_1d, monin_obukhov_stable_mix, monin_obukhov_diff, &
+                              &  monin_obukhov_profile_1d
   use mpp_mod, only : mpp_error, FATAL, stdout, mpp_init, mpp_exit
 
   implicit none
@@ -232,8 +233,10 @@ program test_monin_obukhov
       zt     = (/ 3.69403636275411e-05, 0.0001, 1.01735489109205e-05, 7.63933834969505e-05, 0.00947346982656289/)
       zq     = (/ 5.72575636226887e-05, 0.0001, 5.72575636226887e-05, 5.72575636226887e-05, 5.72575636226887e-05/)
       u_star = (/ 0.109462510724615, 0.0932942802513508, 0.223232887323184, 0.290918439028557, 0.260087579361467/)
-      b_star = (/ 0.00690834676781433, 0.00428178089592372, 0.00121229800895103, 0.00262353784027441, -0.000570314880866852/)
-      q_star = (/ 0.000110861442197537, 9.44983279664197e-05, 4.17643828631936e-05, 0.000133135421415819, 9.36317815993945e-06/)
+      b_star = (/ 0.00690834676781433, 0.00428178089592372, 0.00121229800895103, 0.00262353784027441, &
+               &  -0.000570314880866852/)
+      q_star = (/ 0.000110861442197537, 9.44983279664197e-05, 4.17643828631936e-05, 0.000133135421415819, &
+               &  9.36317815993945e-06/)
 
       avail = (/ .true., .true.,.true.,.true.,.true. /)
 

--- a/test_fms/mpp/fill_halo.F90
+++ b/test_fms/mpp/fill_halo.F90
@@ -90,7 +90,8 @@ end interface fill_folded_west_halo
 contains
 
   !> fill the halo region of a 64-bit real array with zeros
-  subroutine fill_halo_zero_r8(data, whalo, ehalo, shalo, nhalo, xshift, yshift, isc, iec, jsc, jec, isd, ied, jsd, jed)
+  subroutine fill_halo_zero_r8(data, whalo, ehalo, shalo, nhalo, xshift, yshift, isc, iec, jsc, jec, isd, ied, &
+                              &  jsd, jed)
     real(kind=r8_kind), dimension(isd:,jsd:,:), intent(inout) :: data
     integer,                         intent(in) :: isc, iec, jsc, jec, isd, ied, jsd, jed
     integer,                         intent(in) :: whalo, ehalo, shalo, nhalo, xshift, yshift
@@ -113,7 +114,8 @@ contains
   end subroutine fill_halo_zero_r8
 
   !> fill the halo region of a 32-bit real array with zeros
-  subroutine fill_halo_zero_r4(data, whalo, ehalo, shalo, nhalo, xshift, yshift, isc, iec, jsc, jec, isd, ied, jsd, jed)
+  subroutine fill_halo_zero_r4(data, whalo, ehalo, shalo, nhalo, xshift, yshift, isc, iec, jsc, jec, isd, ied, &
+                              &  jsd, jed)
     real(kind=r4_kind), dimension(isd:,jsd:,:), intent(inout) :: data
     integer,                         intent(in) :: isc, iec, jsc, jec, isd, ied, jsd, jed
     integer,                         intent(in) :: whalo, ehalo, shalo, nhalo, xshift, yshift
@@ -136,7 +138,8 @@ contains
   end subroutine fill_halo_zero_r4
 
 !> fill the halo region of a 64-bit integer array with zeros
-  subroutine fill_halo_zero_i8(data, whalo, ehalo, shalo, nhalo, xshift, yshift, isc, iec, jsc, jec, isd, ied, jsd, jed)
+  subroutine fill_halo_zero_i8(data, whalo, ehalo, shalo, nhalo, xshift, yshift, isc, iec, jsc, jec, isd, ied, &
+                              &  jsd, jed)
     integer(kind=i8_kind), dimension(isd:,jsd:,:), intent(inout) :: data
     integer,                         intent(in) :: isc, iec, jsc, jec, isd, ied, jsd, jed
     integer,                         intent(in) :: whalo, ehalo, shalo, nhalo, xshift, yshift
@@ -159,7 +162,8 @@ contains
   end subroutine fill_halo_zero_i8
 
 !> fill the halo region of a 32-bit integer array with zeros
-  subroutine fill_halo_zero_i4(data, whalo, ehalo, shalo, nhalo, xshift, yshift, isc, iec, jsc, jec, isd, ied, jsd, jed)
+  subroutine fill_halo_zero_i4(data, whalo, ehalo, shalo, nhalo, xshift, yshift, isc, iec, jsc, jec, isd, ied, &
+                              &  jsd, jed)
     integer(kind=i4_kind), dimension(isd:,jsd:,:), intent(inout) :: data
     integer,                         intent(in) :: isc, iec, jsc, jec, isd, ied, jsd, jed
     integer,                         intent(in) :: whalo, ehalo, shalo, nhalo, xshift, yshift
@@ -212,7 +216,8 @@ contains
   end subroutine fill_regular_refinement_halo_r8
 
   !> fill the halo region of 32-bit array on a regular grid
-  subroutine fill_regular_refinement_halo_r4( data, data_all, ni, nj, tm, te, tse, ts, tsw, tw, tnw, tn, tne, ioff, joff )
+  subroutine fill_regular_refinement_halo_r4( data, data_all, ni, nj, tm, te, tse, ts, tsw, tw, tnw, tn, tne, &
+                                            &  ioff, joff )
     real(kind=r4_kind), dimension(1-whalo:,1-shalo:,:), intent(inout) :: data
     real(kind=r4_kind), dimension(:,:,:,:),             intent(in)    :: data_all
     integer, dimension(:),                intent(in)    :: ni, nj
@@ -269,7 +274,8 @@ contains
   end subroutine fill_regular_refinement_halo_i8
 
 !> fill the halo region of 32-bit integer array on a regular grid
-  subroutine fill_regular_refinement_halo_i4( data, data_all, ni, nj, tm, te, tse, ts, tsw, tw, tnw, tn, tne, ioff, joff )
+  subroutine fill_regular_refinement_halo_i4( data, data_all, ni, nj, tm, te, tse, ts, tsw, tw, tnw, tn, tne, &
+                                            &  ioff, joff )
     integer(kind=i4_kind), dimension(1-whalo:,1-shalo:,:), intent(inout) :: data
     integer(kind=i4_kind), dimension(:,:,:,:),             intent(in)    :: data_all
     integer, dimension(:),                intent(in)    :: ni, nj

--- a/test_fms/mpp/test_mpp.F90
+++ b/test_fms/mpp/test_mpp.F90
@@ -136,7 +136,8 @@ contains
      end if
 
      if ( mpp_chksum(a(1:n2),(/pe/)) .NE. mpp_chksum(c) ) then
-       call mpp_error(FATAL, 'Test mpp_chksum fails: a whole array and a distributed array did not give identical checksums')
+       call mpp_error(FATAL, &
+                     & 'Test mpp_chksum fails: a whole array and a distributed array did not give identical checksums')
      else
        print *, 'For pe=', pe, ' chksum(a(1:1024))=chksum(c(1:1024))='
      endif

--- a/test_fms/mpp/test_mpp_alltoall.F90
+++ b/test_fms/mpp/test_mpp_alltoall.F90
@@ -119,7 +119,8 @@ program test_mpp_alltoall
        do i=0, (npes-1)
           do jsend=0, isend-1
              if( rbuf(ii) .ne. real( 10*i+isend*pe+jsend, kind=r4_kind ) ) then
-                write(*,'("PE #",i3,"element",i4,"Expected",f6.0,"but received",f6.0)') pe, ii, real(10*i+nsend*pe+jsend), rbuf(ii)
+                write(*,'("PE #",i3,"element",i4,"Expected",f6.0,"but received",f6.0)') pe, ii, &
+                     &  real(10*i+nsend*pe+jsend), rbuf(ii)
                 call mpp_error(FATAL, 'test_mpp_alltoall failed')
              end if
              ii = ii + 1
@@ -181,7 +182,8 @@ program test_mpp_alltoall
        do i=0, (npes-1)
           do jsend=0, isend-1
              if( rbuf(ii) .ne. real( 10*i+isend*pe+jsend, kind=r8_kind ) ) then
-                write(*,'("PE #",i3,"element",i4,"Expected",f6.0,"but received",f6.0)') pe, ii, real(10*i+nsend*pe+jsend), rbuf(ii)
+                write(*,'("PE #",i3,"element",i4,"Expected",f6.0,"but received",f6.0)') pe, ii, &
+                     &  real(10*i+nsend*pe+jsend), rbuf(ii)
                 call mpp_error(FATAL, 'test_mpp_alltoall failed')
              end if
              ii = ii + 1
@@ -243,7 +245,8 @@ program test_mpp_alltoall
        do i=0, (npes-1)
           do jsend=0, isend-1
              if( rbuf(ii) .ne. real( 10*i+isend*pe+jsend, kind=i4_kind ) ) then
-                write(*,'("PE #",i3,"element",i4,"Expected",i6,"but received",i6)') pe, ii, real(10*i+nsend*pe+jsend), rbuf(ii)
+                write(*,'("PE #",i3,"element",i4,"Expected",i6,"but received",i6)') pe, ii, &
+                     &  real(10*i+nsend*pe+jsend), rbuf(ii)
                 call mpp_error(FATAL, 'test_mpp_alltoall failed')
              end if
              ii = ii + 1
@@ -305,7 +308,8 @@ program test_mpp_alltoall
        do i=0, (npes-1)
           do jsend=0, isend-1
              if( rbuf(ii) .ne. real( 10*i+isend*pe+jsend, kind=i8_kind ) ) then
-                write(*,'("PE #",i3,"element",i4,"Expected",i6,"but received",i6)') pe, ii, real(10*i+nsend*pe+jsend), rbuf(ii)
+                write(*,'("PE #",i3,"element",i4,"Expected",i6,"but received",i6)') pe, ii, &
+                     &  real(10*i+nsend*pe+jsend), rbuf(ii)
                 call mpp_error(FATAL, 'test_mpp_alltoall failed')
              end if
              ii = ii + 1

--- a/test_fms/mpp/test_mpp_domains.F90
+++ b/test_fms/mpp/test_mpp_domains.F90
@@ -7746,7 +7746,7 @@ end subroutine test_halosize_update
              call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/iss_c/), (/ies_c/), (/jss_c/), &
                   (/jes_c/), nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, &
                   js_coarse, je_coarse)
-             call fill_nest_data(sbufferx2, iss_c, ies_c, jss_c, jes_c, nnest, t_coarse, shift, 0, iadd_coarse, & 
+             call fill_nest_data(sbufferx2, iss_c, ies_c, jss_c, jes_c, nnest, t_coarse, shift, 0, iadd_coarse, &
                   jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 1E3_r8_kind, 2E3_r8_kind, 1,&
                   -1, nx, ny)
              call fill_nest_data(sbuffery2, iss_c, ies_c, jss_c, jes_c, nnest, t_coarse, 0, 0, iadd_coarse, &

--- a/test_fms/mpp/test_mpp_domains.F90
+++ b/test_fms/mpp/test_mpp_domains.F90
@@ -7632,7 +7632,7 @@ end subroutine test_halosize_update
                   (/jes_c/), nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, &
                   js_coarse, je_coarse)
              call fill_nest_data(sbufferx2, iss_c, ies_c, jss_c, jes_c, nnest, t_coarse, shift, 0, iadd_coarse, &
-                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 1E3_r8_kind, 2E3_r8_kind, 1, &
+                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 1E3_r8_kind, 2E3_r8_kind, 1,&
                   1, nx, ny)
              call fill_nest_data(sbuffery2, iss_c, ies_c, jss_c, jes_c, nnest, t_coarse, 0, 0, iadd_coarse, &
                   jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 2E3_r8_kind, 1E3_r8_kind, 1,&
@@ -7654,7 +7654,7 @@ end subroutine test_halosize_update
                   (/jen_c/), nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, &
                   js_coarse, je_coarse)
              call fill_nest_data(nbufferx2, isn_c, ien_c, jsn_c, jen_c, nnest, t_coarse, shift, 0, iadd_coarse, &
-                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 1E3_r8_kind, 2E3_r8_kind, 1, &
+                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 1E3_r8_kind, 2E3_r8_kind, 1,&
                   1, nx, ny)
              call fill_nest_data(nbuffery2, isn_c, ien_c, jsn_c+shift, jen_c, nnest, t_coarse, 0, shift, iadd_coarse, &
                   jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse+shift, je_coarse, 2E3_r8_kind, &

--- a/test_fms/mpp/test_mpp_domains.F90
+++ b/test_fms/mpp/test_mpp_domains.F90
@@ -173,7 +173,8 @@ program test_mpp_domains
      "test_mpp_domain: nx_cubic and ny_cubic should be both zero or both positive")
 
   if( test_nest .and. (num_nest>0) ) then
-    if (mpp_pe() == mpp_root_pe())  print *, '-----------------> Calling test_update_nest_domain Cubic <----------------'
+    if (mpp_pe() == mpp_root_pe())  print *, &
+       &  '-----------------> Calling test_update_nest_domain Cubic <----------------'
      do n = 1, num_nest
         if( istart_coarse(n) == 0 .OR. jstart_coarse(n) == 0 ) call mpp_error(FATAL, &
         "test_mpp_domain: check the setting of namelist variable istart_coarse, jstart_coarse")
@@ -184,16 +185,21 @@ program test_mpp_domains
      enddo
      if(ANY(refine_ratio(:).LT.1)) call  mpp_error(FATAL, &
         "test_mpp_domain: check the setting of namelist variable refine_ratio")
-    if (mpp_pe() == mpp_root_pe())  print *, '-----------------> Starting test_update_nest_domain_r8 Cubic <----------------'
+    if (mpp_pe() == mpp_root_pe())  print *, &
+       &  '-----------------> Starting test_update_nest_domain_r8 Cubic <----------------'
      call test_update_nest_domain_r8('Cubic-Grid')
-    if (mpp_pe() == mpp_root_pe())  print *, '-----------------> Finished test_update_nest_domain_r8 Cubic <----------------'
-    if (mpp_pe() == mpp_root_pe())  print *, '-----------------> Starting test_update_nest_domain_r4 Cubic <----------------'
+    if (mpp_pe() == mpp_root_pe())  print *, &
+       &  '-----------------> Finished test_update_nest_domain_r8 Cubic <----------------'
+    if (mpp_pe() == mpp_root_pe())  print *, &
+       &  '-----------------> Starting test_update_nest_domain_r4 Cubic <----------------'
      call test_update_nest_domain_r4('Cubic-Grid')
-    if (mpp_pe() == mpp_root_pe())  print *, '-----------------> Finished test_update_nest_domain_r4 Cubic <----------------'
+    if (mpp_pe() == mpp_root_pe())  print *, &
+       &  '-----------------> Finished test_update_nest_domain_r4 Cubic <----------------'
   endif
 
   if( test_nest_regional .and. (num_nest>0) ) then
-    if (mpp_pe() == mpp_root_pe())  print *, '---------------> Calling test_update_nest_domain Regional <--------------'
+    if (mpp_pe() == mpp_root_pe())  print *, &
+       &  '---------------> Calling test_update_nest_domain Regional <--------------'
      do n = 1, num_nest
         if( istart_coarse(n) == 0 .OR. jstart_coarse(n) == 0 ) call mpp_error(FATAL, &
         "test_mpp_domain: check the setting of namelist variable istart_coarse, jstart_coarse")
@@ -204,20 +210,26 @@ program test_mpp_domains
      enddo
      if(ANY(refine_ratio(:).LT.1)) call  mpp_error(FATAL, &
         "test_mpp_domain: check the setting of namelist variable refine_ratio")
-    if (mpp_pe() == mpp_root_pe())  print *, '---------------> Starting test_update_nest_domain_r8 Regional <--------------'
+    if (mpp_pe() == mpp_root_pe())  print *, &
+       &  '---------------> Starting test_update_nest_domain_r8 Regional <--------------'
      call test_update_nest_domain_r8('Regional')
-    if (mpp_pe() == mpp_root_pe())  print *, '---------------> Finished test_update_nest_domain_r8 Regional <--------------'
-    if (mpp_pe() == mpp_root_pe())  print *, '---------------> Starting test_update_nest_domain_r4 Regional <--------------'
+    if (mpp_pe() == mpp_root_pe())  print *, &
+       &  '---------------> Finished test_update_nest_domain_r8 Regional <--------------'
+    if (mpp_pe() == mpp_root_pe())  print *, &
+       &  '---------------> Starting test_update_nest_domain_r4 Regional <--------------'
      call test_update_nest_domain_r4('Regional')
-    if (mpp_pe() == mpp_root_pe())  print *, '---------------> Finished test_update_nest_domain_r4 Regional <--------------'
+    if (mpp_pe() == mpp_root_pe())  print *, &
+       &  '---------------> Finished test_update_nest_domain_r4 Regional <--------------'
   endif
 
   if( test_halosize_performance ) then
-     if (mpp_pe() == mpp_root_pe())  print *, '--------------------> Calling test_halosize_performance <-------------------'
+     if (mpp_pe() == mpp_root_pe())  print *, &
+        &  '--------------------> Calling test_halosize_performance <-------------------'
      call test_halosize_update( 'Folded-north' )
      call test_halosize_update( 'Folded-north symmetry' )
      call test_halosize_update( 'Cubic-Grid' )
-     if (mpp_pe() == mpp_root_pe())  print *, '--------------------> Finished test_halosize_performance <-------------------'
+     if (mpp_pe() == mpp_root_pe())  print *, &
+        &  '--------------------> Finished test_halosize_performance <-------------------'
   endif
 
   if( test_edge_update ) then
@@ -238,13 +250,16 @@ program test_mpp_domains
   if( test_global_sum ) then
       if (mpp_pe() == mpp_root_pe())  print *, '--------------------> Calling test_mpp_global_sum <-------------------'
       call test_mpp_global_sum('Folded-north')
-      if (mpp_pe() == mpp_root_pe())  print *, '--------------------> Finished test_mpp_global_sum <-------------------'
+      if (mpp_pe() == mpp_root_pe())  print *, &
+         &  '--------------------> Finished test_mpp_global_sum <-------------------'
   endif
 
   if( test_cubic_grid_redistribute ) then
-      if (mpp_pe() == mpp_root_pe())  print *, '--------------------> Calling cubic_grid_redistribute <-------------------'
+      if (mpp_pe() == mpp_root_pe())  print *, &
+         &  '--------------------> Calling cubic_grid_redistribute <-------------------'
      call cubic_grid_redistribute()
-      if (mpp_pe() == mpp_root_pe())  print *, '--------------------> Finished cubic_grid_redistribute <-------------------'
+      if (mpp_pe() == mpp_root_pe())  print *, &
+         &  '--------------------> Finished cubic_grid_redistribute <-------------------'
   endif
 
   if(test_boundary) then
@@ -727,7 +742,8 @@ contains
         pe_end(n)   = my_root_pe + n*npes_per_tile-1
      end do
 
-     call define_cubic_mosaic("cubic_grid", domain_ensemble(ensemble_id), (/nx_cubic,nx_cubic,nx_cubic,nx_cubic,nx_cubic,nx_cubic/), &
+     call define_cubic_mosaic("cubic_grid", domain_ensemble(ensemble_id), &
+                              (/nx_cubic,nx_cubic,nx_cubic,nx_cubic,nx_cubic,nx_cubic/), &
                               (/ny_cubic,ny_cubic,ny_cubic,ny_cubic,ny_cubic,ny_cubic/), &
                                 global_indices, layout2D, pe_start, pe_end )
 
@@ -798,7 +814,8 @@ contains
            enddo
         endif
         write(mesg,'(a,i4)') "cubic_grid redistribute to ensemble", n
-        call compare_checksums( x_ens(isc_ens:iec_ens,jsc_ens:jec_ens,:), y(isc_ens:iec_ens,jsc_ens:jec_ens,:), trim(mesg) )
+        call compare_checksums( x_ens(isc_ens:iec_ens,jsc_ens:jec_ens,:), y(isc_ens:iec_ens,jsc_ens:jec_ens,:), &
+                              &  trim(mesg) )
      enddo
 
      deallocate(x, y, x_ens)
@@ -1265,8 +1282,16 @@ contains
           end if
        end do
        ! set the corner value to 0
-       global1_all(1,ny+1,:,:) = 0; global1_all(nx+1,1,:,:) = 0; global1_all(1,1,:,:) = 0; global1_all(nx+1,ny+1,:,:) = 0
-       global2_all(1,ny+1,:,:) = 0; global2_all(nx+1,1,:,:) = 0; global2_all(1,1,:,:) = 0; global2_all(nx+1,ny+1,:,:) = 0
+       global1_all(1,ny+1,:,:) = 0
+       global1_all(nx+1,1,:,:) = 0
+       global1_all(1,1,:,:) = 0
+       global1_all(nx+1,ny+1,:,:) = 0
+
+       global2_all(1,ny+1,:,:) = 0
+       global2_all(nx+1,1,:,:) = 0
+       global2_all(1,1,:,:) = 0
+       global2_all(nx+1,ny+1,:,:) = 0
+
     end if
 
     do n = 1, ntile_per_pe
@@ -1420,8 +1445,10 @@ contains
 
     do n = 1, ntile_per_pe
        if(ntile_per_pe > 1) write(type3, *)trim(type2), " at tile_count = ", n
-       call compare_checksums( x (isd:ied+shift,jsd:jed+shift,:,n),  global1(isd:ied+shift,jsd:jed+shift,:,n), trim(type3)//' X' )
-       call compare_checksums( y (isd:ied+shift,jsd:jed+shift,:,n),  global2(isd:ied+shift,jsd:jed+shift,:,n), trim(type3)//' Y' )
+       call compare_checksums( x (isd:ied+shift,jsd:jed+shift,:,n),  global1(isd:ied+shift,jsd:jed+shift,:,n), &
+                            & trim(type3)//' X' )
+       call compare_checksums( y (isd:ied+shift,jsd:jed+shift,:,n),  global2(isd:ied+shift,jsd:jed+shift,:,n), &
+                            & trim(type3)//' Y' )
     end do
 
     if(ntile_per_pe == 1) then
@@ -1432,14 +1459,22 @@ contains
        call mpp_update_domains( x4, y4, domain, flags=update_flags, gridtype=BGRID_NE, complete=.true.,  name=type2)
        call mpp_clock_end  (id)
 
-       call compare_checksums( x1(isd:ied+shift,jsd:jed+shift,:,1), global1(isd:ied+shift,jsd:jed+shift,:,1), trim(type2)//' X1')
-       call compare_checksums( x2(isd:ied+shift,jsd:jed+shift,:,1), global1(isd:ied+shift,jsd:jed+shift,:,1), trim(type2)//' X2')
-       call compare_checksums( x3(isd:ied+shift,jsd:jed+shift,:,1), global1(isd:ied+shift,jsd:jed+shift,:,1), trim(type2)//' X3')
-       call compare_checksums( x4(isd:ied+shift,jsd:jed+shift,:,1), global1(isd:ied+shift,jsd:jed+shift,:,1), trim(type2)//' X4')
-       call compare_checksums( y1(isd:ied+shift,jsd:jed+shift,:,1), global2(isd:ied+shift,jsd:jed+shift,:,1), trim(type2)//' Y1')
-       call compare_checksums( y2(isd:ied+shift,jsd:jed+shift,:,1), global2(isd:ied+shift,jsd:jed+shift,:,1), trim(type2)//' Y2')
-       call compare_checksums( y3(isd:ied+shift,jsd:jed+shift,:,1), global2(isd:ied+shift,jsd:jed+shift,:,1), trim(type2)//' Y3')
-       call compare_checksums( y4(isd:ied+shift,jsd:jed+shift,:,1), global2(isd:ied+shift,jsd:jed+shift,:,1), trim(type2)//' Y4')
+       call compare_checksums( x1(isd:ied+shift,jsd:jed+shift,:,1), global1(isd:ied+shift,jsd:jed+shift,:,1), &
+                            & trim(type2)//' X1')
+       call compare_checksums( x2(isd:ied+shift,jsd:jed+shift,:,1), global1(isd:ied+shift,jsd:jed+shift,:,1), &
+                            & trim(type2)//' X2')
+       call compare_checksums( x3(isd:ied+shift,jsd:jed+shift,:,1), global1(isd:ied+shift,jsd:jed+shift,:,1), &
+                            & trim(type2)//' X3')
+       call compare_checksums( x4(isd:ied+shift,jsd:jed+shift,:,1), global1(isd:ied+shift,jsd:jed+shift,:,1), &
+                            & trim(type2)//' X4')
+       call compare_checksums( y1(isd:ied+shift,jsd:jed+shift,:,1), global2(isd:ied+shift,jsd:jed+shift,:,1), &
+                            & trim(type2)//' Y1')
+       call compare_checksums( y2(isd:ied+shift,jsd:jed+shift,:,1), global2(isd:ied+shift,jsd:jed+shift,:,1), &
+                            & trim(type2)//' Y2')
+       call compare_checksums( y3(isd:ied+shift,jsd:jed+shift,:,1), global2(isd:ied+shift,jsd:jed+shift,:,1), &
+                            & trim(type2)//' Y3')
+       call compare_checksums( y4(isd:ied+shift,jsd:jed+shift,:,1), global2(isd:ied+shift,jsd:jed+shift,:,1), &
+                            & trim(type2)//' Y4')
 
        !--- arbitrary halo updates ---------------------------------------
        if(wide_halo_x == 0) then
@@ -1459,8 +1494,10 @@ contains
                          x(isc:iec+shift,jsc:jec+shift,:,1) = global1(isc:iec+shift,jsc:jec+shift,:,1)
                          y(isc:iec+shift,jsc:jec+shift,:,1) = global2(isc:iec+shift,jsc:jec+shift,:,1)
 
-                         call fill_halo_zero(local1, wh, eh, sh, nh, shift, shift, isc, iec, jsc, jec, isd, ied, jsd, jed)
-                         call fill_halo_zero(local2, wh, eh, sh, nh, shift, shift, isc, iec, jsc, jec, isd, ied, jsd, jed)
+                         call fill_halo_zero(local1, wh, eh, sh, nh, shift, shift, isc, iec, jsc, jec, isd, &
+                                            &  ied, jsd, jed)
+                         call fill_halo_zero(local2, wh, eh, sh, nh, shift, shift, isc, iec, jsc, jec, isd, &
+                                            &  ied, jsd, jed)
 
                          write(type3,'(a,a,i2,a,i2,a,i2,a,i2)') trim(type2), ' with whalo = ', wh, &
                               ', ehalo = ',eh, ', shalo = ', sh, ', nhalo = ', nh
@@ -2104,8 +2141,8 @@ contains
     !--- compare checksum
        do l = 1, num_fields
           write(text, '(i3.3)') l
-          call compare_checksums(x1(isd:ied+shift,jsd:jed,      :,l),x2(isd:ied+shift,jsd:jed,      :,l),type//' DGRID X'//text)
-          call compare_checksums(y1(isd:ied,      jsd:jed+shift,:,l),y2(isd:ied,      jsd:jed+shift,:,l),type//' DGRID Y'//text)
+          call compare_checksums(x1(isd:ied+shift,jsd:jed, :,l),x2(isd:ied+shift,jsd:jed, :,l),type//' DGRID X'//text)
+          call compare_checksums(y1(isd:ied, jsd:jed+shift,:,l),y2(isd:ied, jsd:jed+shift,:,l),type//' DGRID Y'//text)
        enddo
 
        call mpp_clear_group_update(group_update)
@@ -2142,9 +2179,9 @@ contains
        if( n == num_iter ) then
        do l = 1, num_fields
           write(text, '(i3.3)') l
-          call compare_checksums(a1(isd:ied,      jsd:jed,      :,l),a2(isd:ied,      jsd:jed,      :,l),type//' CENTER '//text)
-          call compare_checksums(x1(isd:ied+shift,jsd:jed,      :,l),x2(isd:ied+shift,jsd:jed,      :,l),type//' CGRID X'//text)
-          call compare_checksums(y1(isd:ied,      jsd:jed+shift,:,l),y2(isd:ied,      jsd:jed+shift,:,l),type//' CGRID Y'//text)
+          call compare_checksums(a1(isd:ied, jsd:jed, :,l),a2(isd:ied, jsd:jed, :,l),type//' CENTER '//text)
+          call compare_checksums(x1(isd:ied+shift,jsd:jed, :,l),x2(isd:ied+shift,jsd:jed, :,l),type//' CGRID X'//text)
+          call compare_checksums(y1(isd:ied, jsd:jed+shift,:,l),y2(isd:ied, jsd:jed+shift,:,l),type//' CGRID Y'//text)
        enddo
        endif
        a1 = 0; x1 = 0; y1 = 0
@@ -2299,9 +2336,12 @@ contains
        if( n == num_iter ) then
        do l = 1, num_fields
           write(text, '(i3.3)') l
-          call compare_checksums(a1(isd:ied+shift,jsd:jed+shift,:,l),a2(isd:ied+shift,jsd:jed+shift,:,l),type//' CORNER '//text)
-          call compare_checksums(x1(isd:ied+shift,jsd:jed+shift,:,l),x2(isd:ied+shift,jsd:jed+shift,:,l),type//' BGRID X'//text)
-          call compare_checksums(y1(isd:ied+shift,jsd:jed+shift,:,l),y2(isd:ied+shift,jsd:jed+shift,:,l),type//' BGRID Y'//text)
+          call compare_checksums(a1(isd:ied+shift,jsd:jed+shift,:,l),a2(isd:ied+shift,jsd:jed+shift,:,l),type//&
+                               & ' CORNER '// text)
+          call compare_checksums(x1(isd:ied+shift,jsd:jed+shift,:,l),x2(isd:ied+shift,jsd:jed+shift,:,l),type//&
+                               & ' BGRID X'// text)
+          call compare_checksums(y1(isd:ied+shift,jsd:jed+shift,:,l),y2(isd:ied+shift,jsd:jed+shift,:,l),type//&
+                               & ' BGRID Y'// text)
        enddo
        endif
 
@@ -2381,7 +2421,8 @@ contains
     end do
 
     do l = 1, num_fields
-       call mpp_update_domains( x2(:,:,:,l), y2(:,:,:,l), domain, gridtype=AGRID, flags=SCALAR_PAIR, complete=l==num_fields)
+       call mpp_update_domains( x2(:,:,:,l), y2(:,:,:,l), domain, gridtype=AGRID, flags=SCALAR_PAIR, &
+                              &  complete=l==num_fields)
     enddo
 
     call mpp_start_group_update(group_update, domain, x1(isc,jsc,1,1))
@@ -2439,7 +2480,8 @@ end subroutine test_group_update
     type(mpp_group_update_type), allocatable :: update_list(:)
 
     if(whalo .ne. ehalo .or. whalo .ne. shalo .or. whalo .ne. nhalo) then
-       call mpp_error(FATAL,"test_mpp_domains: whalo, ehalo, shalo, nhalo must be the same when test_halosize_performance=true")
+       call mpp_error(FATAL, &
+                 & "test_mpp_domains: whalo, ehalo, shalo, nhalo must be the same when test_halosize_performance=true")
     endif
 
     folded_north       = .false.
@@ -2480,7 +2522,8 @@ end subroutine test_group_update
        ny = ny_cubic
        ntiles = 6
        if( mod(npes, ntiles) .ne. 0 ) then
-          call mpp_error(NOTE,'test_halosize_update: npes is not divisible by ntiles, no test is done for '//trim(type) )
+          call mpp_error(NOTE,'test_halosize_update: npes is not divisible by ntiles, no test is done for '// &
+                         & trim(type) )
           return
        endif
        npes_per_tile = npes/ntiles
@@ -2828,7 +2871,8 @@ end subroutine test_halosize_update
 
     data(1-whalo:0,                  1:nyp,:) =      data(nx-whalo+1:nx,        1:ny+jshift,:) ! west
     data(nx+1:nx+ehalo+ishift,       1:nyp,:) =      data(1:ehalo+ishift,       1:ny+jshift,:) ! east
-    if(m1 .GE. 1-whalo) data(1-whalo:m1,  nyp+1:nyp+nhalo,:) = sign*data(whalo+m2:1+ishift:-1, nyp-joff:nyp-nhalo-joff+1:-1,:)
+    if(m1 .GE. 1-whalo) data(1-whalo:m1,  nyp+1:nyp+nhalo,:) = sign*data(whalo+m2:1+ishift:-1, &
+      &  nyp-joff:nyp-nhalo-joff+1:-1,:)
     data(m1+1:nx+m2,       nyp+1:nyp+nhalo,:) = sign*data(nx+ishift:1:-1,       nyp-joff:nyp-nhalo-joff+1:-1,:)
     data(nx+m2+1:nxp+ehalo,nyp+1:nyp+nhalo,:) = sign*data(nx:nx-ehalo+m1+1:-1,  nyp-joff:nyp-nhalo-joff+1:-1,:)
 
@@ -2886,7 +2930,8 @@ end subroutine test_halosize_update
 
     data(1:nxp, 1-shalo:0, :)      = data(1:nxp, ny-shalo+1:ny, :) ! south
     data(1:nxp, ny+1:nyp+nhalo, :) = data(1:nxp, 1:nhalo+jshift,:) ! north
-    if(m1 .GE. 1-shalo) data(nxp+1:nxp+ehalo, 1-shalo:m1, :) = sign*data(nxp-ioff:nxp-ehalo-ioff+1:-1, shalo+m2:1+jshift:-1,:)
+    if(m1 .GE. 1-shalo) data(nxp+1:nxp+ehalo, 1-shalo:m1, :) = sign*data(nxp-ioff:nxp-ehalo-ioff+1:-1, &
+      &  shalo+m2:1+jshift:-1,:)
     data(nxp+1:nxp+ehalo, m1+1:ny+m2, :) = sign*data(nxp-ioff:nxp-ehalo-ioff+1:-1, nyp:1:-1, :)
     data(nxp+1:nxp+ehalo, ny+m2+1:nyp+nhalo,:) = sign*data(nxp-ioff:nxp-ehalo-ioff+1:-1, ny:ny-nhalo+m1+1:-1,:)
 
@@ -3528,52 +3573,57 @@ end subroutine test_halosize_update
 
     select case(tile)
     case(1)
-       data(nxm+1+ioff:nxm+ehalo+ioff,                     1:ny,:) = data_all(1+ioff:ehalo+ioff,              1:ny,:,2) ! east
-       data(nxm+1+ioff:nxm+ehalo+ioff,            ny+1:nym+joff,:) = data_all(1+ioff:ehalo+ioff,         1:ny+joff,:,4) ! east
-       data(1-whalo:0,                                     1:ny,:) = data_all(nx-whalo+1:nx,                  1:ny,:,3) ! west
-       data(1-whalo:0,                            ny+1:nym+joff,:) = data_all(nx-whalo+1:nx,             1:ny+joff,:,5) ! west
-       data(1:nxm+ioff,                               1-shalo:0,:) = data_all(1:nxm+ioff,          nym-shalo+1:nym,:,1) ! south
-       data(1:nxm+ioff,               nym+1+joff:nym+nhalo+joff,:) = data_all(1:nxm+ioff,        1+joff:nhalo+joff,:,1) ! north
-       data(nxm+1+ioff:nxm+ehalo+ioff,                1-shalo:0,:) = data_all(1+ioff:ehalo+ioff,     ny-shalo+1:ny,:,4) ! southeast
-       data(1-whalo:0,                                1-shalo:0,:) = data_all(nx-whalo+1:nx,         ny-shalo+1:ny,:,5) ! southwest
-       data(nxm+1+ioff:nxm+ehalo+ioff,nym+1+joff:nym+nhalo+joff,:) = data_all(1+ioff:ehalo+ioff, 1+joff:nhalo+joff,:,2) ! northeast
-       data(1-whalo:0,                nym+1+joff:nym+nhalo+joff,:) = data_all(nx-whalo+1:nx,     1+joff:nhalo+joff,:,3) ! northwest
+       data(nxm+1+ioff:nxm+ehalo+ioff, 1:ny,:) = data_all(1+ioff:ehalo+ioff, 1:ny,:,2) ! east
+       data(nxm+1+ioff:nxm+ehalo+ioff, ny+1:nym+joff,:) = data_all(1+ioff:ehalo+ioff, 1:ny+joff,:,4) ! east
+       data(1-whalo:0, 1:ny,:) = data_all(nx-whalo+1:nx, 1:ny,:,3) ! west
+       data(1-whalo:0, ny+1:nym+joff,:) = data_all(nx-whalo+1:nx, 1:ny+joff,:,5) ! west
+       data(1:nxm+ioff, 1-shalo:0,:) = data_all(1:nxm+ioff, nym-shalo+1:nym,:,1) ! south
+       data(1:nxm+ioff, nym+1+joff:nym+nhalo+joff,:) = data_all(1:nxm+ioff, 1+joff:nhalo+joff,:,1) ! north
+       data(nxm+1+ioff:nxm+ehalo+ioff, 1-shalo:0,:) = data_all(1+ioff:ehalo+ioff, ny-shalo+1:ny,:,4) ! southeast
+       data(1-whalo:0, 1-shalo:0,:) = data_all(nx-whalo+1:nx, ny-shalo+1:ny,:,5) ! southwest
+       data(nxm+1+ioff:nxm+ehalo+ioff,nym+1+joff:nym+nhalo+joff,:) = &
+                                                  & data_all(1+ioff:ehalo+ioff, 1+joff:nhalo+joff,:,2) ! northeast
+       data(1-whalo:0, nym+1+joff:nym+nhalo+joff,:) = data_all(nx-whalo+1:nx, 1+joff:nhalo+joff,:,3) ! northwest
     case(2)
-       data(nx+1+ioff:nx+ehalo+ioff,              1:ny+joff,:) = data_all(1+ioff:ehalo+ioff,              1:ny+joff,:,3) ! east
-       data(1-whalo:0,                            1:ny+joff,:) = data_all(nxm-whalo+1:nxm,                1:ny+joff,:,1) ! west
-       data(1:nx+ioff,                            1-shalo:0,:) = data_all(1:nx+ioff,                  ny-shalo+1:ny,:,4) ! south
-       data(1:nx+ioff,              ny+1+joff:ny+nhalo+joff,:) = data_all(1:nx+ioff,              1+joff:nhalo+joff,:,4) ! north
-       data(nx+1+ioff:nx+ehalo+ioff,              1-shalo:0,:) = data_all(1+ioff:ehalo+ioff,          ny-shalo+1:ny,:,5) ! southeast
-       data(1-whalo:0,                            1-shalo:0,:) = data_all(nxm-whalo+1:nxm,          nym-shalo+1:nym,:,1) ! southwest
-       data(nx+1+ioff:nx+ehalo+ioff,ny+1+joff:ny+nhalo+joff,:) = data_all(1+ioff:ehalo+ioff,      1+joff:nhalo+joff,:,5) ! northeast
-       data(1-whalo:0,              ny+1+joff:ny+nhalo+joff,:) = data_all(nxm-whalo+1:nxm,  ny+1+joff:ny+nhalo+joff,:,1) ! northwest
+       data(nx+1+ioff:nx+ehalo+ioff, 1:ny+joff,:) = data_all(1+ioff:ehalo+ioff, 1:ny+joff,:,3) ! east
+       data(1-whalo:0, 1:ny+joff,:) = data_all(nxm-whalo+1:nxm, 1:ny+joff,:,1) ! west
+       data(1:nx+ioff, 1-shalo:0,:) = data_all(1:nx+ioff, ny-shalo+1:ny,:,4) ! south
+       data(1:nx+ioff, ny+1+joff:ny+nhalo+joff,:) = data_all(1:nx+ioff, 1+joff:nhalo+joff,:,4) ! north
+       data(nx+1+ioff:nx+ehalo+ioff, 1-shalo:0,:) = data_all(1+ioff:ehalo+ioff, ny-shalo+1:ny,:,5) ! southeast
+       data(1-whalo:0, 1-shalo:0,:) = data_all(nxm-whalo+1:nxm, nym-shalo+1:nym,:,1) ! southwest
+       data(nx+1+ioff:nx+ehalo+ioff,ny+1+joff:ny+nhalo+joff,:) = &
+                                                  & data_all(1+ioff:ehalo+ioff,      1+joff:nhalo+joff,:,5) ! northeast
+       data(1-whalo:0, ny+1+joff:ny+nhalo+joff,:) = data_all(nxm-whalo+1:nxm, ny+1+joff:ny+nhalo+joff,:,1) ! northwest
     case(3)
-       data(nx+1+ioff:nx+ehalo+ioff,              1:ny+joff,:) = data_all(1+ioff:ehalo+ioff,              1:ny+joff,:,1) ! east
-       data(1-whalo:0,                            1:ny+joff,:) = data_all(nx-whalo+1:nx,                  1:ny+joff,:,2) ! west
-       data(1:nx+ioff,                            1-shalo:0,:) = data_all(1:nx+ioff,                  ny-shalo+1:ny,:,5) ! south
-       data(1:nx+ioff,              ny+1+joff:ny+nhalo+joff,:) = data_all(1:nx+ioff,              1+joff:nhalo+joff,:,5) ! north
-       data(nx+1+ioff:nx+ehalo+ioff,              1-shalo:0,:) = data_all(1+ioff:ehalo+ioff,        nym-shalo+1:nym,:,1) ! southeast
-       data(1-whalo:0,                            1-shalo:0,:) = data_all(nx-whalo+1:nx,              ny-shalo+1:ny,:,4) ! southwest
-       data(nx+1+ioff:nx+ehalo+ioff,ny+1+joff:ny+nhalo+joff,:) = data_all(1+ioff:ehalo+ioff,ny+1+joff:ny+nhalo+joff,:,1) ! northeast
-       data(1-whalo:0,              ny+1+joff:ny+nhalo+joff,:) = data_all(nx-whalo+1:nx,          1+joff:nhalo+joff,:,4) ! northwest
+       data(nx+1+ioff:nx+ehalo+ioff, 1:ny+joff,:) = data_all(1+ioff:ehalo+ioff, 1:ny+joff,:,1) ! east
+       data(1-whalo:0, 1:ny+joff,:) = data_all(nx-whalo+1:nx, 1:ny+joff,:,2) ! west
+       data(1:nx+ioff, 1-shalo:0,:) = data_all(1:nx+ioff, ny-shalo+1:ny,:,5) ! south
+       data(1:nx+ioff, ny+1+joff:ny+nhalo+joff,:) = data_all(1:nx+ioff, 1+joff:nhalo+joff,:,5) ! north
+       data(nx+1+ioff:nx+ehalo+ioff, 1-shalo:0,:) = data_all(1+ioff:ehalo+ioff, nym-shalo+1:nym,:,1) ! southeast
+       data(1-whalo:0, 1-shalo:0,:) = data_all(nx-whalo+1:nx, ny-shalo+1:ny,:,4) ! southwest
+       data(nx+1+ioff:nx+ehalo+ioff,ny+1+joff:ny+nhalo+joff,:) = &
+                                                  & data_all(1+ioff:ehalo+ioff,ny+1+joff:ny+nhalo+joff,:,1) ! northeast
+       data(1-whalo:0, ny+1+joff:ny+nhalo+joff,:) = data_all(nx-whalo+1:nx, 1+joff:nhalo+joff,:,4) ! northwest
     case(4)
-       data(nx+1+ioff:nx+ehalo+ioff,              1:ny+joff,:) = data_all(1+ioff:ehalo+ioff,        1:ny+joff,:,5) ! east
-       data(1-whalo:0,                            1:ny+joff,:) = data_all(nxm-whalo+1:nxm,     ny+1:2*ny+joff,:,1) ! west
-       data(1:nx+ioff,                            1-shalo:0,:) = data_all(1:nx+ioff,            ny-shalo+1:ny,:,2) ! south
-       data(1:nx+ioff,              ny+1+joff:ny+nhalo+joff,:) = data_all(1:nx+ioff,        1+joff:nhalo+joff,:,2) ! north
-       data(nx+1+ioff:nx+ehalo+ioff,              1-shalo:0,:) = data_all(1+ioff:ehalo+ioff,    ny-shalo+1:ny,:,3) ! southeast
-       data(1-whalo:0,                            1-shalo:0,:) = data_all(nxm-whalo+1:nxm,      ny-shalo+1:ny,:,1) ! southwest
-       data(nx+1+ioff:nx+ehalo+ioff,ny+1+joff:ny+nhalo+joff,:) = data_all(1+ioff:ehalo+ioff,1+joff:nhalo+joff,:,3) ! northeast
-       data(1-whalo:0,              ny+1+joff:ny+nhalo+joff,:) = data_all(nxm-whalo+1:nxm,  1+joff:nhalo+joff,:,1) ! northwest
+       data(nx+1+ioff:nx+ehalo+ioff, 1:ny+joff,:) = data_all(1+ioff:ehalo+ioff, 1:ny+joff,:,5) ! east
+       data(1-whalo:0, 1:ny+joff,:) = data_all(nxm-whalo+1:nxm, ny+1:2*ny+joff,:,1) ! west
+       data(1:nx+ioff, 1-shalo:0,:) = data_all(1:nx+ioff, ny-shalo+1:ny,:,2) ! south
+       data(1:nx+ioff, ny+1+joff:ny+nhalo+joff,:) = data_all(1:nx+ioff, 1+joff:nhalo+joff,:,2) ! north
+       data(nx+1+ioff:nx+ehalo+ioff, 1-shalo:0,:) = data_all(1+ioff:ehalo+ioff, ny-shalo+1:ny,:,3) ! southeast
+       data(1-whalo:0, 1-shalo:0,:) = data_all(nxm-whalo+1:nxm, ny-shalo+1:ny,:,1) ! southwest
+       data(nx+1+ioff:nx+ehalo+ioff,ny+1+joff:ny+nhalo+joff,:) = &
+                                                  & data_all(1+ioff:ehalo+ioff,1+joff:nhalo+joff,:,3) ! northeast
+       data(1-whalo:0, ny+1+joff:ny+nhalo+joff,:) = data_all(nxm-whalo+1:nxm, 1+joff:nhalo+joff,:,1) ! northwest
     case(5)
-       data(nx+1+ioff:nx+ehalo+ioff,            1:  ny+joff,:) = data_all(1+ioff:ehalo+ioff,   ny+1:2*ny+joff,:,1) ! east
-       data(1-whalo:0,                            1:ny+joff,:) = data_all(nx-whalo+1:nx,            1:ny+joff,:,4) ! west
-       data(1:nx+ioff,                            1-shalo:0,:) = data_all(1:nx+ioff,            ny-shalo+1:ny,:,3) ! south
-       data(1:nx+ioff,              ny+1+joff:ny+nhalo+joff,:) = data_all(1:nx+ioff,        1+joff:nhalo+joff,:,3) ! north
-       data(nx+1+ioff:nx+ehalo+ioff,              1-shalo:0,:) = data_all(1+ioff:ehalo+ioff,    ny-shalo+1:ny,:,1) ! southeast
-       data(1-whalo:0,                            1-shalo:0,:) = data_all(nx-whalo+1:nx,        ny-shalo+1:ny,:,2) ! southwest
-       data(nx+1+ioff:nx+ehalo+ioff,ny+1+joff:ny+nhalo+joff,:) = data_all(1+ioff:ehalo+ioff,1+joff:nhalo+joff,:,1) ! northeast
-       data(1-whalo:0,              ny+1+joff:ny+nhalo+joff,:) = data_all(nx-whalo+1:nx,    1+joff:nhalo+joff,:,2) ! northwest
+       data(nx+1+ioff:nx+ehalo+ioff, 1: ny+joff,:) = data_all(1+ioff:ehalo+ioff, ny+1:2*ny+joff,:,1) ! east
+       data(1-whalo:0, 1:ny+joff,:) = data_all(nx-whalo+1:nx, 1:ny+joff,:,4) ! west
+       data(1:nx+ioff, 1-shalo:0,:) = data_all(1:nx+ioff, ny-shalo+1:ny,:,3) ! south
+       data(1:nx+ioff, ny+1+joff:ny+nhalo+joff,:) = data_all(1:nx+ioff, 1+joff:nhalo+joff,:,3) ! north
+       data(nx+1+ioff:nx+ehalo+ioff, 1-shalo:0,:) = data_all(1+ioff:ehalo+ioff, ny-shalo+1:ny,:,1) ! southeast
+       data(1-whalo:0, 1-shalo:0,:) = data_all(nx-whalo+1:nx, ny-shalo+1:ny,:,2) ! southwest
+       data(nx+1+ioff:nx+ehalo+ioff,ny+1+joff:ny+nhalo+joff,:) = &
+                                                  & data_all(1+ioff:ehalo+ioff,1+joff:nhalo+joff,:,1) ! northeast
+       data(1-whalo:0, ny+1+joff:ny+nhalo+joff,:) = data_all(nx-whalo+1:nx, 1+joff:nhalo+joff,:,2) ! northwest
     end select
 
   end subroutine fill_five_tile_halo
@@ -3736,8 +3786,8 @@ end subroutine test_halosize_update
           call mpp_get_boundary(x(:,:,:,n), domain, sbuffer=sbuffer(:,:,n), wbuffer=wbuffer(:,:,n), &
                                 position=CORNER, tile_count=n  )
        else
-          call mpp_get_boundary(x(:,:,:,n), domain, ebuffer=ebuffer(:,:,n), sbuffer=sbuffer(:,:,n), wbuffer=wbuffer(:,:,n), &
-                                nbuffer=nbuffer(:,:,n), position=CORNER, tile_count=n  )
+          call mpp_get_boundary(x(:,:,:,n), domain, ebuffer=ebuffer(:,:,n), sbuffer=sbuffer(:,:,n), &
+                                wbuffer=wbuffer(:,:,n), nbuffer=nbuffer(:,:,n), position=CORNER, tile_count=n  )
        endif
     end do
 
@@ -3749,10 +3799,10 @@ end subroutine test_halosize_update
           call mpp_get_boundary(x2(:,:,:,n), domain, sbuffer=sbuffer2(:,:,n), wbuffer=wbuffer2(:,:,n), &
                position=CORNER, tile_count=n, complete = .true.  )
        else
-          call mpp_get_boundary(x1(:,:,:,n), domain, ebuffer=ebuffer1(:,:,n), sbuffer=sbuffer1(:,:,n), wbuffer=wbuffer1(:,:,n), &
-               nbuffer=nbuffer1(:,:,n), position=CORNER, tile_count=n, complete = .false.  )
-          call mpp_get_boundary(x2(:,:,:,n), domain, ebuffer=ebuffer2(:,:,n), sbuffer=sbuffer2(:,:,n), wbuffer=wbuffer2(:,:,n), &
-               nbuffer=nbuffer2(:,:,n), position=CORNER, tile_count=n, complete = .true.  )
+          call mpp_get_boundary(x1(:,:,:,n), domain, ebuffer=ebuffer1(:,:,n), sbuffer=sbuffer1(:,:,n), &
+               wbuffer=wbuffer1(:,:,n), nbuffer=nbuffer1(:,:,n), position=CORNER, tile_count=n, complete = .false.  )
+          call mpp_get_boundary(x2(:,:,:,n), domain, ebuffer=ebuffer2(:,:,n), sbuffer=sbuffer2(:,:,n), &
+               wbuffer=wbuffer2(:,:,n), nbuffer=nbuffer2(:,:,n), position=CORNER, tile_count=n, complete = .true.  )
        endif
     end do
 
@@ -3875,7 +3925,8 @@ end subroutine test_halosize_update
     do n = 1, ntile_per_pe
        if(folded_north .or. is_torus) then
           call mpp_get_boundary(x(:,:,:,n), y(:,:,:,n), domain, sbufferx=sbufferx(:,:,n), wbufferx=wbufferx(:,:,n), &
-               sbuffery=sbuffery(:,:,n), wbuffery=wbuffery(:,:,n), gridtype=BGRID_NE, tile_count=n, flags = SCALAR_PAIR  )
+               sbuffery=sbuffery(:,:,n), wbuffery=wbuffery(:,:,n), gridtype=BGRID_NE, tile_count=n, &
+                                &  flags = SCALAR_PAIR  )
        else
           call mpp_get_boundary(x(:,:,:,n), y(:,:,:,n), domain, ebufferx=ebufferx(:,:,n), sbufferx=sbufferx(:,:,n), &
                wbufferx=wbufferx(:,:,n), nbufferx=nbufferx(:,:,n), ebuffery=ebuffery(:,:,n),       &
@@ -3886,18 +3937,18 @@ end subroutine test_halosize_update
 
     do n = 1, ntile_per_pe
        if(folded_north .or. is_torus) then
-          call mpp_get_boundary(x1(:,:,:,n), y1(:,:,:,n), domain, sbufferx=sbufferx1(:,:,n), wbufferx=wbufferx1(:,:,n), &
+          call mpp_get_boundary(x1(:,:,:,n), y1(:,:,:,n), domain, sbufferx=sbufferx1(:,:,n),wbufferx=wbufferx1(:,:,n),&
                sbuffery=sbuffery1(:,:,n), wbuffery=wbuffery1(:,:,n),                           &
                gridtype=BGRID_NE, tile_count=n, flags = SCALAR_PAIR, complete = .false.  )
-          call mpp_get_boundary(x2(:,:,:,n), y2(:,:,:,n), domain, sbufferx=sbufferx2(:,:,n), wbufferx=wbufferx2(:,:,n), &
+          call mpp_get_boundary(x2(:,:,:,n), y2(:,:,:,n), domain, sbufferx=sbufferx2(:,:,n),wbufferx=wbufferx2(:,:,n),&
                sbuffery=sbuffery2(:,:,n), wbuffery=wbuffery2(:,:,n),       &
                gridtype=BGRID_NE, tile_count=n, flags = SCALAR_PAIR, complete = .true.  )
        else
-          call mpp_get_boundary(x1(:,:,:,n), y1(:,:,:,n), domain, ebufferx=ebufferx1(:,:,n), sbufferx=sbufferx1(:,:,n), &
+          call mpp_get_boundary(x1(:,:,:,n), y1(:,:,:,n), domain, ebufferx=ebufferx1(:,:,n),sbufferx=sbufferx1(:,:,n),&
                wbufferx=wbufferx1(:,:,n), nbufferx=nbufferx1(:,:,n), ebuffery=ebuffery1(:,:,n),       &
                sbuffery=sbuffery1(:,:,n), wbuffery=wbuffery1(:,:,n), nbuffery=nbuffery1(:,:,n),       &
                gridtype=BGRID_NE, tile_count=n, flags = SCALAR_PAIR, complete = .false.  )
-          call mpp_get_boundary(x2(:,:,:,n), y2(:,:,:,n), domain, ebufferx=ebufferx2(:,:,n), sbufferx=sbufferx2(:,:,n), &
+          call mpp_get_boundary(x2(:,:,:,n), y2(:,:,:,n), domain, ebufferx=ebufferx2(:,:,n),sbufferx=sbufferx2(:,:,n),&
                wbufferx=wbufferx2(:,:,n), nbufferx=nbufferx2(:,:,n), ebuffery=ebuffery2(:,:,n),       &
                sbuffery=sbuffery2(:,:,n), wbuffery=wbuffery2(:,:,n), nbuffery=nbuffery2(:,:,n),       &
                gridtype=BGRID_NE, tile_count=n, flags = SCALAR_PAIR, complete = .true.  )
@@ -4243,10 +4294,10 @@ end subroutine test_halosize_update
                sbuffery=sbuffery2(:,:,n), gridtype=CGRID_NE, tile_count=n,  &
                complete = .true.  )
        else
-          call mpp_get_boundary(x1(:,:,:,n), y1(:,:,:,n), domain, ebufferx=ebufferx1(:,:,n), wbufferx=wbufferx1(:,:,n), &
+          call mpp_get_boundary(x1(:,:,:,n), y1(:,:,:,n), domain, ebufferx=ebufferx1(:,:,n),wbufferx=wbufferx1(:,:,n),&
                sbuffery=sbuffery1(:,:,n), nbuffery=nbuffery1(:,:,n), gridtype=CGRID_NE, tile_count=n,  &
                complete = .false.  )
-          call mpp_get_boundary(x2(:,:,:,n), y2(:,:,:,n), domain, ebufferx=ebufferx2(:,:,n), wbufferx=wbufferx2(:,:,n), &
+          call mpp_get_boundary(x2(:,:,:,n), y2(:,:,:,n), domain, ebufferx=ebufferx2(:,:,n),wbufferx=wbufferx2(:,:,n),&
                sbuffery=sbuffery2(:,:,n), nbuffery=nbuffery2(:,:,n), gridtype=CGRID_NE, tile_count=n,  &
                complete = .true.  )
        endif
@@ -4575,7 +4626,8 @@ end subroutine test_halosize_update
           end do
        end if
        if(ni(tile) == ni(ln) ) then
-          data(1:ni(tile)+ioff, nj(tile)+1+joff:nj(tile)+nhalo+joff, :) = data1_all(1:ni(ln)+ioff, 1+joff:nhalo+joff, :, ln) ! north
+          data(1:ni(tile)+ioff, nj(tile)+1+joff:nj(tile)+nhalo+joff, :) = &
+                                                  & data1_all(1:ni(ln)+ioff, 1+joff:nhalo+joff, :, ln) ! north
        end if
     else ! tile 1, 3, 5
        lw = tile - 2; le = tile + 1; ls = tile - 1; ln = tile + 2
@@ -4588,7 +4640,8 @@ end subroutine test_halosize_update
           end do
        end if
        if(nj(tile) == nj(le) ) then
-          data(ni(tile)+1+ioff:ni(tile)+ehalo+ioff, 1:nj(tile)+joff, :) = data1_all(1+ioff:ehalo+ioff, 1:nj(le)+joff, :, le) ! east
+          data(ni(tile)+1+ioff:ni(tile)+ehalo+ioff, 1:nj(tile)+joff, :) = &
+                                                  & data1_all(1+ioff:ehalo+ioff, 1:nj(le)+joff, :, le) ! east
        end if
        if(ni(tile) == ni(ls) ) then
           data(1:ni(tile)+ioff, 1-shalo:0, :)     = data1_all(1:ni(ls)+ioff, nj(ls)-shalo+1:nj(ls), :, ls) ! south
@@ -5229,8 +5282,9 @@ end subroutine test_halosize_update
            call mpp_define_domains( (/1,nx,1,ny/), layout, domain, whalo=whalo, ehalo=ehalo, &
                                     shalo=shalo, nhalo=nhalo, name=type, symmetry = .true. )
     case( 'Cyclic symmetry center', 'Cyclic symmetry corner', 'Cyclic symmetry east', 'Cyclic symmetry north' )
-           call mpp_define_domains( (/1,nx,1,ny/), layout, domain, whalo=whalo, ehalo=ehalo, shalo=shalo, nhalo=nhalo, &
-                                    name=type, symmetry = .true., xflags=CYCLIC_GLOBAL_DOMAIN, yflags=CYCLIC_GLOBAL_DOMAIN )
+           call mpp_define_domains( (/1,nx,1,ny/), layout, domain, whalo=whalo, ehalo=ehalo, shalo=shalo, nhalo=nhalo,&
+                                    name=type, symmetry = .true., xflags=CYCLIC_GLOBAL_DOMAIN, &
+                                            &  yflags=CYCLIC_GLOBAL_DOMAIN )
     case default
         call mpp_error( FATAL, 'TEST_MPP_DOMAINS: no such test: '//type//' in test_global_field' )
     end select
@@ -5595,7 +5649,8 @@ end subroutine test_halosize_update
        end if
     case('Ten tile')
        if(mod(npes,10) .NE. 0 .AND. npes .NE. 1 .AND. mod(10,npes) .NE. 0) then
-          call mpp_error(NOTE, 'test_define_mosaic_pelist: npes can not be divided by 10(or reverse), no test for '//type )
+          call mpp_error(NOTE, 'test_define_mosaic_pelist: npes can not be divided by 10(or reverse), no test for '// &
+                         & type )
           return
        end if
        if(mod(10, npes)==0) then
@@ -5701,8 +5756,10 @@ end subroutine test_halosize_update
     type = 'nest grid BGRID_NE'
     call mpp_update_domains( x,  y,  domain, gridtype=BGRID_NE, name=trim(type))
 
-    call compare_checksums( x (isd:ied+shift,jsd:jed+shift,:),  global1(isd:ied+shift,jsd:jed+shift,:), trim(type)//' X' )
-    call compare_checksums( y (isd:ied+shift,jsd:jed+shift,:),  global2(isd:ied+shift,jsd:jed+shift,:), trim(type)//' Y' )
+    call compare_checksums( x (isd:ied+shift,jsd:jed+shift,:),  global1(isd:ied+shift,jsd:jed+shift,:), trim(type)// &
+                         & ' X' )
+    call compare_checksums( y (isd:ied+shift,jsd:jed+shift,:),  global2(isd:ied+shift,jsd:jed+shift,:), trim(type)// &
+                         & ' Y' )
 
     !------------------------------------------------------------------
     !              vector update : CGRID_NE
@@ -5741,7 +5798,8 @@ end subroutine test_halosize_update
   end subroutine test_nest_halo_update
 
   subroutine get_nnest(domain, num_nest, tile_coarse, istart_coarse, iend_coarse, jstart_coarse, jend_coarse, &
-                       nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse)
+                       nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, &
+                               &  js_coarse, je_coarse)
     type(domain2D), intent(inout) :: domain
     integer, intent(in)  :: num_nest, istart_coarse(:), iend_coarse(:), jstart_coarse(:), jend_coarse(:)
     integer, intent(in)  :: tile_coarse(:)
@@ -5864,7 +5922,8 @@ end subroutine test_halosize_update
 
 
   subroutine get_nnest2(domain, num_nest, tile_coarse, istart_coarse, iend_coarse, jstart_coarse, jend_coarse, &
-                       nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse)
+                       nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, &
+                               &  js_coarse, je_coarse)
     type(domain2D), intent(inout) :: domain
     integer, intent(in)  :: num_nest, istart_coarse(:), iend_coarse(:), jstart_coarse(:), jend_coarse(:)
     integer, intent(in)  :: tile_coarse(:)
@@ -6112,8 +6171,8 @@ end subroutine test_halosize_update
           return
        endif
        if( nx_cubic .NE. ny_cubic ) then
-          call mpp_error(NOTE,'test_update_nest_domain: for Regional grid mosaic, nx_cubic does not equal ny_cubic, '//&
-                  'No test is done for Cubic-Grid mosaic. ' )
+          call mpp_error(NOTE,'test_update_nest_domain: for Regional grid mosaic, nx_cubic does not equal ny_cubic, '&
+                   //'No test is done for Cubic-Grid mosaic. ' )
           return
        endif
        nx = nx_cubic
@@ -6125,7 +6184,8 @@ end subroutine test_halosize_update
     end select
 
     if(ntiles_nest_all > MAX_NTILE) call mpp_error(FATAL, 'test_update_nest_domain: ntiles_nest_all > MAX_NTILE')
-    if(ntiles_nest_top .GE. ntiles_nest_all) call mpp_error(FATAL, 'test_update_nest_domain: ntiles_nest_top .GE. ntile_nest_all')
+    if(ntiles_nest_top .GE. ntiles_nest_all) call mpp_error(FATAL, &
+             'test_update_nest_domain: ntiles_nest_top .GE. ntile_nest_all')
     if(ntiles_nest_all .NE. ntiles_nest_top + num_nest) call mpp_error(FATAL, &
              'test_update_nest_domain: ntiles_nest_all .NE. ntiles_nest_top + num_nest')
     !--- for the ntiles_nest_top, number of processors should be same
@@ -6154,7 +6214,7 @@ end subroutine test_halosize_update
     !---make sure nest_level is setup properly
     if(nest_level(1) .NE. 1) call mpp_error(FATAL, "test_mpp_domains: nest_level(1) .NE. 1")
     do n = 2, num_nest
-       if(nest_level(n) > nest_level(n-1)+1) call mpp_error(FATAL, "test_mpp_domains: nest_level(n) > nest_level(n-1)+1")
+       if(nest_level(n) > nest_level(n-1)+1)call mpp_error(FATAL,"test_mpp_domains: nest_level(n) > nest_level(n-1)+1")
        if(nest_level(n) < nest_level(n-1) ) call mpp_error(FATAL, "test_mpp_domains: nest_level(n) < nest_level(n-1)")
     enddo
     num_nest_level = nest_level(num_nest)
@@ -6181,7 +6241,8 @@ end subroutine test_halosize_update
     if(ANY(my_pelist==mpp_pe())) then
        call mpp_set_current_pelist(my_pelist)
 
-       allocate(layout2D(2,ntiles_nest_top), global_indices(4,ntiles_nest_top), pe_start(ntiles_nest_top), pe_end(ntiles_nest_top) )
+       allocate(layout2D(2,ntiles_nest_top), global_indices(4,ntiles_nest_top), pe_start(ntiles_nest_top), &
+               &  pe_end(ntiles_nest_top) )
        npes_per_tile = npes_nest_tile(1)
 
 
@@ -6250,7 +6311,7 @@ end subroutine test_halosize_update
     y_refine(:) = refine_ratio(1:num_nest)
 
     call mpp_define_nest_domains(nest_domain, domain, num_nest, nest_level(1:num_nest), tile_fine(1:num_nest), &
-             tile_coarse(1:num_nest), istart_coarse(1:num_nest), icount_coarse(1:num_nest), jstart_coarse(1:num_nest), &
+             tile_coarse(1:num_nest), istart_coarse(1:num_nest), icount_coarse(1:num_nest), jstart_coarse(1:num_nest),&
              jcount_coarse(1:num_nest), npes_nest_tile(1:ntiles_nest_all), &
              x_refine(1:num_nest), y_refine(1:num_nest), extra_halo=extra_halo, name="nest_domain")
 
@@ -6344,8 +6405,8 @@ end subroutine test_halosize_update
                 je_c = min(je_coarse(n),   jec_coarse)
                 if( tile == t_coarse(n) .AND. ie_c .GE. is_c .AND. je_c .GE. js_c ) then
                    call fill_coarse_data(x2, rotate_coarse(n), iadd_coarse(n), jadd_coarse(n), &
-                        is_c, ie_c, js_c, je_c, nz, isd_coarse, jsd_coarse, nx, ny, 0, 0, 0.001_r8_kind, 0.001_r8_kind, 1, 1, &
-                        .false., .false., iend_coarse(1), jend_coarse(1) )
+                        is_c, ie_c, js_c, je_c, nz, isd_coarse, jsd_coarse, nx, ny, 0, 0, 0.001_r8_kind, &
+                        0.001_r8_kind, 1, 1, .false., .false., iend_coarse(1), jend_coarse(1) )
                 endif
              enddo
           endif
@@ -6369,7 +6430,8 @@ end subroutine test_halosize_update
 
        if(is_fine_pe) then
           call mpp_get_F2C_index(nest_domain, is_cx, ie_cx, js_cx, je_cx, is_fx, ie_fx, js_fx, je_fx, l, position=EAST)
-          call mpp_get_F2C_index(nest_domain, is_cy, ie_cy, js_cy, je_cy, is_fy, ie_fy, js_fy, je_fy, l, position=NORTH)
+          call mpp_get_F2C_index(nest_domain, is_cy, ie_cy, js_cy, je_cy, is_fy, ie_fy, js_fy, je_fy, l, &
+                                &  position=NORTH)
           allocate(x(is_cx:ie_cx, js_cx:je_cx, nz))
           allocate(y(is_cy:ie_cy, js_cy:je_cy, nz))
           x = 0
@@ -6442,13 +6504,13 @@ end subroutine test_halosize_update
              je_c = min(je_coarse(n),   jec_coarse)
              if( tile == t_coarse(n) .AND. ie_c+shift .GE. is_c .AND. je_c .GE. js_c ) then
                 call fill_coarse_data(x2, rotate_coarse(n), iadd_coarse(n), jadd_coarse(n), &
-                     is_c, ie_c, js_c, je_c, nz, isd_coarse, jsd_coarse, nx, ny, shift, 0, 1.0E-6_r8_kind, 2.0E-6_r8_kind, 1, 1, &
-                     x_cyclic, .false., iend_coarse(1)+1, jend_coarse(1)+1)
+                     is_c, ie_c, js_c, je_c, nz, isd_coarse, jsd_coarse, nx, ny, shift, 0, 1.0E-6_r8_kind, &
+                     2.0E-6_r8_kind, 1, 1, x_cyclic, .false., iend_coarse(1)+1, jend_coarse(1)+1)
              endif
              if( tile == t_coarse(n) .AND. ie_c .GE. is_c .AND. je_c+shift .GE. js_c ) then
                 call fill_coarse_data(y2, rotate_coarse(n), iadd_coarse(n), jadd_coarse(n), &
-                     is_c, ie_c, js_c, je_c, nz, isd_coarse, jsd_coarse, nx, ny, 0, shift, 2.0E-6_r8_kind, 1.0E-6_r8_kind, 1, 1, &
-                     .false., y_cyclic, iend_coarse(1)+1, jend_coarse(1)+1)
+                     is_c, ie_c, js_c, je_c, nz, isd_coarse, jsd_coarse, nx, ny, 0, shift, 2.0E-6_r8_kind, &
+                     1.0E-6_r8_kind, 1, 1, .false., y_cyclic, iend_coarse(1)+1, jend_coarse(1)+1)
              endif
           enddo
        endif
@@ -6476,7 +6538,8 @@ end subroutine test_halosize_update
 
        if(is_fine_pe) then
           call mpp_get_F2C_index(nest_domain, is_cx, ie_cx, js_cx, je_cx, is_fx, ie_fx, js_fx, je_fx, l, position=EAST)
-          call mpp_get_F2C_index(nest_domain, is_cy, ie_cy, js_cy, je_cy, is_fy, ie_fy, js_fy, je_fy, l, position=NORTH)
+          call mpp_get_F2C_index(nest_domain, is_cy, ie_cy, js_cy, je_cy, is_fy, ie_fy, js_fy, je_fy, l, &
+                                &  position=NORTH)
           allocate(x(is_cx:ie_cx, js_cx:je_cx, nz))
           allocate(y(is_cy:ie_cy, js_cy:je_cy, nz))
           x = 0
@@ -6529,13 +6592,13 @@ end subroutine test_halosize_update
              je_c = min(je_coarse(n),   jec_coarse)
              if( tile == t_coarse(n) .AND. ie_c+shift .GE. is_c .AND. je_c .GE. js_c ) then
                 call fill_coarse_data(x2, rotate_coarse(n), iadd_coarse(n), jadd_coarse(n), &
-                     is_c, ie_c, js_c, je_c, nz, isd_coarse, jsd_coarse, nx, ny, shift, 0, 1.0E-6_r8_kind, 2.0E-6_r8_kind, 1, -1, &
-                     x_cyclic, .false., iend_coarse(1)+1, jend_coarse(1)+1)
+                     is_c, ie_c, js_c, je_c, nz, isd_coarse, jsd_coarse, nx, ny, shift, 0, 1.0E-6_r8_kind, &
+                     2.0E-6_r8_kind, 1, -1, x_cyclic, .false., iend_coarse(1)+1, jend_coarse(1)+1)
              endif
              if( tile == t_coarse(n) .AND. ie_c .GE. is_c .AND. je_c+shift .GE. js_c ) then
                 call fill_coarse_data(y2, rotate_coarse(n), iadd_coarse(n), jadd_coarse(n), &
-                     is_c, ie_c, js_c, je_c, nz, isd_coarse, jsd_coarse, nx, ny, 0, shift, 2.0E-6_r8_kind, 1.0E-6_r8_kind, -1, 1, &
-                     .false., y_cyclic, iend_coarse(1)+1, jend_coarse(1)+1)
+                     is_c, ie_c, js_c, je_c, nz, isd_coarse, jsd_coarse, nx, ny, 0, shift, 2.0E-6_r8_kind, &
+                     1.0E-6_r8_kind, -1, 1, .false., y_cyclic, iend_coarse(1)+1, jend_coarse(1)+1)
              endif
           enddo
        endif
@@ -6562,7 +6625,8 @@ end subroutine test_halosize_update
        shift = 1
 
        if(is_fine_pe) then
-          call mpp_get_F2C_index(nest_domain, is_cx, ie_cx, js_cx, je_cx, is_fx, ie_fx, js_fx, je_fx, l, position=NORTH)
+          call mpp_get_F2C_index(nest_domain, is_cx, ie_cx, js_cx, je_cx, is_fx, ie_fx, js_fx, je_fx, l, &
+                                &  position=NORTH)
           call mpp_get_F2C_index(nest_domain, is_cy, ie_cy, js_cy, je_cy, is_fy, ie_fy, js_fy, je_fy, l, position=EAST)
           allocate(x(is_cx:ie_cx, js_cx:je_cx, nz))
           allocate(y(is_cy:ie_cy, js_cy:je_cy, nz))
@@ -6616,13 +6680,13 @@ end subroutine test_halosize_update
              je_c = min(je_coarse(n),   jec_coarse)
              if( tile == t_coarse(n) .AND. ie_c .GE. is_c .AND. je_c+shift .GE. js_c ) then
                 call fill_coarse_data(x2, rotate_coarse(n), iadd_coarse(n), jadd_coarse(n), &
-                     is_c, ie_c, js_c, je_c, nz, isd_coarse, jsd_coarse, nx, ny, 0, shift, 1.0E-6_r8_kind, 2.0E-6_r8_kind, 1, -1, &
-                     .false., y_cyclic, iend_coarse(1), jend_coarse(1) )
+                     is_c, ie_c, js_c, je_c, nz, isd_coarse, jsd_coarse, nx, ny, 0, shift, 1.0E-6_r8_kind, &
+                     2.0E-6_r8_kind, 1, -1, .false., y_cyclic, iend_coarse(1), jend_coarse(1) )
              endif
              if( tile == t_coarse(n) .AND. ie_c+shift .GE. is_c .AND. je_c .GE. js_c ) then
                 call fill_coarse_data(y2, rotate_coarse(n), iadd_coarse(n), jadd_coarse(n), &
-                     is_c, ie_c, js_c, je_c, nz, isd_coarse, jsd_coarse, nx, ny, shift, 0, 2.0E-6_r8_kind, 1.0E-6_r8_kind, -1, 1, &
-                     x_cyclic, .false., iend_coarse(1), jend_coarse(1))
+                     is_c, ie_c, js_c, je_c, nz, isd_coarse, jsd_coarse, nx, ny, shift, 0, 2.0E-6_r8_kind, &
+                     1.0E-6_r8_kind, -1, 1, x_cyclic, .false., iend_coarse(1), jend_coarse(1))
              endif
           enddo
        endif
@@ -6793,33 +6857,37 @@ end subroutine test_halosize_update
        if( is_fine_pe ) then
           call mpp_set_current_pelist(my_pelist_fine)
           if( iew_c .GE. isw_c .AND. jew_c .GE. jsw_c ) then
-             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/isw_c/), (/iew_c/), (/jsw_c/), (/jew_c/), &
-                  nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse)
-             call fill_nest_data(wbuffer2, isw_c, iew_c, jsw_c, jew_c, nnest, t_coarse, 0, 0, iadd_coarse, jadd_coarse, &
+             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/isw_c/), (/iew_c/), (/jsw_c/), &
+                  (/jew_c/), nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, &
+                  js_coarse, je_coarse)
+             call fill_nest_data(wbuffer2, isw_c, iew_c, jsw_c, jew_c, nnest, t_coarse, 0, 0, iadd_coarse,jadd_coarse,&
                   rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 0.0_r8_kind, 0.0_r8_kind, 1, 1, nx, ny)
           endif
           call compare_checksums(wbuffer, wbuffer2, trim(type2)//' west buffer coarse to fine scalar')
 
           if( ies_c .GE. iss_c .AND. jes_c .GE. jss_c ) then
-             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/iss_c/), (/ies_c/), (/jss_c/), (/jes_c/), &
-                  nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse)
-             call fill_nest_data(sbuffer2, iss_c, ies_c, jss_c, jes_c, nnest, t_coarse, 0, 0, iadd_coarse, jadd_coarse, &
+             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/iss_c/), (/ies_c/), (/jss_c/), &
+                  (/jes_c/), nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, &
+                  js_coarse, je_coarse)
+             call fill_nest_data(sbuffer2, iss_c, ies_c, jss_c, jes_c, nnest, t_coarse, 0, 0, iadd_coarse,jadd_coarse,&
                   rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 0.0_r8_kind, 0.0_r8_kind, 1, 1, nx, ny)
           endif
           call compare_checksums(sbuffer, sbuffer2, trim(type2)//' south buffer coarse to fine scalar')
 
           if( iee_c .GE. ise_c .AND. jee_c .GE. jse_c ) then
-             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/ise_c/), (/iee_c/), (/jse_c/), (/jee_c/), &
-                  nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse)
-             call fill_nest_data(ebuffer2, ise_c, iee_c, jse_c, jee_c, nnest, t_coarse, 0, 0, iadd_coarse, jadd_coarse, &
+             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/ise_c/), (/iee_c/), (/jse_c/), &
+                  (/jee_c/), nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, &
+                  js_coarse, je_coarse)
+             call fill_nest_data(ebuffer2, ise_c, iee_c, jse_c, jee_c, nnest, t_coarse, 0, 0, iadd_coarse,jadd_coarse,&
                   rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 0.0_r8_kind, 0.0_r8_kind, 1, 1, nx, ny)
           endif
           call compare_checksums(ebuffer, ebuffer2, trim(type2)//' east buffer coarse to fine scalar')
 
           if( ien_c .GE. isn_c .AND. jen_c .GE. jsn_c ) then
-             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/isn_c/), (/ien_c/), (/jsn_c/), (/jen_c/), &
-                  nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse)
-             call fill_nest_data(nbuffer2, isn_c, ien_c, jsn_c, jen_c, nnest, t_coarse, 0, 0, iadd_coarse, jadd_coarse, &
+             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/isn_c/), (/ien_c/), (/jsn_c/), &
+                  (/jen_c/), nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, &
+                  js_coarse, je_coarse)
+             call fill_nest_data(nbuffer2, isn_c, ien_c, jsn_c, jen_c, nnest, t_coarse, 0, 0, iadd_coarse,jadd_coarse,&
                   rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 0.0_r8_kind, 0.0_r8_kind, 1, 1, nx, ny)
           endif
           call compare_checksums(nbuffer, nbuffer2, trim(type2)//' north buffer coarse to fine scalar')
@@ -6841,14 +6909,22 @@ end subroutine test_halosize_update
           !--- The index from nest domain
           call mpp_get_compute_domain(domain_fine, isc_fine, iec_fine, jsc_fine, jec_fine)
           call mpp_get_data_domain(domain_fine, isd_fine, ied_fine, jsd_fine, jed_fine)
-          call mpp_get_C2F_index(nest_domain, isw_fx, iew_fx, jsw_fx, jew_fx, isw_cx, iew_cx, jsw_cx, jew_cx, WEST, l, position=CORNER)
-          call mpp_get_C2F_index(nest_domain, ise_fx, iee_fx, jse_fx, jee_fx, ise_cx, iee_cx, jse_cx, jee_cx, EAST, l, position=CORNER)
-          call mpp_get_C2F_index(nest_domain, iss_fx, ies_fx, jss_fx, jes_fx, iss_cx, ies_cx, jss_cx, jes_cx, SOUTH, l, position=CORNER)
-          call mpp_get_C2F_index(nest_domain, isn_fx, ien_fx, jsn_fx, jen_fx, isn_cx, ien_cx, jsn_cx, jen_cx, NORTH, l, position=CORNER)
-          call mpp_get_C2F_index(nest_domain, isw_fy, iew_fy, jsw_fy, jew_fy, isw_cy, iew_cy, jsw_cy, jew_cy, WEST, l, position=CORNER)
-          call mpp_get_C2F_index(nest_domain, ise_fy, iee_fy, jse_fy, jee_fy, ise_cy, iee_cy, jse_cy, jee_cy, EAST, l, position=CORNER)
-          call mpp_get_C2F_index(nest_domain, iss_fy, ies_fy, jss_fy, jes_fy, iss_cy, ies_cy, jss_cy, jes_cy, SOUTH, l, position=CORNER)
-          call mpp_get_C2F_index(nest_domain, isn_fy, ien_fy, jsn_fy, jen_fy, isn_cy, ien_cy, jsn_cy, jen_cy, NORTH, l, position=CORNER)
+          call mpp_get_C2F_index(nest_domain, isw_fx, iew_fx, jsw_fx, jew_fx, isw_cx, iew_cx, jsw_cx, jew_cx, &
+                                &  WEST, l, position=CORNER)
+          call mpp_get_C2F_index(nest_domain, ise_fx, iee_fx, jse_fx, jee_fx, ise_cx, iee_cx, jse_cx, jee_cx, &
+                                &  EAST, l, position=CORNER)
+          call mpp_get_C2F_index(nest_domain, iss_fx, ies_fx, jss_fx, jes_fx, iss_cx, ies_cx, jss_cx, jes_cx, &
+                                &  SOUTH, l, position=CORNER)
+          call mpp_get_C2F_index(nest_domain, isn_fx, ien_fx, jsn_fx, jen_fx, isn_cx, ien_cx, jsn_cx, jen_cx, &
+                                &  NORTH, l, position=CORNER)
+          call mpp_get_C2F_index(nest_domain, isw_fy, iew_fy, jsw_fy, jew_fy, isw_cy, iew_cy, jsw_cy, jew_cy, &
+                                &  WEST, l, position=CORNER)
+          call mpp_get_C2F_index(nest_domain, ise_fy, iee_fy, jse_fy, jee_fy, ise_cy, iee_cy, jse_cy, jee_cy, &
+                                &  EAST, l, position=CORNER)
+          call mpp_get_C2F_index(nest_domain, iss_fy, ies_fy, jss_fy, jes_fy, iss_cy, ies_cy, jss_cy, jes_cy, &
+                                &  SOUTH, l, position=CORNER)
+          call mpp_get_C2F_index(nest_domain, isn_fy, ien_fy, jsn_fy, jen_fy, isn_cy, ien_cy, jsn_cy, jen_cy, &
+                                &  NORTH, l, position=CORNER)
 
           !-- The assumed index
           isw_fx2 = 0; iew_fx2 = -1; jsw_fx2 = 0; jew_fx2 = -1
@@ -6877,7 +6953,8 @@ end subroutine test_halosize_update
              isw_cx2 = istart_coarse(my_fine_id)-whalo
              iew_cx2 = istart_coarse(my_fine_id)
              jsw_cx2 = jstart_coarse(my_fine_id) + (jsc_fine - jstart_fine(my_fine_id))/y_refine(my_fine_id) - shalo
-             jew_cx2 = jstart_coarse(my_fine_id) + (jec_fine - jstart_fine(my_fine_id))/y_refine(my_fine_id) + nhalo + shift
+             jew_cx2 = jstart_coarse(my_fine_id) + (jec_fine - jstart_fine(my_fine_id))/y_refine(my_fine_id) + nhalo &
+                     & + shift
              isw_fy2 = isd_fine
              iew_fy2 = isc_fine - 1
              jsw_fy2 = jsd_fine
@@ -6885,7 +6962,8 @@ end subroutine test_halosize_update
              isw_cy2 = istart_coarse(my_fine_id)-whalo
              iew_cy2 = istart_coarse(my_fine_id)
              jsw_cy2 = jstart_coarse(my_fine_id) + (jsc_fine - jstart_fine(my_fine_id))/y_refine(my_fine_id) - shalo
-             jew_cy2 = jstart_coarse(my_fine_id) + (jec_fine - jstart_fine(my_fine_id))/y_refine(my_fine_id) + nhalo + shift
+             jew_cy2 = jstart_coarse(my_fine_id) + (jec_fine - jstart_fine(my_fine_id))/y_refine(my_fine_id) + nhalo &
+                     & + shift
           endif
           !--- east
           if( iec_fine == nx_fine ) then
@@ -6896,7 +6974,8 @@ end subroutine test_halosize_update
              ise_cx2 = iend_coarse(my_fine_id)+shift
              iee_cx2 = iend_coarse(my_fine_id)+ehalo+shift
              jse_cx2 = jstart_coarse(my_fine_id) + (jsc_fine - jstart_fine(my_fine_id))/y_refine(my_fine_id) - shalo
-             jee_cx2 = jstart_coarse(my_fine_id) + (jec_fine - jstart_fine(my_fine_id))/y_refine(my_fine_id) + nhalo + shift
+             jee_cx2 = jstart_coarse(my_fine_id) + (jec_fine - jstart_fine(my_fine_id))/y_refine(my_fine_id) + nhalo &
+                     & + shift
              ise_fy2 = iec_fine+1 + shift
              iee_fy2 = ied_fine + shift
              jse_fy2 = jsd_fine
@@ -6904,7 +6983,8 @@ end subroutine test_halosize_update
              ise_cy2 = iend_coarse(my_fine_id) + shift
              iee_cy2 = iend_coarse(my_fine_id)+ehalo + shift
              jse_cy2 = jstart_coarse(my_fine_id) + (jsc_fine - jstart_fine(my_fine_id))/y_refine(my_fine_id) - shalo
-             jee_cy2 = jstart_coarse(my_fine_id) + (jec_fine - jstart_fine(my_fine_id))/y_refine(my_fine_id) + nhalo + shift
+             jee_cy2 = jstart_coarse(my_fine_id) + (jec_fine - jstart_fine(my_fine_id))/y_refine(my_fine_id) + nhalo &
+                     & + shift
           endif
           !--- south
           if( jsc_fine == 1 ) then
@@ -6913,7 +6993,8 @@ end subroutine test_halosize_update
              jss_fx2 = jsd_fine
              jes_fx2 = jsc_fine - 1
              iss_cx2 = istart_coarse(my_fine_id) + (isc_fine - istart_fine(my_fine_id))/x_refine(my_fine_id) - whalo
-             ies_cx2 = istart_coarse(my_fine_id) + (iec_fine - istart_fine(my_fine_id))/x_refine(my_fine_id) + ehalo + shift
+             ies_cx2 = istart_coarse(my_fine_id) + (iec_fine - istart_fine(my_fine_id))/x_refine(my_fine_id) + ehalo &
+                     & + shift
              jss_cx2 = jstart_coarse(my_fine_id)-shalo
              jes_cx2 = jstart_coarse(my_fine_id)
              iss_fy2 = isd_fine
@@ -6921,7 +7002,8 @@ end subroutine test_halosize_update
              jss_fy2 = jsd_fine
              jes_fy2 = jsc_fine - 1
              iss_cy2 = istart_coarse(my_fine_id) + (isc_fine - istart_fine(my_fine_id))/x_refine(my_fine_id) - whalo
-             ies_cy2 = istart_coarse(my_fine_id) + (iec_fine - istart_fine(my_fine_id))/x_refine(my_fine_id) + ehalo + shift
+             ies_cy2 = istart_coarse(my_fine_id) + (iec_fine - istart_fine(my_fine_id))/x_refine(my_fine_id) + ehalo &
+                     & + shift
              jss_cy2 = jstart_coarse(my_fine_id)-shalo
              jes_cy2 = jstart_coarse(my_fine_id)
           endif
@@ -6932,7 +7014,8 @@ end subroutine test_halosize_update
              jsn_fx2 = jec_fine+1 + shift
              jen_fx2 = jed_fine + shift
              isn_cx2 = istart_coarse(my_fine_id) + (isc_fine - istart_fine(my_fine_id))/x_refine(my_fine_id) - whalo
-             ien_cx2 = istart_coarse(my_fine_id) + (iec_fine - istart_fine(my_fine_id))/x_refine(my_fine_id) + ehalo + shift
+             ien_cx2 = istart_coarse(my_fine_id) + (iec_fine - istart_fine(my_fine_id))/x_refine(my_fine_id) + ehalo &
+                     & + shift
              jsn_cx2 = jend_coarse(my_fine_id) + shift
              jen_cx2 = jend_coarse(my_fine_id)+nhalo + shift
              isn_fy2 = isd_fine
@@ -6940,7 +7023,8 @@ end subroutine test_halosize_update
              jsn_fy2 = jec_fine+1 + shift
              jen_fy2 = jed_fine + shift
              isn_cy2 = istart_coarse(my_fine_id) + (isc_fine - istart_fine(my_fine_id))/x_refine(my_fine_id) - whalo
-             ien_cy2 = istart_coarse(my_fine_id) + (iec_fine - istart_fine(my_fine_id))/x_refine(my_fine_id) + ehalo + shift
+             ien_cy2 = istart_coarse(my_fine_id) + (iec_fine - istart_fine(my_fine_id))/x_refine(my_fine_id) + ehalo &
+                     & + shift
              jsn_cy2 = jend_coarse(my_fine_id) + shift
              jen_cy2 = jend_coarse(my_fine_id)+nhalo + shift
           endif
@@ -7084,36 +7168,48 @@ end subroutine test_halosize_update
        if( is_fine_pe ) then
           call mpp_set_current_pelist(my_pelist_fine)
           if( iew_c .GE. isw_c .AND. jew_c .GE. jsw_c ) then
-             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/isw_c/), (/iew_c/), (/jsw_c/), (/jew_c/), &
-                  nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse)
-             call fill_nest_data(wbufferx2, isw_c, iew_c, jsw_c, jew_c, nnest, t_coarse, 0, shift, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 1E3_r8_kind, 2E3_r8_kind, 1, 1, nx, ny)
-             call fill_nest_data(wbuffery2, isw_c, iew_c, jsw_c, jew_c, nnest, t_coarse, 0, shift, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 2E3_r8_kind, 1E3_r8_kind, 1, 1, nx, ny)
+             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/isw_c/), (/iew_c/), (/jsw_c/), &
+                  (/jew_c/), nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, &
+                  js_coarse, je_coarse)
+             call fill_nest_data(wbufferx2, isw_c, iew_c, jsw_c, jew_c, nnest, t_coarse, 0, shift, iadd_coarse, &
+                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 1E3_r8_kind, 2E3_r8_kind, 1,&
+                  1, nx, ny)
+             call fill_nest_data(wbuffery2, isw_c, iew_c, jsw_c, jew_c, nnest, t_coarse, 0, shift, iadd_coarse, &
+                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 2E3_r8_kind, 1E3_r8_kind, 1,&
+                  1, nx, ny)
           endif
           if( ies_c .GE. iss_c .AND. jes_c .GE. jss_c ) then
-             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/iss_c/), (/ies_c/), (/jss_c/), (/jes_c/), &
-                  nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse)
-             call fill_nest_data(sbufferx2, iss_c, ies_c, jss_c, jes_c, nnest, t_coarse, shift, 0, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 1E3_r8_kind, 2E3_r8_kind, 1, 1, nx, ny)
-             call fill_nest_data(sbuffery2, iss_c, ies_c, jss_c, jes_c, nnest, t_coarse, shift, 0, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 2E3_r8_kind, 1E3_r8_kind, 1, 1, nx, ny)
+             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/iss_c/), (/ies_c/), (/jss_c/), &
+                  (/jes_c/), nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, &
+                  js_coarse, je_coarse)
+             call fill_nest_data(sbufferx2, iss_c, ies_c, jss_c, jes_c, nnest, t_coarse, shift, 0, iadd_coarse, &
+                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 1E3_r8_kind, 2E3_r8_kind, 1,&
+                  1, nx, ny)
+             call fill_nest_data(sbuffery2, iss_c, ies_c, jss_c, jes_c, nnest, t_coarse, shift, 0, iadd_coarse, &
+                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 2E3_r8_kind, 1E3_r8_kind, 1,&
+                  1, nx, ny)
           endif
           if( iee_c .GE. ise_c .AND. jee_c .GE. jse_c ) then
-             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/ise_c/), (/iee_c/), (/jse_c/), (/jee_c/), &
-                  nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse)
-             call fill_nest_data(ebufferx2, ise_c+shift, iee_c, jse_c, jee_c, nnest, t_coarse, shift, shift, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse+shift, ie_coarse, js_coarse, je_coarse, 1E3_r8_kind, 2E3_r8_kind, 1, 1, nx, ny)
-             call fill_nest_data(ebuffery2, ise_c+shift, iee_c, jse_c, jee_c, nnest, t_coarse, shift, shift, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse+shift, ie_coarse, js_coarse, je_coarse, 2E3_r8_kind, 1E3_r8_kind, 1, 1, nx, ny)
+             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/ise_c/), (/iee_c/), (/jse_c/), &
+                  (/jee_c/), nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, &
+                  js_coarse, je_coarse)
+             call fill_nest_data(ebufferx2, ise_c+shift, iee_c, jse_c, jee_c, nnest, t_coarse, shift, shift, &
+                  iadd_coarse, jadd_coarse, rotate_coarse, is_coarse+shift, ie_coarse, js_coarse, je_coarse, &
+                  1E3_r8_kind, 2E3_r8_kind, 1, 1, nx, ny)
+             call fill_nest_data(ebuffery2, ise_c+shift, iee_c, jse_c, jee_c, nnest, t_coarse, shift, shift, &
+                  iadd_coarse, jadd_coarse, rotate_coarse, is_coarse+shift, ie_coarse, js_coarse, je_coarse, &
+                  2E3_r8_kind, 1E3_r8_kind, 1, 1, nx, ny)
           endif
           if( ien_c .GE. isn_c .AND. jen_c .GE. jsn_c ) then
-             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/isn_c/), (/ien_c/), (/jsn_c/), (/jen_c/), &
-                  nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse)
-             call fill_nest_data(nbufferx2, isn_c, ien_c, jsn_c+shift, jen_c, nnest, t_coarse, shift, shift, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse+shift, je_coarse, 1E3_r8_kind, 2E3_r8_kind, 1, 1, nx, ny)
-             call fill_nest_data(nbuffery2, isn_c, ien_c, jsn_c+shift, jen_c, nnest, t_coarse, shift, shift, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse+shift, je_coarse, 2E3_r8_kind, 1E3_r8_kind, 1, 1, nx, ny)
+             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/isn_c/), (/ien_c/), (/jsn_c/), &
+                  (/jen_c/), nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, &
+                  js_coarse, je_coarse)
+             call fill_nest_data(nbufferx2, isn_c, ien_c, jsn_c+shift, jen_c, nnest, t_coarse, shift, shift, &
+                  iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse+shift, je_coarse, &
+                  1E3_r8_kind, 2E3_r8_kind, 1, 1, nx, ny)
+             call fill_nest_data(nbuffery2, isn_c, ien_c, jsn_c+shift, jen_c, nnest, t_coarse, shift, shift, &
+                  iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse+shift, je_coarse, &
+                  2E3_r8_kind, 1E3_r8_kind, 1, 1, nx, ny)
           endif
 
           call compare_checksums(wbufferx, wbufferx2, trim(type2)//' west buffer coarse to fine BGRID scalar pair X')
@@ -7209,34 +7305,42 @@ end subroutine test_halosize_update
        if( is_fine_pe ) then
           call mpp_set_current_pelist(my_pelist_fine)
           if( iew_c .GE. isw_c .AND. jew_c .GE. jsw_c ) then
-             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/isw_c/), (/iew_c/), (/jsw_c/), (/jew_c/), &
-                  nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse)
-             call fill_nest_data(wbuffer2, isw_c, iew_c, jsw_c, jew_c, nnest, t_coarse, 0, shift, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 0.0_r8_kind, 0.0_r8_kind, 1, 1, nx, ny)
+             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/isw_c/), (/iew_c/), (/jsw_c/), &
+                  (/jew_c/), nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, &
+                  js_coarse, je_coarse)
+             call fill_nest_data(wbuffer2, isw_c, iew_c, jsw_c, jew_c, nnest, t_coarse, 0, shift, iadd_coarse, &
+                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 0.0_r8_kind, 0.0_r8_kind, &
+                  1, 1, nx, ny)
           endif
           call compare_checksums(wbuffer, wbuffer2, trim(type2)//' west buffer coarse to fine scalar CORNER')
 
           if( ies_c .GE. iss_c .AND. jes_c .GE. jss_c ) then
-             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/iss_c/), (/ies_c/), (/jss_c/), (/jes_c/), &
-                  nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse)
-             call fill_nest_data(sbuffer2, iss_c, ies_c, jss_c, jes_c, nnest, t_coarse, shift, 0, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 0.0_r8_kind, 0.0_r8_kind, 1, 1, nx, ny)
+             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/iss_c/), (/ies_c/), (/jss_c/), &
+                  (/jes_c/), nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, &
+                  js_coarse, je_coarse)
+             call fill_nest_data(sbuffer2, iss_c, ies_c, jss_c, jes_c, nnest, t_coarse, shift, 0, iadd_coarse, &
+                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 0.0_r8_kind, 0.0_r8_kind, 1,&
+                  1, nx, ny)
           endif
           call compare_checksums(sbuffer, sbuffer2, trim(type2)//' south buffer coarse to fine scalar CORNER')
 
           if( iee_c .GE. ise_c .AND. jee_c .GE. jse_c ) then
-             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/ise_c/), (/iee_c/), (/jse_c/), (/jee_c/), &
-                  nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse)
-             call fill_nest_data(ebuffer2, ise_c+shift, iee_c, jse_c, jee_c, nnest, t_coarse, shift, shift, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse+shift, ie_coarse, js_coarse, je_coarse, 0.0_r8_kind, 0.0_r8_kind, 1, 1, nx, ny)
+             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/ise_c/), (/iee_c/), (/jse_c/), &
+                  (/jee_c/), nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, &
+                  js_coarse, je_coarse)
+             call fill_nest_data(ebuffer2, ise_c+shift, iee_c, jse_c, jee_c, nnest, t_coarse, shift, shift, &
+                  iadd_coarse, jadd_coarse, rotate_coarse, is_coarse+shift, ie_coarse, js_coarse, je_coarse,&
+                  0.0_r8_kind, 0.0_r8_kind, 1, 1, nx, ny)
           endif
           call compare_checksums(ebuffer, ebuffer2, trim(type2)//' east buffer coarse to fine scalar CORNER')
 
           if( ien_c .GE. isn_c .AND. jen_c .GE. jsn_c ) then
-             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/isn_c/), (/ien_c/), (/jsn_c/), (/jen_c/), &
-                  nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse)
-             call fill_nest_data(nbuffer2, isn_c, ien_c, jsn_c+shift, jen_c, nnest, t_coarse, shift, shift, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse+shift, je_coarse, 0.0_r8_kind, 0.0_r8_kind, 1, 1, nx, ny)
+             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/isn_c/), (/ien_c/), (/jsn_c/), &
+                  (/jen_c/), nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, &
+                  js_coarse, je_coarse)
+             call fill_nest_data(nbuffer2, isn_c, ien_c, jsn_c+shift, jen_c, nnest, t_coarse, shift, shift, &
+                  iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse+shift, je_coarse,&
+                  0.0_r8_kind, 0.0_r8_kind, 1, 1, nx, ny)
           endif
           call compare_checksums(nbuffer, nbuffer2, trim(type2)//' north buffer coarse to fine scalar CORNER')
 
@@ -7258,14 +7362,22 @@ end subroutine test_halosize_update
           !--- The index from nest domain
           call mpp_get_compute_domain(domain_fine, isc_fine, iec_fine, jsc_fine, jec_fine)
           call mpp_get_data_domain(domain_fine, isd_fine, ied_fine, jsd_fine, jed_fine)
-          call mpp_get_C2F_index(nest_domain, isw_fx, iew_fx, jsw_fx, jew_fx, isw_cx, iew_cx, jsw_cx, jew_cx, WEST, l, position=EAST)
-          call mpp_get_C2F_index(nest_domain, ise_fx, iee_fx, jse_fx, jee_fx, ise_cx, iee_cx, jse_cx, jee_cx, EAST, l, position=EAST)
-          call mpp_get_C2F_index(nest_domain, iss_fx, ies_fx, jss_fx, jes_fx, iss_cx, ies_cx, jss_cx, jes_cx, SOUTH, l, position=EAST)
-          call mpp_get_C2F_index(nest_domain, isn_fx, ien_fx, jsn_fx, jen_fx, isn_cx, ien_cx, jsn_cx, jen_cx, NORTH, l, position=EAST)
-          call mpp_get_C2F_index(nest_domain, isw_fy, iew_fy, jsw_fy, jew_fy, isw_cy, iew_cy, jsw_cy, jew_cy, WEST, l, position=NORTH)
-          call mpp_get_C2F_index(nest_domain, ise_fy, iee_fy, jse_fy, jee_fy, ise_cy, iee_cy, jse_cy, jee_cy, EAST, l, position=NORTH)
-          call mpp_get_C2F_index(nest_domain, iss_fy, ies_fy, jss_fy, jes_fy, iss_cy, ies_cy, jss_cy, jes_cy, SOUTH, l, position=NORTH)
-          call mpp_get_C2F_index(nest_domain, isn_fy, ien_fy, jsn_fy, jen_fy, isn_cy, ien_cy, jsn_cy, jen_cy, NORTH, l, position=NORTH)
+          call mpp_get_C2F_index(nest_domain, isw_fx, iew_fx, jsw_fx, jew_fx, isw_cx, iew_cx, jsw_cx, jew_cx, &
+                                &  WEST, l, position=EAST)
+          call mpp_get_C2F_index(nest_domain, ise_fx, iee_fx, jse_fx, jee_fx, ise_cx, iee_cx, jse_cx, jee_cx, &
+                                &  EAST, l, position=EAST)
+          call mpp_get_C2F_index(nest_domain, iss_fx, ies_fx, jss_fx, jes_fx, iss_cx, ies_cx, jss_cx, jes_cx, &
+                                &  SOUTH, l, position=EAST)
+          call mpp_get_C2F_index(nest_domain, isn_fx, ien_fx, jsn_fx, jen_fx, isn_cx, ien_cx, jsn_cx, jen_cx, &
+                                &  NORTH, l, position=EAST)
+          call mpp_get_C2F_index(nest_domain, isw_fy, iew_fy, jsw_fy, jew_fy, isw_cy, iew_cy, jsw_cy, jew_cy, &
+                                &  WEST, l, position=NORTH)
+          call mpp_get_C2F_index(nest_domain, ise_fy, iee_fy, jse_fy, jee_fy, ise_cy, iee_cy, jse_cy, jee_cy, &
+                                &  EAST, l, position=NORTH)
+          call mpp_get_C2F_index(nest_domain, iss_fy, ies_fy, jss_fy, jes_fy, iss_cy, ies_cy, jss_cy, jes_cy, &
+                                &  SOUTH, l, position=NORTH)
+          call mpp_get_C2F_index(nest_domain, isn_fy, ien_fy, jsn_fy, jen_fy, isn_cy, ien_cy, jsn_cy, jen_cy, &
+                                &  NORTH, l, position=NORTH)
 
           !-- The assumed index
           isw_fx2 = 0; iew_fx2 = -1; jsw_fx2 = 0; jew_fx2 = -1
@@ -7302,7 +7414,8 @@ end subroutine test_halosize_update
              isw_cy2 = istart_coarse(my_fine_id)-whalo
              iew_cy2 = istart_coarse(my_fine_id)
              jsw_cy2 = jstart_coarse(my_fine_id) + (jsc_fine - jstart_fine(my_fine_id))/y_refine(my_fine_id) - shalo
-             jew_cy2 = jstart_coarse(my_fine_id) + (jec_fine - jstart_fine(my_fine_id))/y_refine(my_fine_id) + nhalo + shift
+             jew_cy2 = jstart_coarse(my_fine_id) + (jec_fine - jstart_fine(my_fine_id))/y_refine(my_fine_id) + nhalo &
+                     & + shift
           endif
           !--- east
           if( iec_fine == nx_fine ) then
@@ -7321,7 +7434,8 @@ end subroutine test_halosize_update
              ise_cy2 = iend_coarse(my_fine_id)
              iee_cy2 = iend_coarse(my_fine_id)+ehalo
              jse_cy2 = jstart_coarse(my_fine_id) + (jsc_fine - jstart_fine(my_fine_id))/y_refine(my_fine_id) - shalo
-             jee_cy2 = jstart_coarse(my_fine_id) + (jec_fine - jstart_fine(my_fine_id))/y_refine(my_fine_id) + nhalo + shift
+             jee_cy2 = jstart_coarse(my_fine_id) + (jec_fine - jstart_fine(my_fine_id))/y_refine(my_fine_id) + nhalo &
+                     & + shift
           endif
           !--- south
           if( jsc_fine == 1 ) then
@@ -7330,7 +7444,8 @@ end subroutine test_halosize_update
              jss_fx2 = jsd_fine
              jes_fx2 = jsc_fine - 1
              iss_cx2 = istart_coarse(my_fine_id) + (isc_fine - istart_fine(my_fine_id))/x_refine(my_fine_id) - whalo
-             ies_cx2 = istart_coarse(my_fine_id) + (iec_fine - istart_fine(my_fine_id))/x_refine(my_fine_id) + ehalo + shift
+             ies_cx2 = istart_coarse(my_fine_id) + (iec_fine - istart_fine(my_fine_id))/x_refine(my_fine_id) + ehalo &
+                     & + shift
              jss_cx2 = jstart_coarse(my_fine_id)-shalo
              jes_cx2 = jstart_coarse(my_fine_id)
              iss_fy2 = isd_fine
@@ -7349,7 +7464,8 @@ end subroutine test_halosize_update
              jsn_fx2 = jec_fine+1
              jen_fx2 = jed_fine
              isn_cx2 = istart_coarse(my_fine_id) + (isc_fine - istart_fine(my_fine_id))/x_refine(my_fine_id) - whalo
-             ien_cx2 = istart_coarse(my_fine_id) + (iec_fine - istart_fine(my_fine_id))/x_refine(my_fine_id) + ehalo + shift
+             ien_cx2 = istart_coarse(my_fine_id) + (iec_fine - istart_fine(my_fine_id))/x_refine(my_fine_id) + ehalo &
+                     & + shift
              jsn_cx2 = jend_coarse(my_fine_id)
              jen_cx2 = jend_coarse(my_fine_id)+nhalo
              isn_fy2 = isd_fine
@@ -7501,36 +7617,48 @@ end subroutine test_halosize_update
        if( is_fine_pe ) then
           call mpp_set_current_pelist(my_pelist_fine)
           if( iew_c .GE. isw_c .AND. jew_c .GE. jsw_c ) then
-             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/isw_c/), (/iew_c/), (/jsw_c/), (/jew_c/), &
-                  nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse)
-             call fill_nest_data(wbufferx2, isw_c, iew_c, jsw_c, jew_c, nnest, t_coarse, 0, 0, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 1E3_r8_kind, 2E3_r8_kind, 1, 1, nx, ny)
-             call fill_nest_data(wbuffery2, isw_c, iew_c, jsw_c, jew_c, nnest, t_coarse, 0, shift, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 2E3_r8_kind, 1E3_r8_kind, 1, 1, nx, ny)
+             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/isw_c/), (/iew_c/), (/jsw_c/), &
+                  (/jew_c/), nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, &
+                  js_coarse, je_coarse)
+             call fill_nest_data(wbufferx2, isw_c, iew_c, jsw_c, jew_c, nnest, t_coarse, 0, 0, iadd_coarse, &
+                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 1E3_r8_kind, 2E3_r8_kind, 1,&
+                  1, nx, ny)
+             call fill_nest_data(wbuffery2, isw_c, iew_c, jsw_c, jew_c, nnest, t_coarse, 0, shift, iadd_coarse, &
+                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 2E3_r8_kind, 1E3_r8_kind, 1,&
+                  1, nx, ny)
           endif
           if( ies_c .GE. iss_c .AND. jes_c .GE. jss_c ) then
-             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/iss_c/), (/ies_c/), (/jss_c/), (/jes_c/), &
-                  nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse)
-             call fill_nest_data(sbufferx2, iss_c, ies_c, jss_c, jes_c, nnest, t_coarse, shift, 0, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 1E3_r8_kind, 2E3_r8_kind, 1, 1, nx, ny)
-             call fill_nest_data(sbuffery2, iss_c, ies_c, jss_c, jes_c, nnest, t_coarse, 0, 0, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 2E3_r8_kind, 1E3_r8_kind, 1, 1, nx, ny)
+             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/iss_c/), (/ies_c/), (/jss_c/), &
+                  (/jes_c/), nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, &
+                  js_coarse, je_coarse)
+             call fill_nest_data(sbufferx2, iss_c, ies_c, jss_c, jes_c, nnest, t_coarse, shift, 0, iadd_coarse, &
+                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 1E3_r8_kind, 2E3_r8_kind, 1, &
+                  1, nx, ny)
+             call fill_nest_data(sbuffery2, iss_c, ies_c, jss_c, jes_c, nnest, t_coarse, 0, 0, iadd_coarse, &
+                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 2E3_r8_kind, 1E3_r8_kind, 1,&
+                  1, nx, ny)
           endif
           if( iee_c .GE. ise_c .AND. jee_c .GE. jse_c ) then
-             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/ise_c/), (/iee_c/), (/jse_c/), (/jee_c/), &
-                  nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse)
-             call fill_nest_data(ebufferx2, ise_c+shift, iee_c, jse_c, jee_c, nnest, t_coarse, shift, 0, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse+shift, ie_coarse, js_coarse, je_coarse, 1E3_r8_kind, 2E3_r8_kind, 1, 1, nx, ny)
-             call fill_nest_data(ebuffery2, ise_c, iee_c, jse_c, jee_c, nnest, t_coarse, 0, shift, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 2E3_r8_kind, 1E3_r8_kind, 1, 1, nx, ny)
+             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/ise_c/), (/iee_c/), (/jse_c/), &
+                  (/jee_c/), nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, &
+                  js_coarse, je_coarse)
+             call fill_nest_data(ebufferx2, ise_c+shift, iee_c, jse_c, jee_c, nnest, t_coarse, shift, 0, iadd_coarse, &
+                  jadd_coarse, rotate_coarse, is_coarse+shift, ie_coarse, js_coarse, je_coarse, 1E3_r8_kind, &
+                  2E3_r8_kind, 1, 1, nx, ny)
+             call fill_nest_data(ebuffery2, ise_c, iee_c, jse_c, jee_c, nnest, t_coarse, 0, shift, iadd_coarse, &
+                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 2E3_r8_kind, 1E3_r8_kind, 1,&
+                  1, nx, ny)
           endif
           if( ien_c .GE. isn_c .AND. jen_c .GE. jsn_c ) then
-             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/isn_c/), (/ien_c/), (/jsn_c/), (/jen_c/), &
-                  nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse)
-             call fill_nest_data(nbufferx2, isn_c, ien_c, jsn_c, jen_c, nnest, t_coarse, shift, 0, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 1E3_r8_kind, 2E3_r8_kind, 1, 1, nx, ny)
-             call fill_nest_data(nbuffery2, isn_c, ien_c, jsn_c+shift, jen_c, nnest, t_coarse, 0, shift, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse+shift, je_coarse, 2E3_r8_kind, 1E3_r8_kind, 1, 1, nx, ny)
+             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/isn_c/), (/ien_c/), (/jsn_c/), &
+                  (/jen_c/), nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, &
+                  js_coarse, je_coarse)
+             call fill_nest_data(nbufferx2, isn_c, ien_c, jsn_c, jen_c, nnest, t_coarse, shift, 0, iadd_coarse, &
+                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 1E3_r8_kind, 2E3_r8_kind, 1, &
+                  1, nx, ny)
+             call fill_nest_data(nbuffery2, isn_c, ien_c, jsn_c+shift, jen_c, nnest, t_coarse, 0, shift, iadd_coarse, &
+                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse+shift, je_coarse, 2E3_r8_kind, &
+                  1E3_r8_kind, 1, 1, nx, ny)
           endif
 
           call compare_checksums(wbufferx, wbufferx2, trim(type2)//' west buffer coarse to fine CGRID scalar pair X')
@@ -7604,36 +7732,48 @@ end subroutine test_halosize_update
        if( is_fine_pe ) then
           call mpp_set_current_pelist(my_pelist_fine)
           if( iew_c .GE. isw_c .AND. jew_c .GE. jsw_c ) then
-             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/isw_c/), (/iew_c/), (/jsw_c/), (/jew_c/), &
-                  nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse)
-             call fill_nest_data(wbufferx2, isw_c, iew_c, jsw_c, jew_c, nnest, t_coarse, 0, 0, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 1E3_r8_kind, 2E3_r8_kind, 1, -1, nx, ny)
-             call fill_nest_data(wbuffery2, isw_c, iew_c, jsw_c, jew_c, nnest, t_coarse, 0, shift, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 2E3_r8_kind, 1E3_r8_kind, -1, 1, nx, ny)
+             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/isw_c/), (/iew_c/), (/jsw_c/), &
+                  (/jew_c/), nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, &
+                  js_coarse, je_coarse)
+             call fill_nest_data(wbufferx2, isw_c, iew_c, jsw_c, jew_c, nnest, t_coarse, 0, 0, iadd_coarse, &
+                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 1E3_r8_kind, 2E3_r8_kind, 1,&
+                  -1, nx, ny)
+             call fill_nest_data(wbuffery2, isw_c, iew_c, jsw_c, jew_c, nnest, t_coarse, 0, shift, iadd_coarse, &
+                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 2E3_r8_kind, 1E3_r8_kind, &
+                  -1, 1, nx, ny)
           endif
           if( ies_c .GE. iss_c .AND. jes_c .GE. jss_c ) then
-             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/iss_c/), (/ies_c/), (/jss_c/), (/jes_c/), &
-                  nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse)
-             call fill_nest_data(sbufferx2, iss_c, ies_c, jss_c, jes_c, nnest, t_coarse, shift, 0, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 1E3_r8_kind, 2E3_r8_kind, 1, -1, nx, ny)
-             call fill_nest_data(sbuffery2, iss_c, ies_c, jss_c, jes_c, nnest, t_coarse, 0, 0, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 2E3_r8_kind, 1E3_r8_kind, -1, 1, nx, ny)
+             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/iss_c/), (/ies_c/), (/jss_c/), &
+                  (/jes_c/), nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, &
+                  js_coarse, je_coarse)
+             call fill_nest_data(sbufferx2, iss_c, ies_c, jss_c, jes_c, nnest, t_coarse, shift, 0, iadd_coarse, & 
+                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 1E3_r8_kind, 2E3_r8_kind, 1,&
+                  -1, nx, ny)
+             call fill_nest_data(sbuffery2, iss_c, ies_c, jss_c, jes_c, nnest, t_coarse, 0, 0, iadd_coarse, &
+                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 2E3_r8_kind, 1E3_r8_kind,&
+                  -1, 1, nx, ny)
           endif
           if( iee_c .GE. ise_c .AND. jee_c .GE. jse_c ) then
-             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/ise_c/), (/iee_c/), (/jse_c/), (/jee_c/), &
-                  nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse)
-             call fill_nest_data(ebufferx2, ise_c+shift, iee_c, jse_c, jee_c, nnest, t_coarse, shift, 0, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse+shift, ie_coarse, js_coarse, je_coarse, 1E3_r8_kind, 2E3_r8_kind, 1, -1, nx, ny)
-             call fill_nest_data(ebuffery2, ise_c, iee_c, jse_c, jee_c, nnest, t_coarse, 0, shift, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 2E3_r8_kind, 1E3_r8_kind, -1, 1, nx, ny)
+             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/ise_c/), (/iee_c/), (/jse_c/), &
+                  (/jee_c/), nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, &
+                  js_coarse, je_coarse)
+             call fill_nest_data(ebufferx2, ise_c+shift, iee_c, jse_c, jee_c, nnest, t_coarse, shift, 0, iadd_coarse,&
+                  jadd_coarse, rotate_coarse, is_coarse+shift, ie_coarse, js_coarse, je_coarse, 1E3_r8_kind, &
+                  2E3_r8_kind, 1, -1, nx, ny)
+             call fill_nest_data(ebuffery2, ise_c, iee_c, jse_c, jee_c, nnest, t_coarse, 0, shift, iadd_coarse, &
+                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 2E3_r8_kind, 1E3_r8_kind, &
+                  -1, 1, nx, ny)
           endif
           if( ien_c .GE. isn_c .AND. jen_c .GE. jsn_c ) then
-             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/isn_c/), (/ien_c/), (/jsn_c/), (/jen_c/), &
-                  nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse)
-             call fill_nest_data(nbufferx2, isn_c, ien_c, jsn_c, jen_c, nnest, t_coarse, shift, 0, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 1E3_r8_kind, 2E3_r8_kind, 1, -1, nx, ny)
-             call fill_nest_data(nbuffery2, isn_c, ien_c, jsn_c+shift, jen_c, nnest, t_coarse, 0, shift, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse+shift, je_coarse, 2E3_r8_kind, 1E3_r8_kind, -1, 1, nx, ny)
+             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/isn_c/), (/ien_c/), (/jsn_c/), &
+                  (/jen_c/), nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, &
+                  js_coarse, je_coarse)
+             call fill_nest_data(nbufferx2, isn_c, ien_c, jsn_c, jen_c, nnest, t_coarse, shift, 0, iadd_coarse, &
+                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 1E3_r8_kind, 2E3_r8_kind, 1,&
+                  -1, nx, ny)
+             call fill_nest_data(nbuffery2, isn_c, ien_c, jsn_c+shift, jen_c, nnest, t_coarse, 0, shift, iadd_coarse, &
+                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse+shift, je_coarse, 2E3_r8_kind, &
+                  1E3_r8_kind, -1, 1, nx, ny)
           endif
 
           call compare_checksums(wbufferx, wbufferx2, trim(type2)//' west buffer coarse to fine CGRID vector X')
@@ -7706,14 +7846,22 @@ end subroutine test_halosize_update
        endif
 
        if(is_fine_pe) then
-          call mpp_get_C2F_index(nest_domain, isw_fx, iew_fx, jsw_fx, jew_fx, isw_cx, iew_cx, jsw_cx, jew_cx, WEST, l, position=NORTH)
-          call mpp_get_C2F_index(nest_domain, ise_fx, iee_fx, jse_fx, jee_fx, ise_cx, iee_cx, jse_cx, jee_cx, EAST, l, position=NORTH)
-          call mpp_get_C2F_index(nest_domain, iss_fx, ies_fx, jss_fx, jes_fx, iss_cx, ies_cx, jss_cx, jes_cx, SOUTH, l, position=NORTH)
-          call mpp_get_C2F_index(nest_domain, isn_fx, ien_fx, jsn_fx, jen_fx, isn_cx, ien_cx, jsn_cx, jen_cx, NORTH, l, position=NORTH)
-          call mpp_get_C2F_index(nest_domain, isw_fy, iew_fy, jsw_fy, jew_fy, isw_cy, iew_cy, jsw_cy, jew_cy, WEST, l, position=EAST)
-          call mpp_get_C2F_index(nest_domain, ise_fy, iee_fy, jse_fy, jee_fy, ise_cy, iee_cy, jse_cy, jee_cy, EAST, l, position=EAST)
-          call mpp_get_C2F_index(nest_domain, iss_fy, ies_fy, jss_fy, jes_fy, iss_cy, ies_cy, jss_cy, jes_cy, SOUTH, l, position=EAST)
-          call mpp_get_C2F_index(nest_domain, isn_fy, ien_fy, jsn_fy, jen_fy, isn_cy, ien_cy, jsn_cy, jen_cy, NORTH, l, position=EAST)
+          call mpp_get_C2F_index(nest_domain, isw_fx, iew_fx, jsw_fx, jew_fx, isw_cx, iew_cx, jsw_cx, jew_cx, &
+                                &  WEST, l, position=NORTH)
+          call mpp_get_C2F_index(nest_domain, ise_fx, iee_fx, jse_fx, jee_fx, ise_cx, iee_cx, jse_cx, jee_cx, &
+                                &  EAST, l, position=NORTH)
+          call mpp_get_C2F_index(nest_domain, iss_fx, ies_fx, jss_fx, jes_fx, iss_cx, ies_cx, jss_cx, jes_cx, &
+                                &  SOUTH, l, position=NORTH)
+          call mpp_get_C2F_index(nest_domain, isn_fx, ien_fx, jsn_fx, jen_fx, isn_cx, ien_cx, jsn_cx, jen_cx, &
+                                &  NORTH, l, position=NORTH)
+          call mpp_get_C2F_index(nest_domain, isw_fy, iew_fy, jsw_fy, jew_fy, isw_cy, iew_cy, jsw_cy, jew_cy, &
+                                &  WEST, l, position=EAST)
+          call mpp_get_C2F_index(nest_domain, ise_fy, iee_fy, jse_fy, jee_fy, ise_cy, iee_cy, jse_cy, jee_cy, &
+                                &  EAST, l, position=EAST)
+          call mpp_get_C2F_index(nest_domain, iss_fy, ies_fy, jss_fy, jes_fy, iss_cy, ies_cy, jss_cy, jes_cy, &
+                                &  SOUTH, l, position=EAST)
+          call mpp_get_C2F_index(nest_domain, isn_fy, ien_fy, jsn_fy, jen_fy, isn_cy, ien_cy, jsn_cy, jen_cy, &
+                                &  NORTH, l, position=EAST)
 
           if( iew_cx .GE. isw_cx .AND. jew_cx .GE. jsw_cx ) then
              allocate(wbufferx(isw_cx:iew_cx, jsw_cx:jew_cx,nz))
@@ -7776,36 +7924,48 @@ end subroutine test_halosize_update
        if( is_fine_pe ) then
           call mpp_set_current_pelist(my_pelist_fine)
           if( iew_c .GE. isw_c .AND. jew_c .GE. jsw_c ) then
-             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/isw_c/), (/iew_c/), (/jsw_c/), (/jew_c/), &
-                  nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse)
-             call fill_nest_data(wbufferx2, isw_c, iew_c, jsw_c, jew_c, nnest, t_coarse, 0, shift, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 1E3_r8_kind, 2E3_r8_kind, 1, -1, nx, ny)
-             call fill_nest_data(wbuffery2, isw_c, iew_c, jsw_c, jew_c, nnest, t_coarse, 0, 0, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 2E3_r8_kind, 1E3_r8_kind, -1, 1, nx, ny)
+             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/isw_c/), (/iew_c/), (/jsw_c/), &
+                  (/jew_c/), nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, &
+                  js_coarse, je_coarse)
+             call fill_nest_data(wbufferx2, isw_c, iew_c, jsw_c, jew_c, nnest, t_coarse, 0, shift, iadd_coarse, &
+                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 1E3_r8_kind, 2E3_r8_kind, 1,&
+                  -1, nx, ny)
+             call fill_nest_data(wbuffery2, isw_c, iew_c, jsw_c, jew_c, nnest, t_coarse, 0, 0, iadd_coarse, &
+                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 2E3_r8_kind, 1E3_r8_kind, &
+                  -1, 1, nx, ny)
           endif
           if( ies_c .GE. iss_c .AND. jes_c .GE. jss_c ) then
-             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/iss_c/), (/ies_c/), (/jss_c/), (/jes_c/), &
-                  nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse)
-             call fill_nest_data(sbufferx2, iss_c, ies_c, jss_c, jes_c, nnest, t_coarse, 0, 0, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 1E3_r8_kind, 2E3_r8_kind, 1, -1, nx, ny)
-             call fill_nest_data(sbuffery2, iss_c, ies_c, jss_c, jes_c, nnest, t_coarse, shift, 0, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 2E3_r8_kind, 1E3_r8_kind, -1, 1, nx, ny)
+             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/iss_c/), (/ies_c/), (/jss_c/), &
+                  (/jes_c/), nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, &
+                  js_coarse, je_coarse)
+             call fill_nest_data(sbufferx2, iss_c, ies_c, jss_c, jes_c, nnest, t_coarse, 0, 0, iadd_coarse, &
+                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 1E3_r8_kind, 2E3_r8_kind, 1,&
+                  -1, nx, ny)
+             call fill_nest_data(sbuffery2, iss_c, ies_c, jss_c, jes_c, nnest, t_coarse, shift, 0, iadd_coarse, &
+                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 2E3_r8_kind, 1E3_r8_kind, &
+                  -1, 1, nx, ny)
           endif
           if( iee_c .GE. ise_c .AND. jee_c .GE. jse_c ) then
-             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/ise_c/), (/iee_c/), (/jse_c/), (/jee_c/), &
-                  nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse)
-             call fill_nest_data(ebufferx2, ise_c, iee_c, jse_c, jee_c, nnest, t_coarse, 0, shift, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 1E3_r8_kind, 2E3_r8_kind, 1, -1, nx, ny)
-             call fill_nest_data(ebuffery2, ise_c+shift, iee_c, jse_c, jee_c, nnest, t_coarse, shift, 0, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse+shift, ie_coarse, js_coarse, je_coarse, 2E3_r8_kind, 1E3_r8_kind, -1, 1, nx, ny)
+             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/ise_c/), (/iee_c/), (/jse_c/), &
+                  (/jee_c/), nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, &
+                  js_coarse, je_coarse)
+             call fill_nest_data(ebufferx2, ise_c, iee_c, jse_c, jee_c, nnest, t_coarse, 0, shift, iadd_coarse, &
+                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 1E3_r8_kind, 2E3_r8_kind, 1,&
+                  -1, nx, ny)
+             call fill_nest_data(ebuffery2, ise_c+shift, iee_c, jse_c, jee_c, nnest, t_coarse, shift, 0, iadd_coarse,&
+                  jadd_coarse, rotate_coarse, is_coarse+shift, ie_coarse, js_coarse, je_coarse, 2E3_r8_kind, &
+                  1E3_r8_kind, -1, 1, nx, ny)
           endif
           if( ien_c .GE. isn_c .AND. jen_c .GE. jsn_c ) then
-             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/isn_c/), (/ien_c/), (/jsn_c/), (/jen_c/), &
-                  nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse)
-             call fill_nest_data(nbufferx2, isn_c, ien_c, jsn_c+shift, jen_c, nnest, t_coarse, 0, shift, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse+shift, je_coarse, 1E3_r8_kind, 2E3_r8_kind, 1, -1, nx, ny)
-             call fill_nest_data(nbuffery2, isn_c, ien_c, jsn_c, jen_c, nnest, t_coarse, shift, 0, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 2E3_r8_kind, 1E3_r8_kind, -1, 1, nx, ny)
+             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/isn_c/), (/ien_c/), (/jsn_c/), &
+                  (/jen_c/), nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, &
+                  js_coarse, je_coarse)
+             call fill_nest_data(nbufferx2, isn_c, ien_c, jsn_c+shift, jen_c, nnest, t_coarse, 0, shift, iadd_coarse,&
+                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse+shift, je_coarse, 1E3_r8_kind, &
+                  2E3_r8_kind, 1, -1, nx, ny)
+             call fill_nest_data(nbuffery2, isn_c, ien_c, jsn_c, jen_c, nnest, t_coarse, shift, 0, iadd_coarse, &
+                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 2E3_r8_kind, 1E3_r8_kind, &
+                  -1, 1, nx, ny)
           endif
 
           call compare_checksums(wbufferx, wbufferx2, trim(type2)//' west buffer coarse to fine DGRID vector X')
@@ -7968,8 +8128,8 @@ end subroutine test_halosize_update
           return
        endif
        if( nx_cubic .NE. ny_cubic ) then
-          call mpp_error(NOTE,'test_update_nest_domain: for Regional grid mosaic, nx_cubic does not equal ny_cubic, '//&
-                  'No test is done for Cubic-Grid mosaic. ' )
+          call mpp_error(NOTE,'test_update_nest_domain: for Regional grid mosaic, nx_cubic does not equal ny_cubic,'//&
+                  ' No test is done for Cubic-Grid mosaic. ' )
           return
        endif
        nx = nx_cubic
@@ -7981,7 +8141,8 @@ end subroutine test_halosize_update
     end select
 
     if(ntiles_nest_all > MAX_NTILE) call mpp_error(FATAL, 'test_update_nest_domain: ntiles_nest_all > MAX_NTILE')
-    if(ntiles_nest_top .GE. ntiles_nest_all) call mpp_error(FATAL, 'test_update_nest_domain: ntiles_nest_top .GE. ntile_nest_all')
+    if(ntiles_nest_top .GE. ntiles_nest_all) call mpp_error(FATAL, &
+             'test_update_nest_domain: ntiles_nest_top .GE. ntile_nest_all')
     if(ntiles_nest_all .NE. ntiles_nest_top + num_nest) call mpp_error(FATAL, &
              'test_update_nest_domain: ntiles_nest_all .NE. ntiles_nest_top + num_nest')
     !--- for the ntiles_nest_top, number of processors should be same
@@ -8010,7 +8171,8 @@ end subroutine test_halosize_update
     !---make sure nest_level is setup properly
     if(nest_level(1) .NE. 1) call mpp_error(FATAL, "test_mpp_domains: nest_level(1) .NE. 1")
     do n = 2, num_nest
-       if(nest_level(n) > nest_level(n-1)+1) call mpp_error(FATAL, "test_mpp_domains: nest_level(n) > nest_level(n-1)+1")
+       if(nest_level(n) > nest_level(n-1)+1) call mpp_error(FATAL, &
+                  "test_mpp_domains: nest_level(n) > nest_level(n-1)+1")
        if(nest_level(n) < nest_level(n-1) ) call mpp_error(FATAL, "test_mpp_domains: nest_level(n) < nest_level(n-1)")
     enddo
     num_nest_level = nest_level(num_nest)
@@ -8037,7 +8199,8 @@ end subroutine test_halosize_update
     if(ANY(my_pelist==mpp_pe())) then
        call mpp_set_current_pelist(my_pelist)
 
-       allocate(layout2D(2,ntiles_nest_top), global_indices(4,ntiles_nest_top), pe_start(ntiles_nest_top), pe_end(ntiles_nest_top) )
+       allocate(layout2D(2,ntiles_nest_top), global_indices(4,ntiles_nest_top), pe_start(ntiles_nest_top), &
+               &  pe_end(ntiles_nest_top) )
        npes_per_tile = npes_nest_tile(1)
 
        call mpp_define_layout( (/1,nx,1,ny/), npes_per_tile, layout )
@@ -8105,7 +8268,7 @@ end subroutine test_halosize_update
     y_refine(:) = refine_ratio(1:num_nest)
 
     call mpp_define_nest_domains(nest_domain, domain, num_nest, nest_level(1:num_nest), tile_fine(1:num_nest), &
-             tile_coarse(1:num_nest), istart_coarse(1:num_nest), icount_coarse(1:num_nest), jstart_coarse(1:num_nest), &
+             tile_coarse(1:num_nest), istart_coarse(1:num_nest), icount_coarse(1:num_nest), jstart_coarse(1:num_nest),&
              jcount_coarse(1:num_nest), npes_nest_tile(1:ntiles_nest_all), &
              x_refine(1:num_nest), y_refine(1:num_nest), extra_halo=extra_halo, name="nest_domain")
 
@@ -8199,8 +8362,8 @@ end subroutine test_halosize_update
                 je_c = min(je_coarse(n),   jec_coarse)
                 if( tile == t_coarse(n) .AND. ie_c .GE. is_c .AND. je_c .GE. js_c ) then
                    call fill_coarse_data(x2, rotate_coarse(n), iadd_coarse(n), jadd_coarse(n), &
-                        is_c, ie_c, js_c, je_c, nz, isd_coarse, jsd_coarse, nx, ny, 0, 0, 0.001_r4_kind, 0.001_r4_kind, 1, 1, &
-                        .false., .false., iend_coarse(1), jend_coarse(1) )
+                        is_c, ie_c, js_c, je_c, nz, isd_coarse, jsd_coarse, nx, ny, 0, 0, 0.001_r4_kind, &
+                        0.001_r4_kind, 1, 1, .false., .false., iend_coarse(1), jend_coarse(1) )
                 endif
              enddo
           endif
@@ -8224,7 +8387,8 @@ end subroutine test_halosize_update
 
        if(is_fine_pe) then
           call mpp_get_F2C_index(nest_domain, is_cx, ie_cx, js_cx, je_cx, is_fx, ie_fx, js_fx, je_fx, l, position=EAST)
-          call mpp_get_F2C_index(nest_domain, is_cy, ie_cy, js_cy, je_cy, is_fy, ie_fy, js_fy, je_fy, l, position=NORTH)
+          call mpp_get_F2C_index(nest_domain, is_cy, ie_cy, js_cy, je_cy, is_fy, ie_fy, js_fy, je_fy, l, &
+                                &  position=NORTH)
           allocate(x(is_cx:ie_cx, js_cx:je_cx, nz))
           allocate(y(is_cy:ie_cy, js_cy:je_cy, nz))
           x = 0
@@ -8297,13 +8461,13 @@ end subroutine test_halosize_update
              je_c = min(je_coarse(n),   jec_coarse)
              if( tile == t_coarse(n) .AND. ie_c+shift .GE. is_c .AND. je_c .GE. js_c ) then
                 call fill_coarse_data(x2, rotate_coarse(n), iadd_coarse(n), jadd_coarse(n), &
-                     is_c, ie_c, js_c, je_c, nz, isd_coarse, jsd_coarse, nx, ny, shift, 0, 1.0E-6_r4_kind, 2.0E-6_r4_kind, 1, 1, &
-                     x_cyclic, .false., iend_coarse(1)+1, jend_coarse(1)+1)
+                     is_c, ie_c, js_c, je_c, nz, isd_coarse, jsd_coarse, nx, ny, shift, 0, 1.0E-6_r4_kind, &
+                     2.0E-6_r4_kind, 1, 1, x_cyclic, .false., iend_coarse(1)+1, jend_coarse(1)+1)
              endif
              if( tile == t_coarse(n) .AND. ie_c .GE. is_c .AND. je_c+shift .GE. js_c ) then
                 call fill_coarse_data(y2, rotate_coarse(n), iadd_coarse(n), jadd_coarse(n), &
-                     is_c, ie_c, js_c, je_c, nz, isd_coarse, jsd_coarse, nx, ny, 0, shift, 2.0E-6_r4_kind, 1.0E-6_r4_kind, 1, 1, &
-                     .false., y_cyclic, iend_coarse(1)+1, jend_coarse(1)+1)
+                     is_c, ie_c, js_c, je_c, nz, isd_coarse, jsd_coarse, nx, ny, 0, shift, 2.0E-6_r4_kind, &
+                     1.0E-6_r4_kind, 1, 1, .false., y_cyclic, iend_coarse(1)+1, jend_coarse(1)+1)
              endif
           enddo
        endif
@@ -8331,7 +8495,8 @@ end subroutine test_halosize_update
 
        if(is_fine_pe) then
           call mpp_get_F2C_index(nest_domain, is_cx, ie_cx, js_cx, je_cx, is_fx, ie_fx, js_fx, je_fx, l, position=EAST)
-          call mpp_get_F2C_index(nest_domain, is_cy, ie_cy, js_cy, je_cy, is_fy, ie_fy, js_fy, je_fy, l, position=NORTH)
+          call mpp_get_F2C_index(nest_domain, is_cy, ie_cy, js_cy, je_cy, is_fy, ie_fy, js_fy, je_fy, l, &
+                                &  position=NORTH)
           allocate(x(is_cx:ie_cx, js_cx:je_cx, nz))
           allocate(y(is_cy:ie_cy, js_cy:je_cy, nz))
           x = 0
@@ -8384,13 +8549,13 @@ end subroutine test_halosize_update
              je_c = min(je_coarse(n),   jec_coarse)
              if( tile == t_coarse(n) .AND. ie_c+shift .GE. is_c .AND. je_c .GE. js_c ) then
                 call fill_coarse_data(x2, rotate_coarse(n), iadd_coarse(n), jadd_coarse(n), &
-                     is_c, ie_c, js_c, je_c, nz, isd_coarse, jsd_coarse, nx, ny, shift, 0, 1.0E-6_r4_kind, 2.0E-6_r4_kind, 1, -1, &
-                     x_cyclic, .false., iend_coarse(1)+1, jend_coarse(1)+1)
+                     is_c, ie_c, js_c, je_c, nz, isd_coarse, jsd_coarse, nx, ny, shift, 0, 1.0E-6_r4_kind, &
+                     2.0E-6_r4_kind, 1, -1, x_cyclic, .false., iend_coarse(1)+1, jend_coarse(1)+1)
              endif
              if( tile == t_coarse(n) .AND. ie_c .GE. is_c .AND. je_c+shift .GE. js_c ) then
                 call fill_coarse_data(y2, rotate_coarse(n), iadd_coarse(n), jadd_coarse(n), &
-                     is_c, ie_c, js_c, je_c, nz, isd_coarse, jsd_coarse, nx, ny, 0, shift, 2.0E-6_r4_kind, 1.0E-6_r4_kind, -1, 1, &
-                     .false., y_cyclic, iend_coarse(1)+1, jend_coarse(1)+1)
+                     is_c, ie_c, js_c, je_c, nz, isd_coarse, jsd_coarse, nx, ny, 0, shift, 2.0E-6_r4_kind, &
+                     1.0E-6_r4_kind, -1, 1, .false., y_cyclic, iend_coarse(1)+1, jend_coarse(1)+1)
              endif
           enddo
        endif
@@ -8417,7 +8582,8 @@ end subroutine test_halosize_update
        shift = 1
 
        if(is_fine_pe) then
-          call mpp_get_F2C_index(nest_domain, is_cx, ie_cx, js_cx, je_cx, is_fx, ie_fx, js_fx, je_fx, l, position=NORTH)
+          call mpp_get_F2C_index(nest_domain, is_cx, ie_cx, js_cx, je_cx, is_fx, ie_fx, js_fx, je_fx, l, &
+                                &  position=NORTH)
           call mpp_get_F2C_index(nest_domain, is_cy, ie_cy, js_cy, je_cy, is_fy, ie_fy, js_fy, je_fy, l, position=EAST)
           allocate(x(is_cx:ie_cx, js_cx:je_cx, nz))
           allocate(y(is_cy:ie_cy, js_cy:je_cy, nz))
@@ -8471,13 +8637,13 @@ end subroutine test_halosize_update
              je_c = min(je_coarse(n),   jec_coarse)
              if( tile == t_coarse(n) .AND. ie_c .GE. is_c .AND. je_c+shift .GE. js_c ) then
                 call fill_coarse_data(x2, rotate_coarse(n), iadd_coarse(n), jadd_coarse(n), &
-                     is_c, ie_c, js_c, je_c, nz, isd_coarse, jsd_coarse, nx, ny, 0, shift, 1.0E-6_r4_kind, 2.0E-6_r4_kind, 1, -1, &
-                     .false., y_cyclic, iend_coarse(1), jend_coarse(1) )
+                     is_c, ie_c, js_c, je_c, nz, isd_coarse, jsd_coarse, nx, ny, 0, shift, 1.0E-6_r4_kind, &
+                     2.0E-6_r4_kind, 1, -1, .false., y_cyclic, iend_coarse(1), jend_coarse(1) )
              endif
              if( tile == t_coarse(n) .AND. ie_c+shift .GE. is_c .AND. je_c .GE. js_c ) then
                 call fill_coarse_data(y2, rotate_coarse(n), iadd_coarse(n), jadd_coarse(n), &
-                     is_c, ie_c, js_c, je_c, nz, isd_coarse, jsd_coarse, nx, ny, shift, 0, 2.0E-6_r4_kind, 1.0E-6_r4_kind, -1, 1, &
-                     x_cyclic, .false., iend_coarse(1), jend_coarse(1))
+                     is_c, ie_c, js_c, je_c, nz, isd_coarse, jsd_coarse, nx, ny, shift, 0, 2.0E-6_r4_kind, &
+                     1.0E-6_r4_kind, -1, 1, x_cyclic, .false., iend_coarse(1), jend_coarse(1))
              endif
           enddo
        endif
@@ -8648,33 +8814,37 @@ end subroutine test_halosize_update
        if( is_fine_pe ) then
           call mpp_set_current_pelist(my_pelist_fine)
           if( iew_c .GE. isw_c .AND. jew_c .GE. jsw_c ) then
-             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/isw_c/), (/iew_c/), (/jsw_c/), (/jew_c/), &
-                  nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse)
-             call fill_nest_data(wbuffer2, isw_c, iew_c, jsw_c, jew_c, nnest, t_coarse, 0, 0, iadd_coarse, jadd_coarse, &
+             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/isw_c/), (/iew_c/), (/jsw_c/), &
+                  (/jew_c/), nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, &
+                  js_coarse, je_coarse)
+             call fill_nest_data(wbuffer2, isw_c, iew_c, jsw_c, jew_c, nnest, t_coarse, 0, 0, iadd_coarse,jadd_coarse,&
                   rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 0.0_r4_kind, 0.0_r4_kind, 1, 1, nx, ny)
           endif
           call compare_checksums(wbuffer, wbuffer2, trim(type2)//' west buffer coarse to fine scalar')
 
           if( ies_c .GE. iss_c .AND. jes_c .GE. jss_c ) then
-             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/iss_c/), (/ies_c/), (/jss_c/), (/jes_c/), &
-                  nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse)
-             call fill_nest_data(sbuffer2, iss_c, ies_c, jss_c, jes_c, nnest, t_coarse, 0, 0, iadd_coarse, jadd_coarse, &
+             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/iss_c/), (/ies_c/), (/jss_c/), &
+                  (/jes_c/), nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, &
+                  js_coarse, je_coarse)
+             call fill_nest_data(sbuffer2, iss_c, ies_c, jss_c, jes_c, nnest, t_coarse, 0, 0, iadd_coarse,jadd_coarse,&
                   rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 0.0_r4_kind, 0.0_r4_kind, 1, 1, nx, ny)
           endif
           call compare_checksums(sbuffer, sbuffer2, trim(type2)//' south buffer coarse to fine scalar')
 
           if( iee_c .GE. ise_c .AND. jee_c .GE. jse_c ) then
-             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/ise_c/), (/iee_c/), (/jse_c/), (/jee_c/), &
-                  nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse)
-             call fill_nest_data(ebuffer2, ise_c, iee_c, jse_c, jee_c, nnest, t_coarse, 0, 0, iadd_coarse, jadd_coarse, &
+             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/ise_c/), (/iee_c/), (/jse_c/), &
+                  (/jee_c/), nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, &
+                  js_coarse, je_coarse)
+             call fill_nest_data(ebuffer2, ise_c, iee_c, jse_c, jee_c, nnest, t_coarse, 0, 0, iadd_coarse,jadd_coarse,&
                   rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 0.0_r4_kind, 0.0_r4_kind, 1, 1, nx, ny)
           endif
           call compare_checksums(ebuffer, ebuffer2, trim(type2)//' east buffer coarse to fine scalar')
 
           if( ien_c .GE. isn_c .AND. jen_c .GE. jsn_c ) then
-             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/isn_c/), (/ien_c/), (/jsn_c/), (/jen_c/), &
-                  nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse)
-             call fill_nest_data(nbuffer2, isn_c, ien_c, jsn_c, jen_c, nnest, t_coarse, 0, 0, iadd_coarse, jadd_coarse, &
+             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/isn_c/), (/ien_c/), (/jsn_c/), &
+                  (/jen_c/), nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, &
+                  js_coarse, je_coarse)
+             call fill_nest_data(nbuffer2, isn_c, ien_c, jsn_c, jen_c, nnest, t_coarse, 0, 0, iadd_coarse,jadd_coarse,&
                   rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 0.0_r4_kind, 0.0_r4_kind, 1, 1, nx, ny)
           endif
           call compare_checksums(nbuffer, nbuffer2, trim(type2)//' north buffer coarse to fine scalar')
@@ -8696,14 +8866,22 @@ end subroutine test_halosize_update
           !--- The index from nest domain
           call mpp_get_compute_domain(domain_fine, isc_fine, iec_fine, jsc_fine, jec_fine)
           call mpp_get_data_domain(domain_fine, isd_fine, ied_fine, jsd_fine, jed_fine)
-          call mpp_get_C2F_index(nest_domain, isw_fx, iew_fx, jsw_fx, jew_fx, isw_cx, iew_cx, jsw_cx, jew_cx, WEST, l, position=CORNER)
-          call mpp_get_C2F_index(nest_domain, ise_fx, iee_fx, jse_fx, jee_fx, ise_cx, iee_cx, jse_cx, jee_cx, EAST, l, position=CORNER)
-          call mpp_get_C2F_index(nest_domain, iss_fx, ies_fx, jss_fx, jes_fx, iss_cx, ies_cx, jss_cx, jes_cx, SOUTH, l, position=CORNER)
-          call mpp_get_C2F_index(nest_domain, isn_fx, ien_fx, jsn_fx, jen_fx, isn_cx, ien_cx, jsn_cx, jen_cx, NORTH, l, position=CORNER)
-          call mpp_get_C2F_index(nest_domain, isw_fy, iew_fy, jsw_fy, jew_fy, isw_cy, iew_cy, jsw_cy, jew_cy, WEST, l, position=CORNER)
-          call mpp_get_C2F_index(nest_domain, ise_fy, iee_fy, jse_fy, jee_fy, ise_cy, iee_cy, jse_cy, jee_cy, EAST, l, position=CORNER)
-          call mpp_get_C2F_index(nest_domain, iss_fy, ies_fy, jss_fy, jes_fy, iss_cy, ies_cy, jss_cy, jes_cy, SOUTH, l, position=CORNER)
-          call mpp_get_C2F_index(nest_domain, isn_fy, ien_fy, jsn_fy, jen_fy, isn_cy, ien_cy, jsn_cy, jen_cy, NORTH, l, position=CORNER)
+          call mpp_get_C2F_index(nest_domain, isw_fx, iew_fx, jsw_fx, jew_fx, isw_cx, iew_cx, jsw_cx, jew_cx, &
+                                &  WEST, l, position=CORNER)
+          call mpp_get_C2F_index(nest_domain, ise_fx, iee_fx, jse_fx, jee_fx, ise_cx, iee_cx, jse_cx, jee_cx, &
+                                &  EAST, l, position=CORNER)
+          call mpp_get_C2F_index(nest_domain, iss_fx, ies_fx, jss_fx, jes_fx, iss_cx, ies_cx, jss_cx, jes_cx, &
+                                &  SOUTH, l, position=CORNER)
+          call mpp_get_C2F_index(nest_domain, isn_fx, ien_fx, jsn_fx, jen_fx, isn_cx, ien_cx, jsn_cx, jen_cx, &
+                                &  NORTH, l, position=CORNER)
+          call mpp_get_C2F_index(nest_domain, isw_fy, iew_fy, jsw_fy, jew_fy, isw_cy, iew_cy, jsw_cy, jew_cy, &
+                                &  WEST, l, position=CORNER)
+          call mpp_get_C2F_index(nest_domain, ise_fy, iee_fy, jse_fy, jee_fy, ise_cy, iee_cy, jse_cy, jee_cy, &
+                                &  EAST, l, position=CORNER)
+          call mpp_get_C2F_index(nest_domain, iss_fy, ies_fy, jss_fy, jes_fy, iss_cy, ies_cy, jss_cy, jes_cy, &
+                                &  SOUTH, l, position=CORNER)
+          call mpp_get_C2F_index(nest_domain, isn_fy, ien_fy, jsn_fy, jen_fy, isn_cy, ien_cy, jsn_cy, jen_cy, &
+                                &  NORTH, l, position=CORNER)
 
           !-- The assumed index
           isw_fx2 = 0; iew_fx2 = -1; jsw_fx2 = 0; jew_fx2 = -1
@@ -8732,7 +8910,8 @@ end subroutine test_halosize_update
              isw_cx2 = istart_coarse(my_fine_id)-whalo
              iew_cx2 = istart_coarse(my_fine_id)
              jsw_cx2 = jstart_coarse(my_fine_id) + (jsc_fine - jstart_fine(my_fine_id))/y_refine(my_fine_id) - shalo
-             jew_cx2 = jstart_coarse(my_fine_id) + (jec_fine - jstart_fine(my_fine_id))/y_refine(my_fine_id) + nhalo + shift
+             jew_cx2 = jstart_coarse(my_fine_id) + (jec_fine - jstart_fine(my_fine_id))/y_refine(my_fine_id) + nhalo &
+                     & + shift
              isw_fy2 = isd_fine
              iew_fy2 = isc_fine - 1
              jsw_fy2 = jsd_fine
@@ -8740,7 +8919,8 @@ end subroutine test_halosize_update
              isw_cy2 = istart_coarse(my_fine_id)-whalo
              iew_cy2 = istart_coarse(my_fine_id)
              jsw_cy2 = jstart_coarse(my_fine_id) + (jsc_fine - jstart_fine(my_fine_id))/y_refine(my_fine_id) - shalo
-             jew_cy2 = jstart_coarse(my_fine_id) + (jec_fine - jstart_fine(my_fine_id))/y_refine(my_fine_id) + nhalo + shift
+             jew_cy2 = jstart_coarse(my_fine_id) + (jec_fine - jstart_fine(my_fine_id))/y_refine(my_fine_id) + nhalo &
+                     & + shift
           endif
           !--- east
           if( iec_fine == nx_fine ) then
@@ -8751,7 +8931,8 @@ end subroutine test_halosize_update
              ise_cx2 = iend_coarse(my_fine_id)+shift
              iee_cx2 = iend_coarse(my_fine_id)+ehalo+shift
              jse_cx2 = jstart_coarse(my_fine_id) + (jsc_fine - jstart_fine(my_fine_id))/y_refine(my_fine_id) - shalo
-             jee_cx2 = jstart_coarse(my_fine_id) + (jec_fine - jstart_fine(my_fine_id))/y_refine(my_fine_id) + nhalo + shift
+             jee_cx2 = jstart_coarse(my_fine_id) + (jec_fine - jstart_fine(my_fine_id))/y_refine(my_fine_id) + nhalo &
+                     & + shift
              ise_fy2 = iec_fine+1 + shift
              iee_fy2 = ied_fine + shift
              jse_fy2 = jsd_fine
@@ -8759,7 +8940,8 @@ end subroutine test_halosize_update
              ise_cy2 = iend_coarse(my_fine_id) + shift
              iee_cy2 = iend_coarse(my_fine_id)+ehalo + shift
              jse_cy2 = jstart_coarse(my_fine_id) + (jsc_fine - jstart_fine(my_fine_id))/y_refine(my_fine_id) - shalo
-             jee_cy2 = jstart_coarse(my_fine_id) + (jec_fine - jstart_fine(my_fine_id))/y_refine(my_fine_id) + nhalo + shift
+             jee_cy2 = jstart_coarse(my_fine_id) + (jec_fine - jstart_fine(my_fine_id))/y_refine(my_fine_id) + nhalo &
+                     & + shift
           endif
           !--- south
           if( jsc_fine == 1 ) then
@@ -8768,7 +8950,8 @@ end subroutine test_halosize_update
              jss_fx2 = jsd_fine
              jes_fx2 = jsc_fine - 1
              iss_cx2 = istart_coarse(my_fine_id) + (isc_fine - istart_fine(my_fine_id))/x_refine(my_fine_id) - whalo
-             ies_cx2 = istart_coarse(my_fine_id) + (iec_fine - istart_fine(my_fine_id))/x_refine(my_fine_id) + ehalo + shift
+             ies_cx2 = istart_coarse(my_fine_id) + (iec_fine - istart_fine(my_fine_id))/x_refine(my_fine_id) + ehalo &
+                     & + shift
              jss_cx2 = jstart_coarse(my_fine_id)-shalo
              jes_cx2 = jstart_coarse(my_fine_id)
              iss_fy2 = isd_fine
@@ -8776,7 +8959,8 @@ end subroutine test_halosize_update
              jss_fy2 = jsd_fine
              jes_fy2 = jsc_fine - 1
              iss_cy2 = istart_coarse(my_fine_id) + (isc_fine - istart_fine(my_fine_id))/x_refine(my_fine_id) - whalo
-             ies_cy2 = istart_coarse(my_fine_id) + (iec_fine - istart_fine(my_fine_id))/x_refine(my_fine_id) + ehalo + shift
+             ies_cy2 = istart_coarse(my_fine_id) + (iec_fine - istart_fine(my_fine_id))/x_refine(my_fine_id) + ehalo &
+                     & + shift
              jss_cy2 = jstart_coarse(my_fine_id)-shalo
              jes_cy2 = jstart_coarse(my_fine_id)
           endif
@@ -8787,7 +8971,8 @@ end subroutine test_halosize_update
              jsn_fx2 = jec_fine+1 + shift
              jen_fx2 = jed_fine + shift
              isn_cx2 = istart_coarse(my_fine_id) + (isc_fine - istart_fine(my_fine_id))/x_refine(my_fine_id) - whalo
-             ien_cx2 = istart_coarse(my_fine_id) + (iec_fine - istart_fine(my_fine_id))/x_refine(my_fine_id) + ehalo + shift
+             ien_cx2 = istart_coarse(my_fine_id) + (iec_fine - istart_fine(my_fine_id))/x_refine(my_fine_id) + ehalo &
+                     & + shift
              jsn_cx2 = jend_coarse(my_fine_id) + shift
              jen_cx2 = jend_coarse(my_fine_id)+nhalo + shift
              isn_fy2 = isd_fine
@@ -8795,7 +8980,8 @@ end subroutine test_halosize_update
              jsn_fy2 = jec_fine+1 + shift
              jen_fy2 = jed_fine + shift
              isn_cy2 = istart_coarse(my_fine_id) + (isc_fine - istart_fine(my_fine_id))/x_refine(my_fine_id) - whalo
-             ien_cy2 = istart_coarse(my_fine_id) + (iec_fine - istart_fine(my_fine_id))/x_refine(my_fine_id) + ehalo + shift
+             ien_cy2 = istart_coarse(my_fine_id) + (iec_fine - istart_fine(my_fine_id))/x_refine(my_fine_id) + ehalo &
+                     & + shift
              jsn_cy2 = jend_coarse(my_fine_id) + shift
              jen_cy2 = jend_coarse(my_fine_id)+nhalo + shift
           endif
@@ -8939,36 +9125,48 @@ end subroutine test_halosize_update
        if( is_fine_pe ) then
           call mpp_set_current_pelist(my_pelist_fine)
           if( iew_c .GE. isw_c .AND. jew_c .GE. jsw_c ) then
-             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/isw_c/), (/iew_c/), (/jsw_c/), (/jew_c/), &
-                  nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse)
-             call fill_nest_data(wbufferx2, isw_c, iew_c, jsw_c, jew_c, nnest, t_coarse, 0, shift, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 1.e3_r4_kind, 2.e3_r4_kind, 1, 1, nx, ny)
-             call fill_nest_data(wbuffery2, isw_c, iew_c, jsw_c, jew_c, nnest, t_coarse, 0, shift, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 2.e3_r4_kind, 1.e3_r4_kind, 1, 1, nx, ny)
+             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/isw_c/), (/iew_c/), (/jsw_c/), &
+                  (/jew_c/), nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, &
+                  js_coarse, je_coarse)
+             call fill_nest_data(wbufferx2, isw_c, iew_c, jsw_c, jew_c, nnest, t_coarse, 0, shift, iadd_coarse, &
+                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 1.e3_r4_kind, 2.e3_r4_kind, &
+                  1, 1, nx, ny)
+             call fill_nest_data(wbuffery2, isw_c, iew_c, jsw_c, jew_c, nnest, t_coarse, 0, shift, iadd_coarse, &
+                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 2.e3_r4_kind, 1.e3_r4_kind, &
+                  1, 1, nx, ny)
           endif
           if( ies_c .GE. iss_c .AND. jes_c .GE. jss_c ) then
-             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/iss_c/), (/ies_c/), (/jss_c/), (/jes_c/), &
-                  nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse)
-             call fill_nest_data(sbufferx2, iss_c, ies_c, jss_c, jes_c, nnest, t_coarse, shift, 0, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 1.e3_r4_kind, 2.e3_r4_kind, 1, 1, nx, ny)
-             call fill_nest_data(sbuffery2, iss_c, ies_c, jss_c, jes_c, nnest, t_coarse, shift, 0, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 2.e3_r4_kind, 1.e3_r4_kind, 1, 1, nx, ny)
+             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/iss_c/), (/ies_c/), (/jss_c/), &
+                  (/jes_c/), nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, &
+                  js_coarse, je_coarse)
+             call fill_nest_data(sbufferx2, iss_c, ies_c, jss_c, jes_c, nnest, t_coarse, shift, 0, iadd_coarse, &
+                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 1.e3_r4_kind, 2.e3_r4_kind, &
+                  1, 1, nx, ny)
+             call fill_nest_data(sbuffery2, iss_c, ies_c, jss_c, jes_c, nnest, t_coarse, shift, 0, iadd_coarse, &
+                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 2.e3_r4_kind, 1.e3_r4_kind, &
+                  1, 1, nx, ny)
           endif
           if( iee_c .GE. ise_c .AND. jee_c .GE. jse_c ) then
-             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/ise_c/), (/iee_c/), (/jse_c/), (/jee_c/), &
-                  nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse)
-             call fill_nest_data(ebufferx2, ise_c+shift, iee_c, jse_c, jee_c, nnest, t_coarse, shift, shift, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse+shift, ie_coarse, js_coarse, je_coarse, 1.e3_r4_kind, 2.e3_r4_kind, 1, 1, nx, ny)
-             call fill_nest_data(ebuffery2, ise_c+shift, iee_c, jse_c, jee_c, nnest, t_coarse, shift, shift, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse+shift, ie_coarse, js_coarse, je_coarse, 2.e3_r4_kind, 1.e3_r4_kind, 1, 1, nx, ny)
+             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/ise_c/), (/iee_c/), (/jse_c/), &
+                  (/jee_c/), nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, &
+                  js_coarse, je_coarse)
+             call fill_nest_data(ebufferx2, ise_c+shift, iee_c, jse_c, jee_c, nnest, t_coarse, shift, shift, &
+                  iadd_coarse, jadd_coarse, rotate_coarse, is_coarse+shift, ie_coarse, js_coarse, je_coarse, &
+                  1.e3_r4_kind, 2.e3_r4_kind, 1, 1, nx, ny)
+             call fill_nest_data(ebuffery2, ise_c+shift, iee_c, jse_c, jee_c, nnest, t_coarse, shift, shift, &
+                  iadd_coarse, jadd_coarse, rotate_coarse, is_coarse+shift, ie_coarse, js_coarse, je_coarse, &
+                  2.e3_r4_kind, 1.e3_r4_kind, 1, 1, nx, ny)
           endif
           if( ien_c .GE. isn_c .AND. jen_c .GE. jsn_c ) then
-             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/isn_c/), (/ien_c/), (/jsn_c/), (/jen_c/), &
-                  nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse)
-             call fill_nest_data(nbufferx2, isn_c, ien_c, jsn_c+shift, jen_c, nnest, t_coarse, shift, shift, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse+shift, je_coarse, 1.e3_r4_kind, 2.e3_r4_kind, 1, 1, nx, ny)
-             call fill_nest_data(nbuffery2, isn_c, ien_c, jsn_c+shift, jen_c, nnest, t_coarse, shift, shift, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse+shift, je_coarse, 2.e3_r4_kind, 1.e3_r4_kind, 1, 1, nx, ny)
+             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/isn_c/), (/ien_c/), (/jsn_c/), &
+                  (/jen_c/), nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, &
+                  js_coarse, je_coarse)
+             call fill_nest_data(nbufferx2, isn_c, ien_c, jsn_c+shift, jen_c, nnest, t_coarse, shift, shift, &
+                  iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse+shift, je_coarse, &
+                  1.e3_r4_kind, 2.e3_r4_kind, 1, 1, nx, ny)
+             call fill_nest_data(nbuffery2, isn_c, ien_c, jsn_c+shift, jen_c, nnest, t_coarse, shift, shift, &
+                  iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse+shift, je_coarse, &
+                  2.e3_r4_kind, 1.e3_r4_kind, 1, 1, nx, ny)
           endif
 
           call compare_checksums(wbufferx, wbufferx2, trim(type2)//' west buffer coarse to fine BGRID scalar pair X')
@@ -9064,34 +9262,42 @@ end subroutine test_halosize_update
        if( is_fine_pe ) then
           call mpp_set_current_pelist(my_pelist_fine)
           if( iew_c .GE. isw_c .AND. jew_c .GE. jsw_c ) then
-             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/isw_c/), (/iew_c/), (/jsw_c/), (/jew_c/), &
-                  nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse)
-             call fill_nest_data(wbuffer2, isw_c, iew_c, jsw_c, jew_c, nnest, t_coarse, 0, shift, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 0.0_r4_kind, 0.0_r4_kind, 1, 1, nx, ny)
+             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/isw_c/), (/iew_c/), (/jsw_c/), &
+                  (/jew_c/), nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, &
+                  js_coarse, je_coarse)
+             call fill_nest_data(wbuffer2, isw_c, iew_c, jsw_c, jew_c, nnest, t_coarse, 0, shift, iadd_coarse, &
+                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 0.0_r4_kind, 0.0_r4_kind, &
+                  1, 1, nx, ny)
           endif
           call compare_checksums(wbuffer, wbuffer2, trim(type2)//' west buffer coarse to fine scalar CORNER')
 
           if( ies_c .GE. iss_c .AND. jes_c .GE. jss_c ) then
-             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/iss_c/), (/ies_c/), (/jss_c/), (/jes_c/), &
-                  nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse)
-             call fill_nest_data(sbuffer2, iss_c, ies_c, jss_c, jes_c, nnest, t_coarse, shift, 0, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 0.0_r4_kind, 0.0_r4_kind, 1, 1, nx, ny)
+             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/iss_c/), (/ies_c/), (/jss_c/), &
+                  (/jes_c/), nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, &
+                  js_coarse, je_coarse)
+             call fill_nest_data(sbuffer2, iss_c, ies_c, jss_c, jes_c, nnest, t_coarse, shift, 0, iadd_coarse, &
+                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 0.0_r4_kind, 0.0_r4_kind, &
+                  1, 1, nx, ny)
           endif
           call compare_checksums(sbuffer, sbuffer2, trim(type2)//' south buffer coarse to fine scalar CORNER')
 
           if( iee_c .GE. ise_c .AND. jee_c .GE. jse_c ) then
-             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/ise_c/), (/iee_c/), (/jse_c/), (/jee_c/), &
-                  nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse)
-             call fill_nest_data(ebuffer2, ise_c+shift, iee_c, jse_c, jee_c, nnest, t_coarse, shift, shift, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse+shift, ie_coarse, js_coarse, je_coarse, 0.0_r4_kind, 0.0_r4_kind, 1, 1, nx, ny)
+             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/ise_c/), (/iee_c/), (/jse_c/), &
+                  (/jee_c/), nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, &
+                  js_coarse, je_coarse)
+             call fill_nest_data(ebuffer2, ise_c+shift, iee_c, jse_c, jee_c, nnest, t_coarse, shift, shift, &
+                  iadd_coarse, jadd_coarse, rotate_coarse, is_coarse+shift, ie_coarse, js_coarse, je_coarse,&
+                  0.0_r4_kind, 0.0_r4_kind, 1, 1, nx, ny)
           endif
           call compare_checksums(ebuffer, ebuffer2, trim(type2)//' east buffer coarse to fine scalar CORNER')
 
           if( ien_c .GE. isn_c .AND. jen_c .GE. jsn_c ) then
-             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/isn_c/), (/ien_c/), (/jsn_c/), (/jen_c/), &
-                  nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse)
-             call fill_nest_data(nbuffer2, isn_c, ien_c, jsn_c+shift, jen_c, nnest, t_coarse, shift, shift, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse+shift, je_coarse, 0.0_r4_kind, 0.0_r4_kind, 1, 1, nx, ny)
+             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/isn_c/), (/ien_c/), (/jsn_c/), &
+                  (/jen_c/), nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, &
+                  js_coarse, je_coarse)
+             call fill_nest_data(nbuffer2, isn_c, ien_c, jsn_c+shift, jen_c, nnest, t_coarse, shift, shift, &
+                  iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse+shift, je_coarse,&
+                  0.0_r4_kind, 0.0_r4_kind, 1, 1, nx, ny)
           endif
           call compare_checksums(nbuffer, nbuffer2, trim(type2)//' north buffer coarse to fine scalar CORNER')
 
@@ -9113,14 +9319,22 @@ end subroutine test_halosize_update
           !--- The index from nest domain
           call mpp_get_compute_domain(domain_fine, isc_fine, iec_fine, jsc_fine, jec_fine)
           call mpp_get_data_domain(domain_fine, isd_fine, ied_fine, jsd_fine, jed_fine)
-          call mpp_get_C2F_index(nest_domain, isw_fx, iew_fx, jsw_fx, jew_fx, isw_cx, iew_cx, jsw_cx, jew_cx, WEST, l, position=EAST)
-          call mpp_get_C2F_index(nest_domain, ise_fx, iee_fx, jse_fx, jee_fx, ise_cx, iee_cx, jse_cx, jee_cx, EAST, l, position=EAST)
-          call mpp_get_C2F_index(nest_domain, iss_fx, ies_fx, jss_fx, jes_fx, iss_cx, ies_cx, jss_cx, jes_cx, SOUTH, l, position=EAST)
-          call mpp_get_C2F_index(nest_domain, isn_fx, ien_fx, jsn_fx, jen_fx, isn_cx, ien_cx, jsn_cx, jen_cx, NORTH, l, position=EAST)
-          call mpp_get_C2F_index(nest_domain, isw_fy, iew_fy, jsw_fy, jew_fy, isw_cy, iew_cy, jsw_cy, jew_cy, WEST, l, position=NORTH)
-          call mpp_get_C2F_index(nest_domain, ise_fy, iee_fy, jse_fy, jee_fy, ise_cy, iee_cy, jse_cy, jee_cy, EAST, l, position=NORTH)
-          call mpp_get_C2F_index(nest_domain, iss_fy, ies_fy, jss_fy, jes_fy, iss_cy, ies_cy, jss_cy, jes_cy, SOUTH, l, position=NORTH)
-          call mpp_get_C2F_index(nest_domain, isn_fy, ien_fy, jsn_fy, jen_fy, isn_cy, ien_cy, jsn_cy, jen_cy, NORTH, l, position=NORTH)
+          call mpp_get_C2F_index(nest_domain, isw_fx, iew_fx, jsw_fx, jew_fx, isw_cx, iew_cx, jsw_cx, jew_cx, &
+                                &  WEST, l, position=EAST)
+          call mpp_get_C2F_index(nest_domain, ise_fx, iee_fx, jse_fx, jee_fx, ise_cx, iee_cx, jse_cx, jee_cx, &
+                                &  EAST, l, position=EAST)
+          call mpp_get_C2F_index(nest_domain, iss_fx, ies_fx, jss_fx, jes_fx, iss_cx, ies_cx, jss_cx, jes_cx, &
+                                &  SOUTH, l, position=EAST)
+          call mpp_get_C2F_index(nest_domain, isn_fx, ien_fx, jsn_fx, jen_fx, isn_cx, ien_cx, jsn_cx, jen_cx, &
+                                &  NORTH, l, position=EAST)
+          call mpp_get_C2F_index(nest_domain, isw_fy, iew_fy, jsw_fy, jew_fy, isw_cy, iew_cy, jsw_cy, jew_cy, &
+                                &  WEST, l, position=NORTH)
+          call mpp_get_C2F_index(nest_domain, ise_fy, iee_fy, jse_fy, jee_fy, ise_cy, iee_cy, jse_cy, jee_cy, &
+                                &  EAST, l, position=NORTH)
+          call mpp_get_C2F_index(nest_domain, iss_fy, ies_fy, jss_fy, jes_fy, iss_cy, ies_cy, jss_cy, jes_cy, &
+                                &  SOUTH, l, position=NORTH)
+          call mpp_get_C2F_index(nest_domain, isn_fy, ien_fy, jsn_fy, jen_fy, isn_cy, ien_cy, jsn_cy, jen_cy, &
+                                &  NORTH, l, position=NORTH)
 
           !-- The assumed index
           isw_fx2 = 0; iew_fx2 = -1; jsw_fx2 = 0; jew_fx2 = -1
@@ -9157,7 +9371,8 @@ end subroutine test_halosize_update
              isw_cy2 = istart_coarse(my_fine_id)-whalo
              iew_cy2 = istart_coarse(my_fine_id)
              jsw_cy2 = jstart_coarse(my_fine_id) + (jsc_fine - jstart_fine(my_fine_id))/y_refine(my_fine_id) - shalo
-             jew_cy2 = jstart_coarse(my_fine_id) + (jec_fine - jstart_fine(my_fine_id))/y_refine(my_fine_id) + nhalo + shift
+             jew_cy2 = jstart_coarse(my_fine_id) + (jec_fine - jstart_fine(my_fine_id))/y_refine(my_fine_id) + nhalo &
+                     & + shift
           endif
           !--- east
           if( iec_fine == nx_fine ) then
@@ -9176,7 +9391,8 @@ end subroutine test_halosize_update
              ise_cy2 = iend_coarse(my_fine_id)
              iee_cy2 = iend_coarse(my_fine_id)+ehalo
              jse_cy2 = jstart_coarse(my_fine_id) + (jsc_fine - jstart_fine(my_fine_id))/y_refine(my_fine_id) - shalo
-             jee_cy2 = jstart_coarse(my_fine_id) + (jec_fine - jstart_fine(my_fine_id))/y_refine(my_fine_id) + nhalo + shift
+             jee_cy2 = jstart_coarse(my_fine_id) + (jec_fine - jstart_fine(my_fine_id))/y_refine(my_fine_id) + nhalo &
+                     & + shift
           endif
           !--- south
           if( jsc_fine == 1 ) then
@@ -9185,7 +9401,8 @@ end subroutine test_halosize_update
              jss_fx2 = jsd_fine
              jes_fx2 = jsc_fine - 1
              iss_cx2 = istart_coarse(my_fine_id) + (isc_fine - istart_fine(my_fine_id))/x_refine(my_fine_id) - whalo
-             ies_cx2 = istart_coarse(my_fine_id) + (iec_fine - istart_fine(my_fine_id))/x_refine(my_fine_id) + ehalo + shift
+             ies_cx2 = istart_coarse(my_fine_id) + (iec_fine - istart_fine(my_fine_id))/x_refine(my_fine_id) + ehalo &
+                     & + shift
              jss_cx2 = jstart_coarse(my_fine_id)-shalo
              jes_cx2 = jstart_coarse(my_fine_id)
              iss_fy2 = isd_fine
@@ -9204,7 +9421,8 @@ end subroutine test_halosize_update
              jsn_fx2 = jec_fine+1
              jen_fx2 = jed_fine
              isn_cx2 = istart_coarse(my_fine_id) + (isc_fine - istart_fine(my_fine_id))/x_refine(my_fine_id) - whalo
-             ien_cx2 = istart_coarse(my_fine_id) + (iec_fine - istart_fine(my_fine_id))/x_refine(my_fine_id) + ehalo + shift
+             ien_cx2 = istart_coarse(my_fine_id) + (iec_fine - istart_fine(my_fine_id))/x_refine(my_fine_id) + ehalo &
+                     & + shift
              jsn_cx2 = jend_coarse(my_fine_id)
              jen_cx2 = jend_coarse(my_fine_id)+nhalo
              isn_fy2 = isd_fine
@@ -9356,36 +9574,48 @@ end subroutine test_halosize_update
        if( is_fine_pe ) then
           call mpp_set_current_pelist(my_pelist_fine)
           if( iew_c .GE. isw_c .AND. jew_c .GE. jsw_c ) then
-             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/isw_c/), (/iew_c/), (/jsw_c/), (/jew_c/), &
-                  nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse)
-             call fill_nest_data(wbufferx2, isw_c, iew_c, jsw_c, jew_c, nnest, t_coarse, 0, 0, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 1e3_r4_kind, 2e3_r4_kind, 1, 1, nx, ny)
-             call fill_nest_data(wbuffery2, isw_c, iew_c, jsw_c, jew_c, nnest, t_coarse, 0, shift, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 2e3_r4_kind, 1e3_r4_kind, 1, 1, nx, ny)
+             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/isw_c/), (/iew_c/), (/jsw_c/), &
+                  (/jew_c/), nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, &
+                  js_coarse, je_coarse)
+             call fill_nest_data(wbufferx2, isw_c, iew_c, jsw_c, jew_c, nnest, t_coarse, 0, 0, iadd_coarse, &
+                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 1e3_r4_kind, 2e3_r4_kind, &
+                  1, 1, nx, ny)
+             call fill_nest_data(wbuffery2, isw_c, iew_c, jsw_c, jew_c, nnest, t_coarse, 0, shift, iadd_coarse, &
+                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 2e3_r4_kind, 1e3_r4_kind, &
+                  1, 1, nx, ny)
           endif
           if( ies_c .GE. iss_c .AND. jes_c .GE. jss_c ) then
-             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/iss_c/), (/ies_c/), (/jss_c/), (/jes_c/), &
-                  nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse)
-             call fill_nest_data(sbufferx2, iss_c, ies_c, jss_c, jes_c, nnest, t_coarse, shift, 0, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 1e3_r4_kind, 2e3_r4_kind, 1, 1, nx, ny)
-             call fill_nest_data(sbuffery2, iss_c, ies_c, jss_c, jes_c, nnest, t_coarse, 0, 0, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 2e3_r4_kind, 1e3_r4_kind, 1, 1, nx, ny)
+             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/iss_c/), (/ies_c/), (/jss_c/), &
+                  (/jes_c/), nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, &
+                  js_coarse, je_coarse)
+             call fill_nest_data(sbufferx2, iss_c, ies_c, jss_c, jes_c, nnest, t_coarse, shift, 0, iadd_coarse, &
+                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 1e3_r4_kind, 2e3_r4_kind, &
+                  1, 1, nx, ny)
+             call fill_nest_data(sbuffery2, iss_c, ies_c, jss_c, jes_c, nnest, t_coarse, 0, 0, iadd_coarse, &
+                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 2e3_r4_kind, 1e3_r4_kind, &
+                  1, 1, nx, ny)
           endif
           if( iee_c .GE. ise_c .AND. jee_c .GE. jse_c ) then
-             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/ise_c/), (/iee_c/), (/jse_c/), (/jee_c/), &
-                  nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse)
-             call fill_nest_data(ebufferx2, ise_c+shift, iee_c, jse_c, jee_c, nnest, t_coarse, shift, 0, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse+shift, ie_coarse, js_coarse, je_coarse, 1e3_r4_kind, 2e3_r4_kind, 1, 1, nx, ny)
-             call fill_nest_data(ebuffery2, ise_c, iee_c, jse_c, jee_c, nnest, t_coarse, 0, shift, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 2e3_r4_kind, 1e3_r4_kind, 1, 1, nx, ny)
+             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/ise_c/), (/iee_c/), (/jse_c/), &
+                  (/jee_c/), nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, &
+                  js_coarse, je_coarse)
+             call fill_nest_data(ebufferx2, ise_c+shift, iee_c, jse_c, jee_c, nnest, t_coarse, shift, 0, iadd_coarse,&
+                  jadd_coarse, rotate_coarse, is_coarse+shift, ie_coarse, js_coarse, je_coarse, 1e3_r4_kind, &
+                  2e3_r4_kind, 1, 1, nx, ny)
+             call fill_nest_data(ebuffery2, ise_c, iee_c, jse_c, jee_c, nnest, t_coarse, 0, shift, iadd_coarse, &
+                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 2e3_r4_kind, 1e3_r4_kind, &
+                  1, 1, nx, ny)
           endif
           if( ien_c .GE. isn_c .AND. jen_c .GE. jsn_c ) then
-             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/isn_c/), (/ien_c/), (/jsn_c/), (/jen_c/), &
-                  nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse)
-             call fill_nest_data(nbufferx2, isn_c, ien_c, jsn_c, jen_c, nnest, t_coarse, shift, 0, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 1e3_r4_kind, 2e3_r4_kind, 1, 1, nx, ny)
-             call fill_nest_data(nbuffery2, isn_c, ien_c, jsn_c+shift, jen_c, nnest, t_coarse, 0, shift, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse+shift, je_coarse, 2e3_r4_kind, 1e3_r4_kind, 1, 1, nx, ny)
+             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/isn_c/), (/ien_c/), (/jsn_c/), &
+                  (/jen_c/), nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, &
+                  js_coarse, je_coarse)
+             call fill_nest_data(nbufferx2, isn_c, ien_c, jsn_c, jen_c, nnest, t_coarse, shift, 0, iadd_coarse, &
+                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 1e3_r4_kind, 2e3_r4_kind, &
+                  1, 1, nx, ny)
+             call fill_nest_data(nbuffery2, isn_c, ien_c, jsn_c+shift, jen_c, nnest, t_coarse, 0, shift, iadd_coarse,&
+                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse+shift, je_coarse, 2e3_r4_kind, &
+                  1e3_r4_kind, 1, 1, nx, ny)
           endif
 
           call compare_checksums(wbufferx, wbufferx2, trim(type2)//' west buffer coarse to fine CGRID scalar pair X')
@@ -9459,36 +9689,48 @@ end subroutine test_halosize_update
        if( is_fine_pe ) then
           call mpp_set_current_pelist(my_pelist_fine)
           if( iew_c .GE. isw_c .AND. jew_c .GE. jsw_c ) then
-             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/isw_c/), (/iew_c/), (/jsw_c/), (/jew_c/), &
-                  nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse)
-             call fill_nest_data(wbufferx2, isw_c, iew_c, jsw_c, jew_c, nnest, t_coarse, 0, 0, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 1e3_r4_kind, 2e3_r4_kind, 1, -1, nx, ny)
-             call fill_nest_data(wbuffery2, isw_c, iew_c, jsw_c, jew_c, nnest, t_coarse, 0, shift, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 2e3_r4_kind, 1e3_r4_kind, -1, 1, nx, ny)
+             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/isw_c/), (/iew_c/), (/jsw_c/), &
+                  (/jew_c/), nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, &
+                  js_coarse, je_coarse)
+             call fill_nest_data(wbufferx2, isw_c, iew_c, jsw_c, jew_c, nnest, t_coarse, 0, 0, iadd_coarse, &
+                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 1e3_r4_kind, 2e3_r4_kind, 1,&
+                  -1, nx, ny)
+             call fill_nest_data(wbuffery2, isw_c, iew_c, jsw_c, jew_c, nnest, t_coarse, 0, shift, iadd_coarse, &
+                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 2e3_r4_kind, 1e3_r4_kind,  &
+                  1, 1, nx, ny)
           endif
           if( ies_c .GE. iss_c .AND. jes_c .GE. jss_c ) then
-             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/iss_c/), (/ies_c/), (/jss_c/), (/jes_c/), &
-                  nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse)
-             call fill_nest_data(sbufferx2, iss_c, ies_c, jss_c, jes_c, nnest, t_coarse, shift, 0, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 1e3_r4_kind, 2e3_r4_kind, 1, -1, nx, ny)
-             call fill_nest_data(sbuffery2, iss_c, ies_c, jss_c, jes_c, nnest, t_coarse, 0, 0, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 2e3_r4_kind, 1e3_r4_kind, -1, 1, nx, ny)
+             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/iss_c/), (/ies_c/), (/jss_c/), &
+                  (/jes_c/), nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, &
+                  js_coarse, je_coarse)
+             call fill_nest_data(sbufferx2, iss_c, ies_c, jss_c, jes_c, nnest, t_coarse, shift, 0, iadd_coarse, &
+                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 1e3_r4_kind, 2e3_r4_kind, 1,&
+                  -1, nx, ny)
+             call fill_nest_data(sbuffery2, iss_c, ies_c, jss_c, jes_c, nnest, t_coarse, 0, 0, iadd_coarse, &
+                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 2e3_r4_kind, 1e3_r4_kind,  &
+                  1, 1, nx, ny)
           endif
           if( iee_c .GE. ise_c .AND. jee_c .GE. jse_c ) then
-             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/ise_c/), (/iee_c/), (/jse_c/), (/jee_c/), &
-                  nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse)
-             call fill_nest_data(ebufferx2, ise_c+shift, iee_c, jse_c, jee_c, nnest, t_coarse, shift, 0, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse+shift, ie_coarse, js_coarse, je_coarse, 1e3_r4_kind, 2e3_r4_kind, 1, -1, nx, ny)
-             call fill_nest_data(ebuffery2, ise_c, iee_c, jse_c, jee_c, nnest, t_coarse, 0, shift, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 2e3_r4_kind, 1e3_r4_kind, -1, 1, nx, ny)
+             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/ise_c/), (/iee_c/), (/jse_c/), &
+                  (/jee_c/), nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, &
+                  js_coarse, je_coarse)
+             call fill_nest_data(ebufferx2, ise_c+shift, iee_c, jse_c, jee_c, nnest, t_coarse, shift, 0, iadd_coarse,&
+                  jadd_coarse, rotate_coarse, is_coarse+shift, ie_coarse, js_coarse, je_coarse, 1e3_r4_kind, &
+                  2e3_r4_kind, 1, -1, nx, ny)
+             call fill_nest_data(ebuffery2, ise_c, iee_c, jse_c, jee_c, nnest, t_coarse, 0, shift, iadd_coarse, &
+                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 2e3_r4_kind, 1e3_r4_kind,  &
+                  1, 1, nx, ny)
           endif
           if( ien_c .GE. isn_c .AND. jen_c .GE. jsn_c ) then
-             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/isn_c/), (/ien_c/), (/jsn_c/), (/jen_c/), &
-                  nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse)
-             call fill_nest_data(nbufferx2, isn_c, ien_c, jsn_c, jen_c, nnest, t_coarse, shift, 0, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 1e3_r4_kind, 2e3_r4_kind, 1, -1, nx, ny)
-             call fill_nest_data(nbuffery2, isn_c, ien_c, jsn_c+shift, jen_c, nnest, t_coarse, 0, shift, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse+shift, je_coarse, 2e3_r4_kind, 1e3_r4_kind, -1, 1, nx, ny)
+             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/isn_c/), (/ien_c/), (/jsn_c/), &
+                  (/jen_c/), nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, &
+                  js_coarse, je_coarse)
+             call fill_nest_data(nbufferx2, isn_c, ien_c, jsn_c, jen_c, nnest, t_coarse, shift, 0, iadd_coarse, &
+                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 1e3_r4_kind, 2e3_r4_kind, 1,&
+                  -1, nx, ny)
+             call fill_nest_data(nbuffery2, isn_c, ien_c, jsn_c+shift, jen_c, nnest, t_coarse, 0, shift, iadd_coarse,&
+                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse+shift, je_coarse, 2e3_r4_kind, &
+                  1e3_r4_kind, -1, 1, nx, ny)
           endif
 
           call compare_checksums(wbufferx, wbufferx2, trim(type2)//' west buffer coarse to fine CGRID vector X')
@@ -9561,14 +9803,22 @@ end subroutine test_halosize_update
        endif
 
        if(is_fine_pe) then
-          call mpp_get_C2F_index(nest_domain, isw_fx, iew_fx, jsw_fx, jew_fx, isw_cx, iew_cx, jsw_cx, jew_cx, WEST, l, position=NORTH)
-          call mpp_get_C2F_index(nest_domain, ise_fx, iee_fx, jse_fx, jee_fx, ise_cx, iee_cx, jse_cx, jee_cx, EAST, l, position=NORTH)
-          call mpp_get_C2F_index(nest_domain, iss_fx, ies_fx, jss_fx, jes_fx, iss_cx, ies_cx, jss_cx, jes_cx, SOUTH, l, position=NORTH)
-          call mpp_get_C2F_index(nest_domain, isn_fx, ien_fx, jsn_fx, jen_fx, isn_cx, ien_cx, jsn_cx, jen_cx, NORTH, l, position=NORTH)
-          call mpp_get_C2F_index(nest_domain, isw_fy, iew_fy, jsw_fy, jew_fy, isw_cy, iew_cy, jsw_cy, jew_cy, WEST, l, position=EAST)
-          call mpp_get_C2F_index(nest_domain, ise_fy, iee_fy, jse_fy, jee_fy, ise_cy, iee_cy, jse_cy, jee_cy, EAST, l, position=EAST)
-          call mpp_get_C2F_index(nest_domain, iss_fy, ies_fy, jss_fy, jes_fy, iss_cy, ies_cy, jss_cy, jes_cy, SOUTH, l, position=EAST)
-          call mpp_get_C2F_index(nest_domain, isn_fy, ien_fy, jsn_fy, jen_fy, isn_cy, ien_cy, jsn_cy, jen_cy, NORTH, l, position=EAST)
+          call mpp_get_C2F_index(nest_domain, isw_fx, iew_fx, jsw_fx, jew_fx, isw_cx, iew_cx, jsw_cx, jew_cx, &
+                                &  WEST, l, position=NORTH)
+          call mpp_get_C2F_index(nest_domain, ise_fx, iee_fx, jse_fx, jee_fx, ise_cx, iee_cx, jse_cx, jee_cx, &
+                                &  EAST, l, position=NORTH)
+          call mpp_get_C2F_index(nest_domain, iss_fx, ies_fx, jss_fx, jes_fx, iss_cx, ies_cx, jss_cx, jes_cx, &
+                                &  SOUTH, l, position=NORTH)
+          call mpp_get_C2F_index(nest_domain, isn_fx, ien_fx, jsn_fx, jen_fx, isn_cx, ien_cx, jsn_cx, jen_cx, &
+                                &  NORTH, l, position=NORTH)
+          call mpp_get_C2F_index(nest_domain, isw_fy, iew_fy, jsw_fy, jew_fy, isw_cy, iew_cy, jsw_cy, jew_cy, &
+                                &  WEST, l, position=EAST)
+          call mpp_get_C2F_index(nest_domain, ise_fy, iee_fy, jse_fy, jee_fy, ise_cy, iee_cy, jse_cy, jee_cy, &
+                                &  EAST, l, position=EAST)
+          call mpp_get_C2F_index(nest_domain, iss_fy, ies_fy, jss_fy, jes_fy, iss_cy, ies_cy, jss_cy, jes_cy, &
+                                &  SOUTH, l, position=EAST)
+          call mpp_get_C2F_index(nest_domain, isn_fy, ien_fy, jsn_fy, jen_fy, isn_cy, ien_cy, jsn_cy, jen_cy, &
+                                &  NORTH, l, position=EAST)
 
           if( iew_cx .GE. isw_cx .AND. jew_cx .GE. jsw_cx ) then
              allocate(wbufferx(isw_cx:iew_cx, jsw_cx:jew_cx,nz))
@@ -9631,36 +9881,47 @@ end subroutine test_halosize_update
        if( is_fine_pe ) then
           call mpp_set_current_pelist(my_pelist_fine)
           if( iew_c .GE. isw_c .AND. jew_c .GE. jsw_c ) then
-             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/isw_c/), (/iew_c/), (/jsw_c/), (/jew_c/), &
-                  nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse)
-             call fill_nest_data(wbufferx2, isw_c, iew_c, jsw_c, jew_c, nnest, t_coarse, 0, shift, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 1e3_r4_kind, 2e3_r4_kind, 1, -1, nx, ny)
-             call fill_nest_data(wbuffery2, isw_c, iew_c, jsw_c, jew_c, nnest, t_coarse, 0, 0, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 2e3_r4_kind, 1e3_r4_kind, -1, 1, nx, ny)
+             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/isw_c/), (/iew_c/), (/jsw_c/), &
+                  (/jew_c/), nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, &
+                  js_coarse, je_coarse)
+             call fill_nest_data(wbufferx2, isw_c, iew_c, jsw_c, jew_c, nnest, t_coarse, 0, shift, iadd_coarse, &
+                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 1e3_r4_kind, 2e3_r4_kind, 1,&
+                  -1, nx, ny)
+             call fill_nest_data(wbuffery2, isw_c, iew_c, jsw_c, jew_c, nnest, t_coarse, 0, 0, iadd_coarse, &
+                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 2e3_r4_kind, 1e3_r4_kind,  &
+                  1, 1, nx, ny)
           endif
           if( ies_c .GE. iss_c .AND. jes_c .GE. jss_c ) then
-             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/iss_c/), (/ies_c/), (/jss_c/), (/jes_c/), &
-                  nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse)
-             call fill_nest_data(sbufferx2, iss_c, ies_c, jss_c, jes_c, nnest, t_coarse, 0, 0, iadd_coarse, jadd_coarse, &
+             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/iss_c/), (/ies_c/), (/jss_c/), &
+                  (/jes_c/), nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, &
+                  js_coarse, je_coarse)
+             call fill_nest_data(sbufferx2, iss_c, ies_c, jss_c, jes_c, nnest, t_coarse, 0, 0,iadd_coarse,jadd_coarse,&
                   rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 1e3_r4_kind, 2e3_r4_kind, 1, -1, nx, ny)
-             call fill_nest_data(sbuffery2, iss_c, ies_c, jss_c, jes_c, nnest, t_coarse, shift, 0, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 2e3_r4_kind, 1e3_r4_kind, -1, 1, nx, ny)
+             call fill_nest_data(sbuffery2, iss_c, ies_c, jss_c, jes_c, nnest, t_coarse, shift, 0, iadd_coarse, &
+                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 2e3_r4_kind, 1e3_r4_kind,  &
+                  1, 1, nx, ny)
           endif
           if( iee_c .GE. ise_c .AND. jee_c .GE. jse_c ) then
-             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/ise_c/), (/iee_c/), (/jse_c/), (/jee_c/), &
-                  nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse)
-             call fill_nest_data(ebufferx2, ise_c, iee_c, jse_c, jee_c, nnest, t_coarse, 0, shift, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 1e3_r4_kind, 2e3_r4_kind, 1, -1, nx, ny)
-             call fill_nest_data(ebuffery2, ise_c+shift, iee_c, jse_c, jee_c, nnest, t_coarse, shift, 0, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse+shift, ie_coarse, js_coarse, je_coarse, 2e3_r4_kind, 1e3_r4_kind, -1, 1, nx, ny)
+             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/ise_c/), (/iee_c/), (/jse_c/), &
+                  (/jee_c/), nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, &
+                  js_coarse, je_coarse)
+             call fill_nest_data(ebufferx2, ise_c, iee_c, jse_c, jee_c, nnest, t_coarse, 0, shift, iadd_coarse, &
+                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 1e3_r4_kind, 2e3_r4_kind, 1,&
+                  -1, nx, ny)
+             call fill_nest_data(ebuffery2, ise_c+shift, iee_c, jse_c, jee_c, nnest, t_coarse, shift, 0, iadd_coarse,&
+                  jadd_coarse, rotate_coarse, is_coarse+shift, ie_coarse, js_coarse, je_coarse, 2e3_r4_kind, &
+                  1e3_r4_kind, -1, 1, nx, ny)
           endif
           if( ien_c .GE. isn_c .AND. jen_c .GE. jsn_c ) then
-             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/isn_c/), (/ien_c/), (/jsn_c/), (/jen_c/), &
-                  nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse)
-             call fill_nest_data(nbufferx2, isn_c, ien_c, jsn_c+shift, jen_c, nnest, t_coarse, 0, shift, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse+shift, je_coarse, 1e3_r4_kind, 2e3_r4_kind, 1, -1, nx, ny)
-             call fill_nest_data(nbuffery2, isn_c, ien_c, jsn_c, jen_c, nnest, t_coarse, shift, 0, iadd_coarse, jadd_coarse, &
-                  rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 2e3_r4_kind, 1e3_r4_kind, -1, 1, nx, ny)
+             call get_nnest2(domain_coarse, 1, tile_coarse(my_fine_id:my_fine_id), (/isn_c/), (/ien_c/), (/jsn_c/), &
+                  (/jen_c/), nnest, t_coarse, iadd_coarse, jadd_coarse, rotate_coarse, is_coarse, ie_coarse, &
+                  js_coarse, je_coarse)
+             call fill_nest_data(nbufferx2, isn_c, ien_c, jsn_c+shift, jen_c, nnest, t_coarse, 0, shift, iadd_coarse,&
+                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse+shift, je_coarse, 1e3_r4_kind, &
+                  2e3_r4_kind, 1, -1, nx, ny)
+             call fill_nest_data(nbuffery2, isn_c, ien_c, jsn_c, jen_c, nnest, t_coarse, shift, 0, iadd_coarse, &
+                  jadd_coarse, rotate_coarse, is_coarse, ie_coarse, js_coarse, je_coarse, 2e3_r4_kind, 1e3_r4_kind, &
+                  -1, 1, nx, ny)
           endif
 
           call compare_checksums(wbufferx, wbufferx2, trim(type2)//' west buffer coarse to fine DGRID vector X')

--- a/test_fms/mpp/test_mpp_global_field.F90
+++ b/test_fms/mpp/test_mpp_global_field.F90
@@ -206,7 +206,8 @@ contains
     call mpp_global_field( domain, x, gcheck, flags=XUPDATE, position=position )
     !call mpp_clock_end(id)
     !> compare checksums between global and x arrays
-    call compare_checksums( global1(1:ni,js:je), gcheck(1:ni,js:je), type//' mpp_global_field xupdate only on r4 data domain' )
+    call compare_checksums( global1(1:ni,js:je), gcheck(1:ni,js:je), type// &
+                         & ' mpp_global_field xupdate only on r4 data domain' )
 
     !> yupdate
     gcheck = zero
@@ -214,7 +215,8 @@ contains
     call mpp_global_field( domain, x, gcheck, flags=YUPDATE, position=position )
     !call mpp_clock_end(id)
     !> compare checksums between global and x arrays
-    call compare_checksums( global1(is:ie,1:nj), gcheck(is:ie,1:nj), type//' mpp_global_field yupdate only on r4 data domain' )
+    call compare_checksums( global1(is:ie,1:nj), gcheck(is:ie,1:nj), type// &
+                         & ' mpp_global_field yupdate only on r4 data domain' )
     !call mpp_clock_begin(id)
     call mpp_global_field( domain, x, gcheck, position=position )
     !call mpp_clock_end(id)
@@ -241,7 +243,8 @@ contains
     call mpp_global_field( domain, x(is:ie,js:je), gcheck, flags=XUPDATE, position=position )
     !call mpp_clock_end(id)
     !> compare checksums between global and x arrays
-    call compare_checksums( global1(1:ni,js:je), gcheck(1:ni,js:je), type//' mpp_global_field xupdate only on r4 compute domain' )
+    call compare_checksums( global1(1:ni,js:je), gcheck(1:ni,js:je), type// &
+                         & ' mpp_global_field xupdate only on r4 compute domain' )
 
     !> yupdate
     gcheck = zero
@@ -249,7 +252,8 @@ contains
     call mpp_global_field( domain, x(is:ie,js:je), gcheck, flags=YUPDATE, position=position )
     !call mpp_clock_end(id)
     !> compare checksums between global and x arrays
-    call compare_checksums( global1(is:ie,1:nj), gcheck(is:ie,1:nj), type//' mpp_global_field yupdate only on r4 compute domain' )
+    call compare_checksums( global1(is:ie,1:nj), gcheck(is:ie,1:nj), type// &
+                         & ' mpp_global_field yupdate only on r4 compute domain' )
 
     deallocate(global1, gcheck, x)
 
@@ -354,7 +358,8 @@ contains
     call mpp_global_field( domain, x, gcheck, flags=XUPDATE, position=position )
     !call mpp_clock_end(id)
     !> compare checksums between global and x arrays
-    call compare_checksums( global1(1:ni,js:je), gcheck(1:ni,js:je), type//' mpp_global_field xupdate only on r8 data domain' )
+    call compare_checksums( global1(1:ni,js:je), gcheck(1:ni,js:je), type// &
+                         & ' mpp_global_field xupdate only on r8 data domain' )
 
     !> yupdate
     gcheck = zero
@@ -362,7 +367,8 @@ contains
     call mpp_global_field( domain, x, gcheck, flags=YUPDATE, position=position )
     !call mpp_clock_end(id)
     !> compare checksums between global and x arrays
-    call compare_checksums( global1(is:ie,1:nj), gcheck(is:ie,1:nj), type//' mpp_global_field yupdate only on r8 data domain' )
+    call compare_checksums( global1(is:ie,1:nj), gcheck(is:ie,1:nj), type// &
+                         & ' mpp_global_field yupdate only on r8 data domain' )
     !call mpp_clock_begin(id)
     call mpp_global_field( domain, x, gcheck, position=position )
     !call mpp_clock_end(id)
@@ -389,7 +395,8 @@ contains
     call mpp_global_field( domain, x(is:ie,js:je), gcheck, flags=XUPDATE, position=position )
     !call mpp_clock_end(id)
     !> compare checksums between global and x arrays
-    call compare_checksums( global1(1:ni,js:je), gcheck(1:ni,js:je), type//' mpp_global_field xupdate only on r8 compute domain' )
+    call compare_checksums( global1(1:ni,js:je), gcheck(1:ni,js:je), type// &
+                         & ' mpp_global_field xupdate only on r8 compute domain' )
 
     !> yupdate
     gcheck = zero
@@ -397,7 +404,8 @@ contains
     call mpp_global_field( domain, x(is:ie,js:je), gcheck, flags=YUPDATE, position=position )
     !call mpp_clock_end(id)
     !> compare checksums between global and x arrays
-    call compare_checksums( global1(is:ie,1:nj), gcheck(is:ie,1:nj), type//' mpp_global_field yupdate only on r8 compute domain' )
+    call compare_checksums( global1(is:ie,1:nj), gcheck(is:ie,1:nj), type// &
+                         & ' mpp_global_field yupdate only on r8 compute domain' )
 
     deallocate(global1, gcheck, x)
 
@@ -502,7 +510,8 @@ contains
     call mpp_global_field( domain, x, gcheck, flags=XUPDATE, position=position )
     !call mpp_clock_end(id)
     !> compare checksums between global and x arrays
-    call compare_checksums_int( global1(1:ni,js:je), gcheck(1:ni,js:je), type//' mpp_global_field xupdate only on i4 data domain' )
+    call compare_checksums_int( global1(1:ni,js:je), gcheck(1:ni,js:je), type// &
+                             & ' mpp_global_field xupdate only on i4 data domain' )
 
     !> yupdate
     gcheck = zero
@@ -510,7 +519,8 @@ contains
     call mpp_global_field( domain, x, gcheck, flags=YUPDATE, position=position )
     !call mpp_clock_end(id)
     !> compare checksums between global and x arrays
-    call compare_checksums_int( global1(is:ie,1:nj), gcheck(is:ie,1:nj), type//' mpp_global_field yupdate only on i4 data domain' )
+    call compare_checksums_int( global1(is:ie,1:nj), gcheck(is:ie,1:nj), type// &
+                             & ' mpp_global_field yupdate only on i4 data domain' )
     !call mpp_clock_begin(id)
     call mpp_global_field( domain, x, gcheck, position=position )
     !call mpp_clock_end(id)
@@ -537,7 +547,8 @@ contains
     call mpp_global_field( domain, x(is:ie,js:je), gcheck, flags=XUPDATE, position=position )
     !call mpp_clock_end(id)
     !> compare checksums between global and x arrays
-    call compare_checksums_int( global1(1:ni,js:je), gcheck(1:ni,js:je), type//' mpp_global_field xupdate only on i4 compute domain' )
+    call compare_checksums_int( global1(1:ni,js:je), gcheck(1:ni,js:je), type// &
+                             & ' mpp_global_field xupdate only on i4 compute domain' )
 
     !> yupdate
     gcheck = zero
@@ -545,7 +556,8 @@ contains
     call mpp_global_field( domain, x(is:ie,js:je), gcheck, flags=YUPDATE, position=position )
     !call mpp_clock_end(id)
     !> compare checksums between global and x arrays
-    call compare_checksums_int( global1(is:ie,1:nj), gcheck(is:ie,1:nj), type//' mpp_global_field yupdate only on i4 compute domain' )
+    call compare_checksums_int( global1(is:ie,1:nj), gcheck(is:ie,1:nj), type// &
+                             & ' mpp_global_field yupdate only on i4 compute domain' )
 
     deallocate(global1, gcheck, x)
 
@@ -650,7 +662,8 @@ contains
     call mpp_global_field( domain, x, gcheck, flags=XUPDATE, position=position )
     !call mpp_clock_end(id)
     !> compare checksums between global and x arrays
-    call compare_checksums_int( global1(1:ni,js:je), gcheck(1:ni,js:je), type//' mpp_global_field xupdate only on i8 data domain' )
+    call compare_checksums_int( global1(1:ni,js:je), gcheck(1:ni,js:je), type// &
+                             & ' mpp_global_field xupdate only on i8 data domain' )
 
     !> yupdate
     gcheck = zero
@@ -658,7 +671,8 @@ contains
     call mpp_global_field( domain, x, gcheck, flags=YUPDATE, position=position )
     !call mpp_clock_end(id)
     !> compare checksums between global and x arrays
-    call compare_checksums_int( global1(is:ie,1:nj), gcheck(is:ie,1:nj), type//' mpp_global_field yupdate only on i8 data domain' )
+    call compare_checksums_int( global1(is:ie,1:nj), gcheck(is:ie,1:nj), type// &
+                             & ' mpp_global_field yupdate only on i8 data domain' )
     !call mpp_clock_begin(id)
     call mpp_global_field( domain, x, gcheck, position=position )
     !call mpp_clock_end(id)
@@ -685,7 +699,8 @@ contains
     call mpp_global_field( domain, x(is:ie,js:je), gcheck, flags=XUPDATE, position=position )
     !call mpp_clock_end(id)
     !> compare checksums between global and x arrays
-    call compare_checksums_int( global1(1:ni,js:je), gcheck(1:ni,js:je), type//' mpp_global_field xupdate only on i8 compute domain' )
+    call compare_checksums_int( global1(1:ni,js:je), gcheck(1:ni,js:je), type// &
+                             & ' mpp_global_field xupdate only on i8 compute domain' )
 
     !> yupdate
     gcheck = zero
@@ -693,7 +708,8 @@ contains
     call mpp_global_field( domain, x(is:ie,js:je), gcheck, flags=YUPDATE, position=position )
     !call mpp_clock_end(id)
     !> compare checksums between global and x arrays
-    call compare_checksums_int( global1(is:ie,1:nj), gcheck(is:ie,1:nj), type//' mpp_global_field yupdate only on i8 compute domain' )
+    call compare_checksums_int( global1(is:ie,1:nj), gcheck(is:ie,1:nj), type// &
+                             & ' mpp_global_field yupdate only on i8 compute domain' )
 
     deallocate(global1, gcheck, x)
 
@@ -799,7 +815,8 @@ contains
     call mpp_global_field( domain, x, gcheck, flags=XUPDATE, position=position )
     !call mpp_clock_end(id)
     !> compare checksums between global and x arrays
-    call compare_checksums( global1(1:ni,js:je,:), gcheck(1:ni,js:je,:),type//' mpp_global_field xupdate only on r4 data domain' )
+    call compare_checksums( global1(1:ni,js:je,:), gcheck(1:ni,js:je,:),type// &
+                         & ' mpp_global_field xupdate only on r4 data domain' )
 
     !> yupdate
     gcheck = zero
@@ -807,7 +824,8 @@ contains
     call mpp_global_field( domain, x, gcheck, flags=YUPDATE, position=position )
     !call mpp_clock_end(id)
     !> compare checksums between global and x arrays
-    call compare_checksums( global1(is:ie,1:nj,:), gcheck(is:ie,1:nj,:),type//' mpp_global_field yupdate only on r4 data domain' )
+    call compare_checksums( global1(is:ie,1:nj,:), gcheck(is:ie,1:nj,:),type// &
+                         & ' mpp_global_field yupdate only on r4 data domain' )
 
     !call mpp_clock_begin(id)
     call mpp_global_field( domain, x, gcheck, position=position )
@@ -946,7 +964,8 @@ contains
     call mpp_global_field( domain, x, gcheck, flags=XUPDATE, position=position )
     !call mpp_clock_end(id)
     !> compare checksums between global and x arrays
-    call compare_checksums( global1(1:ni,js:je,:), gcheck(1:ni,js:je,:),type//' mpp_global_field xupdate only on r8 data domain' )
+    call compare_checksums( global1(1:ni,js:je,:), gcheck(1:ni,js:je,:),type// &
+                         & ' mpp_global_field xupdate only on r8 data domain' )
 
     !> yupdate
     gcheck = zero
@@ -954,7 +973,8 @@ contains
     call mpp_global_field( domain, x, gcheck, flags=YUPDATE, position=position )
     !call mpp_clock_end(id)
     !> compare checksums between global and x arrays
-    call compare_checksums( global1(is:ie,1:nj,:), gcheck(is:ie,1:nj,:),type//' mpp_global_field yupdate only on r8 data domain' )
+    call compare_checksums( global1(is:ie,1:nj,:), gcheck(is:ie,1:nj,:),type// &
+                         & ' mpp_global_field yupdate only on r8 data domain' )
 
     !call mpp_clock_begin(id)
     call mpp_global_field( domain, x, gcheck, position=position )
@@ -1093,7 +1113,8 @@ contains
     call mpp_global_field( domain, x, gcheck, flags=XUPDATE, position=position )
     !call mpp_clock_end(id)
     !> compare checksums between global and x arrays
-    call compare_checksums_int( global1(1:ni,js:je,:), gcheck(1:ni,js:je,:),type//' mpp_global_field xupdate only on i4 data domain' )
+    call compare_checksums_int( global1(1:ni,js:je,:), gcheck(1:ni,js:je,:),type// &
+                             & ' mpp_global_field xupdate only on i4 data domain' )
 
     !> yupdate
     gcheck = zero
@@ -1101,7 +1122,8 @@ contains
     call mpp_global_field( domain, x, gcheck, flags=YUPDATE, position=position )
     !call mpp_clock_end(id)
     !> compare checksums between global and x arrays
-    call compare_checksums_int( global1(is:ie,1:nj,:), gcheck(is:ie,1:nj,:),type//' mpp_global_field yupdate only on i4 data domain' )
+    call compare_checksums_int( global1(is:ie,1:nj,:), gcheck(is:ie,1:nj,:),type// &
+                             & ' mpp_global_field yupdate only on i4 data domain' )
 
     !call mpp_clock_begin(id)
     call mpp_global_field( domain, x, gcheck, position=position )
@@ -1240,7 +1262,8 @@ contains
     call mpp_global_field( domain, x, gcheck, flags=XUPDATE, position=position )
     !call mpp_clock_end(id)
     !> compare checksums between global and x arrays
-    call compare_checksums_int( global1(1:ni,js:je,:), gcheck(1:ni,js:je,:),type//' mpp_global_field xupdate only on i8 data domain' )
+    call compare_checksums_int( global1(1:ni,js:je,:), gcheck(1:ni,js:je,:),type// &
+                             & ' mpp_global_field xupdate only on i8 data domain' )
 
     !> yupdate
     gcheck = zero
@@ -1248,7 +1271,8 @@ contains
     call mpp_global_field( domain, x, gcheck, flags=YUPDATE, position=position )
     !call mpp_clock_end(id)
     !> compare checksums between global and x arrays
-    call compare_checksums_int( global1(is:ie,1:nj,:), gcheck(is:ie,1:nj,:),type//' mpp_global_field yupdate only on i8 data domain' )
+    call compare_checksums_int( global1(is:ie,1:nj,:), gcheck(is:ie,1:nj,:),type// &
+                             & ' mpp_global_field yupdate only on i8 data domain' )
 
     !call mpp_clock_begin(id)
     call mpp_global_field( domain, x, gcheck, position=position )

--- a/test_fms/mpp/test_mpp_global_field_ug.F90
+++ b/test_fms/mpp/test_mpp_global_field_ug.F90
@@ -24,7 +24,8 @@ program test_mpp_global_field_ug
   use mpp_mod,         only : mpp_init, mpp_error, FATAL, NOTE, mpp_init_test_requests_allocated
   use mpp_mod,         only : mpp_pe, mpp_npes, mpp_root_pe, mpp_broadcast
   use mpp_domains_mod, only : mpp_domains_init,  mpp_domains_set_stack_size, mpp_domains_exit
-  use mpp_domains_mod, only : mpp_define_layout, mpp_define_mosaic, mpp_get_compute_domain, mpp_get_compute_domains, mpp_get_data_domain
+  use mpp_domains_mod, only : mpp_define_layout, mpp_define_mosaic, mpp_get_compute_domain, &
+                           &  mpp_get_compute_domains, mpp_get_data_domain
   use mpp_domains_mod, only : mpp_get_ug_global_domain, mpp_global_field_ug
   use mpp_domains_mod, only : domain2D, domainUG, mpp_define_unstruct_domain, mpp_get_UG_domain_tile_id
   use mpp_domains_mod, only : mpp_get_UG_compute_domain, mpp_pass_SG_to_UG, mpp_pass_UG_to_SG
@@ -498,7 +499,8 @@ contains
           write(*,*)'NOTE from test_unstruct_update ==> For Mosaic "', trim(type), &
                '", each tile will be distributed over ', npes_per_tile, ' processors.'
        else
-          call mpp_error(FATAL,'test_unstruct_update: npes should be multiple of ntiles No test is done for '//trim(type))
+          call mpp_error(FATAL,'test_unstruct_update: npes should be multiple of ntiles No test is done for '// &
+                         & trim(type))
        endif
        if(layout_cubic(1)*layout_cubic(2) == npes_per_tile) then
           layout = layout_cubic
@@ -578,7 +580,8 @@ contains
     allocate(ntiles_grid(ntotal_land))
     ntiles_grid = 1
     !--- define the unstructured grid domain
-    call mpp_define_unstruct_domain(UG_domain, SG_domain, npts_tile, ntiles_grid, mpp_npes(), 1, grid_index, name="LAND unstruct")
+    call mpp_define_unstruct_domain(UG_domain, SG_domain, npts_tile, ntiles_grid, mpp_npes(), 1, grid_index, &
+                                   &  name="LAND unstruct")
     call mpp_get_UG_compute_domain(UG_domain, istart, iend)
 
     !--- figure out lmask according to grid_index

--- a/test_fms/mpp/test_mpp_sum.F90
+++ b/test_fms/mpp/test_mpp_sum.F90
@@ -185,7 +185,8 @@ contains
       sumc4(2,2) = 1
       if (all(a4 .ne. suma4)) call mpp_error(FATAL, "2D_r4: mpp_sum differs from fortran intrinsic sum")
       if (all(b4 .ne. sumb4)) call mpp_error(FATAL, "2D_r4 with pelist: mpp_sum differs from fortran intrinsic sum")
-      if (all(c4 .ne. sumc4)) call mpp_error(FATAL, "2D_r4 (shorter length): mpp_sum differs from fortran intrinsic sum")
+      if (all(c4 .ne. sumc4)) call mpp_error(FATAL, &
+          &  "2D_r4 (shorter length): mpp_sum differs from fortran intrinsic sum")
     endif
 
   end subroutine test_mpp_sum_2D_r4
@@ -211,7 +212,8 @@ contains
       sumc8(2,2) = 1
       if (all(a8 .ne. suma8)) call mpp_error(FATAL, "2D_r8: mpp_sum differs from fortran intrinsic sum")
       if (all(b8 .ne. sumb8)) call mpp_error(FATAL, "2D_r8 with pelist: mpp_sum differs from fortran intrinsic sum")
-      if (all(c8 .ne. sumc8)) call mpp_error(FATAL, "2D_r8 (shorter length): mpp_sum differs from fortran intrinsic sum")
+      if (all(c8 .ne. sumc8)) call mpp_error(FATAL, &
+          &  "2D_r8 (shorter length): mpp_sum differs from fortran intrinsic sum")
     endif
 
   end subroutine test_mpp_sum_2D_r8
@@ -237,7 +239,8 @@ contains
       sumc4(2,2) = 1
       if (all(a4 .ne. suma4)) call mpp_error(FATAL, "2D_i4: mpp_sum differs from fortran intrinsic sum")
       if (all(b4 .ne. sumb4)) call mpp_error(FATAL, "2D_i4 with pelist: mpp_sum differs from fortran intrinsic sum")
-      if (all(c4 .ne. sumc4)) call mpp_error(FATAL, "2D_i4 (shorter length): mpp_sum differs from fortran intrinsic sum")
+      if (all(c4 .ne. sumc4)) call mpp_error(FATAL, &
+          &  "2D_i4 (shorter length): mpp_sum differs from fortran intrinsic sum")
     endif
 
   end subroutine test_mpp_sum_2D_i4
@@ -263,7 +266,8 @@ contains
       sumc8(2,2) = 1
       if (all(a8 .ne. suma8)) call mpp_error(FATAL, "2D_i8: mpp_sum differs from fortran intrinsic sum")
       if (all(b8 .ne. sumb8)) call mpp_error(FATAL, "2D_i8 with pelist: mpp_sum differs from fortran intrinsic sum")
-      if (all(c8 .ne. sumc8)) call mpp_error(FATAL, "2D_i8 (shorter length): mpp_sum differs from fortran intrinsic sum")
+      if (all(c8 .ne. sumc8)) call mpp_error(FATAL, &
+          &  "2D_i8 (shorter length): mpp_sum differs from fortran intrinsic sum")
     endif
 
   end subroutine test_mpp_sum_2D_i8
@@ -300,7 +304,8 @@ contains
       sumc4(2,2,2) = 1
       if (all(a4 .ne. suma4)) call mpp_error(FATAL, "3D_r4: mpp_sum differs from fortran intrinsic sum")
       if (all(b4 .ne. sumb4)) call mpp_error(FATAL, "3D_r4 with pelist: mpp_sum differs from fortran intrinsic sum")
-      if (all(c4 .ne. sumc4)) call mpp_error(FATAL, "3D_r4 (shorter length): mpp_sum differs from fortran intrinsic sum")
+      if (all(c4 .ne. sumc4)) call mpp_error(FATAL, &
+          &  "3D_r4 (shorter length): mpp_sum differs from fortran intrinsic sum")
     endif
 
   end subroutine test_mpp_sum_3D_r4
@@ -326,7 +331,8 @@ contains
       sumc8(2,2,2) = 1
       if (all(a8 .ne. suma8)) call mpp_error(FATAL, "3D_r8: mpp_sum differs from fortran intrinsic sum")
       if (all(b8 .ne. sumb8)) call mpp_error(FATAL, "3D_r8 with pelist: mpp_sum differs from fortran intrinsic sum")
-      if (all(c8 .ne. sumc8)) call mpp_error(FATAL, "3D_r8 (shorter length): mpp_sum differs from fortran intrinsic sum")
+      if (all(c8 .ne. sumc8)) call mpp_error(FATAL, &
+          &  "3D_r8 (shorter length): mpp_sum differs from fortran intrinsic sum")
     endif
 
   end subroutine test_mpp_sum_3D_r8
@@ -352,7 +358,8 @@ contains
       sumc4(2,2,2) = 1
       if (all(a4 .ne. suma4)) call mpp_error(FATAL, "3D_i4: mpp_sum differs from fortran intrinsic sum")
       if (all(b4 .ne. sumb4)) call mpp_error(FATAL, "3D_i4 with pelist: mpp_sum differs from fortran intrinsic sum")
-      if (all(c4 .ne. sumc4)) call mpp_error(FATAL, "3D_i4 (shorter length): mpp_sum differs from fortran intrinsic sum")
+      if (all(c4 .ne. sumc4)) call mpp_error(FATAL, &
+          &  "3D_i4 (shorter length): mpp_sum differs from fortran intrinsic sum")
     endif
 
   end subroutine test_mpp_sum_3D_i4
@@ -378,7 +385,8 @@ contains
       sumc8(2,2,2) = 1
       if (all(a8 .ne. suma8)) call mpp_error(FATAL, "3D_i8: mpp_sum differs from fortran intrinsic sum")
       if (all(b8 .ne. sumb8)) call mpp_error(FATAL, "3D_i8 with pelist: mpp_sum differs from fortran intrinsic sum")
-      if (all(c8 .ne. sumc8)) call mpp_error(FATAL, "3D_i8 (shorter length): mpp_sum differs from fortran intrinsic sum")
+      if (all(c8 .ne. sumc8)) call mpp_error(FATAL, &
+          &  "3D_i8 (shorter length): mpp_sum differs from fortran intrinsic sum")
     endif
 
   end subroutine test_mpp_sum_3D_i8
@@ -415,7 +423,8 @@ contains
       sumc4(2,2,2,2) = 1
       if (all(a4 .ne. suma4)) call mpp_error(FATAL, "4D_r4: mpp_sum differs from fortran intrinsic sum")
       if (all(b4 .ne. sumb4)) call mpp_error(FATAL, "4D_r4 with pelist: mpp_sum differs from fortran intrinsic sum")
-      if (all(c4 .ne. sumc4)) call mpp_error(FATAL, "4D_r4 (shorter length): mpp_sum differs from fortran intrinsic sum")
+      if (all(c4 .ne. sumc4)) call mpp_error(FATAL, &
+          &  "4D_r4 (shorter length): mpp_sum differs from fortran intrinsic sum")
     endif
 
   end subroutine test_mpp_sum_4D_r4
@@ -441,7 +450,8 @@ contains
       sumc8(2,2,2,2) = 1
       if (all(a8 .ne. suma8)) call mpp_error(FATAL, "4D_r8: mpp_sum differs from fortran intrinsic sum")
       if (all(b8 .ne. sumb8)) call mpp_error(FATAL, "4D_r8 with pelist: mpp_sum differs from fortran intrinsic sum")
-      if (all(c8 .ne. sumc8)) call mpp_error(FATAL, "4D_r8 (shorter length): mpp_sum differs from fortran intrinsic sum")
+      if (all(c8 .ne. sumc8)) call mpp_error(FATAL, &
+          &  "4D_r8 (shorter length): mpp_sum differs from fortran intrinsic sum")
     endif
 
   end subroutine test_mpp_sum_4D_r8
@@ -467,7 +477,8 @@ contains
       sumc4(2,2,2,2) = 1
       if (all(a4 .ne. suma4)) call mpp_error(FATAL, "4D_i4: mpp_sum differs from fortran intrinsic sum")
       if (all(b4 .ne. sumb4)) call mpp_error(FATAL, "4D_i4 with pelist: mpp_sum differs from fortran intrinsic sum")
-      if (all(c4 .ne. sumc4)) call mpp_error(FATAL, "4D_i4 (shorter length): mpp_sum differs from fortran intrinsic sum")
+      if (all(c4 .ne. sumc4)) call mpp_error(FATAL, &
+          &  "4D_i4 (shorter length): mpp_sum differs from fortran intrinsic sum")
     endif
 
   end subroutine test_mpp_sum_4D_i4
@@ -493,7 +504,8 @@ contains
       sumc8(2,2,2,2) = 1
       if (all(a8 .ne. suma8)) call mpp_error(FATAL, "4D_i8: mpp_sum differs from fortran intrinsic sum")
       if (all(b8 .ne. sumb8)) call mpp_error(FATAL, "4D_i8 with pelist: mpp_sum differs from fortran intrinsic sum")
-      if (all(c8 .ne. sumc8)) call mpp_error(FATAL, "4D_i8 (shorter length): mpp_sum differs from fortran intrinsic sum")
+      if (all(c8 .ne. sumc8)) call mpp_error(FATAL, &
+          &  "4D_i8 (shorter length): mpp_sum differs from fortran intrinsic sum")
     endif
 
   end subroutine test_mpp_sum_4D_i8
@@ -530,7 +542,8 @@ contains
       sumc4(2,2,2,2,2) = 1
       if (all(a4 .ne. suma4)) call mpp_error(FATAL, "5D_r4: mpp_sum differs from fortran intrinsic sum")
       if (all(b4 .ne. sumb4)) call mpp_error(FATAL, "5D_r4 with pelist: mpp_sum differs from fortran intrinsic sum")
-      if (all(c4 .ne. sumc4)) call mpp_error(FATAL, "5D_r4 (shorter length): mpp_sum differs from fortran intrinsic sum")
+      if (all(c4 .ne. sumc4)) call mpp_error(FATAL, &
+          &  "5D_r4 (shorter length): mpp_sum differs from fortran intrinsic sum")
     endif
 
   end subroutine test_mpp_sum_5D_r4
@@ -556,7 +569,8 @@ contains
       sumc8(2,2,2,2,2) = 1
       if (all(a8 .ne. suma8)) call mpp_error(FATAL, "5D_r8: mpp_sum differs from fortran intrinsic sum")
       if (all(b8 .ne. sumb8)) call mpp_error(FATAL, "5D_r8 with pelist: mpp_sum differs from fortran intrinsic sum")
-      if (all(c8 .ne. sumc8)) call mpp_error(FATAL, "5D_r8 (shorter length): mpp_sum differs from fortran intrinsic sum")
+      if (all(c8 .ne. sumc8)) call mpp_error(FATAL, &
+          &  "5D_r8 (shorter length): mpp_sum differs from fortran intrinsic sum")
     endif
 
   end subroutine test_mpp_sum_5D_r8
@@ -582,7 +596,8 @@ contains
       sumc4(2,2,2,2,2) = 1
       if (all(a4 .ne. suma4)) call mpp_error(FATAL, "5D_i4: mpp_sum differs from fortran intrinsic sum")
       if (all(b4 .ne. sumb4)) call mpp_error(FATAL, "5D_i4 with pelist: mpp_sum differs from fortran intrinsic sum")
-      if (all(c4 .ne. sumc4)) call mpp_error(FATAL, "5D_i4 (shorter length): mpp_sum differs from fortran intrinsic sum")
+      if (all(c4 .ne. sumc4)) call mpp_error(FATAL, &
+          &  "5D_i4 (shorter length): mpp_sum differs from fortran intrinsic sum")
     endif
 
   end subroutine test_mpp_sum_5D_i4
@@ -608,7 +623,8 @@ contains
       sumc8(2,2,2,2,2) = 1
       if (all(a8 .ne. suma8)) call mpp_error(FATAL, "5D_i8: mpp_sum differs from fortran intrinsic sum")
       if (all(b8 .ne. sumb8)) call mpp_error(FATAL, "5D_i8 with pelist: mpp_sum differs from fortran intrinsic sum")
-      if (all(c8 .ne. sumc8)) call mpp_error(FATAL, "5D_i8 (shorter length): mpp_sum differs from fortran intrinsic sum")
+      if (all(c8 .ne. sumc8)) call mpp_error(FATAL, &
+          &  "5D_i8 (shorter length): mpp_sum differs from fortran intrinsic sum")
     endif
 
   end subroutine test_mpp_sum_5D_i8

--- a/test_fms/mpp/test_mpp_update_domains_real.F90
+++ b/test_fms/mpp/test_mpp_update_domains_real.F90
@@ -212,7 +212,8 @@ module test_mpp_update_domains_real
     call compare_checksums( x4r8(is:ied,js:jed,:), globalr8(is:ied,js:jed,:), domain_type//' partial x4r8' )
 
     !--- test vector update for FOLDED and MASKED case.
-    if(domain_type == 'Simple' .or. domain_type == 'Simple symmetry' .or. domain_type == 'Cyclic' .or. domain_type == 'Cyclic symmetry') then
+    if(domain_type == 'Simple' .or. domain_type == 'Simple symmetry' .or. domain_type == 'Cyclic' .or. &
+     & domain_type == 'Cyclic symmetry') then
       deallocate(xr8,x1r8,x2r8,x3r8,x4r8)
       return
     end if
@@ -605,7 +606,8 @@ module test_mpp_update_domains_real
    call compare_checksums( x4r4(is:ied,js:jed,:), globalr4(is:ied,js:jed,:), domain_type//' partial x4r4' )
 
    !--- test vector update for FOLDED and MASKED case.
-   if(domain_type == 'Simple' .or. domain_type == 'Simple symmetry' .or. domain_type == 'Cyclic' .or. domain_type == 'Cyclic symmetry') then
+   if(domain_type == 'Simple' .or. domain_type == 'Simple symmetry' .or. domain_type == 'Cyclic' .or. &
+    & domain_type == 'Cyclic symmetry') then
       deallocate(xr4,x1r4,x2r4,x3r4,x4r4)
       return
    end if

--- a/test_fms/mpp/test_redistribute_int.F90
+++ b/test_fms/mpp/test_redistribute_int.F90
@@ -397,7 +397,8 @@ contains
         pe_end(n)   = my_root_pe + n*npes_per_tile-1
      end do
 
-     call define_cubic_mosaic("cubic_grid",domain_ensemble(ensemble_id),(/nx_cubic,nx_cubic,nx_cubic,nx_cubic,nx_cubic,nx_cubic/)&
+     call define_cubic_mosaic("cubic_grid",domain_ensemble(ensemble_id), &
+                              (/nx_cubic,nx_cubic,nx_cubic,nx_cubic,nx_cubic,nx_cubic/)&
                              ,(/ny_cubic,ny_cubic,ny_cubic,ny_cubic,ny_cubic,ny_cubic/), &
                                 global_indices, layout2D, pe_start, pe_end )
 
@@ -469,7 +470,7 @@ contains
            enddo
         endif
         write(mesg,'(a,i4)') "cubic_grid redistribute to ensemble", n
-        if(.not.compare_result4( x_ens(isc_ens:iec_ens,jsc_ens:jec_ens,:), y(isc_ens:iec_ens,jsc_ens:jec_ens,:))) call &
+        if(.not.compare_result4( x_ens(isc_ens:iec_ens,jsc_ens:jec_ens,:), y(isc_ens:iec_ens,jsc_ens:jec_ens,:)))call &
            mpp_error(FATAL, "test_mpp_redistribute: failed cubic grid 32-bit check")
      enddo
 
@@ -570,7 +571,8 @@ contains
         pe_end(n)   = my_root_pe + n*npes_per_tile-1
      end do
 
-     call define_cubic_mosaic("cubic_grid",domain_ensemble(ensemble_id),(/nx_cubic,nx_cubic,nx_cubic,nx_cubic,nx_cubic,nx_cubic/)&
+     call define_cubic_mosaic("cubic_grid",domain_ensemble(ensemble_id), &
+                              (/nx_cubic,nx_cubic,nx_cubic,nx_cubic,nx_cubic,nx_cubic/)&
                              ,(/ny_cubic,ny_cubic,ny_cubic,ny_cubic,ny_cubic,ny_cubic/), &
                                 global_indices, layout2D, pe_start, pe_end )
 
@@ -642,7 +644,7 @@ contains
            enddo
         endif
         write(mesg,'(a,i4)') "cubic_grid redistribute to ensemble", n
-        if(.not.compare_result8( x_ens(isc_ens:iec_ens,jsc_ens:jec_ens,:), y(isc_ens:iec_ens,jsc_ens:jec_ens,:))) call &
+        if(.not.compare_result8( x_ens(isc_ens:iec_ens,jsc_ens:jec_ens,:), y(isc_ens:iec_ens,jsc_ens:jec_ens,:)))call &
            mpp_error(FATAL, "test_mpp_redistribute: failed cubic grid 32-bit check")
      enddo
 

--- a/test_fms/mpp/test_update_domains_performance.F90
+++ b/test_fms/mpp/test_update_domains_performance.F90
@@ -154,8 +154,8 @@ program test_update_domains_performance
           return
         endif
         if( nx_cubic .NE. ny_cubic ) then
-          call mpp_error(NOTE,'update_domains_performance_r8: for Cubic_grid mosaic, nx_cubic does not equal ny_cubic, '//&
-                        'No test is done for Cubic-Grid mosaic. ' )
+          call mpp_error(NOTE,'update_domains_performance_r8:'// &
+                   ' for Cubic_grid mosaic, nx_cubic does not equal ny_cubic, No test is done for Cubic-Grid mosaic. ')
           return
         endif
 
@@ -760,8 +760,8 @@ program test_update_domains_performance
           return
         endif
         if( nx_cubic .NE. ny_cubic ) then
-          call mpp_error(NOTE,'update_domains_performance_r4: for Cubic_grid mosaic, nx_cubic does not equal ny_cubic, '//&
-                         'No test is done for Cubic-Grid mosaic. ' )
+          call mpp_error(NOTE,'update_domains_performance_r4:'//&
+                  ' for Cubic_grid mosaic, nx_cubic does not equal ny_cubic, No test is done for Cubic-Grid mosaic. ' )
           return
         endif
 
@@ -942,7 +942,8 @@ program test_update_domains_performance
 
         call mpp_clock_begin(id2)
         do l = 1, num_fields
-          if(mix_2D_3D) call mpp_complete_update_domains(id_update, a1_2D(:,:,l), domain, complete=.false., tile_count=1)
+          if(mix_2D_3D) call mpp_complete_update_domains(id_update, a1_2D(:,:,l), domain, complete=.false., &
+            &  tile_count=1)
           call mpp_complete_update_domains(id_update, a1(:,:,:,l), domain, complete=l==num_fields, tile_count=1)
         enddo
         call mpp_clock_end  (id2)
@@ -1359,8 +1360,8 @@ program test_update_domains_performance
           return
         endif
         if( nx_cubic .NE. ny_cubic ) then
-          call mpp_error(NOTE,'update_domains_performance_r8: for Cubic_grid mosaic, nx_cubic does not equal ny_cubic, '//&
-                        'No test is done for Cubic-Grid mosaic. ' )
+          call mpp_error(NOTE,'update_domains_performance_r8:'//&
+                  ' for Cubic_grid mosaic, nx_cubic does not equal ny_cubic, No test is done for Cubic-Grid mosaic. ' )
           return
         endif
 
@@ -1620,8 +1621,8 @@ program test_update_domains_performance
           return
         endif
         if( nx_cubic .NE. ny_cubic ) then
-          call mpp_error(NOTE,'update_domains_performance_r8: for Cubic_grid mosaic, nx_cubic does not equal ny_cubic, '//&
-                        'No test is done for Cubic-Grid mosaic. ' )
+          call mpp_error(NOTE,'update_domains_performance_r8:'//&
+                 ' for Cubic_grid mosaic, nx_cubic does not equal ny_cubic, No test is done for Cubic-Grid mosaic. ' )
           return
         endif
 

--- a/test_fms/mpp_io/test_io_mosaic_R4_R8.F90
+++ b/test_fms/mpp_io/test_io_mosaic_R4_R8.F90
@@ -213,13 +213,16 @@ program test_io_mosaic_R4_R8
      call mpp_open( unit, output_file, action=MPP_OVERWR, form=MPP_NETCDF, threading=MPP_MULTI, fileset=MPP_MULTI )
   case("Mult_tile_R4")
      write(output_file, '(a,I4.4)') type//'.tile', my_tile
-     call mpp_open( unit, output_file, action=MPP_OVERWR, form=MPP_NETCDF, threading=MPP_SINGLE, is_root_pe=is_root_pe )
+     call mpp_open( unit, output_file, action=MPP_OVERWR, form=MPP_NETCDF, threading=MPP_SINGLE, &
+                  &  is_root_pe=is_root_pe )
   case("Single_tile_with_group_R4")
      call mpp_define_io_domain(domain, io_layout)
-     call mpp_open( unit, output_file, action=MPP_OVERWR, form=MPP_NETCDF, threading=MPP_MULTI, fileset=MPP_MULTI, domain=domain)
+     call mpp_open( unit, output_file, action=MPP_OVERWR, form=MPP_NETCDF, threading=MPP_MULTI, &
+                  &  fileset=MPP_MULTI, domain=domain)
   case("Mult_tile_with_group_R4")
      write(output_file, '(a,I4.4)') type//'.tile', my_tile
-     call mpp_open( unit, output_file, action=MPP_OVERWR, form=MPP_NETCDF, threading=MPP_MULTI, fileset=MPP_MULTI, domain=domain)
+     call mpp_open( unit, output_file, action=MPP_OVERWR, form=MPP_NETCDF, threading=MPP_MULTI, &
+                  &  fileset=MPP_MULTI, domain=domain)
 
   case default
      call mpp_error(FATAL, "program test_io_mosaic_R4_R8: invaid value of type="//type)
@@ -250,7 +253,8 @@ program test_io_mosaic_R4_R8
      call mpp_open( unit, output_file, action=MPP_RDONLY, form=MPP_NETCDF, threading=MPP_MULTI, &
          fileset=MPP_SINGLE, is_root_pe=is_root_pe )
   case("Single_tile_with_group_R4", "Mult_tile_with_group_R4")
-     call mpp_open( unit, output_file, action=MPP_RDONLY, form=MPP_NETCDF, threading=MPP_MULTI, fileset=MPP_MULTI, domain=domain)
+     call mpp_open( unit, output_file, action=MPP_RDONLY, form=MPP_NETCDF, threading=MPP_MULTI, &
+                  &  fileset=MPP_MULTI, domain=domain)
   case default
      call mpp_error(FATAL, "program test_io_mosaic_R4_R8: invaid value of type="//type)
   end select
@@ -351,13 +355,16 @@ program test_io_mosaic_R4_R8
      call mpp_open( unit, output_file, action=MPP_OVERWR, form=MPP_NETCDF, threading=MPP_MULTI, fileset=MPP_MULTI )
   case("Mult_tile_R8")
      write(output_file, '(a,I4.4)') type//'.tile', my_tile
-     call mpp_open( unit, output_file, action=MPP_OVERWR, form=MPP_NETCDF, threading=MPP_SINGLE, is_root_pe=is_root_pe )
+     call mpp_open( unit, output_file, action=MPP_OVERWR, form=MPP_NETCDF, threading=MPP_SINGLE, &
+                  &  is_root_pe=is_root_pe )
   case("Single_tile_with_group_R8")
      call mpp_define_io_domain(domain, io_layout)
-     call mpp_open( unit, output_file, action=MPP_OVERWR, form=MPP_NETCDF, threading=MPP_MULTI, fileset=MPP_MULTI, domain=domain)
+     call mpp_open( unit, output_file, action=MPP_OVERWR, form=MPP_NETCDF, threading=MPP_MULTI, &
+                  &  fileset=MPP_MULTI, domain=domain)
   case("Mult_tile_with_group_R8")
      write(output_file, '(a,I4.4)') type//'.tile', my_tile
-     call mpp_open( unit, output_file, action=MPP_OVERWR, form=MPP_NETCDF, threading=MPP_MULTI, fileset=MPP_MULTI, domain=domain)
+     call mpp_open( unit, output_file, action=MPP_OVERWR, form=MPP_NETCDF, threading=MPP_MULTI, &
+                  &  fileset=MPP_MULTI, domain=domain)
 
   case default
      call mpp_error(FATAL, "program test_io_mosaic_R4_R8: invaid value of type="//type)
@@ -388,7 +395,8 @@ program test_io_mosaic_R4_R8
      call mpp_open( unit, output_file, action=MPP_RDONLY, form=MPP_NETCDF, threading=MPP_MULTI, &
          fileset=MPP_SINGLE, is_root_pe=is_root_pe )
   case("Single_tile_with_group_R8", "Mult_tile_with_group_R8")
-     call mpp_open( unit, output_file, action=MPP_RDONLY, form=MPP_NETCDF, threading=MPP_MULTI, fileset=MPP_MULTI, domain=domain)
+     call mpp_open( unit, output_file, action=MPP_RDONLY, form=MPP_NETCDF, threading=MPP_MULTI, &
+                  &  fileset=MPP_MULTI, domain=domain)
   case default
      call mpp_error(FATAL, "program test_io_mosaic_R4_R8: invaid value of type="//type)
   end select

--- a/test_fms/mpp_io/test_mpp_io.F90
+++ b/test_fms/mpp_io/test_mpp_io.F90
@@ -508,14 +508,17 @@ program test
      call mpp_open( unit, output_file, action=MPP_OVERWR, form=MPP_NETCDF, threading=MPP_MULTI, fileset=MPP_MULTI )
   case("Mult_tile")
      write(output_file, '(a,I4.4)') type//'.tile', my_tile
-     call mpp_open( unit, output_file, action=MPP_OVERWR, form=MPP_NETCDF, threading=MPP_SINGLE, is_root_pe=is_root_pe )
+     call mpp_open( unit, output_file, action=MPP_OVERWR, form=MPP_NETCDF, threading=MPP_SINGLE, &
+                  &  is_root_pe=is_root_pe )
   case("Single_tile_with_group")
      call mpp_define_io_domain(domain, io_layout)
-     call mpp_open( unit, output_file, action=MPP_OVERWR, form=MPP_NETCDF, threading=MPP_MULTI, fileset=MPP_MULTI, domain=domain)
+     call mpp_open( unit, output_file, action=MPP_OVERWR, form=MPP_NETCDF, threading=MPP_MULTI, &
+                  &  fileset=MPP_MULTI, domain=domain)
   case("Mult_tile_with_group")
      write(output_file, '(a,I4.4)') type//'.tile', my_tile
      call mpp_define_io_domain(domain, io_layout)
-     call mpp_open( unit, output_file, action=MPP_OVERWR, form=MPP_NETCDF, threading=MPP_MULTI, fileset=MPP_MULTI, domain=domain)
+     call mpp_open( unit, output_file, action=MPP_OVERWR, form=MPP_NETCDF, threading=MPP_MULTI, &
+                  &  fileset=MPP_MULTI, domain=domain)
 
   case default
      call mpp_error(FATAL, "program test_mpp_io: invaid value of type="//type)
@@ -548,7 +551,8 @@ program test
      call mpp_open( unit, output_file, action=MPP_RDONLY, form=MPP_NETCDF, threading=MPP_MULTI, &
          fileset=MPP_SINGLE, is_root_pe=is_root_pe )
   case("Single_tile_with_group", "Mult_tile_with_group")
-     call mpp_open( unit, output_file, action=MPP_RDONLY, form=MPP_NETCDF, threading=MPP_MULTI, fileset=MPP_MULTI, domain=domain)
+     call mpp_open( unit, output_file, action=MPP_RDONLY, form=MPP_NETCDF, threading=MPP_MULTI, &
+                  &  fileset=MPP_MULTI, domain=domain)
   case default
      call mpp_error(FATAL, "program test_mpp_io: invaid value of type="//type)
   end select

--- a/test_fms/parser/check_crashes.F90
+++ b/test_fms/parser/check_crashes.F90
@@ -49,10 +49,10 @@ logical :: get_num_blocks_bad_block_id     = .false.  !< try to send a bad block
 logical :: get_value_from_key_bad_block_id = .false.  !< try to send a bad block_id to get_value_from_key
 
 namelist / check_crashes_nml / missing_file, bad_conversion, missing_key, get_block_ids_bad_id, &
-                               get_key_name_bad_id, get_key_value_bad_id, get_num_blocks_bad_id, get_value_from_key_bad_id, &
-                               get_nkeys_bad_id, get_key_ids_bad_id, &
-                               get_key_name_bad_key_id, get_key_value_bad_key_id, &
-                               get_key_ids_bad_block_id, get_nkeys_bad_block_id, get_block_ids_bad_block_id, get_num_blocks_bad_block_id, &
+                               get_key_name_bad_id, get_key_value_bad_id, get_num_blocks_bad_id, &
+                               get_value_from_key_bad_id, get_nkeys_bad_id, get_key_ids_bad_id, &
+                               get_key_name_bad_key_id, get_key_value_bad_key_id, get_key_ids_bad_block_id, &
+                               get_nkeys_bad_block_id, get_block_ids_bad_block_id,  get_num_blocks_bad_block_id, &
                                get_value_from_key_bad_block_id, &
                                wrong_buffer_size_key_id, wrong_buffer_size_block_id
 

--- a/test_fms/parser/check_crashes.F90
+++ b/test_fms/parser/check_crashes.F90
@@ -135,7 +135,7 @@ subroutine check_get_value_from_key_bad_block_id
 
 end subroutine check_get_value_from_key_bad_block_id
 
-!> @brief This is to check if the parser crashes correctly if user tries to open a missing file. 
+!> @brief This is to check if the parser crashes correctly if user tries to open a missing file.
 subroutine check_read_and_parse_file_missing
    integer :: yaml_file_id !< file_id for a yaml file
 

--- a/test_fms/parser/test_yaml_parser.F90
+++ b/test_fms/parser/test_yaml_parser.F90
@@ -72,7 +72,8 @@ zero = get_num_blocks(yaml_file_id2, "diag_files")
 if (zero .ne. 0) call mpp_error(FATAL, "'diag_files' should not exist in this file")
 
 !< Try the parent block_id optional argument
-nvariables = get_num_blocks(yaml_file_id1, "varlist", parent_block_id=3) !< Number of variables that belong to the atmos_daily file in the diag_table.yaml
+nvariables = get_num_blocks(yaml_file_id1, "varlist", parent_block_id=3) !< Number of variables that belong to the
+                                                                         !! atmos_daily file in the diag_table.yaml
 if (nvariables .ne. 2) call mpp_error(FATAL, "There should only be 2 variables in the atmos_daily file")
 
 !< -----------------------------------
@@ -133,7 +134,8 @@ if (nkeys .ne. 5) call mpp_error(FATAL, "The number of keys was not read correct
 !< Test get_key_ids
 allocate(key_ids(nkeys))
 call get_key_ids(yaml_file_id1, variable_ids(1), key_ids)
-if (key_ids(1) .ne. 10 .or. key_ids(2) .ne. 11 .or. key_ids(3) .ne. 12 .or. key_ids(4) .ne. 13 .or. key_ids(5) .ne. 14) call mpp_error(FATAL, "The key ids obtained are wrong")
+if (key_ids(1) .ne. 10 .or. key_ids(2) .ne. 11 .or. key_ids(3) .ne. 12 .or. key_ids(4) .ne. 13 .or. key_ids(5) .ne.14)&
+  & call mpp_error(FATAL, "The key ids obtained are wrong")
 
 !< -----------------------------------
 

--- a/test_fms/parser/test_yaml_parser.F90
+++ b/test_fms/parser/test_yaml_parser.F90
@@ -116,7 +116,9 @@ if (r4_buffer .ne. real(-999.9, kind=r4_kind)) call mpp_error(FATAL, "fill_value
 
 !! Try get_value_from_key using a r8 buffer
 call get_value_from_key(yaml_file_id1, variable_ids(1), "fill_value", r8_buffer)
-if (abs(r8_buffer - real(-999.9, kind=r8_kind)) .gt. 5e-5) call mpp_error(FATAL, "fill_value was not read correctly as an r8!")
+if (abs(r8_buffer - real(-999.9, kind=r8_kind)) .gt. 5e-5) then
+  call mpp_error(FATAL, "fill_value was not read correctly as an r8!")
+endif
 
 !! Try the is_optional argument on an key that does not exist
 string_buffer = ""

--- a/test_fms/time_interp/test_time_interp.F90
+++ b/test_fms/time_interp/test_time_interp.F90
@@ -166,7 +166,8 @@ program test_time_interp
  write(outunit,'()')
 
  do ntest=1,num_Time
-   call time_interp(Time(ntest), Time_beg, Time_end, Timelist, weight, index1, index2, correct_leap_year_inconsistency=.true.)
+   call time_interp(Time(ntest), Time_beg, Time_end, Timelist, weight, index1, index2, &
+                   &  correct_leap_year_inconsistency=.true.)
    call print_date(Time(ntest),' Time =')
    write(outunit,99) index1,index2,weight
    write(outunit,'()')
@@ -204,7 +205,8 @@ program test_time_interp
  write(outunit,'()')
 
  do ntest=1,num_Time
-   call time_interp(Time(ntest), Time_beg, Time_end, Timelist, weight, index1, index2, correct_leap_year_inconsistency=.true.)
+   call time_interp(Time(ntest), Time_beg, Time_end, Timelist, weight, index1, index2, &
+                   &  correct_leap_year_inconsistency=.true.)
    call print_date(Time(ntest),' Time=')
    write(outunit,99) index1,index2,weight
    write(outunit,'()')
@@ -232,7 +234,8 @@ program test_time_interp
    call print_date(Time(1),' Time=')
    call time_interp(Time(1), Timelist, weight, index1, index2, modtime=YEAR)
    write(outunit,89) 'time_interp_list with modtime=YEAR:   ', index1,index2,weight
-   call time_interp(Time(1), Time_beg, Time_end, Timelist, weight, index1, index2, correct_leap_year_inconsistency=.true.)
+   call time_interp(Time(1), Time_beg, Time_end, Timelist, weight, index1, index2, &
+                   &  correct_leap_year_inconsistency=.true.)
    write(outunit,89) 'time_interp_modulo: ', index1,index2,weight
    write(outunit,'()')
  enddo

--- a/test_fms/time_interp/test_time_interp_external.F90
+++ b/test_fms/time_interp/test_time_interp_external.F90
@@ -25,13 +25,16 @@ use fms_mod,                   only : check_nml_error
 use mpp_mod,                   only : mpp_init, mpp_exit, mpp_npes, stdout, stdlog, FATAL, mpp_error
 use mpp_mod,                   only : input_nml_file, mpp_pe, mpp_root_pe, mpp_sync
 use mpp_domains_mod,           only : mpp_domains_init, domain2d, mpp_define_layout, mpp_define_domains
-use mpp_domains_mod,           only : mpp_global_sum, mpp_global_max, mpp_global_min, BITWISE_EXACT_SUM, mpp_get_compute_domain
+use mpp_domains_mod, only : mpp_global_sum, mpp_global_max, mpp_global_min, BITWISE_EXACT_SUM, mpp_get_compute_domain
 use mpp_domains_mod,           only : mpp_domains_set_stack_size
 use time_interp_external2_mod, only : time_interp_external, time_interp_external_init, get_external_fileobj
-use time_interp_external2_mod, only : time_interp_external_exit, time_interp_external, init_external_field, get_external_field_size
-use time_manager_mod,          only : get_date, set_date, time_manager_init, set_calendar_type, JULIAN, time_type, increment_time
+use time_interp_external2_mod, only : time_interp_external_exit, time_interp_external, init_external_field, &
+                                   &  get_external_field_size
+use time_manager_mod,          only : get_date, set_date, time_manager_init, set_calendar_type, JULIAN, &
+                                   &  time_type, increment_time
 use time_manager_mod,          only : NOLEAP
-use horiz_interp_mod,          only : horiz_interp, horiz_interp_init, horiz_interp_new, horiz_interp_del, horiz_interp_type
+use horiz_interp_mod,          only : horiz_interp, horiz_interp_init, horiz_interp_new, horiz_interp_del, &
+                                    & horiz_interp_type
 use axis_utils2_mod,           only : axis_edges
 use fms2_io_mod,               only : FmsNetcdfFile_t, fms2_io_init, open_file, close_file, write_data, register_axis
 use fms2_io_mod,               only : register_field, unlimited, register_variable_attribute
@@ -206,7 +209,8 @@ enddo
 id = init_external_field(filename,trim(fieldname)//"_random",domain=domain,axis_names=axis_names,&
       verbose=.false., override=.true.)
 
-if (.not. get_external_fileobj(filename, fileobj)) call mpp_error(FATAL, "Couldn't find the fileobj for: "//trim(filename))
+if (.not. get_external_fileobj(filename, fileobj)) call mpp_error(FATAL, "Couldn't find the fileobj for: "// &
+    & trim(filename))
 
 allocate (lon_local_out(isc:iec,jsc:jec))
 allocate (lat_local_out(isc:iec,jsc:jec))

--- a/test_fms/time_manager/test_time_manager.F90
+++ b/test_fms/time_manager/test_time_manager.F90
@@ -53,8 +53,10 @@ program test_time_manager
  integer, dimension(days_in_400_year_period) :: coded_date
  integer, dimension(400,12,31) :: date_to_day
 
- logical :: test1 =.true.,test2 =.true.,test3 =.true.,test4 =.true.,test5 =.true.,test6 =.true.,test7 =.true.,test8 =.true.
- logical :: test9 =.true.,test10=.true.,test11=.true.,test12=.true.,test13=.true.,test14=.true.,test15=.true.,test16=.true.
+ logical :: test1 =.true.,test2 =.true.,test3 =.true.,test4 =.true.,test5 =.true.,test6 =.true.,test7 =.true., &
+         & test8 =.true.
+ logical :: test9 =.true.,test10=.true.,test11=.true.,test12=.true.,test13=.true.,test14=.true.,test15=.true., &
+         & test16=.true.
  logical :: test17=.true.,test18=.true.,test19=.true.,test20=.true.
 
  namelist / test_nml / test1 ,test2 ,test3 ,test4 ,test5 ,test6 ,test7 ,test8,  &
@@ -119,11 +121,13 @@ program test_time_manager
   if(test3) then
     write(outunit,'(/,a)') '#################################  test3  #################################'
  !  Test of function time_plus
-    call print_time(set_time(seconds=0, days=2, ticks=5) + set_time(seconds=0, days=2, ticks=6), 'test3.1:', unit=outunit)
+    call print_time(set_time(seconds=0, days=2, ticks=5) + set_time(seconds=0, days=2, ticks=6), 'test3.1:', &
+                   &  unit=outunit)
 
  !  Test of function time_minus
  !  The minus operator for time ensures a positive result. In effect is does this: abs(time1-time2)
-    call print_time(set_time(seconds=0, days=2, ticks=5) - set_time(seconds=0, days=2, ticks=6), 'test3.2:', unit=outunit)
+    call print_time(set_time(seconds=0, days=2, ticks=5) - set_time(seconds=0, days=2, ticks=6), 'test3.2:', &
+                   &  unit=outunit)
 
  !  Test of function time_scalar_mult.  Note that 25000*86399 is greater than huge = 2**31 - 1
     call print_time(2*set_time(seconds=0, days=2, ticks=6), 'test3.3:', unit=outunit)
@@ -409,8 +413,10 @@ program test_time_manager
     write(outunit,'(/,a)') '#################################  test11  #################################'
     call print_time(increment_time(set_time(seconds=0, days=2), seconds=0, days=1),'test11.1:', unit=outunit)
     call print_time(decrement_time(set_time(seconds=0, days=2), seconds=0, days=1),'test11.2:', unit=outunit)
-    call print_time(increment_time(set_time(seconds=0, days=2, ticks=5), seconds=400, days=1, ticks=14),'test11.3:', unit=outunit)
-    call print_time(decrement_time(set_time(seconds=0, days=2, ticks=5), seconds=400, days=1, ticks=14),'test11.4:', unit=outunit)
+    call print_time(increment_time(set_time(seconds=0, days=2, ticks=5), seconds=400, days=1, ticks=14), &
+                   & 'test11.3:', unit=outunit)
+    call print_time(decrement_time(set_time(seconds=0, days=2, ticks=5), seconds=400, days=1, ticks=14), &
+                   & 'test11.4:', unit=outunit)
   endif
  !==============================================================================================
  !  Tests of negative increments in increment_time and decrement_time
@@ -419,8 +425,10 @@ program test_time_manager
     write(outunit,'(/,a)') '#################################  test12  #################################'
     call print_time(increment_time(set_time(seconds=0, days=2), seconds=0, days=-1),'test12.1:', unit=outunit)
     call print_time(decrement_time(set_time(seconds=0, days=2), seconds=0, days=-1),'test12.2:', unit=outunit)
-    call print_time(increment_time(set_time(seconds=0, days=2, ticks=5),seconds=-400,days=-1,ticks=-14),'test12.3:',unit=outunit)
-    call print_time(decrement_time(set_time(seconds=0, days=2, ticks=5),seconds=-400,days=-1,ticks=-14),'test12.4:',unit=outunit)
+    call print_time(increment_time(set_time(seconds=0, days=2, ticks=5),seconds=-400,days=-1,ticks=-14), &
+                   & 'test12.3:',unit=outunit)
+    call print_time(decrement_time(set_time(seconds=0, days=2, ticks=5),seconds=-400,days=-1,ticks=-14), &
+                   & 'test12.4:',unit=outunit)
   endif
  !==============================================================================================
  !  Test of trap for negative time
@@ -603,7 +611,8 @@ program test_time_manager
   write(outunit,'(a,i6)') ' ticks_per_second=',get_ticks_per_second()
 
  !==============================================================================================
- !  Tests the new set/get_date_gregorian by comparing against the old set/get_date_gregorian copied over to this test program
+ !  Tests the new set/get_date_gregorian by comparing against the old set/get_date_gregorian
+ !  copied over to this test program
  !  This test loops through every day up to year 3200
 
   if(test20) then
@@ -612,7 +621,7 @@ program test_time_manager
     write(outunit,'(a)')   '  Test get/set_date_gregorian with get/set_date_gregorian_old'
     write(outunit,'(a,/)') ' ====================================================='
     call set_calendar_type(GREGORIAN)
-    call get_coded_date( coded_date, date_to_day ) ! assign coded_date and date_to_day used by get/set_date_gregorian_old
+    call get_coded_date( coded_date, date_to_day )!assign coded_date and date_to_day used by get/set_date_gregorian_old
 
     ! test the new Gregorian methods and compare with the old methods
     do year=1, 3200

--- a/time_interp/time_interp.F90
+++ b/time_interp/time_interp.F90
@@ -108,7 +108,7 @@ public :: time_interp_init, time_interp, fraction_of_year
 !     5. call time_interp( Time, Timelist, weight, index1, index2 [, modtime] )
 !   </TEMPLATE>
 !   <TEMPLATE>
-!     6. call time_interp( Time, Time_beg, Time_end, Timelist, weight, index1, index2 [,correct_leap_year_inconsistency])
+! 6. call time_interp( Time, Time_beg, Time_end, Timelist, weight, index1, index2 [,correct_leap_year_inconsistency])
 !   </TEMPLATE>
 !   <IN NAME="Time">
 !      The time at which the the weight is computed.
@@ -224,7 +224,8 @@ public :: time_interp_init, time_interp, fraction_of_year
 !!              call time_interp( Time, weight, year1, year2, month1, month2 )
 !!              call time_interp( Time, weight, year1, year2, month1, month2, day1, day2 )
 !!              call time_interp( Time, Timelist, weight, index1, index2 [, modtime] )
-!!              call time_interp( Time, Time_beg, Time_end, Timelist, weight, index1, index2 [,correct_leap_year_inconsistency])
+!!              call time_interp( Time, Time_beg, Time_end, Timelist, weight, index1, index2
+!!              [,correct_leap_year_inconsistency])
 !! @endcode
 !> @ingroup time_interp_mod
 interface time_interp

--- a/time_interp/time_interp_external.F90
+++ b/time_interp/time_interp_external.F90
@@ -576,9 +576,12 @@ module time_interp_external_mod
 
          call mpp_get_atts(time_axis,units=units,calendar=calendar_type)
          do j=1,ntime
-            field(num_fields)%time(j)       = get_cal_time(tstamp(j),trim(units),trim(calendar_type),permit_calendar_conversion)
-            field(num_fields)%start_time(j) = get_cal_time(tstart(j),trim(units),trim(calendar_type),permit_calendar_conversion)
-            field(num_fields)%end_time(j)   = get_cal_time(  tend(j),trim(units),trim(calendar_type),permit_calendar_conversion)
+            field(num_fields)%time(j)       = get_cal_time(tstamp(j),trim(units),trim(calendar_type), &
+                 & permit_calendar_conversion)
+            field(num_fields)%start_time(j) = get_cal_time(tstart(j),trim(units),trim(calendar_type), &
+                 & permit_calendar_conversion)
+            field(num_fields)%end_time(j)   = get_cal_time(  tend(j),trim(units),trim(calendar_type), &
+                 & permit_calendar_conversion)
          enddo
 
          if (field(num_fields)%modulo_time) then
@@ -748,7 +751,8 @@ module time_interp_external_mod
 !</IN>
 
     !> @brief 3D time interpolation for @ref time_interp_external
-    subroutine time_interp_external_3d(index, time, data, interp,verbose,horz_interp, mask_out, is_in, ie_in, js_in, je_in, window_id)
+    subroutine time_interp_external_3d(index, time, data, interp,verbose,horz_interp, mask_out, is_in, ie_in, &
+                                      &  js_in, je_in, window_id)
 
       integer,                    intent(in)           :: index
       type(time_type),            intent(in)           :: time
@@ -786,7 +790,8 @@ module time_interp_external_mod
       if (debug_this_module) verb = .true.
 
       if (index < 1.or.index > num_fields) &
-           call mpp_error(FATAL,'invalid index in call to time_interp_ext -- field was not initialized or failed to initialize')
+           call mpp_error(FATAL, &
+                     & 'invalid index in call to time_interp_ext -- field was not initialized or failed to initialize')
 
       isc=field(index)%isc;iec=field(index)%iec
       jsc=field(index)%jsc;jec=field(index)%jec
@@ -929,7 +934,8 @@ module time_interp_external_mod
       if (debug_this_module) verb = .true.
 
       if (index < 1.or.index > num_fields) &
-           call mpp_error(FATAL,'invalid index in call to time_interp_ext -- field was not initialized or failed to initialize')
+           call mpp_error(FATAL, &
+                     & 'invalid index in call to time_interp_ext -- field was not initialized or failed to initialize')
 
       if (field(index)%siz(4) == 1) then
          ! only one record in the file => time-independent field
@@ -1055,7 +1061,8 @@ subroutine load_record(field, rec, interp, is_in, ie_in, js_in, je_in, window_id
 
   if( field%numwindows > 1) then
      if( .NOT. PRESENT(is_in) .OR. .NOT. PRESENT(ie_in) .OR. .NOT. PRESENT(js_in) .OR. .NOT. PRESENT(je_in) ) then
-        call mpp_error(FATAL, 'time_interp_external(load_record): is_in, ie_in, js_in, je_in must be present when numwindows>1')
+        call mpp_error(FATAL, &
+                  &  'time_interp_external(load_record): is_in, ie_in, js_in, je_in must be present when numwindows>1')
      endif
      isw = isw + is_in - 1
      iew = isw + ie_in - is_in

--- a/time_interp/time_interp_external2.F90
+++ b/time_interp/time_interp_external2.F90
@@ -594,9 +594,12 @@ module time_interp_external2_mod
       allocate(field(num_fields)%end_time(ntime))
 
       do j=1,ntime
-         field(num_fields)%time(j)       = get_cal_time(tstamp(j),trim(timeunits),trim(calendar_type),permit_calendar_conversion)
-         field(num_fields)%start_time(j) = get_cal_time(tstart(j),trim(timeunits),trim(calendar_type),permit_calendar_conversion)
-         field(num_fields)%end_time(j)   = get_cal_time(  tend(j),trim(timeunits),trim(calendar_type),permit_calendar_conversion)
+         field(num_fields)%time(j)       = get_cal_time(tstamp(j),trim(timeunits),trim(calendar_type), &
+              & permit_calendar_conversion)
+         field(num_fields)%start_time(j) = get_cal_time(tstart(j),trim(timeunits),trim(calendar_type), &
+              & permit_calendar_conversion)
+         field(num_fields)%end_time(j)   = get_cal_time(  tend(j),trim(timeunits),trim(calendar_type), &
+              & permit_calendar_conversion)
       enddo
 
       if (field(num_fields)%modulo_time) then
@@ -773,7 +776,8 @@ module time_interp_external2_mod
 !</IN>
 
     !> 3D interpolation for @ref time_interp_external
-    subroutine time_interp_external_3d(index, time, data, interp,verbose,horz_interp, mask_out, is_in, ie_in, js_in, je_in, window_id)
+    subroutine time_interp_external_3d(index, time, data, interp,verbose,horz_interp, mask_out, is_in, ie_in, &
+                                      &  js_in, je_in, window_id)
 
       integer,                    intent(in)           :: index
       type(time_type),            intent(in)           :: time
@@ -811,7 +815,8 @@ module time_interp_external2_mod
       if (debug_this_module) verb = .true.
 
       if (index < 1.or.index > num_fields) &
-           call mpp_error(FATAL,'invalid index in call to time_interp_ext -- field was not initialized or failed to initialize')
+           call mpp_error(FATAL, &
+                     & 'invalid index in call to time_interp_ext -- field was not initialized or failed to initialize')
 
       isc=field(index)%isc;iec=field(index)%iec
       jsc=field(index)%jsc;jec=field(index)%jec
@@ -954,7 +959,8 @@ module time_interp_external2_mod
       if (debug_this_module) verb = .true.
 
       if (index < 1.or.index > num_fields) &
-           call mpp_error(FATAL,'invalid index in call to time_interp_ext -- field was not initialized or failed to initialize')
+           call mpp_error(FATAL, &
+                     & 'invalid index in call to time_interp_ext -- field was not initialized or failed to initialize')
 
       if (field(index)%siz(4) == 1) then
          ! only one record in the file => time-independent field
@@ -1075,7 +1081,8 @@ subroutine load_record(field, rec, interp, is_in, ie_in, js_in, je_in, window_id
 
   if( field%numwindows > 1) then
      if( .NOT. PRESENT(is_in) .OR. .NOT. PRESENT(ie_in) .OR. .NOT. PRESENT(js_in) .OR. .NOT. PRESENT(je_in) ) then
-        call mpp_error(FATAL, 'time_interp_external(load_record): is_in, ie_in, js_in, je_in must be present when numwindows>1')
+        call mpp_error(FATAL, &
+                  &  'time_interp_external(load_record): is_in, ie_in, js_in, je_in must be present when numwindows>1')
      endif
      isw = isw + is_in - 1
      iew = isw + ie_in - is_in

--- a/time_manager/get_cal_time.F90
+++ b/time_manager/get_cal_time.F90
@@ -316,9 +316,9 @@ else if(lowercase(units(1:12)) == 'months since') then
   increment_days = floor(dt/86400)
   increment_seconds = int(dt - increment_days*86400)
 else
-  call error_mesg('get_cal_time','"'//trim(units)//'"'//' is not an acceptable units attribute of time.'// &
-    ' It must begin with: "years since", "months since", "days since", "hours since", "minutes since", &
-            &  or "seconds since"',FATAL)
+  call error_mesg('get_cal_time','"'//trim(units)//'" is not an acceptable units attribute of time.'// &
+            & ' It must begin with: "years since", "months since", "days since", "hours since", "minutes since",'// &
+            & ' or "seconds since"',FATAL)
 endif
 
 if (calendar_in_i /= calendar_tm_i) then

--- a/time_manager/get_cal_time.F90
+++ b/time_manager/get_cal_time.F90
@@ -214,7 +214,8 @@ if(.not.permit_conversion_local) then
                  (trim(calendar_in_c) == 'gregorian'         .and. calendar_tm_i == GREGORIAN)
   if(.not.correct_form) then
     call error_mesg('get_cal_time','calendar not consistent with calendar type in use by time_manager.'// &
-         ' calendar='//trim(calendar_in_c)//'. Type in use by time_manager='//valid_calendar_types(calendar_tm_i),FATAL)
+         ' calendar='//trim(calendar_in_c)//'. Type in use by time_manager='// &
+                          & valid_calendar_types(calendar_tm_i),FATAL)
   endif
 endif
 
@@ -317,13 +318,15 @@ else if(lowercase(units(1:12)) == 'months since') then
   increment_seconds = dt - increment_days*86400
 else
   call error_mesg('get_cal_time','"'//trim(units)//'"'//' is not an acceptable units attribute of time.'// &
-    ' It must begin with: "years since", "months since", "days since", "hours since", "minutes since", or "seconds since"',FATAL)
+    ' It must begin with: "years since", "months since", "days since", "hours since", "minutes since", &
+            &  or "seconds since"',FATAL)
 endif
 
 if (calendar_in_i /= calendar_tm_i) then
     if(calendar_in_i == NO_CALENDAR .or. calendar_tm_i == NO_CALENDAR) then
       call error_mesg('get_cal_time','Cannot do calendar conversion because input calendar is '// &
-       trim(valid_calendar_types(calendar_in_i))//' and time_manager is using '//trim(valid_calendar_types(calendar_tm_i))// &
+       trim(valid_calendar_types(calendar_in_i))//' and time_manager is using '// &
+       trim(valid_calendar_types(calendar_tm_i))// &
        ' Conversion cannot be done if either is NO_CALENDAR',FATAL)
     endif
     call get_date(base_time,year, month, day, hour, minute, second)
@@ -333,8 +336,8 @@ if (calendar_in_i /= calendar_tm_i) then
     get_cal_time = set_date(year,month,day,hour,minute,second, err_msg=err_msg)
     if(err_msg /= '') then
       call error_mesg('get_cal_time','Error in function get_cal_time: '//trim(err_msg)// &
-                      ' Note that the time_manager is using the '//trim(valid_calendar_types(calendar_tm_i))//' calendar '// &
-                      'while the calendar type passed to function get_cal_time is '//calendar_in_c,FATAL)
+               ' Note that the time_manager is using the '//trim(valid_calendar_types(calendar_tm_i))//' calendar '// &
+               'while the calendar type passed to function get_cal_time is '//calendar_in_c,FATAL)
     endif
 else
     get_cal_time = base_time + set_time(increment_seconds, increment_days)

--- a/time_manager/time_manager.F90
+++ b/time_manager/time_manager.F90
@@ -328,7 +328,8 @@ contains
  seconds_new = modulo(seconds_new,seconds_per_day)
 
  if ( seconds_new < 0 .or. ticks_new < 0) then
-   call error_mesg('function set_time_i','Bad result for time. Contact those responsible for maintaining time_manager',FATAL)
+   call error_mesg('function set_time_i','Bad result for time. Contact those responsible for maintaining time_manager'&
+                  & ,FATAL)
  endif
 
  if(days_new < 0) then
@@ -601,7 +602,8 @@ end subroutine get_time
    return
  endif
 
- increment_time_private = set_time_private(Time_in%seconds+seconds, Time_in%days+days, Time_in%ticks+ticks, Time_out, err_msg)
+ increment_time_private = set_time_private(Time_in%seconds+seconds, Time_in%days+days, Time_in%ticks+ticks, &
+                                          &  Time_out, err_msg)
 
  end function increment_time_private
 
@@ -2149,7 +2151,8 @@ end function get_ticks_per_second
  if(yearx.gt.0) then
    ncenturies = int( yearx/100 )
    nlpyrs     = int( (yearx-ncenturies*100)/4 )
-   dayx       = ncenturies*36524 + (yearx-ncenturies*100)*365 + nlpyrs ! 36524 days in 100 years, year 100 not leap year
+   dayx       = ncenturies*36524 + (yearx-ncenturies*100)*365 + nlpyrs ! 36524 days in 100 years, year 100 not
+                                                                       !! leap year
    if(ncenturies.eq.4) dayx = dayx + 1 ! year 400 is a leap year
  end if
 
@@ -2461,7 +2464,8 @@ end function get_ticks_per_second
  allow_neg_inc_local=.true.; if(present(allow_neg_inc)) allow_neg_inc_local=allow_neg_inc
 
  if(.not.allow_neg_inc_local) then
-   if(oyears < 0 .or. omonths < 0 .or. odays < 0 .or. ohours < 0 .or. ominutes < 0 .or. oseconds < 0 .or. oticks < 0) then
+   if(oyears < 0 .or. omonths < 0 .or. odays < 0 .or. ohours < 0 .or. ominutes < 0 .or. oseconds < 0 .or. &
+    & oticks < 0) then
      write(err_msg_local,10) oyears, omonths, odays, ohours, ominutes, oseconds, oticks
      if(error_handler('function increment_time', err_msg_local, err_msg)) return
    endif
@@ -2559,13 +2563,16 @@ end function get_ticks_per_second
  ! Convert this back into a time.
    select case(calendar_type)
    case(THIRTY_DAY_MONTHS)
-     increment_date_private = set_date_thirty   (cyear, cmonth, cday, chour, cminute, csecond, ctick, Time_out, err_msg)
+     increment_date_private = set_date_thirty (cyear, cmonth, cday, chour, cminute, csecond, ctick, Time_out, err_msg)
    case(NOLEAP)
-     increment_date_private = set_date_no_leap_private  (cyear, cmonth, cday, chour, cminute, csecond, ctick, Time_out, err_msg)
+     increment_date_private = set_date_no_leap_private  (cyear, cmonth, cday, chour, cminute, csecond, ctick, &
+                                                        &  Time_out, err_msg)
    case(JULIAN)
-     increment_date_private = set_date_julian_private   (cyear, cmonth, cday, chour, cminute, csecond, ctick, Time_out, err_msg)
+     increment_date_private = set_date_julian_private   (cyear, cmonth, cday, chour, cminute, csecond, ctick, &
+                                                        &  Time_out, err_msg)
    case(GREGORIAN)
-     increment_date_private = set_date_gregorian(cyear, cmonth, cday, chour, cminute, csecond, ctick, Time_out, err_msg)
+     increment_date_private = set_date_gregorian(cyear, cmonth, cday, chour, cminute, csecond, ctick, Time_out, &
+                                                &  err_msg)
    end select
  endif ! if(mode_2)
 
@@ -2644,7 +2651,8 @@ end function get_ticks_per_second
  allow_neg_inc_local=.true.; if(present(allow_neg_inc)) allow_neg_inc_local=allow_neg_inc
 
  if(.not.allow_neg_inc_local) then
-   if(oyears < 0 .or. omonths < 0 .or. odays < 0 .or. ohours < 0 .or. ominutes < 0 .or. oseconds < 0 .or. oticks < 0) then
+   if(oyears < 0 .or. omonths < 0 .or. odays < 0 .or. ohours < 0 .or. ominutes < 0 .or. oseconds < 0 .or. &
+    & oticks < 0) then
      write(err_msg_local,10) oyears, omonths, odays, ohours, ominutes, oseconds, oticks
      if(error_handler('function decrement_date', err_msg_local, err_msg)) return
    endif

--- a/tracer_manager/tracer_manager.F90
+++ b/tracer_manager/tracer_manager.F90
@@ -267,7 +267,8 @@ do n=1,nfields
 !   <ERROR MSG="MAX_TRACER_FIELDS exceeded" STATUS="FATAL">
 !     The maximum number of tracer fields has been exceeded.
 !   </ERROR>
-         if(num_tracer_fields > MAX_TRACER_FIELDS) call mpp_error(FATAL,'tracer_manager_init: MAX_TRACER_FIELDS exceeded')
+         if(num_tracer_fields > MAX_TRACER_FIELDS) call mpp_error(FATAL, &
+            & 'tracer_manager_init: MAX_TRACER_FIELDS exceeded')
          TRACER_ARRAY(model,total_tracers(model))  = num_tracer_fields
          tracers(num_tracer_fields)%model          = model
          tracers(num_tracer_fields)%tracer_name    = name
@@ -656,7 +657,8 @@ j = TRACER_ARRAY(model,i)
 !   <ERROR MSG="index array size too small in get_tracer_indices" STATUS="FATAL">
 !     The global index array is too small and cannot contain all the tracer numbers.
 !   </ERROR>
-         if (n > size(ind(:))) call mpp_error(FATAL,'get_tracer_indices : index array size too small in get_tracer_indices')
+         if (n > size(ind(:))) call mpp_error(FATAL, &
+             & 'get_tracer_indices : index array size too small in get_tracer_indices')
          ind(n) = i
       endif
 
@@ -1089,7 +1091,8 @@ if ( query_method ( 'profile_type',model,n,scheme,control)) then
       case (MODEL_OCEAN)
         flag =parse(control,'bottom_value',bottom_value)
         if(mpp_pe() == mpp_root_pe() .and. flag == 0) &
-           call mpp_error(NOTE,'set_tracer_profile : Parameter bottom_value needs to be defined for the tracer profile.')
+           call mpp_error(NOTE, &
+                          & 'set_tracer_profile : Parameter bottom_value needs to be defined for the tracer profile.')
       case default
 !   Should there be a NOTE or WARNING message here?
     end select

--- a/tracer_manager/tracer_manager.F90
+++ b/tracer_manager/tracer_manager.F90
@@ -368,7 +368,8 @@ do n = 1, num_tracer_fields !{
              digit = "_"//trim(digit)
            endif
         else  !}{
-          call mpp_error(FATAL, 'tracer_manager_init: MULTIPLE_TRACER_SET_UP exceeds 100 for '//tracers(n)%tracer_name )
+          call mpp_error(FATAL, 'tracer_manager_init: MULTIPLE_TRACER_SET_UP exceeds 100 for '// &
+                         & tracers(n)%tracer_name )
         endif  !}
 
         select case(model)
@@ -746,7 +747,7 @@ get_tracer_index_integer = NO_TRACER
 
 if (PRESENT(indices)) then
     do i = 1, size(indices(:))
-       if (model == tracers(indices(i))%model .and. lowercase(trim(name)) == trim(tracers(indices(i))%tracer_name)) then
+       if (model == tracers(indices(i))%model .and. lowercase(trim(name)) == trim(tracers(indices(i))%tracer_name))then
            get_tracer_index_integer = i
            exit
        endif

--- a/tracer_manager/tracer_manager.F90
+++ b/tracer_manager/tracer_manager.F90
@@ -97,7 +97,7 @@ public  tracer_manager_init, &
         adjust_positive_def, &
         NO_TRACER,           &
         MAX_TRACER_FIELDS,   &
-        set_tracer_method 
+        set_tracer_method
 
 !> @brief Function which returns the number assigned to the tracer name.
 !!


### PR DESCRIPTION
**Description**
Updates the linter so it'll work correctly and cleans up the code so that it'll pass.

Most files had lines over the max length of 120 (it's really 119 since `\n`''s are counted) so the majority of the changes are line length fixes done mostly with a script.

**How Has This Been Tested?**
passed make distcheck with gcc 9 and intel 19

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

