### PR TITLE
clean up the registers

### DIFF
--- a/diag_manager/fms_diag_field_object.F90
+++ b/diag_manager/fms_diag_field_object.F90
@@ -42,7 +42,6 @@ type fmsDiagField_type
      logical, allocatable, private                    :: mask_variant      !< If there is a mask variant
      logical, allocatable, private                    :: do_not_log        !< .true. if no need to log the diag_field
      logical, allocatable, private                    :: local             !< If the output is local
-     TYPE(time_type), private                         :: init_time         !< The initial time
      integer,          allocatable, private           :: vartype           !< the type of varaible
      character(len=:), allocatable, private           :: varname           !< the name of the variable
      character(len=:), allocatable, private           :: longname          !< longname of the variable
@@ -89,7 +88,6 @@ type fmsDiagField_type
      procedure :: has_registered
      procedure :: has_mask_variant
      procedure :: has_local
-!TODO     procedure :: has_init_time
      procedure :: has_vartype
      procedure :: has_varname
      procedure :: has_longname
@@ -124,14 +122,12 @@ type fmsDiagField_type
      procedure :: get_volume
      procedure :: get_missing_value
      procedure :: get_data_RANGE
-!TODO     procedure :: get_init_time
-!TODO     procedure :: get_axis
+     procedure :: get_axis_id
 end type fmsDiagField_type
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! variables !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 type(fmsDiagField_type) :: null_ob
 
 logical,private :: module_is_initialized = .false. !< Flag indicating if the module is initialized
-integer, private :: registered_variables !< Number of registered variables
 
 !type(fmsDiagField_type) :: diag_object_placeholder (10)
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -160,7 +156,6 @@ logical function fms_diag_fields_object_init(ob)
   class (fmsDiagField_type), allocatable, intent(inout) :: ob(:) !< diag field object
   integer :: i !< For looping
   allocate(ob(get_num_unique_fields()))
-  registered_variables = 0
   do i = 1,size(ob)
       ob(i)%diag_id = diag_not_registered !null_ob%diag_id
       ob(i)%registered = .false.
@@ -172,7 +167,7 @@ end function fms_diag_fields_object_init
 !> \Description Fills in and allocates (when necessary) the values in the diagnostic object
 subroutine fms_register_diag_field_obj &
                 !(dobj, modname, varname, axes, time, longname, units, missing_value, metadata)
