### PR TITLE
Increase length of restart_file_type name string from 128 to 256 characters

### DIFF
--- a/fms/fms_io.F90
+++ b/fms/fms_io.F90
@@ -303,7 +303,7 @@ end type Ptr3Di
 type restart_file_type
    private
    integer                                  :: unit = -1 ! mpp_io unit for netcdf file
-   character(len=128)                       :: name = ''
+   character(len=256)                       :: name = ''
    integer                                  :: register_id = 0
    integer                                  :: nvar = 0
    integer                                  :: natt = 0


### PR DESCRIPTION
**Description**

As the title says: Increase length of restart_file_type name string from 128 to 256 characters.

Fixes #999

**How Has This Been Tested?**

I haven't run any tests for this change (yet).

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- n/a I have commented my code, particularly in hard-to-understand areas
- n/a I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- n/a Any dependent changes have been merged and published in downstream modules
- n/a New check tests, if applicable, are included
- ??? `make distcheck` passes
```
heinzell@JCSDA-L-18146:~/work/fms/build_256char [brew-x86_64]> make distcheck 2>&1 | tee log.distcheck
make: *** No rule to make target `distcheck'.  Stop.
```

