### PR TITLE
`make check` fix

### DIFF
--- a/test_fms/fms2_io/test_atmosphere_io.F90
+++ b/test_fms/fms2_io/test_atmosphere_io.F90
@@ -25,7 +25,7 @@ use mpp_domains_mod
 use mpp_mod
 use setup
 use platform_mod
-
+use fms_mod, only : check_nml_error
 
 type(Params) :: test_params
 type(domain2d) :: domain
@@ -86,6 +86,9 @@ character(len=8) :: timestamp
 logical :: ignore_checksum = .false.
 logical :: bad_checksum = .false.
 
+integer :: io    !< Error code when reading namelist
+integer :: ierr  !< Error code when reading namelist
+
 namelist /test_atmosphere_io_nml/ bad_checksum, ignore_checksum
 
 !Initialize.
@@ -97,7 +100,8 @@ call mpi_check(err)
 call random_seed()
 call fms2_io_init()
 
-read(input_nml_file, nml=test_atmosphere_io_nml)
+read(input_nml_file, nml=test_atmosphere_io_nml, iostat=io)
+ierr = check_nml_error(io, 'test_atmosphere_io_nml')
 
 if (test_params%debug) then
   if (mpp_pe() .eq. 0) then

--- a/test_fms/fms2_io/test_bc_restart.F90
+++ b/test_fms/fms2_io/test_bc_restart.F90
@@ -22,6 +22,7 @@
 program test_bc_restart
 
 use   mpp_mod,         only : mpp_init, mpp_exit, mpp_pe, mpp_root_pe, mpp_sync, input_nml_file
+use   fms_mod,         only : check_nml_error
 use   fms2_io_mod,     only : FmsNetcdfFile_t, fms2_io_init, open_file, register_restart_field, &
                               register_variable_attribute, read_restart_bc, write_restart_bc, close_file
 use   mpp_domains_mod, only : mpp_get_global_domain, mpp_get_data_domain, mpp_get_compute_domain, &
@@ -41,6 +42,8 @@ type atm_type
    real, allocatable, dimension(:,:,:):: var3d            !< 3d variable data
 end type
 
+integer                               :: io               !< Error code when reading namelist
+integer                               :: ierr             !< Error code when reading namelist
 integer, dimension(2)                 :: layout = (/4,4/) !< Domain layout
 integer                               :: nlon             !< Number of points in x axis
 integer                               :: nlat             !< Number of points in y axis
@@ -58,7 +61,8 @@ namelist /test_bc_restart_nml/ bad_checksum, ignore_checksum
 call mpp_init
 call fms2_io_init
 
-read(input_nml_file, nml=test_bc_restart_nml)
+read(input_nml_file, nml=test_bc_restart_nml, iostat=io)
+ierr = check_nml_error(io, 'test_bc_restart_nml')
 
 nlon = 144
 nlat = 144


### PR DESCRIPTION
**Description**
Adds check_nml_error after reading a namelist, so it could crash only as expected

Fixes #903 

**How Has This Been Tested?**
`make check` passes with intel20

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

