### PR TITLE
add check for affinity to self-initialize and update test program

### DIFF
--- a/affinity/fms_affinity.F90
+++ b/affinity/fms_affinity.F90
@@ -135,6 +135,7 @@ contains
     integer:: th_num
     integer:: indx
 
+    if (.not. module_is_initialized) call fms_affinity_init()
     if (.not. affinity) return
 
     if (strict) then

--- a/test_fms/affinity/test_affinity.F90
+++ b/test_fms/affinity/test_affinity.F90
@@ -21,6 +21,7 @@ program test_affinity
 
 !--- FMS modules
  use mpp_mod,          only: input_nml_file, mpp_error, mpp_pe, mpp_root_pe, FATAl
+ use fms_mod,          only: fms_init, fms_end
  use fms_affinity_mod
 
 !--- namelist parameters
@@ -34,12 +35,12 @@ program test_affinity
  integer:: conc_threads
  character(len=32):: h_name
 
+     call fms_init()
+
 !-----------------------------------------------------------------------
 !--- print initial test message
     print *, ''
     print *, '*** Testing affinity placement within FMS library...'
-!--- initialize affinity
-    call FMS_affinity_init()
 
     read(input_nml_file,test_affinity_nml, iostat=io_status)
     if (io_status > 0) then
@@ -50,5 +51,7 @@ program test_affinity
 
 !--- print success or failure message
     if (mpp_pe() == mpp_root_pe()) print *, '*** SUCCESS!'
+
+    call fms_end()
 
 end program test_affinity


### PR DESCRIPTION
**Description**
adds test to fms_affinity_set to ensure fms_affinity_init has been called

Fixes #916 

**How Has This Been Tested?**
modifications were made to fms_affinity.F90 and it was tested via an updated test_affinity.F90 system that explicitly omits affinity initialization

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

