### PR TITLE
Finish register diag

### DIFF
--- a/diag_manager/diag_data.F90
+++ b/diag_manager/diag_data.F90
@@ -104,6 +104,7 @@ use platform_mod
   INTEGER, PARAMETER :: NO_DOMAIN    = 1 !< Use the FmsNetcdfFile_t fileobj
   INTEGER, PARAMETER :: TWO_D_DOMAIN = 2 !< Use the FmsNetcdfDomainFile_t fileobj
   INTEGER, PARAMETER :: UG_DOMAIN    = 3 !< Use the FmsNetcdfUnstructuredDomainFile_t fileobj
+  INTEGER, PARAMETER :: SUB_REGIONAL = 4 !< This is a file with a sub_region use the FmsNetcdfFile_t fileobj
   INTEGER, PARAMETER :: DIRECTION_UP   = 1  !< The axis points up if positive
   INTEGER, PARAMETER :: DIRECTION_DOWN = -1 !< The axis points down if positive
   INTEGER, PARAMETER :: GLO_REG_VAL = -999 !< Value used in the region specification of the diag_table

--- a/diag_manager/diag_manager.F90
+++ b/diag_manager/diag_manager.F90
@@ -477,21 +477,25 @@ end function register_diag_field_array
     CHARACTER(len=*), OPTIONAL, INTENT(in) :: realm         !< String to set as the modeling_realm attribute
 
 #ifdef use_yaml
-    integer, allocatable :: diag_file_indices(:) !< indices where the field was found
+    integer, allocatable :: diag_field_indices(:) !< indices where the field was found
 
-    diag_file_indices = find_diag_field(field_name)
-    if (diag_file_indices(1) .eq. diag_null) then
+    diag_field_indices = find_diag_field(field_name)
+    if (diag_field_indices(1) .eq. diag_null) then
       !< The field was not found in the table, so return diag_null
       register_diag_field_scalar_modern = diag_null
-      deallocate(diag_file_indices)
+      deallocate(diag_field_indices)
       return
     endif
 
     registered_variables = registered_variables + 1
     register_diag_field_scalar_modern = registered_variables
 
-    !< TO DO: Fill in the diag_obj
-    deallocate(diag_file_indices)
+    call diag_objs(registered_variables)%setID(registered_variables)
+    call diag_objs(registered_variables)%register(module_name, field_name, init_time, diag_field_indices, &
+      & longname=long_name, units=units, missing_value=missing_value, varrange=var_range, &
+      & standname=standard_name, do_not_log=do_not_log, err_msg=err_msg, &
+      & area=area, volume=volume, realm=realm)
+    deallocate(diag_field_indices)
 #endif
 
   end function register_diag_field_scalar_modern
@@ -524,21 +528,25 @@ end function register_diag_field_array
     CHARACTER(len=*), OPTIONAL, INTENT(in) :: realm         !< String to set as the modeling_realm attribute
 
 #ifdef use_yaml
-    integer, allocatable :: diag_file_indices(:) !< indices where the field was found
+    integer, allocatable :: diag_field_indices(:) !< indices of diag_field yaml where the field was found
 
-    diag_file_indices = find_diag_field(field_name)
-    if (diag_file_indices(1) .eq. diag_null) then
+    diag_field_indices = find_diag_field(field_name)
+    if (diag_field_indices(1) .eq. diag_null) then
       !< The field was not found in the table, so return diag_null
       register_diag_field_array_modern = diag_null
-      deallocate(diag_file_indices)
+      deallocate(diag_field_indices)
       return
     endif
 
     registered_variables = registered_variables + 1
     register_diag_field_array_modern = registered_variables
 
-    !< TO DO: Fill in the diag_obj
-    deallocate(diag_file_indices)
+    call diag_objs(registered_variables)%setID(registered_variables)
+    call diag_objs(registered_variables)%register(module_name, field_name, init_time, diag_field_indices, axes,  &
+      & longname=long_name, units=units, missing_value=missing_value, varrange=var_range, &
+      & mask_variant=mask_variant, standname=standard_name, do_not_log=do_not_log, err_msg=err_msg, &
+      & interp_method=interp_method, tile_count=tile_count, area=area, volume=volume, realm=realm)
+    deallocate(diag_field_indices)
 #endif
 
    end function register_diag_field_array_modern

