### PR TITLE
fix: adds casts to mosaic2 calls to match doubles in C routines

### DIFF
--- a/mosaic2/mosaic2.F90
+++ b/mosaic2/mosaic2.F90
@@ -450,7 +450,7 @@ end function transfer_to_model_index
        type is (real(r4_kind))
          select type(area)
          type is (real(r4_kind))
-           call get_grid_area( nlon, nlat, lon, lat, area)
+           call get_grid_area( nlon, nlat, real(lon, r8_kind), real(lat, r8_kind), real(area, r8_kind))
            valid_types = .true.
          end select
        end select
@@ -500,7 +500,7 @@ end function transfer_to_model_index
        type is (real(r4_kind))
          select type(area)
          type is (real(r4_kind))
-           call get_grid_great_circle_area( nlon, nlat, lon, lat, area)
+           call get_grid_great_circle_area( nlon, nlat, real(lon, r8_kind), real(lat, r8_kind), real(area, r8_kind))
            valid_types = .true.
          end select
        end select


### PR DESCRIPTION
**Description**
Some of the class(*)'ified routines in mosaic2 call C routines that take doubles which causes a compile error with gcc 11 and openmpi. This just adds casts so the class(*) arguments always get passed as a double precision real.

Fixes #919 

**How Has This Been Tested?**
gcc 11.2.0 and openmpi + oneapi 2022

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

