### PR TITLE
Fix bug in fms2_io:: flush_file

### DIFF
--- a/fms2_io/netcdf_io.F90
+++ b/fms2_io/netcdf_io.F90
@@ -2283,8 +2283,10 @@ subroutine flush_file(fileobj)
 
   integer :: err !< Netcdf error code
 
-  err = nf90_sync(fileobj%ncid)
-  call check_netcdf_code(err, "Flush_file: File:"//trim(fileobj%path))
+  if (fileobj%is_root) then
+    err = nf90_sync(fileobj%ncid)
+    call check_netcdf_code(err, "Flush_file: File:"//trim(fileobj%path))
+  endif
 end subroutine flush_file
 
 end module netcdf_io_mod


### PR DESCRIPTION
**Description**
Wraps the `nf90_sync` call in `flush_file` around a `if (fileobj%is_root)` because only the root io pe has the file opened.

Fixes #957 

**How Has This Been Tested?**
AM4 run with diag_manager_nml::flush_nc_files=.true.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

