### PR TITLE
Modern diag_manager: use integer parameters instead of strings

### DIFF
--- a/diag_manager/diag_data.F90
+++ b/diag_manager/diag_data.F90
@@ -113,7 +113,14 @@ use platform_mod
   INTEGER, PARAMETER :: latlon_gridtype = 1
   INTEGER, PARAMETER :: index_gridtype = 2
   INTEGER, PARAMETER :: null_gridtype = DIAG_NULL
-
+  INTEGER, PARAMETER :: time_none    = 0 !< There is no reduction method
+  INTEGER, PARAMETER :: time_average = 1 !< The reduction method is avera
+  INTEGER, PARAMETER :: time_rms     = 2 !< The reduction method is rms
+  INTEGER, PARAMETER :: time_max     = 3 !< The reduction method is max
+  INTEGER, PARAMETER :: time_min     = 4 !< The reduction method is min
+  INTEGER, PARAMETER :: time_sum     = 5 !< The reudction method is sum
+  INTEGER, PARAMETER :: time_diurnal = 6 !< The reduction method is diurnal
+  INTEGER, PARAMETER :: time_power   = 7 !< The reduction method is power
   !> @}
 
   !> @brief Contains the coordinates of the local domain to output.

--- a/diag_manager/fms_diag_yaml.F90
+++ b/diag_manager/fms_diag_yaml.F90
@@ -764,6 +764,8 @@ subroutine set_field_reduction(field, reduction_method)
       field%var_reduction = time_max
     case ("rms")
       field%var_reduction = time_rms
