### PR TITLE
Updates AM4 regression test suite to run intel 21 only on PW

### DIFF
--- a/.github/workflows/am4_regression_parallelWorks_intel_tag.yml
+++ b/.github/workflows/am4_regression_parallelWorks_intel_tag.yml
@@ -15,11 +15,11 @@ jobs:
       matrix:
         include:
 # Runs AM4 with intel18 on AM4_intel18 
-                - runname: AM4 build and run with intel 18
-                  runscript: python3 /home/Thomas.Robinson/pw/storage/pw_api_python/AM4_intel18StartClusters.py am4_intel18
+#                - runname: AM4 build and run with intel 18
+#                  runscript: python3 /home/Thomas.Robinson/pw/storage/pw_api_python/AM4_intel18StartClusters.py am4_intel18
 # Runs AM4 using a container to build and run the model with intel 21
                 - runname: AM4 regression with intel 21 and answer check
-                  runscript: python3 /home/Thomas.Robinson/pw/storage/pw_api_python/AM4_intel21StartClusters.py am4_container
+                  runscript: python3 /home/Thomas.Robinson/pw/storage/pw_api_python/AM4_intel21StartClusters.py main
 
     steps:
                 - name: FMS make check on paralellWorks
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         include:
-                - cluster: am4_intel18
+#                - cluster: am4_intel18
                 - cluster: am4_container
     steps:
                 - name: Turn off cluster


### PR DESCRIPTION
**Description**
This should run the AM4 regression test with intel 21.

**How Has This Been Tested?**
The script works.  It needs to be tested through the actions interface.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

