### PR TITLE
Dump routines for diag objects

### DIFF
--- a/diag_manager/diag_manager.F90
+++ b/diag_manager/diag_manager.F90
@@ -3917,7 +3917,7 @@ INTEGER FUNCTION register_diag_field_array_old(module_name, field_name, axes, in
 #ifdef use_yaml
     if (use_modern_diag) then
       CALL diag_yaml_object_init(diag_subset_output)
-      CALL fms_diag_object%init(diag_subset_output) 
+      CALL fms_diag_object%init(diag_subset_output)
     endif
 #else
     if (use_modern_diag) &

--- a/diag_manager/fms_diag_field_object.F90
+++ b/diag_manager/fms_diag_field_object.F90
@@ -1018,7 +1018,7 @@ subroutine dump_field_obj (this, unit_num)
     endif
     write(unit_num, *) 'num_attributes:' ,this%num_attributes
     if( allocated(this%attributes)) then
-      do i=1, SIZE(this%attributes)
+      do i=1, this%num_attributes
         if( allocated(this%attributes(i)%att_value)) then
           select type( val => this%attributes(i)%att_value)
             type is (real(r8_kind))

--- a/diag_manager/fms_diag_field_object.F90
+++ b/diag_manager/fms_diag_field_object.F90
@@ -943,6 +943,7 @@ end function diag_field_id_from_name
 subroutine dump_field_obj (this, unit_num)
   class(fmsDiagField_type), intent(in) :: this
   integer, intent(in) :: unit_num !< passed in from dump_diag_obj if log file is being written to
+  integer :: i
 
   if( mpp_pe() .eq. mpp_root_pe()) then
     if( allocated(this%file_ids)) write(unit_num, *) 'file_ids:' ,this%file_ids
@@ -966,31 +967,46 @@ subroutine dump_field_obj (this, unit_num)
     if( allocated(this%area)) write(unit_num, *) 'area:' ,this%area
     if( allocated(this%missing_value)) then
       select type(missing_val => this%missing_value)
-        type is (real(4)) 
+        type is (real(r4_kind))
           write(unit_num, *) 'missing_value:', missing_val
-        type is (real(8)) 
+        type is (real(r8_kind))
           write(unit_num, *) 'missing_value:' ,missing_val
-       type is(integer(4))
+       type is(integer(i4_kind))
           write(unit_num, *) 'missing_value:' ,missing_val
-       type is(integer(8))
+       type is(integer(i8_kind))
           write(unit_num, *) 'missing_value:' ,missing_val
       end select
     endif
     if( allocated( this%data_RANGE)) then
       select type(drange => this%data_RANGE)
-        type is (real(4)) 
+        type is (real(r4_kind))
           write(unit_num, *) 'data_RANGE:' ,drange
-        type is (real(8)) 
+        type is (real(r8_kind))
           write(unit_num, *) 'data_RANGE:' ,drange
-       type is(integer(4))
+       type is(integer(i4_kind))
           write(unit_num, *) 'data_RANGE:' ,drange
-       type is(integer(8))
+       type is(integer(i8_kind))
           write(unit_num, *) 'data_RANGE:' ,drange
       end select
     endif
-    !!!! TODO loop thru attributes (derived type)
-    !print *, this%attributes
-    !if( allocated(this%num_attributes)) print *, 'num_attributes:' ,this%num_attributes
+    write(unit_num, *) 'num_attributes:' ,this%num_attributes
+    if( allocated(this%attributes)) then
+      do i=1, SIZE(this%attributes)
+        if( allocated(this%attributes(i)%att_value)) then
+          select type( val => this%attributes(i)%att_value)
+            type is (real(r8_kind))
+              write(unit_num, *) 'attribute name', this%attributes(i)%att_name, 'val:',  val
+            type is (real(r4_kind))
+              write(unit_num, *) 'attribute name', this%attributes(i)%att_name, 'val:',  val
+            type is (integer(i4_kind))
+              write(unit_num, *) 'attribute name', this%attributes(i)%att_name, 'val:',  val
+            type is (integer(i8_kind))
+              write(unit_num, *) 'attribute name', this%attributes(i)%att_name, 'val:', val
+          end select
+        endif
+      enddo
+    endif
+
   endif
 
 end subroutine

--- a/diag_manager/fms_diag_field_object.F90
+++ b/diag_manager/fms_diag_field_object.F90
@@ -937,5 +937,54 @@ PURE FUNCTION diag_field_id_from_name(this, module_name, field_name) &
         diag_field_id = this%get_id()
   endif
 end function diag_field_id_from_name
+
+!> Dumps any data from a given fmsDiagField_type object
+subroutine dump_field_obj (this)
+  class(fmsDiagField_type), intent(in) :: this
+    print *, 'file_ids:' ,this%file_ids
+    print *, 'diag_id:' ,this%diag_id
+    !print *, this%attributes
+    print *, 'num_attributes:' ,this%num_attributes
+    print *, 'static:' ,this%static
+    print *, 'registered:' ,this%registered
+    print *, 'mask_variant:' ,this%mask_variant
+    print *, 'do_not_log:' ,this%do_not_log
+    print *, 'local:' ,this%local
+    print *, 'vartype:' ,this%vartype
+    print *, 'varname:' ,this%varname
+    print *, 'longname:' ,this%longname
+    print *, 'standname:' ,this%standname
+    print *, 'units:' ,this%units
+    print *, 'modname:' ,this%modname
+    print *, 'realm:' ,this%realm
+    print *, 'interp_method:' ,this%interp_method
+    print *, 'tile_count:' ,this%tile_count
+    print *, 'axis_ids:' ,this%axis_ids
+    !print *, this%domain
+    print *, 'type_of_domain:' ,this%type_of_domain
+    print *, 'area:' ,this%area
+    select type(missing_val => this%missing_value)
+      type is (real(4)) 
+        print *, 'missing_value:', missing_val
+      type is (real(8)) 
+        print *, 'missing_value:' ,missing_val
+     type is(integer(4))
+        print *, 'missing_value:' ,missing_val
+     type is(integer(8))
+        print *, 'missing_value:' ,missing_val
+    end select
+    select type(drange => this%data_RANGE)
+      type is (real(4)) 
+        print *, 'data_RANGE:' ,drange
+      type is (real(8)) 
+        print *, 'data_RANGE:' ,drange
+     type is(integer(4))
+        print *, 'data_RANGE:' ,drange
+     type is(integer(8))
+        print *, 'data_RANGE:' ,drange
+    end select
+
+end subroutine
+
 #endif
 end module fms_diag_field_object_mod

--- a/diag_manager/fms_diag_file_object.F90
+++ b/diag_manager/fms_diag_file_object.F90
@@ -32,7 +32,7 @@ use time_manager_mod, only: time_type, operator(/=), operator(==)
 use fms_diag_yaml_mod, only: diag_yaml, diagYamlObject_type, diagYamlFiles_type
 use fms_diag_axis_object_mod, only: diagDomain_t, get_domain_and_domain_type, fmsDiagAxis_type, &
                                     fmsDiagAxisContainer_type
-use mpp_mod, only: mpp_error, FATAL
+use mpp_mod, only: mpp_error, FATAL, mpp_pe, mpp_root_pe, stdout
 implicit none
 private
 
@@ -113,6 +113,7 @@ type :: fmsDiagFile_type
  procedure, public :: has_file_duration_units
  procedure, public :: has_file_varlist
  procedure, public :: has_file_global_meta
+ procedure, public :: dump_file_obj
 
 end type fmsDiagFile_type
 
@@ -584,31 +585,29 @@ subroutine add_start_time(this, start_time)
 end subroutine
 
 !> writes out internal values for fmsDiagFile_type object
-subroutine dump_file_obj(this)
+subroutine dump_file_obj(this, unit_num)
   class(fmsDiagFile_type), intent(in) :: this !< the file object
-
-  print *, 'file id:', this%id
+  integer, intent(in) :: unit_num !< passed in from dump_diag_obj
+                                  !! will either be for new log file or stdout 
+  write( unit_num, *) 'file id:', this%id
   !! TODO dump time_type
-  !print *, 'start time:', this%start_time
-  !print *, 'last_output', this%last_output
-  !print *, 'next_output', this%next_output
-  !print *,'next_next_output', this%next_next_output
-  !print *,'next_open', this%next_open
+  !write( unit_num, *) 'start time:', this%start_time
+  !write( unit_num, *) 'last_output', this%last_output
+  !write( unit_num, *) 'next_output', this%next_output
+  !write( unit_num, *)'next_next_output', this%next_next_output
+  !write( unit_num, *)'next_open', this%next_open
 
-  !! TODO print file info, might already be a fnct for it
-  !print *,'fileobj', this%fileobj
+  !! TODO file info (maybe just print name)
+  !write( unit_num, *)'fileobj', this%fileobj
 
-  !! dump yaml
-  call diag_yaml_dump()
-
-  print *,'type_of_domain', this%type_of_domain
-  !print *,'domain', this%domain
-  print *,'file_metadata_from_model', this%file_metadata_from_model
-  print *,'field_ids', this%field_ids
-  print *,'field_registered', this%field_registered
-  print *,'num_registered_fields', this%num_registered_fields
-  print *,'axis_ids', this%axis_ids
-  print *,'number_of_axis', this%number_of_axis
+  write( unit_num, *)'type_of_domain', this%type_of_domain
+  !write( unit_num, *)'domain', this%domain
+  if( allocated(this%file_metadata_from_model)) write( unit_num, *)'file_metadata_from_model', this%file_metadata_from_model
+  if( allocated(this%field_ids)) write( unit_num, *)'field_ids', this%field_ids
+  if( allocated(this%field_registered)) write( unit_num, *)'field_registered', this%field_registered
+  if( allocated(this%num_registered_fields)) write( unit_num, *)'num_registered_fields', this%num_registered_fields
+  if( allocated(this%axis_ids)) write( unit_num, *)'axis_ids', this%axis_ids
+  write( unit_num, *)'number_of_axis', this%number_of_axis
 
 end subroutine
 

--- a/diag_manager/fms_diag_file_object.F90
+++ b/diag_manager/fms_diag_file_object.F90
@@ -582,5 +582,36 @@ subroutine add_start_time(this, start_time)
   endif
 
 end subroutine
+
+!> writes out internal values for fmsDiagFile_type object
+subroutine dump_file_obj(this)
+  class(fmsDiagFile_type), intent(in) :: this !< the file object
+
+  print *, 'file id:', this%id
+  !! TODO dump time_type
+  !print *, 'start time:', this%start_time
+  !print *, 'last_output', this%last_output
+  !print *, 'next_output', this%next_output
+  !print *,'next_next_output', this%next_next_output
+  !print *,'next_open', this%next_open
+
+  !! TODO print file info, might already be a fnct for it
+  !print *,'fileobj', this%fileobj
+
+  !! dump yaml
+  call diag_yaml_dump()
+
+  print *,'type_of_domain', this%type_of_domain
+  !print *,'domain', this%domain
+  print *,'file_metadata_from_model', this%file_metadata_from_model
+  print *,'field_ids', this%field_ids
+  print *,'field_registered', this%field_registered
+  print *,'num_registered_fields', this%num_registered_fields
+  print *,'axis_ids', this%axis_ids
+  print *,'number_of_axis', this%number_of_axis
+
+end subroutine
+
+
 #endif
 end module fms_diag_file_object_mod

--- a/diag_manager/fms_diag_file_object.F90
+++ b/diag_manager/fms_diag_file_object.F90
@@ -28,7 +28,7 @@ module fms_diag_file_object_mod
 use fms2_io_mod, only: FmsNetcdfFile_t, FmsNetcdfUnstructuredDomainFile_t, FmsNetcdfDomainFile_t
 use diag_data_mod, only: DIAG_NULL, NO_DOMAIN, max_axes, SUB_REGIONAL, get_base_time, DIAG_NOT_REGISTERED
 use fms_diag_time_utils_mod, only: diag_time_inc
-use time_manager_mod, only: time_type, operator(/=), operator(==)
+use time_manager_mod, only: time_type, operator(/=), operator(==), date_to_string
 use fms_diag_yaml_mod, only: diag_yaml, diagYamlObject_type, diagYamlFiles_type
 use fms_diag_axis_object_mod, only: diagDomain_t, get_domain_and_domain_type, fmsDiagAxis_type, &
                                     fmsDiagAxisContainer_type
@@ -590,18 +590,15 @@ subroutine dump_file_obj(this, unit_num)
   integer, intent(in) :: unit_num !< passed in from dump_diag_obj
                                   !! will either be for new log file or stdout 
   write( unit_num, *) 'file id:', this%id
-  !! TODO dump time_type
-  !write( unit_num, *) 'start time:', this%start_time
-  !write( unit_num, *) 'last_output', this%last_output
-  !write( unit_num, *) 'next_output', this%next_output
-  !write( unit_num, *)'next_next_output', this%next_next_output
-  !write( unit_num, *)'next_open', this%next_open
+  write( unit_num, *) 'start time:', date_to_string(this%start_time)
+  write( unit_num, *) 'last_output', date_to_string(this%last_output)
+  write( unit_num, *) 'next_output', date_to_string(this%next_output)
+  write( unit_num, *)'next_next_output', date_to_string(this%next_next_output)
+  write( unit_num, *)'next_open', date_to_string(this%next_open)
 
-  !! TODO file info (maybe just print name)
-  !write( unit_num, *)'fileobj', this%fileobj
+  if( allocated(this%fileobj)) write( unit_num, *)'fileobj path', this%fileobj%path
 
   write( unit_num, *)'type_of_domain', this%type_of_domain
-  !write( unit_num, *)'domain', this%domain
   if( allocated(this%file_metadata_from_model)) write( unit_num, *)'file_metadata_from_model', this%file_metadata_from_model
   if( allocated(this%field_ids)) write( unit_num, *)'field_ids', this%field_ids
   if( allocated(this%field_registered)) write( unit_num, *)'field_registered', this%field_registered

--- a/diag_manager/fms_diag_file_object.F90
+++ b/diag_manager/fms_diag_file_object.F90
@@ -608,8 +608,7 @@ subroutine dump_file_obj(this, unit_num)
   if( allocated(this%field_ids)) write( unit_num, *)'field_ids', this%field_ids
   if( allocated(this%field_registered)) write( unit_num, *)'field_registered', this%field_registered
   if( allocated(this%num_registered_fields)) write( unit_num, *)'num_registered_fields', this%num_registered_fields
-  if( allocated(this%axis_ids)) write( unit_num, *)'axis_ids', this%axis_ids
-  write( unit_num, *)'number_of_axis', this%number_of_axis
+  if( allocated(this%axis_ids)) write( unit_num, *)'axis_ids', this%axis_ids(1:this%number_of_axis)
 
 end subroutine
 

--- a/diag_manager/fms_diag_file_object.F90
+++ b/diag_manager/fms_diag_file_object.F90
@@ -603,7 +603,8 @@ subroutine dump_file_obj(this, unit_num)
   if( allocated(this%fileobj)) write( unit_num, *)'fileobj path', this%fileobj%path
 
   write( unit_num, *)'type_of_domain', this%type_of_domain
-  if( allocated(this%file_metadata_from_model)) write( unit_num, *)'file_metadata_from_model', this%file_metadata_from_model
+  if( allocated(this%file_metadata_from_model)) write( unit_num, *) 'file_metadata_from_model', &
+                                                                    this%file_metadata_from_model
   if( allocated(this%field_ids)) write( unit_num, *)'field_ids', this%field_ids
   if( allocated(this%field_registered)) write( unit_num, *)'field_registered', this%field_registered
   if( allocated(this%num_registered_fields)) write( unit_num, *)'num_registered_fields', this%num_registered_fields

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -600,6 +600,7 @@ subroutine dump_diag_obj( filename )
     else
       write(unit_num, *) 'fields not initialized'
     endif
+    if( present(filename) ) close(unit_num)
   endif
 #endif
 end subroutine

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -602,6 +602,8 @@ subroutine dump_diag_obj( filename )
     endif
     if( present(filename) ) close(unit_num)
   endif
+#else
+  call mpp_error( FATAL, "You can not use the modern diag manager without compiling with -Duse_yaml")
 #endif
 end subroutine
   

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -500,4 +500,43 @@ result(axis_name)
 #endif
 end function fms_get_axis_name_from_id
 
+#ifdef use_yaml
+!> Dumps as much data as it can from the fmsDiagObject_type.
+!! Will print all fields in the object
+subroutine fms_diag_dump()
+  !type(fmsDiagObject_type) :: diag_obj
+  type(fmsDiagFile_type), pointer :: fileptr !<  pointer for traversing file list
+  type(fmsDiagField_type), pointer :: fieldptr !<  pointer for traversing field list
+  integer :: i !< do loops
+
+  print *, '********** dumping diag object ***********'
+  print *, 'registered_variables:', fms_diag_object%registered_variables
+  print *, 'registered_axis:', fms_diag_object%registered_axis
+  print *, 'initialized:', fms_diag_object%initialized
+  print *, 'files_initialized:', fms_diag_object%files_initialized
+  print *, 'fields_initialized:', fms_diag_object%fields_initialized
+  print *, 'buffers_initialized:', fms_diag_object%buffers_initialized
+  print *, 'axes_initialized:', fms_diag_object%axes_initialized
+  print *, 'Files:'
+  if( fms_diag_object%files_initialized ) then
+    do i=1, SIZE(fms_diag_object%FMS_diag_files) 
+      print *, 'File num:', i
+      fileptr => fms_diag_object%FMS_diag_files(i)%FMS_diag_file
+      call fileptr%dump_file_obj()
+    enddo
+  else
+    print *, 'files not initialized'
+  endif
+  if( fms_diag_object%fields_initialized) then
+    do i=1, SIZE(fms_diag_object%FMS_diag_fields) 
+      print *, 'Field num:', i
+      fieldptr => fms_diag_object%FMS_diag_fields(i)
+      call fieldptr%dump_field_obj()
+    enddo
+  else
+    print *, 'fields not initialized'
+  endif
+end subroutine
+#endif
+
 end module fms_diag_object_mod

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -17,7 +17,7 @@
 !* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
 !***********************************************************************
 module fms_diag_object_mod
-use mpp_mod, only: fatal, note, warning, mpp_error
+use mpp_mod, only: fatal, note, warning, mpp_error, mpp_pe, mpp_root_pe, stdout
 use diag_data_mod,  only: diag_null, diag_not_found, diag_not_registered, diag_registered_id, &
                          &DIAG_FIELD_NOT_FOUND, diag_not_registered, max_axes, TWO_D_DOMAIN
   USE time_manager_mod, ONLY: set_time, set_date, get_time, time_type, OPERATOR(>=), OPERATOR(>),&
@@ -70,6 +70,7 @@ end type fmsDiagObject_type
 type (fmsDiagObject_type), target :: fms_diag_object
 public :: fms_diag_object 
 public :: fmsDiagObject_type
+public :: dump_diag_obj
 
 contains
 
@@ -500,43 +501,53 @@ result(axis_name)
 #endif
 end function fms_get_axis_name_from_id
 
-#ifdef use_yaml
 !> Dumps as much data as it can from the fmsDiagObject_type.
-!! Will print all fields in the object
-subroutine fms_diag_dump()
+!! Will dump any fields and files as well (see d)
+subroutine dump_diag_obj( filename )
+  character(len=*), intent(in), optional :: filename !< optional filename to print to,
+                                            !! otherwise prints to stdout
+#ifdef use_yaml
   !type(fmsDiagObject_type) :: diag_obj
   type(fmsDiagFile_type), pointer :: fileptr !<  pointer for traversing file list
   type(fmsDiagField_type), pointer :: fieldptr !<  pointer for traversing field list
   integer :: i !< do loops
+  integer :: unit_num !< unit num of opened log file or stdout
 
-  print *, '********** dumping diag object ***********'
-  print *, 'registered_variables:', fms_diag_object%registered_variables
-  print *, 'registered_axis:', fms_diag_object%registered_axis
-  print *, 'initialized:', fms_diag_object%initialized
-  print *, 'files_initialized:', fms_diag_object%files_initialized
-  print *, 'fields_initialized:', fms_diag_object%fields_initialized
-  print *, 'buffers_initialized:', fms_diag_object%buffers_initialized
-  print *, 'axes_initialized:', fms_diag_object%axes_initialized
-  print *, 'Files:'
-  if( fms_diag_object%files_initialized ) then
-    do i=1, SIZE(fms_diag_object%FMS_diag_files) 
-      print *, 'File num:', i
-      fileptr => fms_diag_object%FMS_diag_files(i)%FMS_diag_file
-      call fileptr%dump_file_obj()
-    enddo
+  if( present(filename) ) then
+    open(newunit=unit_num, file=trim(filename), action='WRITE')
   else
-    print *, 'files not initialized'
+    unit_num = stdout()
   endif
-  if( fms_diag_object%fields_initialized) then
-    do i=1, SIZE(fms_diag_object%FMS_diag_fields) 
-      print *, 'Field num:', i
-      fieldptr => fms_diag_object%FMS_diag_fields(i)
-      call fieldptr%dump_field_obj()
-    enddo
-  else
-    print *, 'fields not initialized'
+  if( mpp_pe() .eq. mpp_root_pe()) then
+    write(unit_num, *) '********** dumping diag object ***********'
+    write(unit_num, *) 'registered_variables:', fms_diag_object%registered_variables
+    write(unit_num, *) 'registered_axis:', fms_diag_object%registered_axis
+    write(unit_num, *) 'initialized:', fms_diag_object%initialized
+    write(unit_num, *) 'files_initialized:', fms_diag_object%files_initialized
+    write(unit_num, *) 'fields_initialized:', fms_diag_object%fields_initialized
+    write(unit_num, *) 'buffers_initialized:', fms_diag_object%buffers_initialized
+    write(unit_num, *) 'axes_initialized:', fms_diag_object%axes_initialized
+    write(unit_num, *) 'Files:'
+    if( fms_diag_object%files_initialized ) then
+      do i=1, SIZE(fms_diag_object%FMS_diag_files) 
+        write(unit_num, *) 'File num:', i
+        fileptr => fms_diag_object%FMS_diag_files(i)%FMS_diag_file
+        call fileptr%dump_file_obj(unit_num)
+      enddo
+    else
+      write(unit_num, *) 'files not initialized'
+    endif
+    if( fms_diag_object%fields_initialized) then
+      do i=1, SIZE(fms_diag_object%FMS_diag_fields) 
+        write(unit_num, *) 'Field num:', i
+        fieldptr => fms_diag_object%FMS_diag_fields(i)
+        call fieldptr%dump_field_obj(unit_num)
+      enddo
+    else
+      write(unit_num, *) 'fields not initialized'
+    endif
   endif
-end subroutine
 #endif
-
+end subroutine
+  
 end module fms_diag_object_mod

--- a/diag_manager/fms_diag_yaml.F90
+++ b/diag_manager/fms_diag_yaml.F90
@@ -36,7 +36,7 @@ use diag_data_mod,   only: DIAG_NULL, DIAG_OCEAN, DIAG_ALL, DIAG_OTHER, set_base
                            time_diurnal, time_power, time_none, r8, i8, r4, i4
 use yaml_parser_mod, only: open_and_parse_file, get_value_from_key, get_num_blocks, get_nkeys, &
                            get_block_ids, get_key_value, get_key_ids, get_key_name
-use mpp_mod,         only: mpp_error, FATAL
+use mpp_mod,         only: mpp_error, FATAL, mpp_pe, mpp_root_pe, stdout
 use, intrinsic :: iso_c_binding, only : c_ptr, c_null_char
 use fms_string_utils_mod, only: fms_array_to_pointer, fms_find_my_string, fms_sort_this, fms_find_unique
 use platform_mod, only: r4_kind, i4_kind
@@ -50,6 +50,7 @@ public :: diag_yaml_object_init, diag_yaml_object_end
 public :: diagYamlObject_type, get_diag_yaml_obj
 public :: diagYamlFiles_type, diagYamlFilesVar_type
 public :: get_num_unique_fields, find_diag_field, get_diag_fields_entries, get_diag_files_id
+public :: dump_diag_yaml_obj
 !> @}
 
 integer, parameter :: basedate_size = 6
