### PR TITLE
add back in small_fac parameter to constants .h files

### DIFF
--- a/constants/geos_constants.h
+++ b/constants/geos_constants.h
@@ -20,7 +20,7 @@
 character(len=18), public, parameter :: constants_version = 'FMSConstants: GEOS'
 
 !--- temporary definition for backwards compatibility
-real(kind=RKIND, public, parameter :: small_fac = 1._r8_kind
+real(kind=RKIND), public, parameter :: small_fac = 1._r8_kind
 
 !--- Spherical coordinate conversion constants
 real(kind=r8_kind), public, parameter :: PI_8 = 3.14159265358979323846_r8_kind  !< Ratio of circle circumference to diameter [N/A]

--- a/constants/geos_constants.h
+++ b/constants/geos_constants.h
@@ -19,6 +19,8 @@
 
 character(len=18), public, parameter :: constants_version = 'FMSConstants: GEOS'
 
+!--- temporary definition for backwards compatibility
+real(kind=RKIND, public, parameter :: small_fac = 1._r8_kind
 
 !--- Spherical coordinate conversion constants
 real(kind=r8_kind), public, parameter :: PI_8 = 3.14159265358979323846_r8_kind  !< Ratio of circle circumference to diameter [N/A]

--- a/constants/gfdl_constants.h
+++ b/constants/gfdl_constants.h
@@ -19,6 +19,9 @@
 
 character(len=18), public, parameter :: constants_version = 'FMSConstants: GFDL'
 
+!--- temporary definition for backwards compatibility
+real(kind=RKIND, public, parameter :: small_fac = 1._r8_kind
+
 !--- Spherical coordinate conversion constants
 real(kind=r8_kind), public, parameter :: PI_8 = 3.14159265358979323846_r8_kind  !< Ratio of circle circumference to diameter [N/A]
 real(kind=RKIND),   public, parameter :: PI   = PI_8                            !< Ratio of circle circumference to diameter [N/A]

--- a/constants/gfdl_constants.h
+++ b/constants/gfdl_constants.h
@@ -20,7 +20,7 @@
 character(len=18), public, parameter :: constants_version = 'FMSConstants: GFDL'
 
 !--- temporary definition for backwards compatibility
-real(kind=RKIND, public, parameter :: small_fac = 1._r8_kind
+real(kind=RKIND), public, parameter :: small_fac = 1._r8_kind
 
 !--- Spherical coordinate conversion constants
 real(kind=r8_kind), public, parameter :: PI_8 = 3.14159265358979323846_r8_kind  !< Ratio of circle circumference to diameter [N/A]

--- a/constants/gfs_constants.h
+++ b/constants/gfs_constants.h
@@ -20,7 +20,7 @@
 character(len=18), public, parameter :: constants_version = 'FMSConstants: GFS '
 
 !--- temporary definition for backwards compatibility
-real(kind=RKIND, public, parameter :: small_fac = 1._r8_kind
+real(kind=RKIND), public, parameter :: small_fac = 1._r8_kind
 
 !--- Spherical coordinate conversion constants
 real(kind=r8_kind), public, parameter :: PI_8 = 3.1415926535897931_r8_kind    !< Ratio of circle circumference to diameter [N/A]

--- a/constants/gfs_constants.h
+++ b/constants/gfs_constants.h
@@ -19,6 +19,9 @@
 
 character(len=18), public, parameter :: constants_version = 'FMSConstants: GFS '
 
+!--- temporary definition for backwards compatibility
+real(kind=RKIND, public, parameter :: small_fac = 1._r8_kind
+
 !--- Spherical coordinate conversion constants
 real(kind=r8_kind), public, parameter :: PI_8 = 3.1415926535897931_r8_kind    !< Ratio of circle circumference to diameter [N/A]
 real(kind=RKIND),   public, parameter :: PI   = PI_8                          !< Ratio of circle circumference to diameter [N/A]


### PR DESCRIPTION
**Description**
Temporarily reinstate small_fac parameter in the FMS constants.

Fixes #796 

**How Has This Been Tested?**
will be tested as part of alpha testing

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

