### PR TITLE
post release action for version number + fix docs trigger

### DIFF
--- a/.github/workflows/update_docs.yml
+++ b/.github/workflows/update_docs.yml
@@ -1,8 +1,10 @@
 name: Generate and deploy documentation on GH pages
 
 # update on releases or when triggered manually(must have write access)
-on: [release, workflow_dispatch]
-
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
 jobs:
   update_docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -8,3 +8,8 @@ jobs:
       run: sed -i '/20[0-9][0-9]\.[0-9][0-9]/ s/]/-dev]/' configure.ac 
     - name: Create pull request
       uses: peter-evans/create-pull-request@v4 
+      with:
+        base: main                   # creates a new branch off of main
+        branch: add-dev-post-release # name of the created branch
+        branch-suffix: timestamp     # add a timestamp to branch name
+        delete-branch: true          # delete afer merge 

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,0 +1,10 @@
+on: release 
+jobs:
+  add-dev-to-version:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3 
+    - name: Append version with dev
+      run: sed -i '/20[0-9][0-9]\.[0-9][0-9]/ s/]/-dev]/' configure.ac 
+    - name: Create pull request
+      uses: peter-evans/create-pull-request@v4 

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -17,4 +17,3 @@ jobs:
         delete-branch: true          # delete afer merge 
         title: Append dev to version number post-release
         body: automated change, adds '-dev' to the version number upon releases
-        reviewers: rem1776, thomas-robinson, bensonr

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -17,4 +17,4 @@ jobs:
         delete-branch: true          # delete afer merge 
         title: Append dev to version number post-release
         body: automated change, adds '-dev' to the version number upon releases
-        reviewers: rem1776
+        reviewers: rem1776, thomas-robinson, bensonr

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,4 +1,6 @@
-on: release 
+on:
+  release:
+    types: [published]
 jobs:
   add-dev-to-version:
     runs-on: ubuntu-latest
@@ -13,3 +15,6 @@ jobs:
         branch: add-dev-post-release # name of the created branch
         branch-suffix: timestamp     # add a timestamp to branch name
         delete-branch: true          # delete afer merge 
+        title: Append dev to version number post-release
+        body: automated change, adds '-dev' to the version number upon releases
+        reviewers: rem1776


### PR DESCRIPTION
**Description**
adds an action that will submit a pull request automatically after releases in order to add the -dev suffix to the autotools version and then assign me to review + merge it. 

This might require additional permissions in the github settings (mentioned in the [action page](https://github.com/marketplace/actions/create-pull-request)), but in my testing I was able to do it with the default settings. It always makes a new branch (with a timestamp) so shouldn't affect anything else in the repo.

One caveat is that the auto-generated PR won't run the CI workflows (at least not without additional work + messing with the tokens). Doesn't really matter though since the actual release tag will already be getting tested in the CI whenever this runs.

There is also a small bug fix here for the documentation action, apparently github thought it was a good idea to count the `release` trigger as three different events.

**How Has This Been Tested?**
Here's the  generated PR from my fork:
https://github.com/rem1776/FMS/pull/50
i just made releases on my fork till it worked so it should be the same end result

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream xodules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

