### PR TITLE
fix: stack size fix for mpp_chksum

### DIFF
--- a/test_fms/mpp/test_mpp_chksum.F90
+++ b/test_fms/mpp/test_mpp_chksum.F90
@@ -28,7 +28,7 @@ program test_mpp_chksum
   implicit none
 
   integer :: test_num = 1
-  integer :: nx = 96, ny = 96, npz = 63
+  integer :: nx = 64, ny = 64, npz = 63
   logical :: debug = .false.
   integer :: npes, root, pe, ierr
 


### PR DESCRIPTION
**Description**
makes the checksum test use smaller arrays so it can pass with the default system stack size

**How Has This Been Tested?**
amd with oneapi 2022.1

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

