### PR TITLE
Added hack for fm_yaml_null in field_manager_init

### DIFF
--- a/field_manager/field_manager.F90
+++ b/field_manager/field_manager.F90
@@ -559,6 +559,7 @@ type (fmTable_t)                :: my_table       !< the field table
 integer                         :: model !< model assocaited with the current field
 character(len=fm_path_name_len) :: list_name !< field_manager list name
 character(len=fm_string_len)    :: subparamvalue !< subparam value to be used when defining new name
+character(len=fm_string_len)    :: fm_yaml_null !< useful hack when OG subparam does not contain an equals sign
 integer                         :: current_field !< field index within loop
 integer                         :: index_list_name !< integer used as check for "no field"
 integer                         :: subparamindex !< index to identify whether subparams exist for this field
@@ -655,8 +656,13 @@ do h=1,my_table%nchildren
               do m=1,size(my_table%children(h)%children(i)%children(j)%children(subparamindex)%keys)
                 method_control = " "
                 subparamvalue = " "
+                if (trim(my_table%children(h)%children(i)%children(j)%values(k)).eq.'fm_yaml_null') then
+                  fm_yaml_null = ''
+                else
+                  fm_yaml_null = trim(my_table%children(h)%children(i)%children(j)%values(k))//'/'
+                end if
                 method_control = trim(my_table%children(h)%children(i)%children(j)%keys(k))//"/"//&
-                  &trim(my_table%children(h)%children(i)%children(j)%values(k))//"/"//&
+                  &trim(fm_yaml_null)//&
                   &trim(my_table%children(h)%children(i)%children(j)%children(subparamindex)%keys(m))
                 subparamvalue = trim(my_table%children(h)%children(i)%children(j)%children(subparamindex)%values(m))
                 call new_name(list_name, method_control, subparamvalue)


### PR DESCRIPTION
**Description**
field_manager_init now correctly parses a field_table.yaml with fm_yaml_null in it. fm_yaml_null is created with the converter for field table method values that should be empty. Needs the latest fms_yaml_tools field_table converter update (or else fm_yaml_null won't be in the field_table.yaml).

Fixes #1038 

**How Has This Been Tested?**
Skylake

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