--- a/diag_manager/fms_diag_axis_object.F90
+++ b/diag_manager/fms_diag_axis_object.F90
@@ -41,7 +41,7 @@ module fms_diag_axis_object_mod
   PRIVATE
 
   public :: diagAxis_t, set_subaxis, fms_diag_axis_init, fms_diag_axis_object_init, fms_diag_axis_object_end, &
-          & get_domain_and_domain_type, axis_obj
+          & get_domain_and_domain_type, axis_obj, diagDomain_t, sub_axis_objs
   !> @}
 
   !> @brief Type to hold the domain info for an axis
@@ -76,6 +76,7 @@ module fms_diag_axis_object_mod
     INTEGER                       :: starting_index !< Starting index of the subaxis relative to the parent axis
     INTEGER                       :: ending_index   !< Ending index of the subaxis relative to the parent axis
     class(*)        , ALLOCATABLE :: bounds         !< Bounds of the subaxis (lat/lon or indices)
+    INTEGER                       :: parent_axis_id !< Id of the parent_axis
     contains
       procedure :: exists => check_if_subaxis_exists
   END TYPE subaxis_t
@@ -121,6 +122,8 @@ module fms_diag_axis_object_mod
   integer                                :: number_of_axis !< Number of axis that has been registered
   type(diagAxis_t), ALLOCATABLE, TARGET  :: axis_obj(:)    !< Diag_axis objects
   logical                                :: module_is_initialized !< Flag indicating if the module is initialized
