### PR TITLE
Add deprecated io options to build systems and CI

### DIFF
--- a/.github/workflows/build_cmake_gnu.yml
+++ b/.github/workflows/build_cmake_gnu.yml
@@ -9,10 +9,11 @@ jobs:
       matrix:
         omp-flags: [ -DOPENMP=on, -DOPENMP=off ]
         libyaml-flag: [ "", -DWITH_YAML=on ]
+        io-flag: [ "", -DUSE_DEPRECATED_IO=on ]
     container:
       image: noaagfdl/hpc-me.ubuntu-minimal:cmake
       env:
-        CMAKE_FLAGS: "${{ matrix.omp-flags }} ${{ matrix.libyaml-flag }} -D64BIT=on"
+        CMAKE_FLAGS: "${{ matrix.omp-flags }} ${{ matrix.io-flag  }} ${{ matrix.libyaml-flag }} -D64BIT=on"
     steps:
     - name: Checkout code
       uses: actions/checkout@v2

--- a/.github/workflows/build_ubuntu_gnu.yml
+++ b/.github/workflows/build_ubuntu_gnu.yml
@@ -12,11 +12,12 @@ jobs:
       matrix:
         conf-flags: [--disable-openmp, --enable-mixed-mode, --disable-setting-flags, --with-mpi=no]
         input-flag:  [--with-yaml, --enable-test-input=/home/unit_tests_input]
+        io-flag: [ --enable-deprecated-io, --disable-deprecated-io]
     container:
       image: noaagfdl/hpc-me.ubuntu-minimal:gnu-input
       env:
         TEST_VERBOSE: 1
-        DISTCHECK_CONFIGURE_FLAGS: "${{ matrix.conf-flags }} ${{ matrix.input-flag }}"
+        DISTCHECK_CONFIGURE_FLAGS: "${{ matrix.conf-flags }} ${{ matrix.input-flag }} ${{ matrix.io-flag }}"
     steps:
     - name: Checkout code
       uses: actions/checkout@v2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,7 @@ option(ENABLE_QUAD_PRECISION "Enable compiler definition -DENABLE_QUAD_PRECISION
 option(GFS_PHYS              "Enable compiler definition -DGFS_PHYS"              OFF)
 option(LARGEFILE             "Enable compiler definition -Duse_LARGEFILE"         OFF)
 option(WITH_YAML             "Enable compiler definition -Duse_yaml"              OFF)
+option(USE_DEPRECATED_IO     "Enable compiler definition -Duse_deprecated_io (compile with fms_io/mpp_io)"   OFF)
 
 if(32BIT)
   list(APPEND kinds "r4")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,6 +242,10 @@ if(WITH_YAML)
   list(APPEND fms_defs use_yaml)
 endif()
 
+if(USE_DEPRECATED_IO)
+  list(APPEND fms_defs use_deprecated_io)
+endif()
+
 if(INTERNAL_FILE_NML)
   list(APPEND fms_defs INTERNAL_FILE_NML)
 endif()

--- a/configure.ac
+++ b/configure.ac
@@ -111,8 +111,8 @@ AS_IF([test ${enable_8byte_int:-no} = yes],
   [enable_8byte_int=no])
 
 AC_ARG_ENABLE([deprecated-io],
-  [AS_HELP_STRING([],
-    [Enables compilation of deprecated mpp_io and fms_io modules in addition to the updated fms2_io modules])])
+  [AS_HELP_STRING([--enable-deprecated-io],
+    [Enables compilation of deprecated mpp_io and fms_io modules in addition to the updated fms2_io modules (default no)])])
 AS_IF([test ${enable_deprecated_io:-no} = yes],
   [enable_deprecated_io=yes],
   [enable_deprecated_io=no])

--- a/configure.ac
+++ b/configure.ac
@@ -201,7 +201,6 @@ else
   AM_CONDITIONAL([SKIP_PARSER_TESTS], true )
 fi
 
