### PR TITLE
add number of diurnal sample and power level to the yaml

### DIFF
--- a/diag_manager/fms_diag_yaml.F90
+++ b/diag_manager/fms_diag_yaml.F90
@@ -190,6 +190,8 @@ type diagYamlFilesVar_type
   procedure :: has_var_longname 
   procedure :: has_var_units 
   procedure :: has_var_attributes 
+  procedure :: has_n_diurnal
+  procedure :: has_pow_value
 
 end type diagYamlFilesVar_type
 
@@ -1120,8 +1122,18 @@ pure logical function has_var_attributes (obj)
   class(diagYamlFilesVar_type), intent(in) :: obj !< diagYamlvar_type object to initialize
   has_var_attributes = allocated(obj%var_attributes)
 end function has_var_attributes
-
-
+!> @brief Checks if obj%n_diurnal is set
+!! @return true if obj%n_diurnal is set
+pure logical function has_n_diurnal(obj)
+  class(diagYamlFilesVar_type), intent(in) :: obj !< diagYamlvar_type object to inquire
+  has_n_diurnal = (obj%n_diurnal .ne. 0)
+end function has_n_diurnal
+!> @brief Checks if obj%pow_value is set
+!! @return true if obj%pow_value is set
+pure logical function has_pow_value(obj)
+  class(diagYamlFilesVar_type), intent(in) :: obj !< diagYamlvar_type object to inquire
+  has_pow_value = (obj%pow_value .ne. 0)
+end function has_pow_value
 
 !> @brief Checks if obj%diag_title is allocated
 !! @return true if obj%diag_title is allocated


### PR DESCRIPTION
**Description**
Saves the number of diurnal samples and the pow level to the diag_yaml
Adds corresponding get_* and has_* functions

This is to avoid having to get them from the `%reduction` **string** variable, every time they are needed.

**How Has This Been Tested?**
CI

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