@@ -1335,53 +1336,68 @@ function get_diag_files_id(indices) &
 
 end function get_diag_files_id
 
-!> prints out contents of diag_yaml 
-subroutine diag_yaml_dump( ) 
+!> Prints out values from diag_yaml object for debugging.
+!! Only writes on root.
+subroutine dump_diag_yaml_obj( filename ) 
+  character(len=*), optional, intent(in)        :: filename !< optional name of logfile to write to, otherwise prints to stdout
   type(diagyamlfilesvar_type), allocatable      :: fields(:)
   type(diagyamlfiles_type), allocatable         :: files(:)
-  integer                                       :: i
-  !! TODO root, write to log
-  print *, '**********Dumping diag_yaml object**********' 
-  print *, 'FILES'
-  allocate(fields(SIZE(diag_yaml%get_diag_fields())))
-  allocate(files(SIZE(diag_yaml%get_diag_files())))
-  files = diag_yaml%get_diag_files()
-  fields = diag_yaml%get_diag_fields()
-  do i=1, SIZE(files)
-    print *, 'File: ', files(i)%get_file_fname() 
-    if(files(i)%has_file_frequnit()) print *, 'file_frequnit:', files(i)%get_file_frequnit()
-    if(files(i)%has_file_freq()) print *, 'get_file_freq:', files(i)%get_file_freq()
-    if(files(i)%has_file_timeunit()) print *, 'get_file_timeunit:', files(i)%get_file_timeunit()
-    if(files(i)%has_file_unlimdim()) print *, 'get_file_unlimdim:', files(i)%get_file_unlimdim()
-    !if(files(i)%has_file_sub_region()) print *, 'get_file_sub_region:', files(i)%get_file_sub_region()
-    if(files(i)%has_file_new_file_freq()) print *, 'get_file_new_file_freq:', files(i)%get_file_new_file_freq()
-    if(files(i)%has_file_new_file_freq_units()) print *, 'get_file_new_file_freq_units:', &
-                                                                files(i)%get_file_new_file_freq_units()
-    if(files(i)%has_file_start_time()) print *, 'get_file_start_time:', files(i)%get_file_start_time()
-    if(files(i)%has_file_duration()) print *, 'get_file_duration:', files(i)%get_file_duration()
-    if(files(i)%has_file_duration_units()) print *, 'get_file_duration_units:', files(i)%get_file_duration_units()
-    if(files(i)%has_file_varlist()) print *, 'get_file_varlist:', files(i)%get_file_varlist()
-    if(files(i)%has_file_global_meta()) print *, 'get_file_global_meta:', files(i)%get_file_global_meta()
-    if(files(i)%is_global_meta()) print *, 'is_global_meta:', files(i)%is_global_meta()
-    print *, ''
-  enddo
-  print *, 'FIELDS'
-  do i=1, SIZE(fields)
-    print *, 'Field: ', fields(i)%get_var_fname() 
-    if(fields(i)%has_var_fname()) print *, 'get_var_fname:', fields(i)%get_var_fname()
-    if(fields(i)%has_var_varname()) print *, 'get_var_varname:', fields(i)%get_var_varname()
-    if(fields(i)%has_var_reduction()) print *, 'get_var_reduction:', fields(i)%get_var_reduction()
-    if(fields(i)%has_var_module()) print *, 'get_var_module:', fields(i)%get_var_module()
-    if(fields(i)%has_var_kind()) print *, 'get_var_kind:', fields(i)%get_var_kind()
-    if(fields(i)%has_var_outname()) print *, 'get_var_outname:', fields(i)%get_var_outname()
-    if(fields(i)%has_var_longname()) print *, 'get_var_longname:', fields(i)%get_var_longname()
-    if(fields(i)%has_var_units()) print *, 'get_var_units:', fields(i)%get_var_units()
-    if(fields(i)%has_var_zbounds()) print *, 'get_var_zbounds:', fields(i)%get_var_zbounds()
-    if(fields(i)%has_var_attributes()) print *, 'get_var_attributes:', fields(i)%get_var_attributes()
-    if(fields(i)%has_n_diurnal()) print *, 'get_n_diurnal:', fields(i)%get_n_diurnal()
-    if(fields(i)%has_pow_value()) print *, 'get_pow_value:', fields(i)%get_pow_value()
-    if(fields(i)%has_var_attributes()) print *, 'is_var_attributes:', fields(i)%is_var_attributes()
-  enddo
+  integer                                       :: i, unit_num
+  if( present(filename)) then
+    open(newunit=unit_num, file=trim(filename), action='WRITE') 
+  else
+    unit_num = stdout() 
+  endif
+  !! TODO write to log
+  if( mpp_pe() .eq. mpp_root_pe()) then
+    write(unit_num, *) '**********Dumping diag_yaml object**********' 
+    if( diag_yaml%has_diag_title())    write(unit_num, *) 'Title:', diag_yaml%diag_title
+    if( diag_yaml%has_diag_basedate()) write(unit_num, *) 'basedate array:', diag_yaml%diag_basedate
+    write(unit_num, *) 'FILES'
+    allocate(fields(SIZE(diag_yaml%get_diag_fields())))
+    allocate(files(SIZE(diag_yaml%get_diag_files())))
+    files = diag_yaml%get_diag_files()
+    fields = diag_yaml%get_diag_fields()
+    do i=1, SIZE(files)
+      write(unit_num, *) 'File: ', files(i)%get_file_fname() 
+      if(files(i)%has_file_frequnit()) write(unit_num, *) 'file_frequnit:', files(i)%get_file_frequnit()
+      if(files(i)%has_file_freq()) write(unit_num, *) 'freq:', files(i)%get_file_freq()
+      if(files(i)%has_file_timeunit()) write(unit_num, *) 'timeunit:', files(i)%get_file_timeunit()
+      if(files(i)%has_file_unlimdim()) write(unit_num, *) 'unlimdim:', files(i)%get_file_unlimdim()
+      !if(files(i)%has_file_sub_region()) write(unit_num, *) 'sub_region:', files(i)%get_file_sub_region()
+      if(files(i)%has_file_new_file_freq()) write(unit_num, *) 'new_file_freq:', files(i)%get_file_new_file_freq()
+      if(files(i)%has_file_new_file_freq_units()) write(unit_num, *) 'new_file_freq_units:', &
+                                                         & files(i)%get_file_new_file_freq_units()
+      if(files(i)%has_file_start_time()) write(unit_num, *) 'start_time:', files(i)%get_file_start_time()
+      if(files(i)%has_file_duration()) write(unit_num, *) 'duration:', files(i)%get_file_duration()
+      if(files(i)%has_file_duration_units()) write(unit_num, *) 'duration_units:', files(i)%get_file_duration_units()
+      if(files(i)%has_file_varlist()) write(unit_num, *) 'varlist:', files(i)%get_file_varlist()
+      if(files(i)%has_file_global_meta()) write(unit_num, *) 'global_meta:', files(i)%get_file_global_meta()
+      if(files(i)%is_global_meta()) write(unit_num, *) 'global_meta:', files(i)%is_global_meta()
+      write(unit_num, *) ''
+    enddo
+    write(unit_num, *) 'FIELDS'
+    do i=1, SIZE(fields)
+      write(unit_num, *) 'Field: ', fields(i)%get_var_fname() 
+      if(fields(i)%has_var_fname()) write(unit_num, *) 'fname:', fields(i)%get_var_fname()
+      if(fields(i)%has_var_varname()) write(unit_num, *) 'varname:', fields(i)%get_var_varname()
+      if(fields(i)%has_var_reduction()) write(unit_num, *) 'reduction:', fields(i)%get_var_reduction()
+      if(fields(i)%has_var_module()) write(unit_num, *) 'module:', fields(i)%get_var_module()
+      if(fields(i)%has_var_kind()) write(unit_num, *) 'kind:', fields(i)%get_var_kind()
+      if(fields(i)%has_var_outname()) write(unit_num, *) 'outname:', fields(i)%get_var_outname()
+      if(fields(i)%has_var_longname()) write(unit_num, *) 'longname:', fields(i)%get_var_longname()
+      if(fields(i)%has_var_units()) write(unit_num, *) 'units:', fields(i)%get_var_units()
+      if(fields(i)%has_var_zbounds()) write(unit_num, *) 'zbounds:', fields(i)%get_var_zbounds()
+      if(fields(i)%has_var_attributes()) write(unit_num, *) 'attributes:', fields(i)%get_var_attributes()
+      if(fields(i)%has_n_diurnal()) write(unit_num, *) 'n_diurnal:', fields(i)%get_n_diurnal()
+      if(fields(i)%has_pow_value()) write(unit_num, *) 'pow_value:', fields(i)%get_pow_value()
+      if(fields(i)%has_var_attributes()) write(unit_num, *) 'is_var_attributes:', fields(i)%is_var_attributes()
+    enddo
+    deallocate(files, fields)
+    if( present(filename)) then
+      close(unit_num)
+    endif
+  endif
 end subroutine
 
 #endif

