### PR TITLE
Update supported types in diag_manager

### DIFF
--- a/diag_manager/fms_diag_yaml.F90
+++ b/diag_manager/fms_diag_yaml.F90
@@ -667,10 +667,10 @@ subroutine check_field_kind(field)
   type(diagYamlFilesVar_type), intent(in) :: field        !< diagYamlFilesVar_type obj to read the contents into
 
   select case (TRIM(field%var_skind))
-  case ("real64", "real32", "int64", "int32")
+  case ("r4", "r8", "i4", "i8")
   case default
     call mpp_error(FATAL, trim(field%var_skind)//" is an invalid kind! &
-      &The acceptable values are real64, real32, int64, int32. &
+      &The acceptable values are r4, r8, i4, i8. &
       &Check your entry for file:"//trim(field%var_varname)//" in file "//trim(field%var_fname))
   end select
 

--- a/diag_manager/fms_diag_yaml.F90
+++ b/diag_manager/fms_diag_yaml.F90
@@ -667,10 +667,10 @@ subroutine check_field_kind(field)
   type(diagYamlFilesVar_type), intent(in) :: field        !< diagYamlFilesVar_type obj to read the contents into
 
   select case (TRIM(field%var_skind))
-  case ("double", "float")
+  case ("real64", "real32", "int64", "int32")
   case default
     call mpp_error(FATAL, trim(field%var_skind)//" is an invalid kind! &
-      &The acceptable values are double and float. &
+      &The acceptable values are real64, real32, int64, int32. &
       &Check your entry for file:"//trim(field%var_varname)//" in file "//trim(field%var_fname))
   end select
 

--- a/test_fms/diag_manager/test_diag_manager2.sh
+++ b/test_fms/diag_manager/test_diag_manager2.sh
@@ -517,7 +517,7 @@ diag_files:
     var_name: sst
     output_name: sst
     reduction: average
-    kind: float
+    kind: r4
   global_meta:
   - is_a_file: true
 - file_name: normal
@@ -530,7 +530,7 @@ diag_files:
     var_name: sst
     output_name: sst
     reduction: average
-    kind: float
+    kind: r4
     write_var: true
     attributes:
     - do_sst: .true.
@@ -549,13 +549,13 @@ diag_files:
     var_name: sstt
     output_name: sstt
     reduction: average
-    kind: float
+    kind: r4
     long_name: S S T
   - module: test_diag_manager_mod
     var_name: sstt2
     output_name: sstt2
     reduction: average
-    kind: float
+    kind: r4
     long_name: S S T
     write_var: false
   sub_region:
@@ -594,7 +594,7 @@ diag_files:
     var_name: sst1
     output_name: sst1
     reduction: average
-    kind: float
+    kind: r4
 - file_name: file2
   freq: 6
   freq_units: hours
@@ -606,7 +606,7 @@ diag_files:
     var_name: sst2
     output_name: sst2
     reduction: average
-    kind: float
+    kind: r4
 - file_name: file3
   freq: 6
   freq_units: hours
@@ -617,12 +617,12 @@ diag_files:
     var_name: sst3
     output_name: sst3
     reduction: average
-    kind: float
+    kind: r4
   - module: test_diag_manager_mod
     var_name: sst4
     output_name: sst4
     reduction: average
-    kind: float
+    kind: r4
 _EOF
 test_expect_success "Test the diag_ocean feature in diag_manager_init (test $my_test_count)" '
   mpirun -n 2 ../test_diag_ocean

--- a/test_fms/diag_manager/test_diag_yaml.F90
+++ b/test_fms/diag_manager/test_diag_yaml.F90
@@ -123,9 +123,9 @@ subroutine compare_diag_fields(res)
   call compare_result("var_module 2", res(2)%get_var_module(), "test_diag_manager_mod")
   call compare_result("var_module 3", res(3)%get_var_module(), "test_diag_manager_mod")
 
-  call compare_result("var_skind 1", res(1)%get_var_skind(), "float")
-  call compare_result("var_skind 2", res(2)%get_var_skind(), "float")
-  call compare_result("var_skind 3", res(3)%get_var_skind(), "float")
+  call compare_result("var_skind 1", res(1)%get_var_skind(), "r4")
+  call compare_result("var_skind 2", res(2)%get_var_skind(), "r4")
+  call compare_result("var_skind 3", res(3)%get_var_skind(), "r4")
 
   call compare_result("var_outname 1", res(1)%get_var_outname(), "sst")
   call compare_result("var_outname 2", res(2)%get_var_outname(), "sst")


### PR DESCRIPTION
**Description**
Changes supported types to r4, r8, i4, i8 instead of just "double" and "float". 

The converter and the diag_table.yaml checker need to be updated as well. 

Fixes # (issue)

**How Has This Been Tested?**
CI

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

