### PR TITLE
build system updates

### DIFF
--- a/CMAKE_INSTRUCTIONS.md
+++ b/CMAKE_INSTRUCTIONS.md
@@ -27,6 +27,17 @@ export NetCDF_ROOT=`nc-config --prefix`
 export LIBYAML_ROOT=<your libyaml install directory>
 ```
 
+### Setting custom flags with the bash shell
+To override the default compiler flags:
+```
+export FCFLAGS="<fortran flags>"
+export CFLAGS="<c flags>"
+```
+In addition, the flag below must be included with the cmake command:
+```
+cmake <any other options> -DCMAKE_BUILD_TYPE=Debug ..
+```
+
 ## 2. Build and install FMS with CMake
 `<prefix>` is the full install directory for FMS provided by user
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,6 @@ endif()
 find_package(MPI REQUIRED COMPONENTS C Fortran)
 find_package(NetCDF REQUIRED COMPONENTS C Fortran)
 
-
 # Check for the OpenMP library and set the required compile flags
 if (OPENMP)
   find_package(OpenMP REQUIRED COMPONENTS C Fortran)
@@ -259,6 +258,9 @@ if(APPLE)
   list(APPEND fms_defs __APPLE__)
 endif()
 
+# Obtain compiler-specific flags
+include(fms_compiler_flags)
+
 foreach(kind ${kinds})
 
   set(libTgt fms_${kind})
@@ -291,7 +293,6 @@ foreach(kind ${kinds})
 
   string(TOLOWER ${CMAKE_BUILD_TYPE} build_type)
   if (NOT build_type STREQUAL debug)
-    include(fms_compiler_flags)
     set_target_properties(${libTgt}_f PROPERTIES COMPILE_FLAGS
                                                "${${kind}_flags}")
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,9 @@
 
 cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
 
+# add build type for debug, overrides default flags (set with $FCFLAGS, $CFLAGS)
+set(CMAKE_Fortran_FLAGS_DEBUG)
+
 # Define the CMake project
 project(FMS
   VERSION 2022.02.0
@@ -79,6 +82,7 @@ endif()
 # Find dependencies
 find_package(MPI REQUIRED COMPONENTS C Fortran)
 find_package(NetCDF REQUIRED COMPONENTS C Fortran)
+
 
 # Check for the OpenMP library and set the required compile flags
 if (OPENMP)
@@ -255,9 +259,6 @@ if(APPLE)
   list(APPEND fms_defs __APPLE__)
 endif()
 
-# Obtain compiler-specific flags
-include(fms_compiler_flags)
-
 foreach(kind ${kinds})
 
   set(libTgt fms_${kind})
@@ -288,8 +289,12 @@ foreach(kind ${kinds})
   target_compile_definitions(${libTgt}_f PRIVATE "${fms_defs}")
   target_compile_definitions(${libTgt}_f PRIVATE "${${kind}_defs}")
 
-  set_target_properties(${libTgt}_f PROPERTIES COMPILE_FLAGS
+  string(TOLOWER ${CMAKE_BUILD_TYPE} build_type)
+  if (NOT build_type STREQUAL debug)
+    include(fms_compiler_flags)
+    set_target_properties(${libTgt}_f PROPERTIES COMPILE_FLAGS
                                                "${${kind}_flags}")
+  endif()
   set_target_properties(${libTgt}_f PROPERTIES Fortran_MODULE_DIRECTORY
                                                ${moduleDir})
 
@@ -298,6 +303,14 @@ foreach(kind ${kinds})
 
   if(OpenMP_Fortran_FOUND)
     target_link_libraries(${libTgt}_f PRIVATE OpenMP::OpenMP_Fortran)
+  endif()
+
+  # Check if gnu 10 or higher with mpich
+  if ( CMAKE_Fortran_COMPILER_VERSION MATCHES "1[0-9]\.[0-9]*\.[0-9]*" AND CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
+    if(MPI_C_COMPILER MATCHES ".*mpich.*" )
+      message(STATUS "Adding -fallow-argument-mismatch flag to compile with GCC >=10 and MPICH")
+      set_target_properties(${libTgt}_f PROPERTIES COMPILE_FLAGS "-fallow-argument-mismatch -w")
+    endif()
   endif()
 
   # FMS (C + Fortran)

--- a/configure.ac
+++ b/configure.ac
@@ -384,7 +384,7 @@ fi
 # Check if gcc >=10 is used with mpich
 # adds compiler arg needed for mpich compilation if found
 AC_MSG_CHECKING([if gcc 10 or greater is loaded with mpich])
-if [ test -n "`$FC --version | grep GNU | grep 1.\..\..`" && test -n "which $FC | grep mpich" ]; then
+if [ test "`$FC --version | grep GNU | grep -E ' 1[0-9]\.[0-9]*\.[0-9]*$'`" -a "`which $FC | grep -i mpich`" ]; then
   AC_MSG_RESULT([yes])
   AC_MSG_WARN([Adding -fallow-argument-mismatch to FCFLAGS to allow compilation with gcc >=10 and mpich])
   FCFLAGS="$FCFLAGS -fallow-argument-mismatch"

--- a/configure.ac
+++ b/configure.ac
@@ -291,13 +291,13 @@ if test $enable_setting_flags = yes; then
   fi
   # individual mixed precision overloads
   if test $enable_overload_r4 = yes; then
-    AC_DEFINE([OVERLOAD_R4], [1], [Set to overload the R4 Fortran routines])
+    AC_DEFINE([OVERLOAD_R4], [1], [Set to overload with the R4 Fortran routines])
   fi
   if test $enable_overload_c4 = yes; then
-    AC_DEFINE([OVERLOAD_C4], [1], [Set to overload the C4 Fortran routines])
+    AC_DEFINE([OVERLOAD_C4], [1], [Set to overload with the C4 Fortran routines])
   fi
   if test $enable_overload_c8 = yes; then
-    AC_DEFINE([OVERLOAD_C8], [1], [Set to overload the C8 Fortran routines])
+    AC_DEFINE([OVERLOAD_C8], [1], [Set to overload with the C8 Fortran routines])
   fi
   if test $enable_8byte_int = yes; then
     AC_DEFINE([no_8byte_integers], [1], [Set to disable 8 byte integer Fortran routines])

--- a/configure.ac
+++ b/configure.ac
@@ -25,10 +25,10 @@ AC_PREREQ([2.69])
 
 # Initialize with name, version, and support email address.
 AC_INIT([GFDL FMS Library],
-  [2022.02.0],
+  [2022.03.0-dev],
   [gfdl.climate.model.info@noaa.gov],
   [FMS],
-  [https://www.gfdl.noaa.gov/fms])
+  [https://www.github.com/NOAA-GFDL/FMS])
 
 # Find out about the host we're building on.
 AC_CANONICAL_HOST
@@ -85,6 +85,31 @@ AC_ARG_ENABLE([code-coverage],
 AS_IF([test ${enable_code_coverage:-no} = no],
   [enable_code_coverage=no],
   [enable_code_coverage=yes])
+# individual mixed precision overload macros
+AC_ARG_ENABLE([overload-r4],
+  [AS_HELP_STRING([--enable-overload-r4],
+    [Enables the OVERLOAD_R4 macro to compile with 4 byte real routine overloads. (Default no)])])
+AS_IF([test ${enable_overload_r4:-no} = yes],
+  [enable_overload_r4=yes],
+  [enable_overload_r4=no])
+AC_ARG_ENABLE([overload-c4],
+  [AS_HELP_STRING([--enable-overload-c4],
+    [Enables the OVERLOAD_C4 macro to compile with 4 byte complex routine overloads. (Default no)])])
+AS_IF([test ${enable_overload_c4:-no} = yes],
+  [enable_overload_c4=yes],
+  [enable_overload_c4=no])
+AC_ARG_ENABLE([overload-c8],
+  [AS_HELP_STRING([--enable-overload-c8],
+    [Enables the OVERLOAD_C8 macro to compile with 8 byte real routine overloads. (Default no)])])
+AS_IF([test ${enable_overload_c8:-no} = yes],
+  [enable_overload_c8=yes],
+  [enable_overload_c8=no])
+AC_ARG_ENABLE([8byte-int],
+  [AS_HELP_STRING([--disable-8byte-int],
+    [Enables the no_8byte_integers macro to compile with only 4 byte integer routines. (Default no)])])
+AS_IF([test ${enable_8byte_int:-no} = yes],
+  [enable_8byte_int=yes],
+  [enable_8byte_int=no])
 
 # user enabled testing with input files
 AC_MSG_CHECKING([whether to enable tests with input files])
@@ -264,6 +289,19 @@ if test $enable_setting_flags = yes; then
     GX_FC_DEFAULT_REAL_KIND8_FLAG([dnl
       FCFLAGS="$FCFLAGS $FC_DEFAULT_REAL_KIND8_FLAG"])
   fi
+  # individual mixed precision overloads
+  if test $enable_overload_r4 = yes; then
+    AC_DEFINE([OVERLOAD_R4], [1], [Set to overload the R4 Fortran routines])
+  fi
+  if test $enable_overload_c4 = yes; then
+    AC_DEFINE([OVERLOAD_C4], [1], [Set to overload the C4 Fortran routines])
+  fi
+  if test $enable_overload_c8 = yes; then
+    AC_DEFINE([OVERLOAD_C8], [1], [Set to overload the C8 Fortran routines])
+  fi
+  if test $enable_8byte_int = yes; then
+    AC_DEFINE([no_8byte_integers], [1], [Set to disable 8 byte integer Fortran routines])
+  fi
 
   # Add Cray Pointer support flag
   if test ! -z "$FC_CRAY_POINTER_FLAG"; then
@@ -340,6 +378,16 @@ if [ test -n "`$FC --version | grep GNU | grep 11\.1\..`" ]; then
   AC_MSG_RESULT([yes])
   AC_MSG_ERROR([Compilation with gcc and gfortran 11.1.0 is unsupported \
 by this version of FMS due to a bug in the compiler. Please use a different version of gcc/gfortran.])
+else
+  AC_MSG_RESULT([no])
+fi
+# Check if gcc >=10 is used with mpich
+# adds compiler arg needed for mpich compilation if found
+AC_MSG_CHECKING([if gcc 10 or greater is loaded with mpich])
+if [ test -n "`$FC --version | grep GNU | grep 1.\..\..`" && test -n "which $FC | grep mpich" ]; then
+  AC_MSG_RESULT([yes])
+  AC_MSG_WARN([Adding -fallow-argument-mismatch to FCFLAGS to allow compilation with gcc >=10 and mpich])
+  FCFLAGS="$FCFLAGS -fallow-argument-mismatch"
 else
   AC_MSG_RESULT([no])
 fi

--- a/libFMS/BUILD_SYSTEM.md
+++ b/libFMS/BUILD_SYSTEM.md
@@ -85,6 +85,10 @@ Configure build options for FMS:
 * `--enable-mixed-mode` : Build in mixed precision mode, with default 4 byte reals and 8 byte real overloads
 * `--disable-setting-flags` : Build without automatically setting flags during configuration
 * `--with-mpi` : Build with MPI support, enabled by default
+* `--enable-overload-r4` : Compiles with 4 byte real routine overloads
+* `--enable-overload-c4` : Compiles with 4 byte complex routine overloads
+* `--enable-overload-c8` : Compiles with 8 byte complex routine overloads
+* `--disable-8byte-int`  : Compiles with only 4 byte integer routines
 
 ## Standard Make Targets
 


### PR DESCRIPTION
**Description**
Fixes a few different build system issues in cmake and autotools. Adds individual options to set mixed precision macros, a debug mode to be able to override the default flags in cmake, and some checks to add a required flag if compiling with gcc and mpich.

Fixes #639 
Fixes #645 

**How Has This Been Tested?**
tested the builds with the modules on amd

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

