### PR TITLE
fix update step for intel ci

### DIFF
--- a/.github/workflows/intel_pr.yml
+++ b/.github/workflows/intel_pr.yml
@@ -44,7 +44,7 @@ jobs:
         ./configure --prefix=/libs
         make -j install && cd
     - name: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Configure
       run: autoreconf -if ./configure.ac && ./configure --with-yaml
     - name: Compile

--- a/.github/workflows/intel_pr.yml
+++ b/.github/workflows/intel_pr.yml
@@ -3,7 +3,7 @@ jobs:
   intel-autotools:
     runs-on: ubuntu-latest
     container:
-      image: intel/oneapi-hpckit:2022.2-devel-ubuntu20.04
+      image: intel/oneapi-hpckit:latest
       env:
         CC: mpiicc
         FC: mpiifort
@@ -22,7 +22,7 @@ jobs:
         path: /libs
         key: ${{ runner.os }}-intel-libs
     - name: Install packages for building
-      run: apt update && apt install -y autoconf libtool automake zlibc zlib1g-dev
+      run: apt-get update && apt-get install -y autoconf libtool automake zlibc zlib1g-dev
     - if: steps.cache.outputs.cache-hit != 'true'
       name: Build netcdf
       run: |


### PR DESCRIPTION
**Description**
the intel-provided docker image started to fail on updates due to an incorrect hash from the oneapi package repositories, causing any runs to fail. This pr changes the image tag to 'latest' to always use an up to date version, since they're regularly maintained by intel it should work consistently and will always be using the latest oneapi version.

The other changes are just for warnings/best practices

**How Has This Been Tested?**
CI

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

