### PR TITLE
Update build action for yaml parser

### DIFF
--- a/.github/workflows/build_cmake_gnu.yml
+++ b/.github/workflows/build_cmake_gnu.yml
@@ -10,7 +10,7 @@ jobs:
         omp-flags: [ -DOPENMP=on, -DOPENMP=off ]
         libyaml-flag: [ "", -DWITH_YAML=on ]
     container:
-      image: noaagfdl/ubuntu_libfms_gnu:cmake-3.22.0
+      image: ryanmulhall/ubuntu_libfms_gnu
       env:
         CMAKE_FLAGS: "${{ matrix.omp-flags }} ${{ matrix.libyaml-flag }} -D64BIT=on"
     steps:

--- a/.github/workflows/build_cmake_gnu.yml
+++ b/.github/workflows/build_cmake_gnu.yml
@@ -10,7 +10,7 @@ jobs:
         omp-flags: [ -DOPENMP=on, -DOPENMP=off ]
         libyaml-flag: [ "", -DWITH_YAML=on ]
     container:
-      image: ryanmulhall/ubuntu_libfms_gnu
+      image: noaagfdl/ubuntu_libfms_gnu
       env:
         CMAKE_FLAGS: "${{ matrix.omp-flags }} ${{ matrix.libyaml-flag }} -D64BIT=on"
     steps:

--- a/.github/workflows/build_ubuntu_gnu.yml
+++ b/.github/workflows/build_ubuntu_gnu.yml
@@ -10,7 +10,7 @@ jobs:
         distcheck-conf-flags: [--enable-openmp, --disable-openmp, --enable-mixed-mode, --disable-setting-flags ]
         yaml-flag: [ --with-yaml, "" ]
     container:
-      image: ryanmulhall/ubuntu_libfms_gnu
+      image: noaagfdl/ubuntu_libfms_gnu
       env:
         FCFLAGS: "-I/usr/include"
         VERBOSE: 1

--- a/.github/workflows/build_ubuntu_gnu.yml
+++ b/.github/workflows/build_ubuntu_gnu.yml
@@ -7,28 +7,26 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        distcheck-conf-flags: [--enable-openmp, --disable-openmp, --enable-mixed-mode, --disable-setting-flags]
-        fcflags: ["-I/usr/include", "-fdefault-real-8 -fdefault-double-8 -fcray-pointer -ffree-line-length-none -I/usr/include"]
-        exclude:
-          - distcheck-conf-flags: --disable-setting-flags
-            fcflags: -I/usr/include
-          - distcheck-conf-flags: --enable-mixed-mode
-            fcflags: "-fdefault-real-8 -fdefault-double-8 -fcray-pointer -ffree-line-length-none -I/usr/include"
+        distcheck-conf-flags: [--enable-openmp, --disable-openmp, --enable-mixed-mode, --disable-setting-flags ]
+        yaml-flag: [ --with-yaml, "" ]
     container:
-      image: underwoo/ubuntu_libfms_gnu
+      image: ryanmulhall/ubuntu_libfms_gnu
       env:
-        FCFLAGS: "${{ matrix.fcflags }}"
+        FCFLAGS: "-I/usr/include"
         VERBOSE: 1
+        DISTCHECK_CONFIGURE_FLAGS: "${{ matrix.distcheck-conf-flags }} ${{ matrix.yaml-flag }}"
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Prepare GNU autoconf for build
       run: autoreconf -if
     - name: Configure the build
-      run: ./configure ${{ matrix.distcheck-conf-flags }}
+      if: ${{ matrix.distcheck-conf-flags != '--disable-setting-flags' }}
+      run: ./configure ${DISTCHECK_CONFIGURE_FLAGS}
+    - name: Configure the build with compiler flags
+      if: ${{ matrix.distcheck-conf-flags == '--disable-setting-flags' }}
+      run: ./configure ${DISTCHECK_CONFIGURE_FLAGS}
       env:
-        DISTCHECK_CONFIGURE_FLAGS: "${{ matrix.distcheck-conf-flags }}"
+        FCFLAGS: "-fdefault-real-8 -fdefault-double-8 -fcray-pointer -ffree-line-length-none -I/usr/include"
     - name: Build the library
       run: make -j distcheck
-      env:
-        DISTCHECK_CONFIGURE_FLAGS: "${{ matrix.distcheck-conf-flags }}"

--- a/test_fms/parser/test_yaml_parser.F90
+++ b/test_fms/parser/test_yaml_parser.F90
@@ -115,7 +115,7 @@ if (r4_buffer .ne. real(-999.9, kind=r4_kind)) call mpp_error(FATAL, "fill_value
 
 !! Try get_value_from_key using a r8 buffer
 call get_value_from_key(yaml_file_id1, variable_ids(1), "fill_value", r8_buffer)
-if (r8_buffer .ne. real(-999.9, kind=r8_kind)) call mpp_error(FATAL, "fill_value was not read correctly as an r8!")
+if (abs(r8_buffer - real(-999.9, kind=r8_kind)) .gt. 5e-5) call mpp_error(FATAL, "fill_value was not read correctly as an r8!")
 
 !! Try the is_optional argument on an key that does not exist
 string_buffer = ""


### PR DESCRIPTION
**Description**
- Changes both containers to one hosted on the organizations account with libyaml installed and adds the flag to the build.
- Changes the build matrix in the action so that fortran compiler flags are pre-set only when `--disable-setting-flags` is used and removes the repeated `env`'s on the last two steps
- Fixes the parser test failing in mixed mode due to real comparisons

**How Has This Been Tested?**
CI

Fixes #862 

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

