### PR TITLE
Add m4 tests for mpich and gnu argument mismatch

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -178,8 +178,7 @@ if test $with_mpi = yes; then
   # Require MPI
   # We expect users to set CC and FC to MPI compiler wrappers, or that the correct
   # CPPFLAGS, {C,FC}FLAGS, LDFLAGS and LIBS options are given.
-  AC_CHECK_HEADERS([mpi.h], [], [AC_MSG_ERROR([Can't find the MPI C header file.  Set CC/CPPFLAGS/CFLAGS])])
-  AC_CHECK_FUNC([MPI_Init], [], [AC_MSG_ERROR([Can't find the MPI C library.  Set CC/LDFLAGS/LIBS])])
+  GX_MPI()
 fi
 
 # Require yaml
@@ -225,9 +224,16 @@ AC_LANG_POP(C)
 AC_LANG_PUSH(Fortran)
 if test $with_mpi = yes; then
   # Require MPI
-  GX_FC_CHECK_MOD([mpi], [], [], [AC_MSG_ERROR([Can't find the MPI Fortran module.  Set FC/CPPFLAGS/FCFLAGS])])
-  AC_CHECK_FUNC([MPI_init], [], [AC_MSG_ERROR([Can't find the MPI Fortran library.  Set FC/LDFLAGS/LIBS])])
+  GX_MPI()
+  GX_MPI_FC_LEGACY_INTERFACE()
+  # Determine if a flag is required to allow external procedure argument mismatch when
+  # an explicit interface does not exist
+  if test ! -z "$HAVE_MPI_FC_LEGACY"; then
+    GX_FC_ALLOW_ARG_MISMATCH([dnl
+    FCFLAGS="$FCFLAGS $FC_ALLOW_ARG_MISMATCH_FLAG"])
+  fi
 fi
+
 # check intel compiler and coverage tools are avaiable if code coverage is enabled
 if test "$enable_code_coverage" = yes; then
   if test ! -z "`$FC --version | grep ifort`"; then
@@ -381,16 +387,6 @@ if [ test -n "`$FC --version | grep GNU | grep 11\.1\..`" ]; then
   AC_MSG_RESULT([yes])
   AC_MSG_ERROR([Compilation with gcc and gfortran 11.1.0 is unsupported \
 by this version of FMS due to a bug in the compiler. Please use a different version of gcc/gfortran.])
-else
-  AC_MSG_RESULT([no])
-fi
-# Check if gcc >=10 is used with mpich
-# adds compiler arg needed for mpich compilation if found
-AC_MSG_CHECKING([if gcc 10 or greater is loaded with mpich])
-if [ test "`$FC --version | grep GNU | grep -E ' 1[0-9]\.[0-9]*\.[0-9]*$'`" -a "`which $FC | grep -i mpich`" ]; then
-  AC_MSG_RESULT([yes])
-  AC_MSG_WARN([Adding -fallow-argument-mismatch to FCFLAGS to allow compilation with gcc >=10 and mpich])
-  FCFLAGS="$FCFLAGS -fallow-argument-mismatch"
 else
   AC_MSG_RESULT([no])
 fi

--- a/m4/gx_fortran_legacy_options.m4
+++ b/m4/gx_fortran_legacy_options.m4
@@ -1,0 +1,97 @@
+#***********************************************************************
+#*                   GNU Lesser General Public License
+#*
+#* This file is part of the GFDL Flexible Modeling System (FMS).
+#*
+#* FMS is free software: you can redistribute it and/or modify it under
+#* the terms of the GNU Lesser General Public License as published by
+#* the Free Software Foundation, either version 3 of the License, or (at
+#* your option) any later version.
+#*
+#* FMS is distributed in the hope that it will be useful, but WITHOUT
+#* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+#* for more details.
+#*
+#* You should have received a copy of the GNU Lesser General Public
+#* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
+#***********************************************************************
+
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   GX_FC_ALLOW_ARG_MISMATCH([ACTION-IF-SUCCESS], [ACTION-IF-FAILURE = FAILURE])
+#
+# DESCRIPTION
+#
+#   Set of functions that check for compiler flags to support legacy Fortran
+#   language syntax
+#
+# LICENSE
+#
+#   Copyright (c) 2022 Seth Underwood <underwoo@underwoo.io>
+#
+#   This program is free software; you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation; either version 3 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+
+# GX_FC_ALLOW_ARG_MISMATCH([ACTION-IF-SUCCESS], [ACTION-IF-FAILURE = FAILURE])
+# ----------------------------------------------------------------------
+# Check if a compiler flag is required when calls to external procedures
+# have argument mismatches between the different calls.
+#
+# Sets the variable FC_ALLOW_ARG_MISMATCH_FLAG to hold the flag.
+#
+# The known flags are:
+# -fallow-argument-mismatch: gfortran (version 10 and later.  Not required
+#                                      for versions less than 10.)
+AC_DEFUN([GX_FC_ALLOW_ARG_MISMATCH],[
+AC_LANG_PUSH([Fortran])
+AC_CACHE_CHECK([for Fortran flag to allow procedure arg mismatch], [gx_cv_fc_allow_arg_mismatch_flag],[
+gx_cv_fc_allow_arg_mismatch_flag=unknown
+gx_fc_allow_arg_mismatch_flag_FCFLAGS_save=$FCFLAGS
+for ac_flag in none \
+               '-fallow-argument-mismatch'; do
+test "x$ac_flag" != xnone && FCFLAGS="$gx_fc_allow_arg_mismatch_flag_FCFLAGS_save ${ac_flag}"
+AC_COMPILE_IFELSE([[      program test
+      logical(kind=8) :: arg8
+      logical(kind=4) :: arg4
+      call something(arg8)
+      call something(arg4)
+      end program test]],
+      [gx_cv_fc_allow_arg_mismatch_flag=$ac_flag; break])
+done
+rm -f conftest.err conftest.$ac_objext conftest.$ac_ext
+FCFLAGS=$gx_fc_allow_arg_mismatch_flag_FCFLAGS_save
+])
+if test "x$gx_cv_fc_allow_arg_mismatch_flag" = xunknown; then
+  m4_default([$2],
+    [AC_MSG_ERROR([Unable to determine flag to allow argument mismatch])])
+else
+  FC_ALLOW_ARG_MISMATCH_FLAG=$gx_cv_fc_allow_arg_mismatch_flag
+  if test "x$FC_ALLOW_ARG_MISMATCH_FLAG" = "xnone"; then
+    FC_ALLOW_ARG_MISMATCH_FLAG=
+  fi
+  $1
+fi
+AC_LANG_POP([Fortran])
+AC_SUBST([FC_ALLOW_ARG_MISMATCH_FLAG])
+])

--- a/m4/gx_mpi.m4
+++ b/m4/gx_mpi.m4
@@ -1,0 +1,141 @@
+#***********************************************************************
+#*                   GNU Lesser General Public License
+#*
+#* This file is part of the GFDL Flexible Modeling System (FMS).
+#*
+#* FMS is free software: you can redistribute it and/or modify it under
+#* the terms of the GNU Lesser General Public License as published by
+#* the Free Software Foundation, either version 3 of the License, or (at
+#* your option) any later version.
+#*
+#* FMS is distributed in the hope that it will be useful, but WITHOUT
+#* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+#* for more details.
+#*
+#* You should have received a copy of the GNU Lesser General Public
+#* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
+#***********************************************************************
+
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   GX_MPI([ACTION-IF-SUCCESS], [ACTION-IF-FAILURE = FAILURE])
+#   GX_MPI_FC_LEGACY_INTERFACE()
+#
+# DESCRIPTION
+#
+#   Determine the compiler can find the MPI headers and library.
+#   This required gx_fortran_options.m4 for GX_FC_CHECK_MOD.
+#
+#   Also test if the MPI library uses legacy, Fortran interfaces.  In some compilers
+#   these legacy interfaces can lead to an error with non-matching arguments.
+#   In particular, GCC version >= 11.0.0
+#
+# LICENSE
+#
+#   Copyright (c) 2022 Seth Underwood <underwoo@underwoo.io>
+#
+#   This program is free software; you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation; either version 3 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+
+# GX_MPI([ACTION-IF-SUCCESS], [ACTION-IF-FAILURE = FAILURE])
+# ----------------------------------------------------------------------
+# Check if the compiler can find the MPI headers and libraries
+AC_DEFUN([GX_MPI], [
+AC_PREREQ(2.50) dnl for AC_LANG_CASE
+
+AS_VAR_PUSHDEF([gx_cv_mpi_h],[gx_cv_[]_AC_LANG_ABBREV[]_mpi_h])
+dnl Check for the MPI header.  Here we use AC_TRY_COMPILE as AC_CHECK_HEADER
+dnl Note, we use AC_TRY_COMPILE as AC_CHECK_HEADER will call $CPP. Since
+dnl CC may be a mpi-specific compiler (e.g. mpicc), we don't want to use $CPP.
+AC_LANG_CASE([C], [
+    AC_REQUIRE([AC_PROG_CC])
+    AC_CACHE_CHECK([for mpi.h], [gx_cv_mpi_h], [dnl
+    gx_cv_mpi_h=no
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include <mpi.h>])], [dnl
+      gx_cv_mpi_h=yes])])
+],
+[C++], [
+    AC_REQUIRE([AC_PROG_CXX])
+    AC_CACHE_CHECK([for mpi.h], [gx_cv_mpi_h], [dnl
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include <mpi.h>])],[dnl
+      gx_cv_mpi_h=yes])])
+],
+[Fortran 77], [
+    AC_REQUIRE([AC_PROG_F77])
+    AC_CACHE_CHECK([for mpif.h], [gx_cv_mpi_h], [dnl
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [      include "mpif.h"])], [dnl
+      gx_cv_mpi_h=yes])])
+],
+[Fortran], [
+    AC_REQUIRE([AC_PROG_FC])
+    AC_CACHE_CHECK([for mpif.h], [gx_cv_mpi_h], [dnl
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [      include "mpif.h"])], [dnl
+      gx_cv_mpi_h=yes])])
+    GX_FC_CHECK_MOD([mpi])
+])
+# Check for library
+AC_SEARCH_LIBS([MPI_Init], [mpi])
+
+AS_VAR_PUSHDEF([gx_mpi_lang_usable], [gx_[]_AC_LANG_ABBREV[]mpi])
+AC_LANG_CASE([C], [test "$gx_cv_mpi_h" = yes -a "x$ac_cv_search_MPI_Init" != "xno" && gx_mpi_lang_usable=yes],
+    [C++], [test "$gx_cv_mpi_h" = yes -a "x$ac_cv_search_MPI_Init" != "xno" && gx_mpi_lang_usable=yes],
+    [Fortran 77], [test "$gx_cv_mpi_h" = yes -a "x$ac_cv_search_MPI_Init" != "xno" && gx_mpi_lang_usable=yes],
+    [Fortran], [test \( "$gx_cv_mpi_h" = yes -o $gx_cv_fc_check_mod_mpi = yes \) -a "x$ac_cv_search_MPI_Init" != "xno" && gx_mpi_lang_usable=yes
+])
+AS_VAR_IF([gx_mpi_lang_usable], [yes], [dnl
+    m4_default([$1], [])
+    AC_LANG_CASE([C], [AC_DEFINE([HAVE_MPI_H], 1, [Define to 1 if the mpi.h header file $1 is found])],
+        [C++], [AC_DEFINE([HAVE_MPI_H], 1, [Define to 1 if the mpi.h header file $1 is found])],
+        [Fortran 77], [AC_DEFINE([HAVE_MPI_H], 1, [Define to 1 if the mpif.h header file $1 is found])],
+        [Fortran 77], [AC_DEFINE([HAVE_MPI_H], 1, [Define to 1 if the mpif.h header file $1 is found])]
+    )], [dnl
+    m4_default([$2], [AC_MSG_ERROR([Unable to find the MPI headers or library for _AC_LANG])])
+])
+AS_VAR_POPDEF([gx_mpi_lang_usable])
+AS_VAR_POPDEF([gx_cv_mpi_h])
+])
+
+# GX_MPI_FC_LEGACY_INTERFACE()
+# ----------------------------------------------------------------------
+# Check if the Fortran MPI library uses legacy interfaces.
+# 
+# If the Fortran MPI library uses legacy interfaces, the variable
+# HAVE_MPI_FC_LEGACY will be set.
+AC_DEFUN([GX_MPI_FC_LEGACY_INTERFACE], [
+    AC_LANG_ASSERT([Fortran])
+    AC_MSG_CHECKING([if the MPI Fortran library uses legacy interfaces])
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [dnl
+      use mpi
+      integer(kind=8) :: rarg8(10), sarg8(10)
+      integer(kind=4) :: rarg4(10), sarg4(10)
+      integer :: ssize(10), rsize(10), sdislp(10), rdispl(10), ierr
+      call MPI_Alltoallv(sarg4, ssize, sdispl, MPI_INTEGER4, &
+            rarg4, rsize, rdispl, MPI_INTEGER4, 1, error)
+      call MPI_Alltoallv(sarg8, ssize, sdispl, MPI_INTEGER8, &
+            rarg8, rsize, rdispl, MPI_INTEGER8, 1, error)])], [dnl
+            AC_DEFINE([HAVE_MPI_FC_LEGACY], 1 [Define to 1 if the MPI Fortran library uses legacy interfaces])
+            AC_MSG_RESULT(yes)], [dnl
+            AC_MSG_RESULT(no)]
+    )
+])


### PR DESCRIPTION
GFortran >=10 does not allow interface argument mismatch by default.  The MPICH library does not define interfaces for all Fortran kinds.  When using MPICH and Gfortran, an additional flag is needed `-fallow-argument-mismatch`.  This commit include autoconf tests to determine if this is required.

**Description**
Include a summary of the change and which issue is fixed. Please also include
relevant motivation and context. List any dependencies that are required for
this change.

Fixes # (issue)

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes. Please also note
any relevant details for your test configuration (e.g. compiler, OS).  Include
enough information so someone can reproduce your tests.

**Checklist:**
- [X ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
- [X] New check tests, if applicable, are included
- [x] `make distcheck` passes