+  integer                                :: nsubaxis_objs  !< Number of sub_axis that has been registered
+  type(subaxis_t), ALLOCATABLE, Target   :: sub_axis_objs(:) !< Registered sub_axis objects
 
   !> @addtogroup fms_diag_yaml_mod
   !> @{
@@ -319,9 +322,13 @@ module fms_diag_axis_object_mod
   end function
 
   !> @brief Set the subaxis of the axis obj
-  subroutine set_subaxis(obj, bounds)
-    class(diagAxis_t), INTENT(INOUT) :: obj       !< diag_axis obj
+  !> @return A sub_axis id corresponding to the indices of the sub_axes in the sub_axes_objs array
+  function set_subaxis(obj, bounds) &
+  result(sub_axes_id)
+    class(diagAxis_t),  INTENT(INOUT) :: obj       !< diag_axis obj
     class(*),           INTENT(INOUT) :: bounds(:) !< bound of the subaxis
+
+    integer :: sub_axes_id
 
     integer :: i !< For do loops
 
@@ -332,7 +339,11 @@ module fms_diag_axis_object_mod
 
     !< TO DO: everything
     obj%nsubaxis = obj%nsubaxis + 1
-  end subroutine
+
+    nsubaxis_objs = nsubaxis_objs + 1
+    sub_axes_id = nsubaxis_objs
+    !< TO DO: set the parent_axis_id
+  end function
 
   !!!!!!!!!!!!!!!!!! SUB AXIS PROCEDURES !!!!!!!!!!!!!!!!!
   !> @brief Check if a subaxis was already defined

--- a/diag_manager/fms_diag_file_object.F90
+++ b/diag_manager/fms_diag_file_object.F90
@@ -26,11 +26,12 @@
 module fms_diag_file_object_mod
 !use mpp_mod, only: mpp_error, FATAL
 use fms2_io_mod, only: FmsNetcdfFile_t, FmsNetcdfUnstructuredDomainFile_t, FmsNetcdfDomainFile_t
-use diag_data_mod, only: DIAG_NULL
+use diag_data_mod, only: DIAG_NULL, NO_DOMAIN, max_axes, SUB_REGIONAL
 #ifdef use_yaml
 use fms_diag_yaml_mod, only: diag_yaml, diagYamlObject_type, diagYamlFiles_type
 #endif
-
+use fms_diag_axis_object_mod, only: diagDomain_t
+use mpp_mod, only: mpp_error, FATAL
 implicit none
 private
 
@@ -44,10 +45,12 @@ type :: fmsDiagFile_type
  private
   integer :: id !< The number associated with this file in the larger array of files
   class(FmsNetcdfFile_t), allocatable :: fileobj !< fms2_io file object for this history file
-  character(len=1) :: file_domain_type !< (I don't think we will need this)
 #ifdef use_yaml
   type(diagYamlFiles_type), pointer :: diag_yaml_file => null() !< Pointer to the diag_yaml_file data
 #endif
+  integer                                      :: type_of_domain !< The type of domain to use to open the file
+                                                                 !! NO_DOMAIN, TWO_D_DOMAIN, UG_DOMAIN, SUB_REGIONAL
+  class(diagDomain_t), pointer                 :: domain         !< The domain to use, null if NO_DOMAIN or SUB_REGIONAL
   character(len=:) , dimension(:), allocatable :: file_metadata_from_model !< File metadata that comes from
                                                                            !! the model.
   integer, dimension(:), allocatable :: var_ids !< Variable IDs corresponding to file_varlist
@@ -57,9 +60,13 @@ type :: fmsDiagFile_type
   logical, dimension(:), private, allocatable :: var_reg   !< Array corresponding to `file_varlist`, .true.
                                                                  !! if the variable has been registered and
                                                                  !! `file_var_index` has been set for the variable
+  integer, dimension(:), allocatable :: axis_ids !< Array of axis ids in the file
+  integer, dimension(:), allocatable :: sub_axis_ids !< Array of axis ids in the file
+  integer :: number_of_axis !< Number of axis in the file
 
  contains
-
+  procedure, public :: set_file_domain
+  procedure, public :: add_axes
   procedure, public :: has_file_metadata_from_model
   procedure, public :: has_fileobj
 #ifdef use_yaml
@@ -68,7 +75,6 @@ type :: fmsDiagFile_type
   procedure, public :: has_var_ids
   procedure, public :: get_id
 ! TODO  procedure, public :: get_fileobj ! TODO
-  procedure, public :: get_file_domain_type
 ! TODO  procedure, public :: get_diag_yaml_file ! TODO
   procedure, public :: get_file_metadata_from_model
   procedure, public :: get_var_ids
@@ -128,6 +134,23 @@ logical function fms_diag_files_object_init ()
      FMS_diag_files(i)%var_ids = DIAG_NULL
      FMS_diag_files(i)%var_reg = .FALSE.
      FMS_diag_files(i)%var_index = DIAG_NULL
+
+     !> These will be set in a set_file_domain
+     FMS_diag_files(i)%type_of_domain = NO_DOMAIN
+     FMS_diag_files(i)%domain => null()
+
+     !> This will be set in a add_axes
+     allocate(FMS_diag_files(i)%axis_ids(max_axes))
+
+     !> If the file has a sub_regional, define it as one and allocate the sub_axis_ids array.
+     !! This will be set in a add_axes
+     if (FMS_diag_files(i)%has_file_sub_region()) then
+      FMS_diag_files(i)%type_of_domain = SUB_REGIONAL
+      allocate(FMS_diag_files(i)%sub_axis_ids(max_axes))
+      FMS_diag_files(i)%sub_axis_ids = diag_null
+     endif
+
+     FMS_diag_files(i)%number_of_axis = 0
    enddo set_ids_loop
    fms_diag_files_object_init = .true.
   else
@@ -181,13 +204,6 @@ end function get_id
 !  class(FmsNetcdfFile_t) :: res
 !  res = obj%fileobj
 !end function get_fileobj
-!> \brief Returns a copy of the value of file_domain_type
-!! \return A copy of file_domain_type
-pure function get_file_domain_type (obj) result (res)
-  class(fmsDiagFile_type), intent(in) :: obj !< The file object
-  character(1) :: res
-  res = obj%file_domain_type
-end function get_file_domain_type
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !! TODO
 !!> \brief Returns a copy of the value of diag_yaml_file
@@ -399,5 +415,60 @@ pure function has_file_global_meta (obj) result(res)
  logical :: res
   res = obj%diag_yaml_file%has_file_global_meta()
 end function has_file_global_meta
+
+!> @brief Set the domain and the type_of_domain for a file
+!> @details This subroutine is going to be called once by every variable in the file
+!! in register_diag_field. It will update the domain and the type_of_domain if needed and verify that
+!! all the variables are in the same domain
+subroutine set_file_domain(obj, domain, type_of_domain)
+  class(fmsDiagFile_type), intent(inout)       :: obj            !< The file object
+  integer,                 INTENT(in)          :: type_of_domain !< fileobj_type to use
+  CLASS(diagDomain_t),     INTENT(in), target  :: domain         !< Domain
+
+  if (type_of_domain .ne. obj%type_of_domain) then
+  !! If the current type_of_domain in the file obj is not the same as the variable calling this subroutine
+
+    if (type_of_domain .eq. NO_DOMAIN .or. obj%type_of_domain .eq. NO_DOMAIN) then
+    !! If they are not the same then one of them can be NO_DOMAIN
+    !! (i.e a file can have variables that are not domain decomposed and variables that are)
+
+      if (type_of_domain .ne. NO_DOMAIN) then
+      !! Update the file's type_of_domain and domain if needed
+        obj%type_of_domain = type_of_domain
+        obj%domain => domain
+      endif
+
+    else
+    !! If they are not the same and of them is not NO_DOMAIN, then crash because the variables don't have the
+    !! same domain (i.e a file has a variable is that in a 2D domain and one that is in a UG domain)
+
+      call mpp_error(FATAL, "The file: "//obj%get_file_fname()//" has variables that are not in the same domain")
+    endif
+  endif
+
+end subroutine set_file_domain
+
+subroutine add_axes(obj, axis_ids)
+  class(fmsDiagFile_type), intent(inout)       :: obj            !< The file object
+  integer,                 INTENT(in)          :: axis_ids(:)    !< Array of axes_ids
+
+  integer :: i, j !< For do loops
+
+  do i = 1, size(axis_ids)
+    do j = 1, obj%number_of_axis
+      !> Check if the axis already exists, if it does leave this do loop
+      if (axis_ids(i) .eq. obj%axis_ids(j)) exit
+    enddo
+
+    !> If the axis does not exist add it to the list
+    obj%number_of_axis = obj%number_of_axis + 1
+    obj%axis_ids(obj%number_of_axis) = axis_ids(i)
+
+    !> If this is a sub_regional file, set up the sub_axes
+    !> TO DO:
+    !!
+  enddo
+
+end subroutine add_axes
 #endif
 end module fms_diag_file_object_mod

--- a/diag_manager/fms_diag_file_object.F90
+++ b/diag_manager/fms_diag_file_object.F90
@@ -426,6 +426,9 @@ subroutine set_file_domain(obj, domain, type_of_domain)
   integer,                 INTENT(in)          :: type_of_domain !< fileobj_type to use
   CLASS(diagDomain_t),     INTENT(in), target  :: domain         !< Domain
 
+  !! If this a sub_regional, don't do anything here
+  if (obj%type_of_domain .eq. SUB_REGIONAL) return
+
   if (type_of_domain .ne. obj%type_of_domain) then
   !! If the current type_of_domain in the file obj is not the same as the variable calling this subroutine
 

--- a/diag_manager/fms_diag_file_object.F90
+++ b/diag_manager/fms_diag_file_object.F90
@@ -50,7 +50,8 @@ type :: fmsDiagFile_type
 #endif
   integer                                      :: type_of_domain !< The type of domain to use to open the file
                                                                  !! NO_DOMAIN, TWO_D_DOMAIN, UG_DOMAIN, SUB_REGIONAL
-  class(diagDomain_t), pointer                 :: domain         !< The domain to use, null if NO_DOMAIN or SUB_REGIONAL
+  class(diagDomain_t), pointer                 :: domain         !< The domain to use,
+                                                                 !! null if NO_DOMAIN or SUB_REGIONAL
   character(len=:) , dimension(:), allocatable :: file_metadata_from_model !< File metadata that comes from
                                                                            !! the model.
   integer, dimension(:), allocatable :: var_ids !< Variable IDs corresponding to file_varlist
@@ -65,12 +66,12 @@ type :: fmsDiagFile_type
   integer :: number_of_axis !< Number of axis in the file
 
  contains
-  procedure, public :: set_file_domain
-  procedure, public :: add_axes
   procedure, public :: has_file_metadata_from_model
   procedure, public :: has_fileobj
 #ifdef use_yaml
   procedure, public :: has_diag_yaml_file
+  procedure, public :: set_file_domain
+  procedure, public :: add_axes
 #endif
   procedure, public :: has_var_ids
   procedure, public :: get_id
@@ -448,6 +449,7 @@ subroutine set_file_domain(obj, domain, type_of_domain)
 
 end subroutine set_file_domain
 
+!> @brief Loops through a variable's axis_ids and adds them to the FMSDiagFile object if they don't exist
 subroutine add_axes(obj, axis_ids)
   class(fmsDiagFile_type), intent(inout)       :: obj            !< The file object
   integer,                 INTENT(in)          :: axis_ids(:)    !< Array of axes_ids

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -244,9 +244,8 @@ subroutine fms_register_diag_field_obj &
   if (present(realm))         dobj%realm         = trim(realm)
   if (present(interp_method)) dobj%interp_method = trim(interp_method)
   if (present(tile_count)) then
+    allocate(dobj%tile_count)
     dobj%tile_count = tile_count
-  else
-    dobj%tile_count = diag_null
   endif
 
   if (present(metadata)) then
@@ -312,9 +311,8 @@ subroutine fms_register_diag_field_obj &
                      "The area id passed with field_name"//trim(varname)//" has not been registered."&
                      "Check that there is a register_diag_field call for the AREA measure and that is in the"&
                      "diag_table.yaml", FATAL)
+    allocate(dobj%area)
     dobj%area = area
-  else
-    dobj%area = diag_null
   endif
 
   if (present(volume)) then
@@ -322,21 +320,18 @@ subroutine fms_register_diag_field_obj &
                      "The volume id passed with field_name"//trim(varname)//" has not been registered."&
                      "Check that there is a register_diag_field call for the VOLUME measure and that is in the"&
                      "diag_table.yaml", FATAL)
+    allocate(dobj%volume)
     dobj%volume = volume
-  else
-    dobj%volume = diag_null
   endif
 
   if (present(mask_variant)) then
+    allocate(dobj%mask_variant)
     dobj%mask_variant = mask_variant
-  else
-    dobj%mask_variant = .false.
   endif
 
   if (present(do_not_log)) then
+    allocate(dobj%do_not_log)
     dobj%do_not_log = do_not_log
-  else
-    dobj%do_not_log = .false.
   endif
 
  dobj%registered = .true.

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -250,6 +250,7 @@ subroutine fms_register_diag_field_obj &
      dobj%units = trim(units)
   endif
   if (present(metadata)) then
+     allocate(character(len=MAX_LEN_META) :: dobj%metadata(size(metadata)))
      dobj%metadata = metadata
   endif
   if (present(missing_value)) then

--- a/diag_manager/fms_diag_yaml.F90
+++ b/diag_manager/fms_diag_yaml.F90
@@ -47,7 +47,7 @@ public :: diag_yaml
 public :: diag_yaml_object_init, diag_yaml_object_end
 public :: diagYamlObject_type, get_diag_yaml_obj, get_title, get_basedate, get_diag_files, get_diag_fields
 public :: diagYamlFiles_type, diagYamlFilesVar_type
-public :: get_num_unique_fields, find_diag_field, get_diag_fields_entries, get_diag_files_entries
+public :: get_num_unique_fields, find_diag_field, get_diag_fields_entries, get_diag_files_id
 !> @}
 
 integer, parameter :: basedate_size = 6