--- a/diag_manager/fms_diag_yaml.F90
+++ b/diag_manager/fms_diag_yaml.F90
@@ -1339,7 +1339,8 @@ end function get_diag_files_id
 !> Prints out values from diag_yaml object for debugging.
 !! Only writes on root.
 subroutine dump_diag_yaml_obj( filename ) 
-  character(len=*), optional, intent(in)        :: filename !< optional name of logfile to write to, otherwise prints to stdout
+  character(len=*), optional, intent(in)        :: filename !< optional name of logfile to write to, otherwise
+                                                            !! prints to stdout
   type(diagyamlfilesvar_type), allocatable      :: fields(:)
   type(diagyamlfiles_type), allocatable         :: files(:)
   integer                                       :: i, unit_num

--- a/diag_manager/fms_diag_yaml.F90
+++ b/diag_manager/fms_diag_yaml.F90
@@ -1334,6 +1334,56 @@ function get_diag_files_id(indices) &
   end do
 
 end function get_diag_files_id
+
+!> prints out contents of diag_yaml 
+subroutine diag_yaml_dump( ) 
+  type(diagyamlfilesvar_type), allocatable      :: fields(:)
+  type(diagyamlfiles_type), allocatable         :: files(:)
+  integer                                       :: i
+  !! TODO root, write to log
+  print *, '**********Dumping diag_yaml object**********' 
+  print *, 'FILES'
+  allocate(fields(SIZE(diag_yaml%get_diag_fields())))
+  allocate(files(SIZE(diag_yaml%get_diag_files())))
+  files = diag_yaml%get_diag_files()
+  fields = diag_yaml%get_diag_fields()
+  do i=1, SIZE(files)
+    print *, 'File: ', files(i)%get_file_fname() 
+    if(files(i)%has_file_frequnit()) print *, 'file_frequnit:', files(i)%get_file_frequnit()
+    if(files(i)%has_file_freq()) print *, 'get_file_freq:', files(i)%get_file_freq()
+    if(files(i)%has_file_timeunit()) print *, 'get_file_timeunit:', files(i)%get_file_timeunit()
+    if(files(i)%has_file_unlimdim()) print *, 'get_file_unlimdim:', files(i)%get_file_unlimdim()
+    !if(files(i)%has_file_sub_region()) print *, 'get_file_sub_region:', files(i)%get_file_sub_region()
+    if(files(i)%has_file_new_file_freq()) print *, 'get_file_new_file_freq:', files(i)%get_file_new_file_freq()
+    if(files(i)%has_file_new_file_freq_units()) print *, 'get_file_new_file_freq_units:', &
+                                                                files(i)%get_file_new_file_freq_units()
+    if(files(i)%has_file_start_time()) print *, 'get_file_start_time:', files(i)%get_file_start_time()
+    if(files(i)%has_file_duration()) print *, 'get_file_duration:', files(i)%get_file_duration()
+    if(files(i)%has_file_duration_units()) print *, 'get_file_duration_units:', files(i)%get_file_duration_units()
+    if(files(i)%has_file_varlist()) print *, 'get_file_varlist:', files(i)%get_file_varlist()
+    if(files(i)%has_file_global_meta()) print *, 'get_file_global_meta:', files(i)%get_file_global_meta()
+    if(files(i)%is_global_meta()) print *, 'is_global_meta:', files(i)%is_global_meta()
+    print *, ''
+  enddo
+  print *, 'FIELDS'
+  do i=1, SIZE(fields)
+    print *, 'Field: ', fields(i)%get_var_fname() 
+    if(fields(i)%has_var_fname()) print *, 'get_var_fname:', fields(i)%get_var_fname()
+    if(fields(i)%has_var_varname()) print *, 'get_var_varname:', fields(i)%get_var_varname()
+    if(fields(i)%has_var_reduction()) print *, 'get_var_reduction:', fields(i)%get_var_reduction()
+    if(fields(i)%has_var_module()) print *, 'get_var_module:', fields(i)%get_var_module()
+    if(fields(i)%has_var_kind()) print *, 'get_var_kind:', fields(i)%get_var_kind()
+    if(fields(i)%has_var_outname()) print *, 'get_var_outname:', fields(i)%get_var_outname()
+    if(fields(i)%has_var_longname()) print *, 'get_var_longname:', fields(i)%get_var_longname()
+    if(fields(i)%has_var_units()) print *, 'get_var_units:', fields(i)%get_var_units()
+    if(fields(i)%has_var_zbounds()) print *, 'get_var_zbounds:', fields(i)%get_var_zbounds()
+    if(fields(i)%has_var_attributes()) print *, 'get_var_attributes:', fields(i)%get_var_attributes()
+    if(fields(i)%has_n_diurnal()) print *, 'get_n_diurnal:', fields(i)%get_n_diurnal()
+    if(fields(i)%has_pow_value()) print *, 'get_pow_value:', fields(i)%get_pow_value()
+    if(fields(i)%has_var_attributes()) print *, 'is_var_attributes:', fields(i)%is_var_attributes()
+  enddo
+end subroutine
+
 #endif
 end module fms_diag_yaml_mod
 !> @}

