### PR TITLE
String utils module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,6 +161,7 @@ list(APPEND fms_fortran_src_files
   random_numbers/random_numbers.F90
   sat_vapor_pres/sat_vapor_pres_k.F90
   sat_vapor_pres/sat_vapor_pres.F90
+  string_utils/fms_string_utils.F90
   time_interp/time_interp_external.F90
   time_interp/time_interp_external2.F90
   time_interp/time_interp.F90
@@ -184,6 +185,7 @@ list(APPEND fms_c_src_files
   mosaic/read_mosaic.c
   mpp/mpp_memuse.c
   parser/yaml_parser_binding.c
+  string_utils/fms_string_utils_binding.c
 )
 
 # Collect FMS header files

--- a/Makefile.am
+++ b/Makefile.am
@@ -43,6 +43,7 @@ SUBDIRS = \
   mosaic2 \
   fms \
   parser \
+  string_utils \
   affinity \
   mosaic \
   time_manager \

--- a/configure.ac
+++ b/configure.ac
@@ -357,6 +357,7 @@ AC_CONFIG_FILES([
   libFMS/Makefile
   docs/Makefile
   parser/Makefile
+  string_utils/Makefile
   test_fms/test_common.sh
   test_fms/Makefile
   test_fms/diag_manager/Makefile
@@ -378,6 +379,7 @@ AC_CONFIG_FILES([
   test_fms/affinity/Makefile
   test_fms/coupler/Makefile
   test_fms/parser/Makefile
+  test_fms/string_utils/Makefile
   FMS.pc
   ])
 

--- a/docs/grouping.h
+++ b/docs/grouping.h
@@ -130,6 +130,10 @@
  *
  */
 
+/** @defgroup string_utils String Utils
+ *
+ */
+
 /** @defgroup time_interp Time Interpolator
  *
  */

--- a/libFMS/Makefile.am
+++ b/libFMS/Makefile.am
@@ -63,6 +63,7 @@ libFMS_la_LIBADD += $(top_builddir)/random_numbers/librandom_numbers.la
 libFMS_la_LIBADD += $(top_builddir)/diag_integral/libdiag_integral.la
 libFMS_la_LIBADD += $(top_builddir)/sat_vapor_pres/libsat_vapor_pres.la
 libFMS_la_LIBADD += $(top_builddir)/parser/libparser.la
+libFMS_la_LIBADD += $(top_builddir)/string_utils/libstring_utils.la
 libFMS_la_LIBADD += $(top_builddir)/libFMS_mod.la
 
 # At least one source file must be included to please Automake.

--- a/string_utils/Makefile.am
+++ b/string_utils/Makefile.am
@@ -1,0 +1,40 @@
+#***********************************************************************
+#*                   GNU Lesser General Public License
+#*
+#* This file is part of the GFDL Flexible Modeling System (FMS).
+#*
+#* FMS is free software: you can redistribute it and/or modify it under
+#* the terms of the GNU Lesser General Public License as published by
+#* the Free Software Foundation, either version 3 of the License, or (at
+#* your option) any later version.
+#*
+#* FMS is distributed in the hope that it will be useful, but WITHOUT
+#* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+#* for more details.
+#*
+#* You should have received a copy of the GNU Lesser General Public
+#* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
+#***********************************************************************
+
+# This is an automake file for the constants directory of the FMS
+# package.
+
+# Include .h and .mod files.
+AM_CPPFLAGS = -I$(top_srcdir)/include
+AM_FCFLAGS = $(FC_MODINC). $(FC_MODOUT)$(MODDIR)
+
+# Build this uninstalled convenience library.
+noinst_LTLIBRARIES = libstring_utils.la
+
+# The convenience library depends on its source.
+libstring_utils_la_SOURCES = \
+  fms_string_utils.F90 \
+  fms_string_utils_binding.c
+
+MODFILES = \
+  fms_string_utils_mod.$(FC_MODEXT)
+BUILT_SOURCES = $(MODFILES)
+nodist_include_HEADERS = $(MODFILES)
+
+include $(top_srcdir)/mkmods.mk

--- a/string_utils/fms_string_utils.F90
+++ b/string_utils/fms_string_utils.F90
@@ -41,8 +41,8 @@ module fms_string_utils_mod
 !> @}
 
   interface
-  !> @brief Sorts an array of pointers (my pointer) of size (p_size) in 
-  !! alphabetical order. 
+  !> @brief Sorts an array of pointers (my pointer) of size (p_size) in
+  !! alphabetical order.
   subroutine fms_sort_this(my_pointer, p_size, indices) bind(c)
     use iso_c_binding
 
@@ -98,7 +98,7 @@ module fms_string_utils_mod
     type(c_ptr), intent(in)       :: my_pointer(*) !< Array of c pointer
     integer,     intent(in)       :: narray        !< Length of the array
     character(len=:), allocatable :: my_array(:)
- 
+
     character(len=:), allocatable :: buffer !< Buffer to store a string
     integer                       :: i      !< For do loops
 
@@ -112,6 +112,7 @@ module fms_string_utils_mod
 
   !> @brief Searches through a SORTED array of pointers for a string
   !! @return the indices where the array was found
+  !! If the string was not found, indices will be indices(1) = -999
   !> <br>Example usage:
   !!     my_pointer = fms_array_to_pointer(my_array)
   !!     call fms_sort_this(my_pointer, n_array, indices)
@@ -131,10 +132,13 @@ module fms_string_utils_mod
 
     if (allocated(ifind)) call mpp_error(FATAL, "The indices array is already allocated. &
     Deallocate it before calling fms_find_my_string")
-    
+
     if (nfind .gt. 0) then
       allocate(ifind(nfind))
       read(buffer,*) ifind
+    else
+      allocate(ifind(1))
+      ifind = -999
     endif
 
   end function fms_find_my_string

--- a/string_utils/fms_string_utils.F90
+++ b/string_utils/fms_string_utils.F90
@@ -1,0 +1,144 @@
+!***********************************************************************
+!*                   GNU Lesser General Public License
+!*
+!* This file is part of the GFDL Flexible Modeling System (FMS).
+!*
+!* FMS is free software: you can redistribute it and/or modify it under
+!* the terms of the GNU Lesser General Public License as published by
+!* the Free Software Foundation, either version 3 of the License, or (at
+!* your option) any later version.
+!*
+!* FMS is distributed in the hope that it will be useful, but WITHOUT
+!* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+!* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+!* for more details.
+!*
+!* You should have received a copy of the GNU Lesser General Public
+!* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
+!***********************************************************************
+
+!> @defgroup fms_string_utils_mod fms_string_utils_mod
+!> @ingroup parser
+!> @brief Routines to use for string manipulation
+
+!> @file
+!> @brief File for @ref fms_string_utils_mod
+
+!> @addtogroup fms_string_utils_mod
+!> @{
+module fms_string_utils_mod
+  use, intrinsic :: iso_c_binding
+  use fms_mod, only: fms_c2f_string
+  use mpp_mod
+
+  implicit none
+  private
+
+  public :: fms_array_to_pointer
+  public :: fms_pointer_to_array
+  public :: fms_sort_this
+  public :: fms_find_my_string
+!> @}
+
+  interface
+  !> @brief Sorts an array of pointers (my pointer) of size (p_size) in 
+  !! alphabetical order. 
+  subroutine fms_sort_this(my_pointer, p_size, indices) bind(c)
+    use iso_c_binding
+
+    type(c_ptr),         intent(inout) :: my_pointer(*) !< IN:  Array of c pointers to sort
+                                                        !! OUT: Sorted array of c pointers
+    integer(kind=c_int), intent(in)    :: p_size        !< Size of the array
+    integer(kind=c_int), intent(inout) :: indices(*)    !< IN:  Array of the indices of my_pointer
+                                                        !! OUT: Sorted array of indices
+  end subroutine fms_sort_this
+
+  !> @brief Private c function that finds a string in a SORTED array of c pointers
+  !! @return Indices of my_pointer where the string was found as a string!!!
+  function fms_find_my_string_binding(my_pointer, p_size, string_to_find, nfound) bind(c) &
+  result(indices)
+    use iso_c_binding
+
+    type(c_ptr),            intent(in) :: my_pointer(*)     !< Array of sorted c pointer
+    integer(kind=c_int),    intent(in) :: p_size            !< Size of the array
+    character(kind=c_char), intent(in) :: string_to_find(*) !< String to find
+    integer(kind=c_int), intent(inout) :: nfound            !< Number of times the array was found
+
+    type(c_ptr) :: indices
+  end function fms_find_my_string_binding
+
+  end interface
+
+  !> @addtogroup fms_string_utils_mod
+  !> @{
+  contains
+
+  !> @brief Converts a character array to an array of c pointers!
+  !! @return An array of c pointers
+  function fms_array_to_pointer(my_array) &
+  result(my_pointer)
+    character(len=*), target :: my_array(:) !!< Array of strings to convert
+    type(c_ptr), allocatable :: my_pointer(:)
+
+    integer :: i !< For do loops
+
+    if (allocated(my_pointer)) call mpp_error(FATAL, "The c pointer array is &
+      already allocated. Deallocated before calling fms_array_to_pointer")
+    allocate(my_pointer(size(my_array)))
+
+    do i = 1, size(my_array)
+      my_pointer(i) = c_loc(my_array(i))
+    enddo
+  end function fms_array_to_pointer
+
+  !> @brief Convert an array of c pointers back to a character array
+  !! @return A character array
+  function fms_pointer_to_array(my_pointer, narray) &
+  result(my_array)
+    type(c_ptr), intent(in)       :: my_pointer(*) !< Array of c pointer
+    integer,     intent(in)       :: narray        !< Length of the array
+    character(len=:), allocatable :: my_array(:)
+ 
+    character(len=:), allocatable :: buffer !< Buffer to store a string
+    integer                       :: i      !< For do loops
+
+    allocate(character(len=255) :: my_array(narray))
+    do i = 1, narray
+      buffer = fms_c2f_string(my_pointer(i))
+      my_array(i) = buffer
+      deallocate(buffer)
+    enddo
+  end function fms_pointer_to_array
+
+  !> @brief Searches through a SORTED array of pointers for a string
+  !! @return the indices where the array was found
+  !> <br>Example usage:
+  !!     my_pointer = fms_array_to_pointer(my_array)
+  !!     call fms_sort_this(my_pointer, n_array, indices)
+  !!     ifind = fms_find_my_string(my_pointer, n_array, string_to_find)
+  function fms_find_my_string(my_pointer, narray, string_to_find) &
+  result(ifind)
+    type(c_ptr),      intent(in)    :: my_pointer(*)  !< Array of c pointer
+    integer,          intent(in)    :: narray         !< Length of the array
+    character(len=*), intent(in)    :: string_to_find !< string to find
+    integer, allocatable            :: ifind(:)
+
+    integer                       :: nfind  !< number of times the string was found
+    character(len=:), allocatable :: buffer !< buffer to read the indices into
+
+    buffer = fms_c2f_string(&
+      fms_find_my_string_binding(my_pointer, narray, trim(string_to_find)//c_null_char, nfind))
+
+    if (allocated(ifind)) call mpp_error(FATAL, "The indices array is already allocated. &
+    Deallocate it before calling fms_find_my_string")
+    
+    if (nfind .gt. 0) then
+      allocate(ifind(nfind))
+      read(buffer,*) ifind
+    endif
+
+  end function fms_find_my_string
+
+end module fms_string_utils_mod
+!> @}
+! close documentation grouping

--- a/string_utils/fms_string_utils_binding.c
+++ b/string_utils/fms_string_utils_binding.c
@@ -83,16 +83,16 @@ char* fms_find_my_string_binding(char** arr, int *n, char *find_me, int *np)
   while(L != R){
     // Start looking in the midle of the array
 	  m = ceil((L + R) / 2);
-   //printf("L is set to %i from L=%i and R=%i \n", m, L, R);
+    //printf("L is set to %i from L=%i and R=%i \n", m, L, R);
 
-   //printf("Checking %i:%s \n", m, (arr[m]));
+    //printf("Checking %i:%s \n", m, (arr[m]));
 	  is_found = strcmp(find_me,(arr[m]));
 	  if (is_found == 0)
 	  {
       *np = 1;
       p = malloc(sizeof(int) * *np);
       p[*np-1] = m + 1; //Because fortran indices start at 1 ;)
-     //printf("Array found at %i %i %i \n", *np, m, p[*np-1]);
+      //printf("Array found at %i %i %i \n", *np, m, p[*np-1]);
 
       // The string can be found in multiple indices of the array, so look to the left of the index where the string
       // was initially found
@@ -105,7 +105,7 @@ char* fms_find_my_string_binding(char** arr, int *n, char *find_me, int *np)
             *np = *np + 1;
             p = realloc(p, sizeof(int) * *np);
             p[*np-1] = mm + 1;
-           //printf("Array found at %i %i %i\n", *np, mm, p[*np-1]);
+            //printf("Array found at %i %i %i\n", *np, mm, p[*np-1]);
           }
         } else {is_found = -999;} //Done looking
 		  }
@@ -121,7 +121,7 @@ char* fms_find_my_string_binding(char** arr, int *n, char *find_me, int *np)
             *np = *np + 1;
             p = realloc(p, sizeof(int) * *np);
 		        p[*np-1] = mm + 1;
-           //printf("Array found at %i %i %i\n", *np, mm, p[*np-1]);
+            //printf("Array found at %i %i %i\n", *np, mm, p[*np-1]);
          }
         } else {is_found = -999;} //Done looking}
       }
@@ -129,14 +129,14 @@ char* fms_find_my_string_binding(char** arr, int *n, char *find_me, int *np)
       // If find_me is greater than arr[m] (i.e find_me="potato" is greater than arr[m]="banana")
 	  } else if (is_found > 0) {
       // Set the lower bound to start in m (ignore the first half)
-  	  L = m;
-     //printf("L is set to %i \n", L);
+  	  L = m + 1;
+      //printf("L is set to %i \n", L);
     } else
     // If find_me is less than arr[m] (i.e find_me="potato" is less than arr[m] = "soccer")
     {
       // Set the upper bound to start in m (ignore the lower half)
       R = m;
-     //printf("R is set to %i \n", R);
+      //printf("R is set to %i \n", R);
 	}
 
 }

--- a/string_utils/fms_string_utils_binding.c
+++ b/string_utils/fms_string_utils_binding.c
@@ -79,6 +79,7 @@ char* fms_find_my_string_binding(char** arr, int *n, char *find_me, int *np)
   int *p;       // Array to store the indices
   int i;        // For do loops
 
+  *np = 0;
   is_found = -1;
   while(L != R){
     // Start looking in the midle of the array

--- a/string_utils/fms_string_utils_binding.c
+++ b/string_utils/fms_string_utils_binding.c
@@ -1,0 +1,163 @@
+/***********************************************************************
+ *                   GNU Lesser General Public License
+ *
+ * This file is part of the GFDL Flexible Modeling System (FMS).
+ *
+ * FMS is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * FMS is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
+ **********************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+
+// struct to store a string and id associated with that string
+typedef struct{
+  char arr_name[255];
+  int id;
+}my_type;
+
+// Compares two my_type types by the arr_name
+static int arr_name_sorter(const void* p1, const void* p2)
+{
+  const my_type *the_type1 = p1;
+  const my_type *the_type2 = p2;
+
+  return strcmp(the_type1->arr_name, the_type2->arr_name);
+}
+
+// Sorts an array of strings in alphabetical order
+// Implements a binary search to search for a string in an array of strings
+// arr -> pointer of character array
+// n -> length of the array
+// id - > indices of the character array
+void fms_sort_this(char **arr, int* n, int* id)
+{
+  int i; // For do loops
+  my_type *the_type;
+
+  // Save the array and the id into a struct
+  the_type = (my_type*)calloc(*n, sizeof(my_type));
+    for(i=0; i<*n; i++){
+      the_type[i].id = id[i];
+      strcpy(the_type[i].arr_name, arr[i]);
+    }
+
+  qsort(the_type, *n, sizeof(my_type), arr_name_sorter);
+
+  // Copy the sorted array and the sorted ids
+  for(i=0; i<*n; i++){
+    id[i] = the_type[i].id;
+    strcpy(arr[i], the_type[i].arr_name);
+  }
+}
+
+// Implements a binary search to search for a string in an array of strings
+// arr -> pointer of character array
+// n -> length of the array
+// find me -> string to find
+// np -> the number of times the string was found
+// returns a string with the indices ;)
+char* fms_find_my_string_binding(char** arr, int *n, char *find_me, int *np)
+{
+  int L= 0;     // Left bound
+  int R = *n;   // Right bound
+  int m;        // Middle of the bound
+  int mm;       // Index currently looking at
+  int is_found; // Result from strcmp: 0 if string was found  <0 if the string is "less" >0 if the string is "greater"
+  int *p;       // Array to store the indices
+  int i;        // For do loops
+
+  is_found = -1;
+  while(L != R){
+    // Start looking in the midle of the array
+	  m = ceil((L + R) / 2);
+   //printf("L is set to %i from L=%i and R=%i \n", m, L, R);
+
+   //printf("Checking %i:%s \n", m, (arr[m]));
+	  is_found = strcmp(find_me,(arr[m]));
+	  if (is_found == 0)
+	  {
+      *np = 1;
+      p = malloc(sizeof(int) * *np);
+      p[*np-1] = m + 1; //Because fortran indices start at 1 ;)
+     //printf("Array found at %i %i %i \n", *np, m, p[*np-1]);
+
+      // The string can be found in multiple indices of the array, so look to the left of the index where the string
+      // was initially found
+      mm = m;
+      while (is_found == 0) {
+        if (mm != 0) { // Only look to the left if m is not the begining of the array
+			    mm= mm -1;
+          is_found = strcmp(find_me,(arr[mm]));
+			    if (is_found == 0 ) {
+            *np = *np + 1;
+            p = realloc(p, sizeof(int) * *np);
+            p[*np-1] = mm + 1;
+           //printf("Array found at %i %i %i\n", *np, mm, p[*np-1]);
+          }
+        } else {is_found = -999;} //Done looking
+		  }
+      // The string can be found in multiple indices of the array, so look to the right of the index where the string was
+      // initially found
+		  mm = m;
+		  is_found =0;
+      while (is_found == 0) {
+        if (mm != *n-1) { // Only look to the right if m is not the end of the array
+          mm = mm + 1;
+          is_found = strcmp(find_me,(arr[mm]));
+          if (is_found == 0 ) {
+            *np = *np + 1;
+            p = realloc(p, sizeof(int) * *np);
+		        p[*np-1] = mm + 1;
+           //printf("Array found at %i %i %i\n", *np, mm, p[*np-1]);
+         }
+        } else {is_found = -999;} //Done looking}
+      }
+		  L = R;
+      // If find_me is greater than arr[m] (i.e find_me="potato" is greater than arr[m]="banana")
+	  } else if (is_found > 0) {
+      // Set the lower bound to start in m (ignore the first half)
+  	  L = m;
+     //printf("L is set to %i \n", L);
+    } else
+    // If find_me is less than arr[m] (i.e find_me="potato" is less than arr[m] = "soccer")
+    {
+      // Set the upper bound to start in m (ignore the lower half)
+      R = m;
+     //printf("R is set to %i \n", R);
+	}
+
+}
+
+  // This is the magical part:
+  // Save the array of indices where the string was found into a string
+  // The fortran side is going to allocate the array to the correct size and read the string into the array
+  // The alternative (normal) way is to have a seperate function that gets the number of times the string is found
+  // The fortran side will allocate the array to the correct size and send that into another function that
+  // fill in that array. That will require you to search through the array twice ...
+  char string[255];
+  char *string_p;
+
+  strcpy(string, "");
+
+  for(i=0; i<*np; i++){
+    if (i == *np-1) {sprintf( &string[ strlen(string) ],  "%d ", p[i] );}
+    else {sprintf( &string[ strlen(string) ],  "%d ,", p[i] );}
+  }
+
+  string_p = (char*) malloc((strlen(string)+1)*sizeof(char));
+  strcpy(string_p, string);
+  return string_p;
+}

--- a/test_fms/Makefile.am
+++ b/test_fms/Makefile.am
@@ -26,7 +26,7 @@ ACLOCAL_AMFLAGS = -I m4
 # Make targets will be run in each subdirectory. Order is significant.
 SUBDIRS = coupler diag_manager data_override exchange monin_obukhov drifters \
 mosaic interpolator fms mpp mpp_io time_interp time_manager \
-horiz_interp field_manager axis_utils affinity fms2_io parser
+horiz_interp field_manager axis_utils affinity fms2_io parser string_utils
 
 # This input file must be distributed, it is turned into
 # test_common.sh by configure.

--- a/test_fms/string_utils/Makefile.am
+++ b/test_fms/string_utils/Makefile.am
@@ -1,0 +1,44 @@
+#***********************************************************************
+#*                   GNU Lesser General Public License
+#*
+#* This file is part of the GFDL Flexible Modeling System (FMS).
+#*
+#* FMS is free software: you can redistribute it and/or modify it under
+#* the terms of the GNU Lesser General Public License as published by
+#* the Free Software Foundation, either version 3 of the License, or (at
+#* your option) any later version.
+#*
+#* FMS is distributed in the hope that it will be useful, but WITHOUT
+#* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+#* for more details.
+#*
+#* You should have received a copy of the GNU Lesser General Public
+#* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
+#***********************************************************************
+
+# This is an automake file for the test_fms/data_override directory of the FMS
+# package.
+
+# uramirez
+
+# Find the needed mod and .inc files.
+AM_CPPFLAGS = -I${top_srcdir}/include -I$(MODDIR)
+
+# Link to the FMS library.
+LDADD = ${top_builddir}/libFMS/libFMS.la
+
+# Build this test program.
+check_PROGRAMS = test_string_utils
+
+# This is the source code for the test.
+test_string_utils_SOURCES = test_string_utils.F90
+
+# Run the test program.
+TESTS = test_string_utils.sh
+
+# Include these files with the distribution.
+EXTRA_DIST = test_string_utils.sh
+
+# Clean up
+CLEANFILES = input.nml *.out

--- a/test_fms/string_utils/test_string_utils.F90
+++ b/test_fms/string_utils/test_string_utils.F90
@@ -64,7 +64,7 @@ program test_fms_string_utils
   print *, "Checking if 'alpha' was found in the array at all the right places"
   call check_my_indices(ifind, (/1/), "alpha")
   deallocate(ifind)
-  
+
   ifind = fms_find_my_string(my_pointer, 10, "beta")
   print *, "Checking if 'beta' was found in the array at all the right places"
   call check_my_indices(ifind, (/2/), "beta")
@@ -77,7 +77,7 @@ program test_fms_string_utils
 
   ifind = fms_find_my_string(my_pointer, 10, "foxtrop")
   print *, "Checking if 'foxtrop' was found in the array at all the right places"
-  call check_my_indices(ifind, (/4,5/), "foxtrop")
+  call check_my_indices(ifind, (/5,4/), "foxtrop")
   deallocate(ifind)
 
   ifind = fms_find_my_string(my_pointer, 10, "golf")
@@ -93,6 +93,11 @@ program test_fms_string_utils
   ifind = fms_find_my_string(my_pointer, 10, "juliet")
   print *, "Checking if 'juliet' was found in the array at all the right places"
   call check_my_indices(ifind, (/10/), "juliet")
+  deallocate(ifind)
+
+  ifind = fms_find_my_string(my_pointer, 10, "tamales")
+  print *, "Checking if 'tamales' was found in the array at all the right places"
+  call check_my_indices(ifind, (/-999/), "tamales")
   deallocate(ifind)
 
   call fms_end()

--- a/test_fms/string_utils/test_string_utils.F90
+++ b/test_fms/string_utils/test_string_utils.F90
@@ -1,0 +1,153 @@
+!***********************************************************************
+!*                   GNU Lesser General Public License
+!*
+!* This file is part of the GFDL Flexible Modeling System (FMS).
+!*
+!* FMS is free software: you can redistribute it and/or modify it under
+!* the terms of the GNU Lesser General Public License as published by
+!* the Free Software Foundation, either version 3 of the License, or (at
+!* your option) any later version.
+!*
+!* FMS is distributed in the hope that it will be useful, but WITHOUT
+!* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+!* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+!* for more details.
+!*
+!* You should have received a copy of the GNU Lesser General Public
+!* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
+!***********************************************************************
+
+!> @brief  This programs tests the public subroutines in test_fms_string_utils:
+!! fms_array_to_pointer, fms_pointer_to_array, fms_sort_this, fms_find_my_string
+program test_fms_string_utils
+  use fms_string_utils_mod
+  use fms_mod, only: fms_init, fms_end
+  use mpp_mod
+  use, intrinsic :: iso_c_binding
+
+  implicit none
+
+  character(len=10), allocatable :: my_array(:) !< Array of strings
+  character(len=:), allocatable :: my_sorted_array(:) !< Sorted array of strings
+  type(c_ptr), allocatable :: my_pointer(:) !< Array of pointers
+  integer, allocatable :: my_ids(:) !< Array of indices
+  integer :: i !< For do loops
+  integer, allocatable :: ifind(:) !< Array of indices where a string was found
+
+  call fms_init()
+
+  allocate(my_array(10))
+  allocate(my_ids(10))
+
+  my_array(1) = "golf"//c_null_char
+  my_array(2) = "charlie"//c_null_char
+  my_array(3) = "golf"//c_null_char
+  my_array(4) = "beta"//c_null_char
+  my_array(5) = "alpha"//c_null_char
+  my_array(6) = "foxtrop"//c_null_char
+  my_array(7) = "golf"//c_null_char
+  my_array(8) = "foxtrop"//c_null_char
+  my_array(9) = "juliet"//c_null_char
+  my_array(10) ="india"//c_null_char
+
+  do i=1, 10
+    my_ids(i) = i
+  end do
+
+  my_pointer = fms_array_to_pointer(my_array)
+  call fms_sort_this(my_pointer, 10, my_ids)
+  my_sorted_array = fms_pointer_to_array(my_pointer, 10)
+  print *, "Checking if the array was sorted correctly"
+  call check_my_sorted_array(my_sorted_array)
+
+  ifind = fms_find_my_string(my_pointer, 10, "alpha")
+  print *, "Checking if 'alpha' was found in the array at all the right places"
+  call check_my_indices(ifind, (/1/), "alpha")
+  deallocate(ifind)
+  
+  ifind = fms_find_my_string(my_pointer, 10, "beta")
+  print *, "Checking if 'beta' was found in the array at all the right places"
+  call check_my_indices(ifind, (/2/), "beta")
+  deallocate(ifind)
+
+  ifind = fms_find_my_string(my_pointer, 10, "charlie")
+  print *, "Checking if 'charlie' was found in the array at all the right places"
+  call check_my_indices(ifind, (/3/), "charlie")
+  deallocate(ifind)
+
+  ifind = fms_find_my_string(my_pointer, 10, "foxtrop")
+  print *, "Checking if 'foxtrop' was found in the array at all the right places"
+  call check_my_indices(ifind, (/4,5/), "foxtrop")
+  deallocate(ifind)
+
+  ifind = fms_find_my_string(my_pointer, 10, "golf")
+  print *, "Checking if 'golf' was found in the array at all the right places"
+  call check_my_indices(ifind, (/6,7,8/), "golf")
+  deallocate(ifind)
+
+  ifind = fms_find_my_string(my_pointer, 10, "india")
+  print *, "Checking if 'india' was found in the array at all the right places"
+  call check_my_indices(ifind, (/9/), "india")
+  deallocate(ifind)
+
+  ifind = fms_find_my_string(my_pointer, 10, "juliet")
+  print *, "Checking if 'juliet' was found in the array at all the right places"
+  call check_my_indices(ifind, (/10/), "juliet")
+  deallocate(ifind)
+
+  call fms_end()
+
+  deallocate(my_array)
+  deallocate(my_ids)
+  deallocate(my_pointer)
+
+  contains
+
+  !< Checks if the array was sorted correctly!
+  subroutine check_my_sorted_array(sorted_array)
+    character(len=*), intent(in) :: sorted_array(:) !< Array of sorted strings
+    integer :: j !< For do loops
+    character(len=10) :: ans(10) !< Expected array of sorted strings
+
+    ans(1) = "alpha"//c_null_char
+    ans(2) = "beta"//c_null_char
+    ans(3) = "charlie"//c_null_char
+    ans(4) = "foxtrop"//c_null_char
+    ans(5) = "foxtrop"//c_null_char
+    ans(6) = "golf"//c_null_char
+    ans(7) = "golf"//c_null_char
+    ans(8) = "golf"//c_null_char
+    ans(9) = "india"//c_null_char
+    ans(10) = "juliet"//c_null_char
+
+    do j = 1, size(ans)
+      print *, "Comparing ", trim(sorted_array(j)), " and ", trim(ans(j))
+      if (trim(sorted_array(j)) .eq. trim(ans(j))) &
+        call mpp_error(FATAL, "The sorted array is not correct!")
+    end do
+
+  end subroutine check_my_sorted_array
+
+  !< Checks if an array of integers is the expected result
+  subroutine check_my_indices(indices, ans, string)
+    integer, intent(in) :: indices(:) !< Array of indices
+    integer, intent(in) :: ans(:) !< Expected answers
+    character(len=*), intent(in) :: string !< Name of field comparing
+
+    integer :: j !< For do loops
+
+    if (size(indices) .ne. size(ans)) then
+      print *, "The size of ", trim(string), " is ", size(indices)
+      call mpp_error(FATAL, "The size of the indices where "//trim(string)//" was found is not correct")
+    endif
+
+    do j = 1, size(indices)
+      print *, "Checking if the ", j, " index is ", ans(j)
+      if (indices(j) .ne. ans(j)) then
+        print *, "The indices of ", trim(string), " are ", indices
+        call mpp_error(FATAL, "The indices where "//trim(string)//" was found is not correct")
+      endif
+    end do
+  end subroutine check_my_indices
+
+end program test_fms_string_utils

--- a/test_fms/string_utils/test_string_utils.sh
+++ b/test_fms/string_utils/test_string_utils.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+#***********************************************************************
+#*                   GNU Lesser General Public License
+#*
+#* This file is part of the GFDL Flexible Modeling System (FMS).
+#*
+#* FMS is free software: you can redistribute it and/or modify it under
+#* the terms of the GNU Lesser General Public License as published by
+#* the Free Software Foundation, either version 3 of the License, or (at
+#* your option) any later version.
+#*
+#* FMS is distributed in the hope that it will be useful, but WITHOUT
+#* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+#* for more details.
+#*
+#* You should have received a copy of the GNU Lesser General Public
+#* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
+#***********************************************************************
+
+# This is part of the GFDL FMS package. This is a shell script to
+# execute tests in the test_fms/string_utils directory.
+
+# Set common test settings.
+. ../test_common.sh
+
+touch input.nml
+run_test test_string_utils 1


### PR DESCRIPTION
**Description**
Adds a string_utils module that contains the following public routines and added unit tests for each:
-  fms_array_to_pointer : to convert an array of strings to c_pointers
-  fms_pointer_to_array : to convert an array of c_pointers back to an array of strings
-  fms_sort_this: sorts an array of c_pointers in alphabetical order
-  fms_find_my_string: uses a binary search to search for a string in an array of sorted c_pointers

These routines will be implemented in the diag_manager rewrite (i.e when searching the diag_yaml for a field)

To do (in a separate pr):
- Move other string-related routines to the string_utils_mods (i.e fms_c2f_string, string, str_copy, etc ...)

**How Has This Been Tested?**
`make check` passes with intel20, gnu 9.3.0, and intel18 on skylake

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