@@ -1224,40 +1224,41 @@ function get_diag_fields_entries(indices) &
 
 end function get_diag_fields_entries
 
-!> @brief Gets the diag_files entries corresponding to the indices of the sorted variable_list
-!! @return Array of diag_files
-function get_diag_files_entries(indices) &
-  result(diag_file)
+!> @brief Finds the indices of the diag_yaml%diag_files(:) corresponding to fields in variable_list(indices)
+!! @return indices of the diag_yaml%diag_files(:)
+function get_diag_files_id(indices) &
+  result(file_id)
 
   integer, intent(in) :: indices(:) !< Indices of the field in the sorted variable_list
-  type(diagYamlFiles_type), dimension (:), allocatable :: diag_file
+  integer, allocatable :: file_id(:)
 
+  integer :: field_id !< Indices of the field in the diag_yaml field array
   integer :: i !< For do loops
-  integer :: field_id !< Indices of the field in the diag_yaml array
-  integer :: file_id !< Indices of the file in the diag_yaml array
   character(len=120) :: filename !< Filename of the field
   integer, allocatable :: file_indices(:) !< Indices of the file in the sorted variable_list
 
-  allocate(diag_file(size(indices)))
+  allocate(file_id(size(indices)))
 
   do i = 1, size(indices)
     field_id = variable_list%diag_field_indices(indices(i))