-       (dobj, modname, varname, diag_field_indices, axes, init_time, &
+       (dobj, modname, varname, diag_field_indices, axes, &
        longname, units, missing_value, varRange, mask_variant, standname, &
        do_not_log, err_msg, interp_method, tile_count, area, volume, realm, static)
 
@@ -181,7 +176,6 @@ subroutine fms_register_diag_field_obj &
  CHARACTER(len=*),               INTENT(in)    :: varname               !< The variable name
  integer,                        INTENT(in)    :: diag_field_indices(:) !< Array of indices to the field
                                                                         !! in the yaml object
- TYPE(time_type),  OPTIONAL,     INTENT(in)    :: init_time             !< Initial time
  INTEGER, TARGET,  OPTIONAL,     INTENT(in)    :: axes(:)               !< The axes indicies
  CHARACTER(len=*), OPTIONAL,     INTENT(in)    :: longname              !< THe variables long name
  CHARACTER(len=*), OPTIONAL,     INTENT(in)    :: units                 !< The units of the variables
@@ -208,6 +202,10 @@ subroutine fms_register_diag_field_obj &
 !> Fill in information from the register call
   dobj%varname = trim(varname)
   dobj%modname = trim(modname)
+
+!> Add the yaml info to the diag_object
+  dobj%diag_field = get_diag_fields_entries(diag_field_indices)
+
 !> Add axis and domain information
   if (present(axes)) then
     dobj%axis_ids = axes
@@ -500,7 +498,7 @@ end function get_attributes
 pure function get_static (obj) &
 result(rslt)
      class (fmsDiagField_type), intent(in) :: obj !< diag object
-     logical :: rslt 
+     logical :: rslt
      rslt = obj%static
 end function get_static
 !> @brief Gets regisetered
@@ -508,7 +506,7 @@ end function get_static
 pure function get_registered (obj) &
 result(rslt)
      class (fmsDiagField_type), intent(in) :: obj !< diag object
-     logical :: rslt 
+     logical :: rslt
      rslt = obj%registered
 end function get_registered
 !> @brief Gets mask variant
@@ -516,7 +514,7 @@ end function get_registered
 pure function get_mask_variant (obj) &
 result(rslt)
      class (fmsDiagField_type), intent(in) :: obj !< diag object
-     logical :: rslt 
+     logical :: rslt
      rslt = obj%mask_variant
 end function get_mask_variant
 !> @brief Gets local
@@ -524,24 +522,15 @@ end function get_mask_variant
 pure function get_local (obj) &
 result(rslt)
      class (fmsDiagField_type), intent(in) :: obj !< diag object
-     logical :: rslt 
+     logical :: rslt
      rslt = obj%local
 end function get_local
-!> @brief Gets initial time 
-!! @return copy of the initial time
-!! TODO
-!function get_init_time (obj) &
-!result(rslt)
-!     class (fmsDiagField_type), intent(in) :: obj !< diag object
-!     TYPE(time_type) :: rslt 
-!
-!end function get_init_time
-!> @brief Gets vartype 
+!> @brief Gets vartype
 !! @return copy of The integer related to the variable type
 pure function get_vartype (obj) &
 result(rslt)
      class (fmsDiagField_type), intent(in) :: obj !< diag object
-     integer :: rslt 
+     integer :: rslt
      rslt = obj%vartype
 end function get_vartype
 !> @brief Gets varname
@@ -549,7 +538,7 @@ end function get_vartype
 pure function get_varname (obj) &
 result(rslt)
      class (fmsDiagField_type), intent(in) :: obj !< diag object
-     character(len=:), allocatable :: rslt 
+     character(len=:), allocatable :: rslt
      rslt = obj%varname
 end function get_varname
 !> @brief Gets longname
@@ -557,7 +546,7 @@ end function get_varname
 pure function get_longname (obj) &
 result(rslt)
      class (fmsDiagField_type), intent(in) :: obj !< diag object
-     character(len=:), allocatable :: rslt 
+     character(len=:), allocatable :: rslt
      if (allocated(obj%longname)) then
        rslt = obj%longname
      else
@@ -569,7 +558,7 @@ end function get_longname
 pure function get_standname (obj) &
 result(rslt)
      class (fmsDiagField_type), intent(in) :: obj !< diag object
-     character(len=:), allocatable :: rslt 
+     character(len=:), allocatable :: rslt
      if (allocated(obj%standname)) then
        rslt = obj%standname
      else
@@ -581,7 +570,7 @@ end function get_standname
 pure function get_units (obj) &
 result(rslt)
      class (fmsDiagField_type), intent(in) :: obj !< diag object
-     character(len=:), allocatable :: rslt 
+     character(len=:), allocatable :: rslt
      if (allocated(obj%units)) then
        rslt = obj%units
      else
@@ -593,7 +582,7 @@ end function get_units
 pure function get_modname (obj) &
 result(rslt)
      class (fmsDiagField_type), intent(in) :: obj !< diag object
-     character(len=:), allocatable :: rslt 
+     character(len=:), allocatable :: rslt
      if (allocated(obj%modname)) then
        rslt = obj%modname
      else
@@ -605,7 +594,7 @@ end function get_modname
 pure function get_realm (obj) &
 result(rslt)
      class (fmsDiagField_type), intent(in) :: obj !< diag object
-     character(len=:), allocatable :: rslt 
+     character(len=:), allocatable :: rslt
      if (allocated(obj%realm)) then
        rslt = obj%realm
      else
@@ -617,7 +606,7 @@ end function get_realm
 pure function get_interp_method (obj) &
 result(rslt)
      class (fmsDiagField_type), intent(in) :: obj !< diag object
-     character(len=:), allocatable :: rslt 
+     character(len=:), allocatable :: rslt
      if (allocated(obj%interp_method)) then
        rslt = obj%interp_method
      else
@@ -629,7 +618,7 @@ end function get_interp_method
 pure function get_frequency (obj) &
 result(rslt)
      class (fmsDiagField_type), intent(in) :: obj !< diag object
-     integer, allocatable, dimension (:) :: rslt 
+     integer, allocatable, dimension (:) :: rslt
      if (allocated(obj%frequency)) then
        allocate (rslt(size(obj%frequency)))
        rslt = obj%frequency
@@ -643,7 +632,7 @@ end function get_frequency
 pure function get_tile_count (obj) &
 result(rslt)
      class (fmsDiagField_type), intent(in) :: obj !< diag object
-     integer :: rslt 
+     integer :: rslt
      if (allocated(obj%tile_count)) then
        rslt = obj%tile_count
      else
@@ -655,7 +644,7 @@ end function get_tile_count
 pure function get_area (obj) &
 result(rslt)
      class (fmsDiagField_type), intent(in) :: obj !< diag object
-     integer :: rslt 
+     integer :: rslt
      if (allocated(obj%area)) then
        rslt = obj%area
      else
@@ -709,7 +698,7 @@ end function get_missing_value
 function get_data_RANGE (obj) &
 result(rslt)
      class (fmsDiagField_type), intent(in) :: obj !< diag object
-     class(*),allocatable :: rslt(:) 
+     class(*),allocatable :: rslt(:)
      if (allocated(obj%data_RANGE)) then
        select type (r => obj%data_RANGE)
          type is (integer(kind=i4_kind))
@@ -734,15 +723,19 @@ result(rslt)
                  "The data_RANGE value is not allocated", FATAL)
        endif
 end function get_data_RANGE