+    case ("sum")
+      field%var_reduction = time_sum
     case default
       call mpp_error(FATAL, trim(reduction_method)//" is an invalid reduction method! &
         &The acceptable values are none, average, pow##, diurnal##, min, max, and rms. &

--- a/diag_manager/fms_diag_yaml.F90
+++ b/diag_manager/fms_diag_yaml.F90
@@ -139,19 +139,19 @@ type diagYamlFiles_type
  procedure :: is_global_meta
  !> Has functions to determine if allocatable variables are true.  If a variable is not an allocatable
  !! then is will always return .true.
- procedure :: has_file_fname 
- procedure :: has_file_frequnit 
- procedure :: has_file_freq 
- procedure :: has_file_timeunit 
- procedure :: has_file_unlimdim 
- procedure :: has_file_sub_region 
- procedure :: has_file_new_file_freq 
- procedure :: has_file_new_file_freq_units 
- procedure :: has_file_start_time 
- procedure :: has_file_duration 
- procedure :: has_file_duration_units 
- procedure :: has_file_varlist 
- procedure :: has_file_global_meta 
+ procedure :: has_file_fname
+ procedure :: has_file_frequnit
+ procedure :: has_file_freq
+ procedure :: has_file_timeunit
+ procedure :: has_file_unlimdim
+ procedure :: has_file_sub_region
+ procedure :: has_file_new_file_freq
+ procedure :: has_file_new_file_freq_units
+ procedure :: has_file_start_time
+ procedure :: has_file_duration
+ procedure :: has_file_duration_units
+ procedure :: has_file_varlist
+ procedure :: has_file_global_meta
 
 end type diagYamlFiles_type
 
@@ -191,15 +191,15 @@ type diagYamlFilesVar_type
   procedure :: get_pow_value
   procedure :: is_var_attributes
 
-  procedure :: has_var_fname 
-  procedure :: has_var_varname 
-  procedure :: has_var_reduction 
-  procedure :: has_var_module 
+  procedure :: has_var_fname
+  procedure :: has_var_varname
+  procedure :: has_var_reduction
+  procedure :: has_var_module
   procedure :: has_var_kind
-  procedure :: has_var_outname 
-  procedure :: has_var_longname 
-  procedure :: has_var_units 
-  procedure :: has_var_attributes 
+  procedure :: has_var_outname
+  procedure :: has_var_longname
+  procedure :: has_var_units
+  procedure :: has_var_attributes
   procedure :: has_n_diurnal
   procedure :: has_pow_value
 
@@ -220,10 +220,10 @@ type diagYamlObject_type
   procedure :: get_diag_files   !< Returns the diag_files array
   procedure :: get_diag_fields  !< Returns the diag_field array
 
-  procedure :: has_diag_title                   
-  procedure :: has_diag_basedate           
+  procedure :: has_diag_title
+  procedure :: has_diag_basedate
   procedure :: has_diag_files
-  procedure :: has_diag_fields 
+  procedure :: has_diag_fields
 
 end type diagYamlObject_type
 
@@ -1077,7 +1077,7 @@ pure logical function has_file_unlimdim (obj)
   has_file_unlimdim = allocated(obj%file_unlimdim)
 end function has_file_unlimdim
 !> @brief Checks if obj%file_write is on the stack, so this will always be true
-!! @return true 
+!! @return true
 pure logical function has_file_write (obj)
   class(diagYamlFiles_type), intent(in) :: obj !< diagYamlFiles_type object to initialize
   has_file_write = .true.
@@ -1093,7 +1093,7 @@ pure logical function has_file_sub_region (obj)
   endif
 end function has_file_sub_region
 !> @brief obj%file_new_file_freq is defined on the stack, so this will return true
-!! @return true 
+!! @return true
 pure logical function has_file_new_file_freq (obj)
   class(diagYamlFiles_type), intent(in) :: obj !< diagYamlFiles_type object to initialize
   has_file_new_file_freq = .true.
@@ -1111,13 +1111,13 @@ pure logical function has_file_start_time (obj)
   has_file_start_time = allocated(obj%file_start_time)
 end function has_file_start_time
 !> @brief obj%file_duration is allocated on th stack, so this is always true
-!! @return true 
+!! @return true
 pure logical function has_file_duration (obj)
   class(diagYamlFiles_type), intent(in) :: obj !< diagYamlFiles_type object to initialize
   has_file_duration = .true.
 end function has_file_duration
 !> @brief obj%file_duration_units is on the stack, so this will retrun true
-!! @return true 
+!! @return true
 pure logical function has_file_duration_units (obj)
   class(diagYamlFiles_type), intent(in) :: obj !< diagYamlFiles_type object to initialize
   has_file_duration_units = obj%file_duration_units .ne. diag_null
@@ -1166,7 +1166,7 @@ pure logical function has_var_kind (obj)
   has_var_kind = allocated(obj%var_kind)
 end function has_var_kind
 !> @brief obj%var_write is on the stack, so this returns true
-!! @return true 
+!! @return true
 pure logical function has_var_write (obj)
   class(diagYamlFilesVar_type), intent(in) :: obj !< diagYamlvar_type object to initialize
   has_var_write = .true.
@@ -1213,13 +1213,13 @@ end function has_pow_value
 pure logical function has_diag_title (obj)
   class(diagYamlObject_type), intent(in) :: obj !< diagYamlObject_type object to initialize
   has_diag_title = allocated(obj%diag_title)
-end function has_diag_title                    
+end function has_diag_title
 !> @brief obj%diag_basedate is on the stack, so this is always true
 !! @return true
 pure logical function has_diag_basedate (obj)
   class(diagYamlObject_type), intent(in) :: obj !< diagYamlObject_type object to initialize
   has_diag_basedate = .true.
-end function has_diag_basedate            
+end function has_diag_basedate
 !> @brief Checks if obj%diag_files is allocated
 !! @return true if obj%diag_files is allocated
 pure logical function has_diag_files (obj)
@@ -1231,7 +1231,7 @@ end function has_diag_files
 pure logical function has_diag_fields (obj)
   class(diagYamlObject_type), intent(in) :: obj !< diagYamlObject_type object to initialize
   has_diag_fields = allocated(obj%diag_fields)
-end function has_diag_fields  
+end function has_diag_fields
 
 !> @brief Determine the number of unique diag_fields in the diag_yaml_object
 !! @return The number of unique diag_fields

--- a/test_fms/diag_manager/test_diag_yaml.F90
+++ b/test_fms/diag_manager/test_diag_yaml.F90
@@ -25,7 +25,7 @@ use FMS_mod, only: fms_init, fms_end
 use fms_diag_yaml_mod
 use diag_data_mod, only: DIAG_NULL, DIAG_ALL, get_base_year, get_base_month, get_base_day, get_base_hour, &
                        & get_base_minute, get_base_second, diag_data_init, DIAG_HOURS, DIAG_NULL, DIAG_DAYS, &
-                       & time_average
+                       & time_average, r4
 use  time_manager_mod, only: set_calendar_type, JULIAN
 use mpp_mod
 use platform_mod
@@ -170,9 +170,9 @@ subroutine compare_diag_fields(res)
   call compare_result("var_module 2", res(2)%get_var_module(), "test_diag_manager_mod")
   call compare_result("var_module 3", res(3)%get_var_module(), "test_diag_manager_mod")
 
-  call compare_result("var_skind 1", res(1)%get_var_skind(), "r4")
-  call compare_result("var_skind 2", res(2)%get_var_skind(), "r4")
-  call compare_result("var_skind 3", res(3)%get_var_skind(), "r4")
+  call compare_result("var_kind 1", res(1)%get_var_kind(), r4)
+  call compare_result("var_kind 2", res(2)%get_var_kind(), r4)
+  call compare_result("var_kind 3", res(3)%get_var_kind(), r4)
 
   call compare_result("var_outname 1", res(1)%get_var_outname(), "sst")
   call compare_result("var_outname 2", res(2)%get_var_outname(), "sst")

--- a/test_fms/diag_manager/test_diag_yaml.F90
+++ b/test_fms/diag_manager/test_diag_yaml.F90
@@ -24,7 +24,8 @@ program test_diag_yaml
 use FMS_mod, only: fms_init, fms_end
 use fms_diag_yaml_mod
 use diag_data_mod, only: DIAG_NULL, DIAG_ALL, get_base_year, get_base_month, get_base_day, get_base_hour, &
-                       & get_base_minute, get_base_second, diag_data_init, DIAG_HOURS, DIAG_NULL, DIAG_DAYS
+                       & get_base_minute, get_base_second, diag_data_init, DIAG_HOURS, DIAG_NULL, DIAG_DAYS, &
+                       & time_average
 use  time_manager_mod, only: set_calendar_type, JULIAN
 use mpp_mod
 use platform_mod
@@ -161,9 +162,9 @@ subroutine compare_diag_fields(res)
   call compare_result("var_varname 2", res(2)%get_var_varname(), "sst")
   call compare_result("var_varname 3", res(3)%get_var_varname(), "sstt")
 
-  call compare_result("var_reduction 1", res(1)%get_var_reduction(), "average")
-  call compare_result("var_reduction 2", res(2)%get_var_reduction(), "average")
-  call compare_result("var_reduction 3", res(3)%get_var_reduction(), "average")
+  call compare_result("var_reduction 1", res(1)%get_var_reduction(), time_average)
+  call compare_result("var_reduction 2", res(2)%get_var_reduction(), time_average)
+  call compare_result("var_reduction 3", res(3)%get_var_reduction(), time_average)
 
   call compare_result("var_module 1", res(1)%get_var_module(), "test_diag_manager_mod")
   call compare_result("var_module 2", res(2)%get_var_module(), "test_diag_manager_mod")


### PR DESCRIPTION
**Description**
Saves the reduction method and variable kind as integers instead of strings to avoid having to compare strings.

Adds sum as a valid reduction method to reproduce old behavior:
https://github.com/NOAA-GFDL/FMS/blob/a2cfd3192abbec55def073a26cc8ce3e5d5fcb89/diag_manager/diag_util.F90#L1463-L1470

Removes some extra white space
Fixes # (issue)

**How Has This Been Tested?**
CI

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

