### PR TITLE
test(parser): change real comparison value to double

### DIFF
--- a/test_fms/parser/test_yaml_parser.F90
+++ b/test_fms/parser/test_yaml_parser.F90
@@ -115,7 +115,7 @@ if (r4_buffer .ne. real(-999.9, kind=r4_kind)) call mpp_error(FATAL, "fill_value
 
 !! Try get_value_from_key using a r8 buffer
 call get_value_from_key(yaml_file_id1, variable_ids(1), "fill_value", r8_buffer)
-if (abs(r8_buffer - real(-999.9, kind=r8_kind)) .gt. 5e-5) call mpp_error(FATAL, "fill_value was not read correctly as an r8!")
+if (abs(r8_buffer - real(-999.9, kind=r8_kind)) .gt. 5d-5) call mpp_error(FATAL, "fill_value was not read correctly as an r8!")
 
 !! Try the is_optional argument on an key that does not exist
 string_buffer = ""


### PR DESCRIPTION
**Description**
changes real comparison value in parser test since its an r8 value

**How Has This Been Tested?**
CI

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