-!> @brief Gets axis
-!! @return copy of axis information
-!! TODO
-!function get_axis (obj) &
-!result(rslt)
-!     class (fmsDiagField_type), intent(in) :: obj !< diag object
-!     type (diag_axis_type), allocatable, dimension(:) :: rslt 
-!
-!end function get_axis
+!> @brief Gets axis_ids
+!! @return pointer to the axis ids
+function get_axis_id (obj) &
+result(rslt)
+  class (fmsDiagField_type), target, intent(in) :: obj   !< diag object
+  integer, pointer, dimension(:)    :: rslt  !< field's axis_ids
+
+  if(allocated(obj%axis_ids)) then
+    rslt => obj%axis_ids
+  else
+    rslt => null()
+  endif
+end function get_axis_id
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !!!!! Allocation checks
 !!> @brief Checks if obj%diag_field is allocated
@@ -787,12 +780,6 @@ pure logical function has_local (obj)
   class (fmsDiagField_type), intent(in) :: obj !< diag object
   has_local = allocated(obj%local)
 end function has_local
-!!> @brief Checks if obj%init_time is allocated
-!!! @return true if obj%init_time is allocated
-!logical function has_init_time (obj)
-!  class (fmsDiagField_type), intent(in) :: obj !< diag object
-!  has_init_time = allocated(obj%init_time)
-!end function has_init_time
 !> @brief Checks if obj%vartype is allocated
 !! @return true if obj%vartype is allocated
 pure logical function has_vartype (obj)

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -36,7 +36,7 @@ type fmsDiagObject_type
 !TODO add container arrays
 #ifdef use_yaml
 private
-!TODO: Remove FMS prefix from variables in this type 
+!TODO: Remove FMS prefix from variables in this type
   class(fmsDiagFileContainer_type), allocatable :: FMS_diag_files (:) !< array of diag files
   class(fmsDiagField_type), allocatable :: FMS_diag_fields(:) !< Array of diag fields
   integer, private :: registered_variables !< Number of registered variables
@@ -58,14 +58,13 @@ private
 end type fmsDiagObject_type
 
 type (fmsDiagObject_type), target :: fms_diag_object
-integer, private :: registered_variables !< Number of registered variables
 public :: fms_register_diag_field_obj
 public :: fms_register_diag_field_scalar
-public :: fms_register_diag_field_array 
+public :: fms_register_diag_field_array
 public :: fms_register_static_field
 public :: fms_diag_field_add_attribute
 public :: fms_get_diag_field_id_from_name
-public :: fms_diag_object 
+public :: fms_diag_object
 public :: fmsDiagObject_type
 
 contains
