### PR TITLE
find_diag_field,  get_num_unique_fields fix

### DIFF
--- a/diag_manager/diag_manager.F90
+++ b/diag_manager/diag_manager.F90
@@ -479,7 +479,7 @@ end function register_diag_field_array
 #ifdef use_yaml
     integer, allocatable :: diag_field_indices(:) !< indices where the field was found
 
-    diag_field_indices = find_diag_field(field_name)
+    diag_field_indices = find_diag_field(field_name, module_name)
     if (diag_field_indices(1) .eq. diag_null) then
       !< The field was not found in the table, so return diag_null
       register_diag_field_scalar_modern = diag_null
@@ -530,7 +530,7 @@ end function register_diag_field_array
 #ifdef use_yaml
     integer, allocatable :: diag_field_indices(:) !< indices of diag_field yaml where the field was found
 
-    diag_field_indices = find_diag_field(field_name)
+    diag_field_indices = find_diag_field(field_name, module_name)
     if (diag_field_indices(1) .eq. diag_null) then
       !< The field was not found in the table, so return diag_null
       register_diag_field_array_modern = diag_null

--- a/diag_manager/fms_diag_yaml.F90
+++ b/diag_manager/fms_diag_yaml.F90
@@ -392,8 +392,9 @@ subroutine diag_yaml_object_init(diag_subset_output)
       !> Save the variable name in the diag_file type
       diag_yaml%diag_files(file_count)%file_varlist(file_var_count) = diag_yaml%diag_fields(var_count)%var_varname
 
-      !> Save the variable name in the variable_list
-      variable_list%var_name(var_count) = trim(diag_yaml%diag_fields(var_count)%var_varname)//c_null_char
+      !> Save the variable name and the module name in the variable_list
+      variable_list%var_name(var_count) = trim(diag_yaml%diag_fields(var_count)%var_varname)//&
+                                        ":"//trim(diag_yaml%diag_fields(var_count)%var_module)//c_null_char
       variable_list%diag_field_indices(var_count) = var_count
     enddo nvars_loop
     deallocate(var_ids)
@@ -1193,15 +1194,16 @@ end function get_num_unique_fields
 
 !> @brief Determines if a diag_field is in the diag_yaml_object
 !! @return Indices of the locations where the field was found
-function find_diag_field(diag_field_name) &
+function find_diag_field(diag_field_name, module_name) &
 result(indices)
 
   character(len=*), intent(in) :: diag_field_name !< diag_field name to search for
+  character(len=*), intent(in) :: module_name     !< Name of the module, the variable is in
 
   integer, allocatable :: indices(:)
 
   indices = fms_find_my_string(variable_list%var_pointer, size(variable_list%var_pointer), &
-                               & diag_field_name//c_null_char)
+                               & trim(diag_field_name)//":"//trim(module_name)//c_null_char)
 end function find_diag_field
 
 !> @brief Gets the diag_field entries corresponding to the indices of the sorted variable_list

--- a/test_fms/diag_manager/test_diag_manager2.sh
+++ b/test_fms/diag_manager/test_diag_manager2.sh
@@ -696,7 +696,7 @@ diag_files:
   unlimdim: time
   varlist:
   - module: lnd_mod
-    var_name: var6
+    var_name: var1
     reduction: average
     kind: r4
 _EOF

--- a/test_fms/diag_manager/test_diag_yaml.F90
+++ b/test_fms/diag_manager/test_diag_yaml.F90
@@ -97,7 +97,7 @@ if (.not. checking_crashes) then
   deallocate(diag_files)
   deallocate(diag_fields)
 
-  indices = find_diag_field("sst")
+  indices = find_diag_field("sst", "test_diag_manager_mod")
   print *, "sst was found in ", indices
   if (size(indices) .ne. 2) &
     call mpp_error(FATAL, 'sst was supposed to be found twice!')
@@ -121,7 +121,7 @@ if (.not. checking_crashes) then
   deallocate(diag_files)
   deallocate(indices)
 
-  indices = find_diag_field("sstt")
+  indices = find_diag_field("sstt", "test_diag_manager_mod")
   print *, "sstt was found in ", indices
   if (size(indices) .ne. 1) &
     call mpp_error(FATAL, 'sstt was supposed to be found twice!')
@@ -129,12 +129,12 @@ if (.not. checking_crashes) then
     call mpp_error(FATAL, 'sstt was supposed to be found in indices 1 and 2')
   deallocate(indices)
 
-  indices = find_diag_field("sstt2") !< This is in diag_table but it has write_var = false
+  indices = find_diag_field("sstt2", "test_diag_manager_mod") !< This is in diag_table but it has write_var = false
   print *, "sstt2 was found in ", indices
   if (indices(1) .ne. -999) &
     call mpp_error(FATAL, "sstt2 is not in the diag_table!")
 
-  indices = find_diag_field("tamales")
+  indices = find_diag_field("tamales", "test_diag_manager_mod")
   print *, "tamales was found in ", indices
   if (indices(1) .ne. -999) &
     call mpp_error(FATAL, "tamales is not in the diag_table!")

--- a/test_fms/diag_manager/test_modern_diag.F90
+++ b/test_fms/diag_manager/test_modern_diag.F90
@@ -123,8 +123,11 @@ id_var3 = register_diag_field  ('atm_mod', 'var3', (/id_x3, id_y3/), Time, 'Var 
 id_var4 = register_diag_field  ('atm_mod', 'var4', (/id_x3, id_y3, id_z/), Time, &
                                 '3D var in a cube sphere domain', 'mullions')
 id_var5 = register_diag_field  ('lnd_mod', 'var5', (/id_ug/), Time, 'Var in a UG domain', 'mullions')
-id_var6 = register_diag_field  ('lnd_mod', 'var6', (/id_z/), Time, 'Var not domain decomposed', 'mullions')
-id_var7 = register_diag_field  ('lnd_mod', 'var7', Time, 'Some scalar var', 'mullions')
+id_var6 = register_diag_field  ('atm_mod', 'var6', (/id_z/), Time, 'Var not domain decomposed', 'mullions')
+
+!< This has the same name as var1, but it should have a different id because the module is different
+!! so it should have its own diag_obj
+id_var7 = register_diag_field  ('lnd_mod', 'var1', Time, 'Some scalar var', 'mullions')
 
 if (id_var1  .ne. 1) call mpp_error(FATAL, "var1 does not have the expected id")
 if (id_var2  .ne. 2) call mpp_error(FATAL, "var2 does not have the expected id")


### PR DESCRIPTION
**Description**
`find_diag_field` only searches for the variable_name, it needs to search for the module name too. It is possible to have duplicate variable names that come from different modules:

For example, in AM4 the diag_field `area` is present twice with two different modules and two different grids!
https://github.com/NOAA-GFDL/AM4/blob/7fe212ab2f942f808c51f701c809c336cf5176f6/run/diag_table#L20
https://github.com/NOAA-GFDL/AM4/blob/7fe212ab2f942f808c51f701c809c336cf5176f6/run/diag_table#L402

`get_num_unique_fields` also needs to count these as two unique diag_fields.

This PR:
- Instead of saving just the variable name, it saves `varname:module_name` to the `variable_list`
- Adds module_name as an argument to `find_diag_field` and it now searches for `varname:module_name` to be consistent with the `variable_list`
- Because the `variable_list` has both the variable name and the module name it will be able to get the correct number of unique fields 

Fixes #
**How Has This Been Tested?**
CI including updated tests

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

