### PR TITLE
Need for 2021.04: Updating CMakeLists.txt to include the fms_c.c and fms_c.h files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,6 +176,7 @@ list(APPEND fms_fortran_src_files
 # Collect FMS C source files
 list(APPEND fms_c_src_files
   affinity/affinity.c
+  fms/fms_c.c
   mosaic/create_xgrid.c
   mosaic/gradient_c2l.c
   mosaic/interp.c
@@ -189,6 +190,7 @@ list(APPEND fms_c_src_files
 list(APPEND fms_header_files
   include/file_version.h
   include/fms_platform.h
+  fms/fms_c.h
 )
 
 # Standard FMS compiler definitions


### PR DESCRIPTION
**Description**
When testing 2021.04-beta1 tag, the ufs did not compile without this change.  This adds the fms_c.c and fms_h.c files into the CMakeLists.txt file so that CMake can correctly find these files.

Fixes #N/A

**How Has This Been Tested?**
Tested with the UFS weather model 

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

