### PR TITLE
Add option for position independent code in CMake

### DIFF
--- a/CMAKE_INSTRUCTIONS.md
+++ b/CMAKE_INSTRUCTIONS.md
@@ -43,9 +43,10 @@ By default, FMS is built without `OpenMP` and in `single precision (r4)`
 
 The following build options are available:
 ```
--DOPENMP   "Build FMS with OpenMP support" DEFAULT: OFF
--D32BIT    "Build 32-bit (r4) FMS library" DEFAULT: ON
--D64BIT    "Build 64-bit (r8) FMS library" DEFAULT: OFF
+-DOPENMP   "Build FMS with OpenMP support"        DEFAULT: OFF
+-D32BIT    "Build 32-bit (r4) FMS library"        DEFAULT: ON
+-D64BIT    "Build 64-bit (r8) FMS library"        DEFAULT: OFF
+-DFPIC     "Build with position independent code" DEFAULT: OFF
 
 -DINTERNAL_FILE_NML     "Enable compiler definition -DINTERNAL_FILE_NML"     DEFAULT: ON
 -DENABLE_QUAD_PRECISION "Enable compiler definition -DENABLE_QUAD_PRECISION" DEFAULT: ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,9 +52,10 @@ endif()
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 # Build options
-option(OPENMP    "Build FMS with OpenMP support" OFF)
-option(32BIT     "Build 32-bit (r4) FMS library"  ON)
-option(64BIT     "Build 64-bit (r8) FMS library" OFF)
+option(OPENMP "Build FMS with OpenMP support"        OFF)
+option(32BIT  "Build 32-bit (r4) FMS library"         ON)
+option(64BIT  "Build 64-bit (r8) FMS library"        OFF)
+option(FPIC   "Build with position independent code" OFF)
 
 # Options for compiler definitions
 option(INTERNAL_FILE_NML     "Enable compiler definition -DINTERNAL_FILE_NML"      ON)
@@ -87,6 +88,11 @@ endif()
 if (WITH_YAML)
   find_package(libyaml REQUIRED)
   include_directories(${LIBYAML_INCLUDE_DIR})
+endif ()
+
+# Enables position independent code (i.e., -fPIC)
+if (FPIC)
+  set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 endif ()
 
 # Collect FMS Fortran source files


### PR DESCRIPTION
**Description**

Fixes #806 

This PR adds an option to enable position independent code when building with CMake. As documented in #806, I got stymied at building with Autotools, so I moved to CMake. The error encountered:
```
relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
```
was one I've seen quite a few times and the answer is to set:
```cmake
  set(CMAKE_POSITION_INDEPENDENT_CODE ON)
```
in `CMakeLists.txt`. This adds `-fPIC` when building as a static library. Per CMake, this is `True` for shared libraries, but [off by default for static](https://cmake.org/cmake/help/latest/prop_tgt/POSITION_INDEPENDENT_CODE.html#prop_tgt:POSITION_INDEPENDENT_CODE). 

Now in all my testing, this flag never hurts, but to be safe, I've added a `-DFPIC` option where it's default `OFF`, so `CMAKE_POSITION_INDEPENDENT_CODE` will be `OFF` as it currently is  in FMS.

Note that I am not good at Autotools and I couldn't build with it anyway, so I'm not sure how to affect a similar change in that build processes.

**How Has This Been Tested?**

I've built FMS with a similar more "hard-coded" change with GEOS, see:

https://github.com/NOAA-GFDL/FMS/compare/2021.04...GEOS-ESM:geos/2021.04

and run GEOS with that build. And it's zero-diff.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] `make distcheck` passes