+    !< Get the filename of the field
     filename = diag_yaml%diag_fields(field_id)%var_fname
 
+    !< File indice of that file in the array of list of sorted files
     file_indices = fms_find_my_string(file_list%file_pointer, size(file_list%file_pointer), &
       & trim(filename)//c_null_char)
 
     if (size(file_indices) .ne. 1) &
-      & call mpp_error(FATAL, "get_diag_files_entries: Error getting the correct number of file indices!")
+      & call mpp_error(FATAL, "get_diag_files_id: Error getting the correct number of file indices!")
 
     if (file_indices(1) .eq. diag_null) &
-      & call mpp_error(FATAL, "get_diag_files_entries: Error finding the filename in the diag_files")
+      & call mpp_error(FATAL, "get_diag_files_id: Error finding the filename in the diag_files yaml")
 
-    file_id = file_list%diag_file_indices(file_indices(1))
-    diag_file(i) = diag_yaml%diag_files(file_id)
+    !< Get the index of the file in the diag_yaml file
+    file_id(i) = file_list%diag_file_indices(file_indices(1))
   end do
 
-end function get_diag_files_entries
+end function get_diag_files_id
 #endif
 end module fms_diag_yaml_mod
 !> @}

--- a/test_fms/diag_manager/Makefile.am
+++ b/test_fms/diag_manager/Makefile.am
@@ -28,14 +28,13 @@ AM_CPPFLAGS = -I$(top_srcdir)/include -I$(MODDIR)
 LDADD = $(top_builddir)/libFMS/libFMS.la
 
 # Build this test program.