-
 # Require netCDF
 AC_CHECK_HEADERS([netcdf.h], [], [AC_MSG_ERROR([Can't find the netCDF C header file.  Set CPPFLAGS/CFLAGS])])
 AC_SEARCH_LIBS([nc_create], [netcdf], [], [AC_MSG_ERROR([Can't find the netCDF C library.  Set LDFLAGS/LIBS])])
@@ -283,8 +282,8 @@ fi
 
 # check if compiling old io
 if test $enable_deprecated_io = yes; then
+  #If the test pass, define use_deprecated_io macro and skip it's unit tests
   AC_DEFINE([use_deprecated_io], [1], [This is required to use mpp_io and fms_io modules])
-  #If the test pass, define use_yaml macro
   AM_CONDITIONAL([SKIP_DEPRECATED_IO_TESTS], true)
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -210,7 +210,6 @@ AC_MSG_CHECKING([if netCDF was built with HDF5])
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [[
 #include <netcdf_meta.h>
 #if !(NC_HAS_NC4)
-      choke me
 #endif]])], [nc_has_nc4=yes], [nc_has_nc4=no])
 AC_MSG_RESULT([$nc_has_nc4])
 if test $nc_has_nc4 = no; then
@@ -285,6 +284,8 @@ if test $enable_deprecated_io = yes; then
   #If the test pass, define use_deprecated_io macro and skip it's unit tests
   AC_DEFINE([use_deprecated_io], [1], [This is required to use mpp_io and fms_io modules])
   AM_CONDITIONAL([SKIP_DEPRECATED_IO_TESTS], true)
+else
+  AM_CONDITIONAL([SKIP_DEPRECATED_IO_TESTS], false)
 fi
 
 # Set any required compile flags.  This will not be done if the user wants to

--- a/configure.ac
+++ b/configure.ac
@@ -110,6 +110,13 @@ AS_IF([test ${enable_8byte_int:-no} = yes],
   [enable_8byte_int=yes],
   [enable_8byte_int=no])
 
+AC_ARG_ENABLE([deprecated-io],
+  [AS_HELP_STRING([],
+    [Enables compilation of deprecated mpp_io and fms_io modules in addition to the updated fms2_io modules])])
+AS_IF([test ${enable_deprecated_io:-no} = yes],
+  [enable_deprecated_io=yes],
+  [enable_deprecated_io=no])
+
 # user enabled testing with input files
 AC_MSG_CHECKING([whether to enable tests with input files])
 AC_ARG_ENABLE([test-input],
@@ -194,6 +201,7 @@ else
   AM_CONDITIONAL([SKIP_PARSER_TESTS], true )
 fi
 
+
 # Require netCDF
 AC_CHECK_HEADERS([netcdf.h], [], [AC_MSG_ERROR([Can't find the netCDF C header file.  Set CPPFLAGS/CFLAGS])])
 AC_SEARCH_LIBS([nc_create], [netcdf], [], [AC_MSG_ERROR([Can't find the netCDF C library.  Set LDFLAGS/LIBS])])
@@ -271,6 +279,13 @@ AC_LANG_POP(Fortran)
 AC_DEFINE([use_netCDF], [1], [This is required for the library to build])
 if test $with_mpi = yes; then
   AC_DEFINE([use_libMPI], [1], [This is required for the library to build])
+fi
+
+# check if compiling old io
+if test $enable_deprecated_io = yes; then
+  AC_DEFINE([use_deprecated_io], [1], [This is required to use mpp_io and fms_io modules])
+  #If the test pass, define use_yaml macro
+  AM_CONDITIONAL([SKIP_DEPRECATED_IO_TESTS], true)
 fi
 
 # Set any required compile flags.  This will not be done if the user wants to

--- a/test_fms/mpp_io/Makefile.am
+++ b/test_fms/mpp_io/Makefile.am
@@ -38,6 +38,10 @@ test_mpp_io_SOURCES = test_mpp_io.F90
 test_io_R4_R8_SOURCES = test_io_R4_R8.F90
 test_io_mosaic_R4_R8_SOURCES = test_io_mosaic_R4_R8.F90
 
+if SKIP_DEPRECATED_IO_TESTS
+TESTS_ENVIRONMENT= SKIP_TESTS="test_mpp_io2.1 test_io_R4_R8.1 test_io_mosaic_R4_R8.1"
+endif
+
 # Run the test program.
 TESTS = test_mpp_io2.sh \
 	test_io_R4_R8.sh      \


### PR DESCRIPTION
**Description**
Adds a `--enable-deprecated-io` configure flag to autotools and `-DUSE_DEPRECATED_IO` option to cmake that will be needed for compilation of the old io modules after the ifdef update. Also skips the mpp_io tests when used and updates CI to add that option to the matrix.

**How Has This Been Tested?**
tested with cmake/autoconf on the amd box

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