--- a/test_fms/diag_manager/test_diag_yaml.F90
+++ b/test_fms/diag_manager/test_diag_yaml.F90
@@ -142,6 +142,10 @@ if (.not. checking_crashes) then
 
 endif
 
+!! test dump routines
+call dump_diag_yaml_obj('test_dump.log')
+call dump_diag_yaml_obj() ! to stdout
+
 call diag_yaml_object_end
 
 call fms_end()

--- a/test_fms/diag_manager/test_modern_diag.F90
+++ b/test_fms/diag_manager/test_modern_diag.F90
@@ -30,6 +30,7 @@ use   diag_manager_mod, only: diag_manager_init, diag_manager_end, diag_axis_ini
 use   fms_mod,          only: fms_init, fms_end
 use   mpp_mod,          only: FATAL, mpp_error, mpp_npes, mpp_pe, mpp_root_pe, mpp_broadcast
 use   time_manager_mod, only: time_type, set_calendar_type, set_date, JULIAN, set_time
+use fms_diag_object_mod,only: dump_diag_obj
 
 implicit none
 
@@ -148,6 +149,11 @@ call diag_field_add_attribute (id_var1, "integer", 10)
 call diag_field_add_attribute (id_var1, "1d integer", (/10, 10/))
 call diag_field_add_attribute (id_var1, "real", 10.)
 call diag_field_add_attribute (id_var2, '1d real', (/10./))
+
+!! test dump routines
+!! prints fields from objects for debugging to log if name is provided, othwerise goes to stdout
+call dump_diag_obj('diag_obj_dump.log')
+call dump_diag_obj()
 
 call diag_manager_end(Time)
 call fms_end


### PR DESCRIPTION
**Description**
adds `dump_diag_obj` and `dump_diag_yaml_obj` routines that will dump the set fields of the objects for debugging. Uses helper routines that are private for the field and file obj output. Will also write to a log file if a name is given otherwise goes to stdout

**How Has This Been Tested?**
make check, intel 21

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

