### PR TITLE
Register_diag_field

### DIFF
--- a/diag_manager/diag_manager.F90
+++ b/diag_manager/diag_manager.F90
@@ -3870,7 +3870,7 @@ INTEGER FUNCTION register_diag_field_array_old(module_name, field_name, axes, in
     endif
 #else
     if (use_modern_diag) &
-      call error_mseg("diag_manager_mod::diag_manager_init", &
+      call error_mesg("diag_manager_mod::diag_manager_init", &
                        & "You need to compile with -Duse_yaml if diag_manager_nml::use_modern_diag=.true.", FATAL)
 #endif
 

--- a/diag_manager/diag_manager.F90
+++ b/diag_manager/diag_manager.F90
@@ -232,7 +232,7 @@ use platform_mod
        & max_out_per_in_field, flush_nc_files, region_out_use_alt_value, max_field_attributes, output_field_type,&
        & max_file_attributes, max_axis_attributes, prepend_date, DIAG_FIELD_NOT_FOUND, diag_init_time,diag_data_init,&
        & use_modern_diag, diag_null
-  
+
   USE diag_data_mod, ONLY:  fileobj, fileobjU, fnum_for_domain, fileobjND
   USE diag_table_mod, ONLY: parse_diag_table
   USE diag_output_mod, ONLY: get_diag_global_att, set_diag_global_att
@@ -240,7 +240,7 @@ use platform_mod
   USE fms_diag_object_mod, ONLY: fmsDiagObject_type
 
 #ifdef use_yaml
-  use fms_diag_yaml_mod, only: diag_yaml_object_init, diag_yaml_object_end, get_num_unique_fields
+  use fms_diag_yaml_mod, only: diag_yaml_object_init, diag_yaml_object_end, get_num_unique_fields, find_diag_field
 #endif
 
   USE constants_mod, ONLY: SECONDS_PER_DAY
@@ -475,8 +475,23 @@ end function register_diag_field_array
     INTEGER,          OPTIONAL, INTENT(in) :: volume        !< Id of the volume field
     CHARACTER(len=*), OPTIONAL, INTENT(in) :: realm         !< String to set as the modeling_realm attribute
 
-    ! TODO: Check if the diag_field is in the yaml, if it is not return diag_null. If it is fill in the diag_obj
-    register_diag_field_scalar_modern = diag_null
+#ifdef use_yaml
+    integer, allocatable :: diag_file_indices(:) !< indices where the field was found
+
+    diag_file_indices = find_diag_field(field_name)
+    if (diag_file_indices(1) .eq. diag_null) then
+      !< The field was not found in the table, so return diag_null
+      register_diag_field_scalar_modern = diag_null
+      deallocate(diag_file_indices)
+      return
+    endif
+
+    registered_variables = registered_variables + 1
+    register_diag_field_scalar_modern = registered_variables
+
+    !< TO DO: Fill in the diag_obj
+    deallocate(diag_file_indices)
+#endif
 
   end function register_diag_field_scalar_modern
 
@@ -507,8 +522,24 @@ end function register_diag_field_array
     INTEGER,          OPTIONAL, INTENT(in) :: volume        !< Id of the volume field
     CHARACTER(len=*), OPTIONAL, INTENT(in) :: realm         !< String to set as the modeling_realm attribute
 
-    ! TODO: Check if the diag_field is in the yaml, if it is not return diag_null. If it is fill in the diag_obj
-    register_diag_field_array_modern = diag_null
+#ifdef use_yaml
+    integer, allocatable :: diag_file_indices(:) !< indices where the field was found
+
+    diag_file_indices = find_diag_field(field_name)
+    if (diag_file_indices(1) .eq. diag_null) then
+      !< The field was not found in the table, so return diag_null
+      register_diag_field_array_modern = diag_null
+      deallocate(diag_file_indices)
+      return
+    endif
+
+    registered_variables = registered_variables + 1
+    register_diag_field_array_modern = registered_variables
+
+    !< TO DO: Fill in the diag_obj
+    deallocate(diag_file_indices)
+#endif
+
    end function register_diag_field_array_modern
 
   !> @brief Registers a scalar field

--- a/diag_manager/diag_manager.F90
+++ b/diag_manager/diag_manager.F90
@@ -3868,7 +3868,11 @@ INTEGER FUNCTION register_diag_field_array_old(module_name, field_name, axes, in
       allocate(diag_objs(get_num_unique_fields()))
       registered_variables = 0
     endif
+#else
+    if (use_modern_diag) &
+      call mpp_error(FATAL, "You need to compile with -Duse_yaml if diag_manager_nml::use_modern_diag=.true.")
 #endif
+
    if (.not. use_modern_diag) then
      CALL parse_diag_table(DIAG_SUBSET=diag_subset_output, ISTAT=mystat, ERR_MSG=err_msg_local)
      IF ( mystat /= 0 ) THEN

--- a/diag_manager/diag_manager.F90
+++ b/diag_manager/diag_manager.F90
@@ -3870,7 +3870,8 @@ INTEGER FUNCTION register_diag_field_array_old(module_name, field_name, axes, in
     endif
 #else
     if (use_modern_diag) &
-      call mpp_error(FATAL, "You need to compile with -Duse_yaml if diag_manager_nml::use_modern_diag=.true.")
+      call error_mseg("diag_manager_mod::diag_manager_init", &
+                       & "You need to compile with -Duse_yaml if diag_manager_nml::use_modern_diag=.true.", FATAL)
 #endif
 
    if (.not. use_modern_diag) then

--- a/diag_manager/diag_manager.F90
+++ b/diag_manager/diag_manager.F90
@@ -238,10 +238,9 @@ use platform_mod
   USE diag_output_mod, ONLY: get_diag_global_att, set_diag_global_att
   USE diag_grid_mod, ONLY: diag_grid_init, diag_grid_end
   USE fms_diag_object_mod, ONLY: fmsDiagObject_type
-  use fms_diag_object_container_mod, ONLY: FmsDiagObjectContainer_t
 
 #ifdef use_yaml
-  use fms_diag_yaml_mod, only: diag_yaml_object_init, diag_yaml_object_end
+  use fms_diag_yaml_mod, only: diag_yaml_object_init, diag_yaml_object_end, get_num_unique_fields
 #endif
 
   USE constants_mod, ONLY: SECONDS_PER_DAY
@@ -279,7 +278,8 @@ use platform_mod
 
   type(time_type) :: Time_end
 
-  TYPE(FmsDiagObjectContainer_t), ALLOCATABLE :: the_diag_object_container
+  TYPE(fmsDiagObject_type), ALLOCATABLE :: diag_objs(:) !< Array of diag objects, one for each registered variable
+  integer :: registered_variables !< Number of registered variables
 
   !> @brief Send data over to output fields.
   !!
@@ -3646,7 +3646,10 @@ INTEGER FUNCTION register_diag_field_array_old(module_name, field_name, axes, in
     if (allocated(fnum_for_domain)) deallocate(fnum_for_domain)
 
 #ifdef use_yaml
-    if (use_modern_diag) call diag_yaml_object_end
+    if (use_modern_diag) then
+      call diag_yaml_object_end
+      if (allocated(diag_objs)) deallocate(diag_objs)
+    endif
 #endif
   END SUBROUTINE diag_manager_end
 
@@ -3860,7 +3863,11 @@ INTEGER FUNCTION register_diag_field_array_old(module_name, field_name, axes, in
     END IF
 
 #ifdef use_yaml
-    if (use_modern_diag) CALL diag_yaml_object_init(diag_subset_output)
+    if (use_modern_diag) then
+      CALL diag_yaml_object_init(diag_subset_output)
+      allocate(diag_objs(get_num_unique_fields()))
+      registered_variables = 0
+    endif
 #endif
    if (.not. use_modern_diag) then
      CALL parse_diag_table(DIAG_SUBSET=diag_subset_output, ISTAT=mystat, ERR_MSG=err_msg_local)
@@ -3881,10 +3888,6 @@ INTEGER FUNCTION register_diag_field_array_old(module_name, field_name, axes, in
             & 'Missing Value', SEP, 'Min Value',      SEP, 'Max Value',    SEP,&
             & 'AXES LIST'
     END IF
-
-    !!Create the diag_object container; Its a singleton in the diag_data mod
-    allocate(the_diag_object_container)
-    call the_diag_object_container%initialize()
 
     module_is_initialized = .TRUE.
     ! create axis_id for scalars here

--- a/diag_manager/fms_diag_yaml.F90
+++ b/diag_manager/fms_diag_yaml.F90
@@ -56,14 +56,14 @@ integer, parameter :: MAX_STR_LEN = 255
 type varList
   character(len=255), allocatable :: var_name(:) !< Array of diag_field
   type(c_ptr), allocatable :: var_pointer(:) !< Array of pointers
-  integer, allocatable :: ids(:) !< Array of ids
+  integer, allocatable :: diag_field_indices(:) !< Index of the field in the diag_field array
 end type
 
 !> @brief type to hold an array of sorted diag_files
 type fileList
   character(len=255), allocatable :: file_name(:) !< Array of diag_field
   type(c_ptr), allocatable :: file_pointer(:) !< Array of pointers
-  integer, allocatable :: ids(:) !< Array of ids
+  integer, allocatable :: diag_file_indices(:)  !< Index of the file in the diag_file array
 end type
 
 !> @brief type to hold the sub region information about a file
@@ -335,9 +335,9 @@ subroutine diag_yaml_object_init(diag_subset_output)
   allocate(diag_yaml%diag_files(actual_num_files))
   allocate(diag_yaml%diag_fields(total_nvars))
   allocate(variable_list%var_name(total_nvars))
-  allocate(variable_list%ids(total_nvars))
+  allocate(variable_list%diag_field_indices(total_nvars))
   allocate(file_list%file_name(actual_num_files))
-  allocate(file_list%ids(actual_num_files))
+  allocate(file_list%diag_file_indices(actual_num_files))
 
   var_count = 0
   file_count = 0
@@ -350,7 +350,7 @@ subroutine diag_yaml_object_init(diag_subset_output)
 
     !> Save the file name in the file_list
     file_list%file_name(file_count) = trim(diag_yaml%diag_files(file_count)%file_fname)//c_null_char
-    file_list%ids(file_count) = file_count
+    file_list%diag_file_indices(file_count) = file_count
 
     nvars = 0
     nvars = get_num_blocks(diag_yaml_id, "varlist", parent_block_id=diag_file_ids(i))
@@ -376,17 +376,17 @@ subroutine diag_yaml_object_init(diag_subset_output)
 
       !> Save the variable name in the variable_list
       variable_list%var_name(var_count) = trim(diag_yaml%diag_fields(var_count)%var_varname)//c_null_char
-      variable_list%ids(var_count) = var_count
+      variable_list%diag_field_indices(var_count) = var_count
     enddo nvars_loop
     deallocate(var_ids)
   enddo nfiles_loop
 
   !> Sort the file list in alphabetical order
   file_list%file_pointer = fms_array_to_pointer(file_list%file_name)
-  call fms_sort_this(file_list%file_pointer, actual_num_files, file_list%ids)
+  call fms_sort_this(file_list%file_pointer, actual_num_files, file_list%diag_file_indices)
 
   variable_list%var_pointer = fms_array_to_pointer(variable_list%var_name)
-  call fms_sort_this(variable_list%var_pointer, total_nvars, variable_list%ids)
+  call fms_sort_this(variable_list%var_pointer, total_nvars, variable_list%diag_field_indices)
 
   deallocate(diag_file_ids)
 end subroutine
@@ -412,11 +412,11 @@ subroutine diag_yaml_object_end()
 
   if(allocated(file_list%file_pointer)) deallocate(file_list%file_pointer)
   if(allocated(file_list%file_name)) deallocate(file_list%file_name)
-  if(allocated(file_list%ids)) deallocate(file_list%ids)
+  if(allocated(file_list%diag_file_indices)) deallocate(file_list%diag_file_indices)
 
   if(allocated(variable_list%var_pointer)) deallocate(variable_list%var_pointer)
   if(allocated(variable_list%var_name)) deallocate(variable_list%var_name)
-  if(allocated(variable_list%ids)) deallocate(variable_list%ids)
+  if(allocated(variable_list%diag_field_indices)) deallocate(variable_list%diag_field_indices)
 
 end subroutine diag_yaml_object_end
 

--- a/diag_manager/fms_diag_yaml.F90
+++ b/diag_manager/fms_diag_yaml.F90
@@ -1136,7 +1136,8 @@ end function get_num_unique_fields
 function find_diag_field(diag_field_name) &
 result(indices)
 
-  character(len=*), intent(in) :: diag_field_name
+  character(len=*), intent(in) :: diag_field_name !< diag_field name to search for
+
   integer, allocatable :: indices(:)
 
   indices = fms_find_my_string(variable_list%var_pointer, size(variable_list%var_pointer), &

--- a/diag_manager/fms_diag_yaml.F90
+++ b/diag_manager/fms_diag_yaml.F90
@@ -44,7 +44,7 @@ private
 public :: diag_yaml_object_init, diag_yaml_object_end
 public :: diagYamlObject_type, get_diag_yaml_obj, get_title, get_basedate, get_diag_files, get_diag_fields
 public :: diagYamlFiles_type, diagYamlFilesVar_type
-public :: get_num_unique_fields
+public :: get_num_unique_fields, find_diag_field, get_diag_fields_entries, get_diag_files_entries
 
 !> @}
 
@@ -1131,6 +1131,72 @@ function get_num_unique_fields() &
 
 end function get_num_unique_fields
 
+!> @brief Determines if a diag_field is in the diag_yaml_object
+!! @return Indices of the locations where the field was found
+function find_diag_field(diag_field_name) &
+result(indices)
+
+  character(len=*), intent(in) :: diag_field_name
+  integer, allocatable :: indices(:)
+
+  indices = fms_find_my_string(variable_list%var_pointer, size(variable_list%var_pointer), &
+                               & diag_field_name//c_null_char)
+end function find_diag_field
+
+!> @brief Gets the diag_field entries corresponding to the indices of the sorted variable_list
+!! @return Array of diag_fields
+function get_diag_fields_entries(indices) &
+  result(diag_field)
+
+  integer, intent(in) :: indices(:) !< Indices of the field in the sorted variable_list array
+  type(diagYamlFilesVar_type), dimension (:), allocatable :: diag_field
+
+  integer :: i !< For do loops
+  integer :: field_id !< Indices of the field in the diag_yaml array
+
+  allocate(diag_field(size(indices)))
+
+  do i = 1, size(indices)
+    field_id = variable_list%diag_field_indices(indices(i))
+    diag_field(i) = diag_yaml%diag_fields(field_id)
+  end do
+
+end function get_diag_fields_entries
+
+!> @brief Gets the diag_files entries corresponding to the indices of the sorted variable_list
+!! @return Array of diag_files
+function get_diag_files_entries(indices) &
+  result(diag_file)
+
+  integer, intent(in) :: indices(:) !< Indices of the field in the sorted variable_list
+  type(diagYamlFiles_type), dimension (:), allocatable :: diag_file
+
+  integer :: i !< For do loops
+  integer :: field_id !< Indices of the field in the diag_yaml array
+  integer :: file_id !< Indices of the file in the diag_yaml array
+  character(len=120) :: filename !< Filename of the field
+  integer, allocatable :: file_indices(:) !< Indices of the file in the sorted variable_list
+
+  allocate(diag_file(size(indices)))
+
+  do i = 1, size(indices)
+    field_id = variable_list%diag_field_indices(indices(i))
+    filename = diag_yaml%diag_fields(field_id)%var_fname
+
+    file_indices = fms_find_my_string(file_list%file_pointer, size(file_list%file_pointer), &
+      & trim(filename)//c_null_char)
+
+    if (size(file_indices) .ne. 1) &
+      & call mpp_error(FATAL, "get_diag_files_entries: Error getting the correct number of file indices!")
+
+    if (file_indices(1) .eq. diag_null) &
+      & call mpp_error(FATAL, "get_diag_files_entries: Error finding the filename in the diag_files")
+
+    file_id = file_list%diag_file_indices(file_indices(1))
+    diag_file(i) = diag_yaml%diag_files(file_id)
+  end do
+
+end function get_diag_files_entries
 #endif
 end module fms_diag_yaml_mod
 !> @}

--- a/diag_manager/fms_diag_yaml.F90
+++ b/diag_manager/fms_diag_yaml.F90
@@ -53,14 +53,14 @@ integer, parameter :: NUM_SUB_REGION_ARRAY = 8
 integer, parameter :: MAX_STR_LEN = 255
 
 !> @brief type to hold an array of sorted diag_fiels
-type varList
+type varList_type
   character(len=255), allocatable :: var_name(:) !< Array of diag_field
   type(c_ptr), allocatable :: var_pointer(:) !< Array of pointers
   integer, allocatable :: diag_field_indices(:) !< Index of the field in the diag_field array
 end type
 
 !> @brief type to hold an array of sorted diag_files
-type fileList
+type fileList_type
   character(len=255), allocatable :: file_name(:) !< Array of diag_field
   type(c_ptr), allocatable :: file_pointer(:) !< Array of pointers
   integer, allocatable :: diag_file_indices(:)  !< Index of the file in the diag_file array
@@ -211,8 +211,8 @@ type diagYamlObject_type
 end type diagYamlObject_type
 
 type (diagYamlObject_type) :: diag_yaml  !< Obj containing the contents of the diag_table.yaml
-type (varList), save :: variable_list !< List of all the variables in the diag_table.yaml
-type (fileList), save :: file_list !< List of all files in the diag_table.yaml
+type (varList_type), save :: variable_list !< List of all the variables in the diag_table.yaml
+type (fileList_type), save :: file_list !< List of all files in the diag_table.yaml
 
 !> @addtogroup fms_diag_yaml_mod
 !> @{

--- a/diag_manager/fms_diag_yaml.F90
+++ b/diag_manager/fms_diag_yaml.F90
@@ -34,6 +34,8 @@ use diag_data_mod,   only: DIAG_NULL, DIAG_OCEAN, DIAG_ALL, DIAG_OTHER, set_base
 use yaml_parser_mod, only: open_and_parse_file, get_value_from_key, get_num_blocks, get_nkeys, &
                            get_block_ids, get_key_value, get_key_ids, get_key_name
 use mpp_mod,         only: mpp_error, FATAL
+use, intrinsic :: iso_c_binding, only : c_ptr, c_null_char
+use fms_string_utils_mod, only: fms_array_to_pointer, fms_find_my_string, fms_sort_this, fms_find_unique
 
 implicit none
 
@@ -42,11 +44,27 @@ private
 public :: diag_yaml_object_init, diag_yaml_object_end
 public :: diagYamlObject_type, get_diag_yaml_obj, get_title, get_basedate, get_diag_files, get_diag_fields
 public :: diagYamlFiles_type, diagYamlFilesVar_type
+public :: get_num_unique_fields
+
 !> @}
 
 integer, parameter :: basedate_size = 6
 integer, parameter :: NUM_SUB_REGION_ARRAY = 8
 integer, parameter :: MAX_STR_LEN = 255
+
+!> @brief type to hold an array of sorted diag_fiels
+type varList
+  character(len=255), allocatable :: var_name(:) !< Array of diag_field
+  type(c_ptr), allocatable :: var_pointer(:) !< Array of pointers
+  integer, allocatable :: ids(:) !< Array of ids
+end type
+
+!> @brief type to hold an array of sorted diag_files
+type fileList
+  character(len=255), allocatable :: file_name(:) !< Array of diag_field
+  type(c_ptr), allocatable :: file_pointer(:) !< Array of pointers
+  integer, allocatable :: ids(:) !< Array of ids
+end type
 
 !> @brief type to hold the sub region information about a file
 type subRegion_type
@@ -193,6 +211,8 @@ type diagYamlObject_type
 end type diagYamlObject_type
 
 type (diagYamlObject_type) :: diag_yaml  !< Obj containing the contents of the diag_table.yaml
+type (varList), save :: variable_list !< List of all the variables in the diag_table.yaml
+type (fileList), save :: file_list !< List of all files in the diag_table.yaml
 
 !> @addtogroup fms_diag_yaml_mod
 !> @{
@@ -314,6 +334,10 @@ subroutine diag_yaml_object_init(diag_subset_output)
 
   allocate(diag_yaml%diag_files(actual_num_files))
   allocate(diag_yaml%diag_fields(total_nvars))
+  allocate(variable_list%var_name(total_nvars))
+  allocate(variable_list%ids(total_nvars))
+  allocate(file_list%file_name(actual_num_files))
+  allocate(file_list%ids(actual_num_files))
 
   var_count = 0
   file_count = 0
@@ -323,6 +347,10 @@ subroutine diag_yaml_object_init(diag_subset_output)
     file_count = file_count + 1
     call diag_yaml_files_obj_init(diag_yaml%diag_files(file_count))
     call fill_in_diag_files(diag_yaml_id, diag_file_ids(i), diag_yaml%diag_files(file_count))
+
+    !> Save the file name in the file_list
+    file_list%file_name(file_count) = trim(diag_yaml%diag_files(file_count)%file_fname)//c_null_char
+    file_list%ids(file_count) = file_count
 
     nvars = 0
     nvars = get_num_blocks(diag_yaml_id, "varlist", parent_block_id=diag_file_ids(i))
@@ -345,9 +373,20 @@ subroutine diag_yaml_object_init(diag_subset_output)
 
       !> Save the variable name in the diag_file type
       diag_yaml%diag_files(file_count)%file_varlist(file_var_count) = diag_yaml%diag_fields(var_count)%var_varname
+
+      !> Save the variable name in the variable_list
+      variable_list%var_name(var_count) = trim(diag_yaml%diag_fields(var_count)%var_varname)//c_null_char
+      variable_list%ids(var_count) = var_count
     enddo nvars_loop
     deallocate(var_ids)
   enddo nfiles_loop
+
+  !> Sort the file list in alphabetical order
+  file_list%file_pointer = fms_array_to_pointer(file_list%file_name)
+  call fms_sort_this(file_list%file_pointer, actual_num_files, file_list%ids)
+
+  variable_list%var_pointer = fms_array_to_pointer(variable_list%var_name)
+  call fms_sort_this(variable_list%var_pointer, total_nvars, variable_list%ids)
 
   deallocate(diag_file_ids)
 end subroutine
@@ -370,6 +409,14 @@ subroutine diag_yaml_object_end()
     if(allocated(diag_yaml%diag_fields(i)%var_attributes)) deallocate(diag_yaml%diag_fields(i)%var_attributes)
   enddo
   if(allocated(diag_yaml%diag_fields)) deallocate(diag_yaml%diag_fields)
+
+  if(allocated(file_list%file_pointer)) deallocate(file_list%file_pointer)
+  if(allocated(file_list%file_name)) deallocate(file_list%file_name)
+  if(allocated(file_list%ids)) deallocate(file_list%ids)
+
+  if(allocated(variable_list%var_pointer)) deallocate(variable_list%var_pointer)
+  if(allocated(variable_list%var_name)) deallocate(variable_list%var_name)
+  if(allocated(variable_list%ids)) deallocate(variable_list%ids)
 
 end subroutine diag_yaml_object_end
 
@@ -1109,6 +1156,14 @@ pure logical function has_diag_fields (obj)
   has_diag_fields = allocated(obj%diag_fields)
 end function has_diag_fields  
 
+!> @brief Determine the number of unique diag_fields in the diag_yaml_object
+!! @return The number of unique diag_fields
+function get_num_unique_fields() &
+  result(nfields)
+  integer :: nfields
+  nfields = fms_find_unique(variable_list%var_pointer, size(variable_list%var_pointer))
+
+end function get_num_unique_fields
 
 #endif
 end module fms_diag_yaml_mod

--- a/test_fms/diag_manager/test_diag_yaml.F90
+++ b/test_fms/diag_manager/test_diag_yaml.F90
@@ -49,6 +49,7 @@ end interface compare_result
 logical :: checking_crashes = .false.!< Flag indicating that you are checking crashes
 integer :: i !< For do loops
 integer :: io_status !< The status after reading the input.nml
+integer, allocatable :: indices(:) !< Array of indices
 
 #ifdef use_yaml
 type(diagYamlFiles_type), allocatable, dimension (:) :: diag_files !< Files from the diag_yaml
@@ -91,9 +92,49 @@ if (.not. checking_crashes) then
 
   !< Check that get_num_unique_fields is getting the correct number of unique fields
   call compare_result("number of unique fields", get_num_unique_fields(), 2)
+
+  deallocate(diag_files)
+  deallocate(diag_fields)
+
+  indices = find_diag_field("sst")
+  print *, "sst was found in ", indices
+  if (size(indices) .ne. 2) &
+    call mpp_error(FATAL, 'sst was supposed to be found twice!')
+  if (indices(1) .ne. 2 .and. indices(2) .ne. 1) &
+    call mpp_error(FATAL, 'sst was supposed to be found in indices 1 and 2')
+
+  diag_fields = get_diag_fields_entries(indices)
+  call compare_result("sst - nfields", size(diag_fields), 2)
+  call compare_result("sst - fieldname", diag_fields(1)%get_var_varname(), "sst")
+  call compare_result("sst - fieldname", diag_fields(2)%get_var_varname(), "sst")
+  deallocate(diag_fields)
+
+  diag_files = get_diag_files_entries(indices)
+  call compare_result("sst - nfiles", size(diag_files), 2)
+  call compare_result("sst - filename", diag_files(1)%get_file_fname(), "normal")
+  call compare_result("sst - filename", diag_files(2)%get_file_fname(), "wild_card_name%4yr%2mo%2dy%2hr")
+  deallocate(diag_files)
+  deallocate(indices)
+
+  indices = find_diag_field("sstt")
+  print *, "sstt was found in ", indices
+  if (size(indices) .ne. 1) &
+    call mpp_error(FATAL, 'sstt was supposed to be found twice!')
+  if (indices(1) .ne. 3) &
+    call mpp_error(FATAL, 'sstt was supposed to be found in indices 1 and 2')
+  deallocate(indices)
+
+  indices = find_diag_field("sstt2") !< This is in diag_table but it has write_var = false
+  print *, "sstt2 was found in ", indices
+  if (indices(1) .ne. -999) &
+    call mpp_error(FATAL, "sstt2 is not in the diag_table!")
+
+  indices = find_diag_field("tamales")
+  print *, "tamales was found in ", indices
+  if (indices(1) .ne. -999) &
+    call mpp_error(FATAL, "tamales is not in the diag_table!")
+
 endif
-deallocate(diag_files)
-deallocate(diag_fields)
 
 call diag_yaml_object_end
 

--- a/test_fms/diag_manager/test_diag_yaml.F90
+++ b/test_fms/diag_manager/test_diag_yaml.F90
@@ -89,6 +89,8 @@ if (.not. checking_crashes) then
   call compare_result("nfields", size(diag_fields), 3) !< the fourth variable has var_write = false so it doesn't count
   call compare_diag_fields(diag_fields)
 
+  !< Check that get_num_unique_fields is getting the correct number of unique fields
+  call compare_result("number of unique fields", get_num_unique_fields(), 2)
 endif
 deallocate(diag_files)
 deallocate(diag_fields)


### PR DESCRIPTION
**Description**
Adds function, `find_diag_field`, to determine if a diag_field is in the diag_table.yaml
Adds functions, `get_diag_fields_entries` and `get_diag_files_entries` that will be used fill in diag_obj
Adds tests for these functions
Uses `find_diag_field` in register_diag_field, returns diag_null if the fields does not exist in the diag_yaml, assigns an id if it does

**How Has This Been Tested?**
CI, including new tests

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