@@ -86,8 +85,8 @@ subroutine fms_diag_object_init (obj,diag_subset_output)
   CALL fms_diag_axis_object_init()
   obj%files_initialized = fms_diag_files_object_init(obj%FMS_diag_files)
   obj%fields_initialized = fms_diag_fields_object_init (obj%FMS_diag_fields)
- registered_variables = 0
- obj%initialized = .true.
+  obj%registered_variables = 0
+  obj%initialized = .true.
 #else
   call mpp_error("fms_diag_object_init",&
     "You must compile with -Duse_yaml to use the option use_modern_diag", FATAL)
@@ -106,18 +105,18 @@ subroutine fms_diag_object_end (obj)
   obj%initialized = .false.
 #endif
 end subroutine fms_diag_object_end
-!> \Description Fills in and allocates (when necessary) the values in the diagnostic object
-subroutine fms_register_diag_field_obj &
-                !(field_obj, modname, varname, axes, time, longname, units, missing_value, metadata)
-       (fms_diag_object, modname, varname, diag_field_indices, axes, init_time, &
+
+!> @brief Registers a field.
+!! @description This to avoid having duplicate code in each of the _scalar, _array and _static register calls
+!! @return field index for subsequent call to send_data.
+integer function fms_register_diag_field_obj &
+       (fms_diag_object, modname, varname, axes, init_time, &
        longname, units, missing_value, varRange, mask_variant, standname, &
-       do_not_log, err_msg, interp_method, tile_count, area, volume, realm)
+       do_not_log, err_msg, interp_method, tile_count, area, volume, realm, static)
 
  class(fmsDiagObject_type),TARGET,INTENT(inout):: fms_diag_object       !< Diaj_obj to fill
  CHARACTER(len=*),               INTENT(in)    :: modname               !< The module name
  CHARACTER(len=*),               INTENT(in)    :: varname               !< The variable name
- integer,                        INTENT(in)    :: diag_field_indices(:) !< Array of indices to the field
-                                                                        !! in the yaml object
  TYPE(time_type),  OPTIONAL,     INTENT(in)    :: init_time             !< Initial time
  INTEGER, TARGET,  OPTIONAL,     INTENT(in)    :: axes(:)               !< The axes indicies
  CHARACTER(len=*), OPTIONAL,     INTENT(in)    :: longname              !< THe variables long name
@@ -137,20 +136,34 @@ subroutine fms_register_diag_field_obj &
  INTEGER,          OPTIONAL,     INTENT(in)    :: volume                !< diag_field_id of the cell volume field
  CHARACTER(len=*), OPTIONAL,     INTENT(in)    :: realm                 !< String to set as the value to the
                                                                         !! modeling_realm attribute
+ LOGICAL,          OPTIONAL,     INTENT(in)    :: static                !< True if the variable is static
 #ifdef use_yaml
 
- class (fmsDiagFile_type), pointer :: fileptr => null()
- class (fmsDiagField_type), pointer :: fieldptr => null()
+ class (fmsDiagFile_type), pointer :: fileptr => null() !< Pointer to the diag_file
+ class (fmsDiagField_type), pointer :: fieldptr => null() !< Pointer to the diag_field
  integer, allocatable :: file_ids(:) !< The file IDs for this variable
  integer :: i !< For do loops
- integer :: j !< fms_diag_object%FMS_diag_fields%file_ids(i) (for less typing :)
-  
+ integer, allocatable :: diag_field_indices(:) !< indices where the field was found in the yaml
+
+ diag_field_indices = find_diag_field(varname, modname)
+ if (diag_field_indices(1) .eq. diag_null) then
+    !< The field was not found in the table, so return diag_null
+    fms_register_diag_field_obj = diag_null
+    deallocate(diag_field_indices)
+    return
+  endif
+
+  fms_diag_object%registered_variables = fms_diag_object%registered_variables + 1
+  fms_register_diag_field_obj = fms_diag_object%registered_variables
+
+  call fms_diag_object%FMS_diag_fields(fms_diag_object%registered_variables)%setID(fms_diag_object%registered_variables)
+
 !> Use pointers for convenience
