### PR TITLE
make type bound procedures private except when through the type 

### DIFF
--- a/diag_manager/fms_diag_axis_object.F90
+++ b/diag_manager/fms_diag_axis_object.F90
@@ -40,7 +40,7 @@ module fms_diag_axis_object_mod
 
   PRIVATE
 
-  public :: diagAxis_t, set_subaxis, fms_diag_axis_init, fms_diag_axis_object_init, fms_diag_axis_object_end, &
+  public :: diagAxis_t, fms_diag_axis_init, fms_diag_axis_object_init, fms_diag_axis_object_end, &
           & get_domain_and_domain_type, axis_obj, diagDomain_t, sub_axis_objs, fms_diag_axis_add_attribute, &
           & DIAGDOMAIN2D_T, fms_get_axis_length
   !> @}

--- a/diag_manager/fms_diag_dlinked_list.F90
+++ b/diag_manager/fms_diag_dlinked_list.F90
@@ -43,6 +43,9 @@
 MODULE fms_diag_dlinked_list_mod
    USE fms_mod, ONLY: error_mesg, FATAL, WARNING, NOTE
    implicit none
+
+   private
+
    !> The doubly-linked list node type.
    type, public:: FmsDlListNode_t
       private

--- a/diag_manager/fms_diag_field_object.F90
+++ b/diag_manager/fms_diag_field_object.F90
@@ -29,10 +29,14 @@ use iso_c_binding
 
 implicit none
 
+private
+
 !> \brief Object that holds all variable information
 type fmsDiagField_type
-     type (diagYamlFilesVar_type), allocatable, dimension(:) :: diag_field !< info from diag_table for this variable
-     integer,                      allocatable, dimension(:) :: file_ids   !< Ids of the FMS_diag_files the variable
+     private
+
+     type (diagYamlFilesVar_type), public, allocatable, dimension(:) :: diag_field !< info from diag_table for this variable
+     integer, public, allocatable, dimension(:)                      :: file_ids   !< Ids of the FMS_diag_files the variable
                                                                            !! belongs to
      integer, allocatable, private                    :: diag_id           !< unique id for varable
      type(fmsDiagAttribute_type), allocatable         :: attributes(:)     !< attributes for the variable
@@ -138,7 +142,6 @@ integer, private :: registered_variables !< Number of registered variables
 public :: fmsDiagField_type
 public :: fms_diag_fields_object_init
 public :: null_ob
-public :: copy_diag_obj, fms_diag_get_id
 public :: fms_diag_field_object_end
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/diag_manager/fms_diag_field_object.F90
+++ b/diag_manager/fms_diag_field_object.F90
@@ -33,10 +33,8 @@ private
 
 !> \brief Object that holds all variable information
 type fmsDiagField_type
-     private
-
-     type (diagYamlFilesVar_type), public, allocatable, dimension(:) :: diag_field !< info from diag_table for this variable
-     integer, public, allocatable, dimension(:)                      :: file_ids   !< Ids of the FMS_diag_files the variable
+     type (diagYamlFilesVar_type), allocatable, dimension(:) :: diag_field !< info from diag_table for this variable
+     integer,                      allocatable, dimension(:) :: file_ids   !< Ids of the FMS_diag_files the variable
                                                                            !! belongs to
      integer, allocatable, private                    :: diag_id           !< unique id for varable
      type(fmsDiagAttribute_type), allocatable         :: attributes(:)     !< attributes for the variable

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -60,11 +60,6 @@ end type fmsDiagObject_type
 type (fmsDiagObject_type), target :: fms_diag_object
 integer, private :: registered_variables !< Number of registered variables
 public :: fms_register_diag_field_obj
-public :: fms_register_diag_field_scalar
-public :: fms_register_diag_field_array 
-public :: fms_register_static_field
-public :: fms_diag_field_add_attribute
-public :: fms_get_diag_field_id_from_name
 public :: fms_diag_object 
 public :: fmsDiagObject_type
 

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -59,7 +59,6 @@ end type fmsDiagObject_type
 
 type (fmsDiagObject_type), target :: fms_diag_object
 integer, private :: registered_variables !< Number of registered variables
-public :: fms_register_diag_field_obj
 public :: fms_diag_object 
 public :: fmsDiagObject_type
 

--- a/diag_manager/fms_diag_object_container.F90
+++ b/diag_manager/fms_diag_object_container.F90
@@ -49,6 +49,8 @@ MODULE fms_diag_object_container_mod
 
    implicit none
 
+   private
+
    !> @brief A container of fmsDiagField_type instances providing insert, remove ,
    !!  find/search, and size public member functions. Iterator is provided by
    !!  the associated iterator class (see  dig_obj_iterator class).

--- a/diag_manager/fms_diag_yaml.F90
+++ b/diag_manager/fms_diag_yaml.F90
@@ -47,7 +47,7 @@ private
 
 public :: diag_yaml
 public :: diag_yaml_object_init, diag_yaml_object_end
-public :: diagYamlObject_type, get_diag_yaml_obj, get_title, get_basedate, get_diag_files, get_diag_fields
+public :: diagYamlObject_type, get_diag_yaml_obj
 public :: diagYamlFiles_type, diagYamlFilesVar_type
 public :: get_num_unique_fields, find_diag_field, get_diag_fields_entries, get_diag_files_id
 !> @}


### PR DESCRIPTION
**Description**
Adds some private statements and removes the public visibility for any type bound procedures, so that they can only be used via the type.

Fixes #1021 

**How Has This Been Tested?**
make check with intel 21 on amd

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

