### PR TITLE
Fixes 2 string errors

### DIFF
--- a/fms2_io/blackboxio.F90
+++ b/fms2_io/blackboxio.F90
@@ -269,7 +269,7 @@ subroutine copy_metadata(fileobj, new_fileobj)
               deallocate(buf_double)
             else
               call error(append_error_msg//" "//trim(varname)//" has an unsupported type, "&
-                         "only nf90_int, nf90_float, and nf90_double are currently supported")
+                        //"only nf90_int, nf90_float, and nf90_double are currently supported")
 
             endif
             call check_netcdf_code(err, append_error_msg)

--- a/fms2_io/netcdf_io.F90
+++ b/fms2_io/netcdf_io.F90
@@ -2126,7 +2126,7 @@ function is_registered_to_restart(fileobj, variable_name) &
 
   if (.not. fileobj%is_restart) then
     call error("file "//trim(fileobj%path)//" is not a restart file. "&
-               "Add is_restart=.true. to your open_file call")
+              //"Add is_restart=.true. to your open_file call")
   endif
   is_registered = .false.
   do i = 1, fileobj%num_restart_vars


### PR DESCRIPTION
**Description**
After running a `make` on an FMS build with the cce complier I ran into 2 errors in fortran code. The code was missing string concatenaters which are now fixed. 

Fixes #1029 

**How Has This Been Tested?**
Tested using a `make` using the cce/14.0.0 on gaea

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [ ] `make distcheck` passes

