### PR TITLE
class(*) updates needed for compatibility of dmUpdate with 2022.03

### DIFF
--- a/diag_manager/fms_diag_axis_object.F90
+++ b/diag_manager/fms_diag_axis_object.F90
@@ -449,7 +449,7 @@ module fms_diag_axis_object_mod
     & result(id)
 
     CHARACTER(len=*),   INTENT(in)           :: axis_name       !< Name of the axis
-    REAL,               INTENT(in)           :: axis_data(:)    !< Array of coordinate values
+    CLASS(*),           INTENT(in)           :: axis_data(:)    !< Array of coordinate values
     CHARACTER(len=*),   INTENT(in)           :: units           !< Units for the axis
     CHARACTER(len=1),   INTENT(in)           :: cart_name       !< Cartesian axis ("X", "Y", "Z", "T", "U", "N")
     CHARACTER(len=*),   INTENT(in), OPTIONAL :: long_name       !< Long name for the axis.

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -1078,8 +1078,8 @@ INTEGER FUNCTION fms_register_static_field(module_name, field_name, axes, long_n
     CHARACTER(len=*),               OPTIONAL, INTENT(in) :: long_name     !< Longname to be added as a attribute
     CHARACTER(len=*),               OPTIONAL, INTENT(in) :: units         !< Units to be added as a attribute
     CHARACTER(len=*),               OPTIONAL, INTENT(in) :: standard_name !< Standard name to be added as a attribute
-    real,                           OPTIONAL, INTENT(in) :: missing_value !< Missing value to be added as a attribute
-    real,             DIMENSION(2), OPTIONAL, INTENT(in) :: range         !< Range to be added as a attribute
+    class(*),                       OPTIONAL, INTENT(in) :: missing_value !< Missing value to be added as a attribute
+    class(*),         DIMENSION(:), OPTIONAL, INTENT(in) :: range         !< Range to be added as a attribute
     LOGICAL,                        OPTIONAL, INTENT(in) :: mask_variant  !< Flag indicating if the field is has
                                                                           !! a mask variant
     LOGICAL,                        OPTIONAL, INTENT(in) :: DYNAMIC       !< Flag indicating if the field is dynamic


### PR DESCRIPTION
**Description**
There were some `class(*)`s missing from `missing_value` and `axis_data` declarations needed for use with 2022.03.


**How Has This Been Tested?**
inel 2022 compiler on GFDL devbox
 
**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [ ] `make distcheck` passes

