### PR TITLE
get_unit warning fix to only print on root_pe

### DIFF
--- a/mpp/include/mpp_util.inc
+++ b/mpp/include/mpp_util.inc
@@ -1088,7 +1088,7 @@ end function rarray_to_char
     integer,save :: i
     logical      :: l_open
 
-    call mpp_error(WARNING,'get_unit is deprecated and will be removed in a future release, please use the Fortran intrinsic newunit')
+    if (pe == root_pe) call mpp_error(WARNING,'get_unit is deprecated and will be removed in a future release, please use the Fortran intrinsic newunit')
     do i=10,99
        inquire(unit=i,opened=l_open)
        if(.not.l_open)exit


### PR DESCRIPTION
**Description**
Updates warning message to only print on root

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