-check_PROGRAMS = test_diag_manager test_diag_manager_time test_diag_object_container \
+check_PROGRAMS = test_diag_manager test_diag_manager_time \
  test_diag_dlinked_list test_diag_yaml test_diag_ocean test_modern_diag
 
 # This is the source code for the test.
 test_diag_manager_SOURCES = test_diag_manager.F90
 test_diag_manager_time_SOURCES = test_diag_manager_time.F90
 test_diag_yaml_SOURCES = test_diag_yaml.F90
-test_diag_object_container_SOURCES = test_diag_object_container.F90
 test_diag_dlinked_list_SOURCES = test_diag_dlinked_list.F90
 test_diag_ocean_SOURCES = test_diag_ocean.F90
 test_modern_diag_SOURCES = test_modern_diag.F90

--- a/test_fms/diag_manager/test_diag_manager2.sh
+++ b/test_fms/diag_manager/test_diag_manager2.sh
@@ -631,9 +631,6 @@ test_expect_success "Test the diag_ocean feature in diag_manager_init (test $my_
   mpirun -n 2 ../test_diag_ocean
 '
 
-test_expect_success "test_diag_object_container (test $my_test_count)" '
-  mpirun -n 1 ../test_diag_object_container
-'
 test_expect_success "test_diag_dlinked_list (test $my_test_count)" '
   mpirun -n 1 ../test_diag_dlinked_list
 '

--- a/test_fms/diag_manager/test_diag_yaml.F90
+++ b/test_fms/diag_manager/test_diag_yaml.F90
@@ -56,6 +56,7 @@ type(diagYamlFiles_type), allocatable, dimension (:) :: diag_files !< Files from
 type(diagYamlFilesVar_type), allocatable, dimension(:) :: diag_fields !< Fields from the diag_yaml
 type(diagYamlObject_type) :: my_yaml !< diagYamlObject obtained from diag_yaml_object_init
 type(diagYamlObject_type) :: ans     !< expected diagYamlObject
+integer, ALLOCATABLE :: diag_files_ids(:) !< Ids of the diag_files
 #endif
 
 namelist / check_crashes_nml / checking_crashes
@@ -109,7 +110,11 @@ if (.not. checking_crashes) then
   call compare_result("sst - fieldname", diag_fields(2)%get_var_varname(), "sst")
   deallocate(diag_fields)
 
-  diag_files = get_diag_files_entries(indices)
+  diag_files_ids = get_diag_files_id(indices)
+  allocate(diag_files(size(diag_files_ids)))
+
+  diag_files(1) = my_yaml%diag_files(diag_files_ids(1))
+  diag_files(2) = my_yaml%diag_files(diag_files_ids(2))
   call compare_result("sst - nfiles", size(diag_files), 2)
   call compare_result("sst - filename", diag_files(1)%get_file_fname(), "normal")
   call compare_result("sst - filename", diag_files(2)%get_file_fname(), "wild_card_name%4yr%2mo%2dy%2hr")


### PR DESCRIPTION
**Description**
This PR:

- Changes the `fms_register_diag_field_obj`  arguments by adding `diag_field_indices`, so that the diag_field yaml can be added to the diag_obj, and makes `axes` public, so that this interface can be used for scalar and array variables. This breaks the `test_diag_object_container`, so the test is no longer compiled. This will need to be removed later.
- Sets up an array of `subaxis_t` objects to store any sub axis for sub_regions
- Adds the domain and sub_axis info to the diag_file_obj
- Completes (almost!) the register_diag_field work! Just need to fill in the `var_reg`, `var_ids` and `var_index` part of the diag_file object and the sub_regional stuff still needs to be set up

Fixes # (issue)

**How Has This Been Tested?**
CI

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