-  fieldptr => fms_diag_object%FMS_diag_fields(registered_variables)
+  fieldptr => fms_diag_object%FMS_diag_fields(fms_diag_object%registered_variables)
 !> Register the data for the field
   call fieldptr%register(modname, varname, diag_field_indices, &
-       axes, init_time, longname, units, missing_value, varRange, mask_variant, standname, &
-       do_not_log, err_msg, interp_method, tile_count, area, volume, realm)
+       axes, longname, units, missing_value, varRange, mask_variant, standname, &
+       do_not_log, err_msg, interp_method, tile_count, area, volume, realm, static)
 !> Get the file IDs from the field indicies from the yaml
   file_ids = get_diag_files_id(diag_field_indices)
 !> Add the axis information, initial time, and field IDs to the files
@@ -183,8 +196,9 @@ subroutine fms_register_diag_field_obj &
   endif
   nullify (fileptr)
   nullify (fieldptr)
+  deallocate(diag_field_indices)
 #endif
-end subroutine fms_register_diag_field_obj
+end function fms_register_diag_field_obj
 
   !> @brief Registers a scalar field
   !! @return field index for subsequent call to send_data.
@@ -207,27 +221,12 @@ INTEGER FUNCTION fms_register_diag_field_scalar(fms_diag_object,module_name, fie
     CHARACTER(len=*), OPTIONAL, INTENT(in) :: realm         !< String to set as the modeling_realm attribute
 
 #ifdef use_yaml
-    integer, allocatable :: diag_field_indices(:) !< indices where the field was found
-
-    diag_field_indices = find_diag_field(field_name, module_name)
-    if (diag_field_indices(1) .eq. diag_null) then
-      !< The field was not found in the table, so return diag_null
-      fms_register_diag_field_scalar = diag_null
-      deallocate(diag_field_indices)
-      return
-    endif
-
-    registered_variables = registered_variables + 1
-    fms_register_diag_field_scalar = registered_variables
-
-    call fms_diag_object%FMS_diag_fields(registered_variables)%setID(registered_variables)
-    call fms_diag_object%FMS_diag_fields(registered_variables)%register(&
-      & module_name, field_name, diag_field_indices, init_time=init_time, &
+    fms_register_diag_field_scalar = fms_diag_object%register(&
+      & module_name, field_name, init_time=init_time, &
       & longname=long_name, units=units, missing_value=missing_value, varrange=var_range, &
       & standname=standard_name, do_not_log=do_not_log, err_msg=err_msg, &
       & area=area, volume=volume, realm=realm)
-    deallocate(diag_field_indices)
-#else 
+#else
 fms_register_diag_field_scalar = diag_not_registered
 #endif
 end function fms_register_diag_field_scalar
@@ -261,26 +260,11 @@ INTEGER FUNCTION fms_register_diag_field_array(fms_diag_object, module_name, fie
     CHARACTER(len=*), OPTIONAL, INTENT(in) :: realm         !< String to set as the modeling_realm attribute
 
 #ifdef use_yaml
-    integer, allocatable :: diag_field_indices(:) !< indices of diag_field yaml where the field was found
-
-    diag_field_indices = find_diag_field(field_name, module_name)
-    if (diag_field_indices(1) .eq. diag_null) then
-      !< The field was not found in the table, so return diag_null
-      fms_register_diag_field_array = diag_null
-      deallocate(diag_field_indices)
-      return
-    endif
-
-    registered_variables = registered_variables + 1
-    fms_register_diag_field_array = registered_variables
-
-    call fms_diag_object%FMS_diag_fields(registered_variables)%setID (registered_variables)
-    call fms_diag_object%FMS_diag_fields(registered_variables)%register( &
-      & module_name, field_name, diag_field_indices, init_time=init_time, &
+    fms_register_diag_field_array = fms_diag_object%register( &
+      & module_name, field_name, init_time=init_time, &
       & axes=axes, longname=long_name, units=units, missing_value=missing_value, varrange=var_range, &
       & mask_variant=mask_variant, standname=standard_name, do_not_log=do_not_log, err_msg=err_msg, &
       & interp_method=interp_method, tile_count=tile_count, area=area, volume=volume, realm=realm)
-    deallocate(diag_field_indices)
 #else
 fms_register_diag_field_array = diag_not_registered
 #endif
@@ -317,27 +301,12 @@ INTEGER FUNCTION fms_register_static_field(fms_diag_object, module_name, field_n
                                                                           !! modeling_realm attribute
 
 #ifdef use_yaml
-    integer, allocatable :: diag_field_indices(:) !< indices where the field was foun
-
-    diag_field_indices = find_diag_field(field_name, module_name)
-    if (diag_field_indices(1) .eq. diag_null) then
-      !< The field was not found in the table, so return diag_null
-      fms_register_static_field = diag_null
-      deallocate(diag_field_indices)
-      return
-    endif
-
-    registered_variables = registered_variables + 1
-    fms_register_static_field = registered_variables
-
-    call fms_diag_object%FMS_diag_fields(registered_variables)%setID(registered_variables)
 ! Include static as optional variable to register here
-    call fms_diag_object%FMS_diag_fields(registered_variables)%register( &
-      & module_name, field_name, diag_field_indices, axes=axes, &
+  fms_register_static_field = fms_diag_object%register( &
+      & module_name, field_name, axes=axes, &
       & longname=long_name, units=units, missing_value=missing_value, varrange=range, &
       & standname=standard_name, do_not_log=do_not_log, area=area, volume=volume, realm=realm, &
       & static=.true.)
-    deallocate(diag_field_indices)
 #else
 fms_register_static_field = diag_not_registered
 #endif
@@ -351,8 +320,8 @@ subroutine fms_diag_field_add_attribute(fms_diag_object, diag_field_id, att_name
   class(*),         intent(in) :: att_value(:) !< The attribute value to add
 #ifdef use_yaml
 !TODO: Value for diag not found
-  if ( diag_field_id .LE. 0 ) THEN 
-    RETURN 
+  if ( diag_field_id .LE. 0 ) THEN
+    RETURN
   else
     if (fms_diag_object%FMS_diag_fields(diag_field_id)%is_registered() ) &
       call fms_diag_object%FMS_diag_fields(diag_field_id)%add_attribute(att_name, att_value)
@@ -368,12 +337,12 @@ PURE FUNCTION fms_get_diag_field_id_from_name(fms_diag_object, module_name, fiel
   CHARACTER(len=*), INTENT(in) :: field_name !< Variable name
   integer :: diag_field_id
   integer :: i !< For looping
-!> Initialize to not found 
+!> Initialize to not found
   diag_field_id = DIAG_FIELD_NOT_FOUND
 #ifdef use_yaml
 !> Loop through fields to find it.
-  if (registered_variables < 1) return
-  do i=1,registered_variables
+  if (fms_diag_object%registered_variables < 1) return
+  do i=1,fms_diag_object%registered_variables
    diag_field_id = fms_diag_object%FMS_diag_fields(i)%id_from_name(module_name, field_name)
    if(diag_field_id .ne. DIAG_FIELD_NOT_FOUND) return
   enddo

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -156,7 +156,8 @@ integer function fms_register_diag_field_obj &
   fms_diag_object%registered_variables = fms_diag_object%registered_variables + 1
   fms_register_diag_field_obj = fms_diag_object%registered_variables
 
-  call fms_diag_object%FMS_diag_fields(fms_diag_object%registered_variables)%setID(fms_diag_object%registered_variables)
+  call fms_diag_object%FMS_diag_fields(fms_diag_object%registered_variables)%&
+    &setID(fms_diag_object%registered_variables)
 
 !> Use pointers for convenience
   fieldptr => fms_diag_object%FMS_diag_fields(fms_diag_object%registered_variables)


### PR DESCRIPTION
**Description**
- Saves the diag_yaml field information in the diag_field_object
- Removes extra white space
- Remove the variable `init_time` in the diag_field object (the time is handled by the file object)
- Removes duplicate code in `fms_register_diag_field_scalar`, `fms_register_diag_field_array`, `fms_register_static_field` and moves it to `fms_register_diag_field_obj`
- The number of registered_variables is now kept tracked in the diag_object instead of a module variable

Fixes # (issue)

**How Has This Been Tested?**
CI

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

