### PR TITLE
Adds deflate_level and shuffle as arguments to fms2_io_nml

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -210,6 +210,14 @@ if test $nc_has_nc4 = no; then
   AC_MSG_ERROR([NetCDF must be built with HDF5.])
 fi
 
+# Check if ncdump is avaiable
+AC_CHECK_PROG([USE_NCDUMP],[ncdump], [yes], [no])
+if test $USE_NCDUMP = yes; then
+  AM_CONDITIONAL([SKIP_NCDUMP_CHECKS], true )
+else
+  AM_CONDITIONAL([SKIP_NCDUMP_CHECKS], false )
+fi
+
 # Check if Linux gettid is avaiable
 AC_CHECK_FUNCS([gettid], [], [])
 

--- a/fms2_io/fms2_io.F90
+++ b/fms2_io/fms2_io.F90
@@ -410,7 +410,8 @@ subroutine fms2_io_init ()
     call mpp_error(FATAL, "header_buffer_val in fms2_io_nml must be a positive number.")
   endif
   if (deflate_level .lt. 0 .or. deflate_level .gt. 9) then
-    call mpp_error(FATAL, "deflate_level in fms2_io_nml must be a positive number between 1 and 9")
+    call mpp_error(FATAL, &
+      "deflate_level in fms2_io_nml must be a positive number between 1 and 9 as it is required by NetCDF")
   endif
   call netcdf_io_init (ncchksz,header_buffer_val,netcdf_default_format, deflate_level, shuffle)
   call blackboxio_init (ncchksz)

--- a/fms2_io/fms2_io.F90
+++ b/fms2_io/fms2_io.F90
@@ -383,8 +383,9 @@ character (len = 10) :: netcdf_default_format = "64bit" !< User defined netcdf f
                               !! "nc_format" in the open_file call
 integer :: header_buffer_val = 16384 !< Use defined netCDF header buffer size(in bytes) used in
                                      !! NF__ENDDEF
-integer :: deflate_level = 0
-logical :: shuffle = .false.
+integer :: deflate_level = 0 !< Netcdf deflate level to use in nf90_def_var
+                             !! (integer between 1 to 9)
+logical :: shuffle = .false. !< Flag indicating whether to use the netcdf shuffle filter
 namelist / fms2_io_nml / &
                       ncchksz, netcdf_default_format, header_buffer_val, deflate_level, shuffle
 

--- a/fms2_io/fms2_io.F90
+++ b/fms2_io/fms2_io.F90
@@ -383,8 +383,8 @@ character (len = 10) :: netcdf_default_format = "64bit" !< User defined netcdf f
                               !! "nc_format" in the open_file call
 integer :: header_buffer_val = 16384 !< Use defined netCDF header buffer size(in bytes) used in
                                      !! NF__ENDDEF
-integer :: deflate_level = 0 !< Netcdf deflate level to use in nf90_def_var
-                             !! (integer between 1 to 9)
+integer :: deflate_level = default_deflate_level !< Netcdf deflate level to use in nf90_def_var
+                                                 !! (integer between 1 to 9)
 logical :: shuffle = .false. !< Flag indicating whether to use the netcdf shuffle filter
 namelist / fms2_io_nml / &
                       ncchksz, netcdf_default_format, header_buffer_val, deflate_level, shuffle

--- a/fms2_io/include/netcdf_add_restart_variable.inc
+++ b/fms2_io/include/netcdf_add_restart_variable.inc
@@ -25,7 +25,7 @@
 
 !> @brief Add a restart variable to a netcdf file.
 subroutine netcdf_add_restart_variable_0d(fileobj, variable_name, vdata, dimensions, &
-                                          is_optional, deflate_level, chunksizes)
+                                          is_optional,  chunksizes)
 
   class(FmsNetcdfFile_t), intent(inout) :: fileobj !< File object.
   character(len=*), intent(in) :: variable_name !< Variable name.
@@ -34,9 +34,6 @@ subroutine netcdf_add_restart_variable_0d(fileobj, variable_name, vdata, dimensi
   character(len=*), dimension(1), intent(in), optional :: dimensions !< Dimension names.
   logical, intent(in), optional :: is_optional !< Prevent errors in read-only files
                                                !! if a variable does not exist.
-  integer, intent(in), optional :: deflate_level !< The netcdf deflate level
-                                                 !! This feature is only
-                                                 !! available for netcdf4 files
   integer, intent(in), optional :: chunksizes(:) !< netcdf chunksize to use for this variable
                                                  !! This feature is only
                                                  !! available for netcdf4 files
@@ -57,7 +54,7 @@ subroutine netcdf_add_restart_variable_0d(fileobj, variable_name, vdata, dimensi
       endif
     endif
     call netcdf_add_variable(fileobj, variable_name, buf, dimensions, &
-                             deflate_level=deflate_level, chunksizes=chunksizes)
+                              chunksizes=chunksizes)
   endif
 end subroutine netcdf_add_restart_variable_0d
 
@@ -65,7 +62,7 @@ end subroutine netcdf_add_restart_variable_0d
 !> @brief Wrapper to distinguish interfaces.
 subroutine netcdf_add_restart_variable_0d_wrap(fileobj, variable_name, vdata, &
                                                dimensions, is_optional, &
-                                                deflate_level, chunksizes)
+                                                 chunksizes)
   type(FmsNetcdfFile_t), intent(inout) :: fileobj !< File object.
   character(len=*), intent(in) :: variable_name !< Variable name.
   class(*),  intent(in), target :: vdata !< Pointer to
@@ -73,21 +70,18 @@ subroutine netcdf_add_restart_variable_0d_wrap(fileobj, variable_name, vdata, &
   character(len=*), dimension(1), intent(in), optional :: dimensions !< Dimension names.
   logical, intent(in), optional :: is_optional !< Prevent errors in read-only files
                                                !! if a variable does not exist.
-  integer, intent(in), optional :: deflate_level !< The netcdf deflate level
-                                                 !! This feature is only
-                                                 !! available for netcdf4 files
   integer, intent(in), optional :: chunksizes(:) !< netcdf chunksize to use for this variable
                                                  !! This feature is only
                                                  !! available for netcdf4 files
 
   call netcdf_add_restart_variable(fileobj, variable_name, vdata, dimensions, is_optional, &
-                                   deflate_level=deflate_level, chunksizes=chunksizes)
+                                    chunksizes=chunksizes)
 end subroutine netcdf_add_restart_variable_0d_wrap
 
 
 !> @brief Add a restart variable to a netcdf file.
 subroutine netcdf_add_restart_variable_1d(fileobj, variable_name, vdata, &
-                                          dimensions, is_optional, deflate_level, &
+                                          dimensions, is_optional,  &
                                           chunksizes)
   class(FmsNetcdfFile_t), intent(inout) :: fileobj !< File object.
   character(len=*), intent(in) :: variable_name !< Variable name.
@@ -96,9 +90,6 @@ subroutine netcdf_add_restart_variable_1d(fileobj, variable_name, vdata, &
   character(len=*), dimension(:), intent(in), optional :: dimensions !< Dimension names.
   logical, intent(in), optional :: is_optional !< Prevent errors in read-only files
                                                !! if a variable does not exist.
-  integer, intent(in), optional :: deflate_level !< The netcdf deflate level
-                                                 !! This feature is only
-                                                 !! available for netcdf4 files
   integer, intent(in), optional :: chunksizes(:) !< netcdf chunksize to use for this variable
                                                  !! This feature is only
                                                  !! available for netcdf4 files
@@ -128,14 +119,14 @@ subroutine netcdf_add_restart_variable_1d(fileobj, variable_name, vdata, &
       call error("rank mismatch between vdata and dimensions arrays.")
     endif
     call netcdf_add_variable(fileobj, variable_name, buf, dimensions, &
-                             deflate_level=deflate_level, chunksizes=chunksizes)
+                              chunksizes=chunksizes)
   endif
 end subroutine netcdf_add_restart_variable_1d
 
 
 !> @brief Wrapper to distinguish interfaces.
 subroutine netcdf_add_restart_variable_1d_wrap(fileobj, variable_name, vdata, &
-                                               dimensions, is_optional, deflate_level, &
+                                               dimensions, is_optional,  &
                                                chunksizes)
   type(FmsNetcdfFile_t), intent(inout) :: fileobj !< File object.
   character(len=*), intent(in) :: variable_name !< Variable name.
@@ -144,21 +135,18 @@ subroutine netcdf_add_restart_variable_1d_wrap(fileobj, variable_name, vdata, &
   character(len=*), dimension(:), intent(in), optional :: dimensions !< Dimension names.
   logical, intent(in), optional :: is_optional !< Prevent errors in read-only files
                                                !! if a variable does not exist.
-  integer, intent(in), optional :: deflate_level !< The netcdf deflate level
-                                                 !! This feature is only
-                                                 !! available for netcdf4 files
   integer, intent(in), optional :: chunksizes(:) !< netcdf chunksize to use for this variable
                                                  !! This feature is only
                                                  !! available for netcdf4 files
 
   call netcdf_add_restart_variable(fileobj, variable_name, vdata, dimensions, is_optional, &
-                                   deflate_level=deflate_level, chunksizes=chunksizes)
+                                    chunksizes=chunksizes)
 end subroutine netcdf_add_restart_variable_1d_wrap
 
 
 !> @brief Add a restart variable to a netcdf file.
 subroutine netcdf_add_restart_variable_2d(fileobj, variable_name, vdata, &
-                                          dimensions, is_optional, deflate_level, &
+                                          dimensions, is_optional,  &
                                           chunksizes)
   class(FmsNetcdfFile_t), intent(inout) :: fileobj !< File object.
   character(len=*), intent(in) :: variable_name !< Variable name.
@@ -167,9 +155,6 @@ subroutine netcdf_add_restart_variable_2d(fileobj, variable_name, vdata, &
   character(len=*), dimension(:), intent(in), optional :: dimensions !< Dimension names.
   logical, intent(in), optional :: is_optional !< Prevent errors in read-only files
                                                !! if a variable does not exist.
-  integer, intent(in), optional :: deflate_level !< The netcdf deflate level
-                                                 !! This feature is only
-                                                 !! available for netcdf4 files
   integer, intent(in), optional :: chunksizes(:) !< netcdf chunksize to use for this variable
                                                  !! This feature is only
                                                  !! available for netcdf4 files
@@ -199,14 +184,14 @@ subroutine netcdf_add_restart_variable_2d(fileobj, variable_name, vdata, &
       call error("rank mismatch between vdata and dimensions arrays.")
     endif
     call netcdf_add_variable(fileobj, variable_name, buf, dimensions, &
-                             deflate_level=deflate_level, chunksizes=chunksizes)
+                              chunksizes=chunksizes)
   endif
 end subroutine netcdf_add_restart_variable_2d
 
 
 !> @brief Wrapper to distinguish interfaces.
 subroutine netcdf_add_restart_variable_2d_wrap(fileobj, variable_name, vdata, &
-                                               dimensions, is_optional, deflate_level, &
+                                               dimensions, is_optional,  &
                                                chunksizes)
   type(FmsNetcdfFile_t), intent(inout) :: fileobj !< File object.
   character(len=*), intent(in) :: variable_name !< Variable name.
@@ -215,21 +200,18 @@ subroutine netcdf_add_restart_variable_2d_wrap(fileobj, variable_name, vdata, &
   character(len=*), dimension(:), intent(in), optional :: dimensions !< Dimension names.
   logical, intent(in), optional :: is_optional !< Prevent errors in read-only files
                                                !! if a variable does not exist.
-  integer, intent(in), optional :: deflate_level !< The netcdf deflate level
-                                                 !! This feature is only
-                                                 !! available for netcdf4 files
   integer, intent(in), optional :: chunksizes(:) !< netcdf chunksize to use for this variable
                                                  !! This feature is only
                                                  !! available for netcdf4 files
 
   call netcdf_add_restart_variable(fileobj, variable_name, vdata, dimensions, is_optional, &
-                                   deflate_level=deflate_level, chunksizes=chunksizes) 
+                                    chunksizes=chunksizes)
 end subroutine netcdf_add_restart_variable_2d_wrap
 
 
 !> @brief Add a restart variable to a netcdf file.
 subroutine netcdf_add_restart_variable_3d(fileobj, variable_name, vdata, &
-                                          dimensions, is_optional, deflate_level, &
+                                          dimensions, is_optional,  &
                                           chunksizes)
   class(FmsNetcdfFile_t), intent(inout) :: fileobj !< File object.
   character(len=*), intent(in) :: variable_name !< Variable name.
@@ -238,9 +220,6 @@ subroutine netcdf_add_restart_variable_3d(fileobj, variable_name, vdata, &
   character(len=*), dimension(:), intent(in), optional :: dimensions !< Dimension names.
   logical, intent(in), optional :: is_optional !< Prevent errors in read-only files
                                                !! if a variable does not exist.
-  integer, intent(in), optional :: deflate_level !< The netcdf deflate level
-                                                 !! This feature is only
-                                                 !! available for netcdf4 files
   integer, intent(in), optional :: chunksizes(:) !< netcdf chunksize to use for this variable
                                                  !! This feature is only
                                                  !! available for netcdf4 files
@@ -270,14 +249,14 @@ subroutine netcdf_add_restart_variable_3d(fileobj, variable_name, vdata, &
       call error("rank mismatch between vdata and dimensions arrays.")
     endif
     call netcdf_add_variable(fileobj, variable_name, buf, dimensions, &
-                             deflate_level=deflate_level, chunksizes=chunksizes)
+                              chunksizes=chunksizes)
   endif
 end subroutine netcdf_add_restart_variable_3d
 
 
 !> @brief Wrapper to distinguish interfaces.
 subroutine netcdf_add_restart_variable_3d_wrap(fileobj, variable_name, vdata, &
-                                               dimensions, is_optional, deflate_level, &
+                                               dimensions, is_optional,  &
                                                chunksizes)
   type(FmsNetcdfFile_t), intent(inout) :: fileobj !< File object.
   character(len=*), intent(in) :: variable_name !< Variable name.
@@ -286,21 +265,18 @@ subroutine netcdf_add_restart_variable_3d_wrap(fileobj, variable_name, vdata, &
   character(len=*), dimension(:), intent(in), optional :: dimensions !< Dimension names.
   logical, intent(in), optional :: is_optional !< Prevent errors in read-only files
                                                !! if a variable does not exist.
-  integer, intent(in), optional :: deflate_level !< The netcdf deflate level
-                                                 !! This feature is only
-                                                 !! available for netcdf4 files
   integer, intent(in), optional :: chunksizes(:) !< netcdf chunksize to use for this variable
                                                  !! This feature is only
                                                  !! available for netcdf4 files
 
   call netcdf_add_restart_variable(fileobj, variable_name, vdata, dimensions, is_optional, &
-                                   deflate_level=deflate_level, chunksizes=chunksizes)
+                                    chunksizes=chunksizes)
 end subroutine netcdf_add_restart_variable_3d_wrap
 
 
 !> @brief Add a restart variable to a netcdf file.
 subroutine netcdf_add_restart_variable_4d(fileobj, variable_name, vdata, &
-                                          dimensions, is_optional, deflate_level, &
+                                          dimensions, is_optional,  &
                                           chunksizes)
   class(FmsNetcdfFile_t), intent(inout) :: fileobj !< File object.
   character(len=*), intent(in) :: variable_name !< Variable name.
@@ -309,9 +285,6 @@ subroutine netcdf_add_restart_variable_4d(fileobj, variable_name, vdata, &
   character(len=*), dimension(:), intent(in), optional :: dimensions !< Dimension names.
   logical, intent(in), optional :: is_optional !< Prevent errors in read-only files
                                                !! if a variable does not exist.
-  integer, intent(in), optional :: deflate_level !< The netcdf deflate level
-                                                 !! This feature is only
-                                                 !! available for netcdf4 files
   integer, intent(in), optional :: chunksizes(:) !< netcdf chunksize to use for this variable
                                                  !! This feature is only
                                                  !! available for netcdf4 files
@@ -341,14 +314,14 @@ subroutine netcdf_add_restart_variable_4d(fileobj, variable_name, vdata, &
       call error("rank mismatch between vdata and dimensions arrays.")
     endif
     call netcdf_add_variable(fileobj, variable_name, buf, dimensions, &
-                            deflate_level=deflate_level, chunksizes=chunksizes)
+                             chunksizes=chunksizes)
   endif
 end subroutine netcdf_add_restart_variable_4d
 
 
 !> @brief Wrapper to distinguish interfaces.
 subroutine netcdf_add_restart_variable_4d_wrap(fileobj, variable_name, vdata, &
-                                               dimensions, is_optional, deflate_level, &
+                                               dimensions, is_optional,  &
                                                chunksizes)
   type(FmsNetcdfFile_t), intent(inout) :: fileobj !< File object.
   character(len=*), intent(in) :: variable_name !< Variable name.
@@ -357,21 +330,18 @@ subroutine netcdf_add_restart_variable_4d_wrap(fileobj, variable_name, vdata, &
   character(len=*), dimension(:), intent(in), optional :: dimensions !< Dimension names.
   logical, intent(in), optional :: is_optional !< Prevent errors in read-only files
                                                !! if a variable does not exist.
-  integer, intent(in), optional :: deflate_level !< The netcdf deflate level
-                                                 !! This feature is only
-                                                 !! available for netcdf4 files
   integer, intent(in), optional :: chunksizes(:) !< netcdf chunksize to use for this variable
                                                  !! This feature is only
                                                  !! available for netcdf4 files
 
   call netcdf_add_restart_variable(fileobj, variable_name, vdata, dimensions, is_optional, &
-                                   deflate_level=deflate_level, chunksizes=chunksizes)
+                                    chunksizes=chunksizes)
 end subroutine netcdf_add_restart_variable_4d_wrap
 
 
 !> @brief Add a restart variable to a netcdf file.
 subroutine netcdf_add_restart_variable_5d(fileobj, variable_name, vdata, &
-                                          dimensions, is_optional, deflate_level, &
+                                          dimensions, is_optional,  &
                                           chunksizes)
   class(FmsNetcdfFile_t), intent(inout) :: fileobj !< File object.
   character(len=*), intent(in) :: variable_name !< Variable name.
@@ -380,9 +350,6 @@ subroutine netcdf_add_restart_variable_5d(fileobj, variable_name, vdata, &
   character(len=*), dimension(:), intent(in), optional :: dimensions !< Dimension names.
   logical, intent(in), optional :: is_optional !< Prevent errors in read-only files
                                                !! if a variable does not exist.
-  integer, intent(in), optional :: deflate_level !< The netcdf deflate level
-                                                 !! This feature is only
-                                                 !! available for netcdf4 files
   integer, intent(in), optional :: chunksizes(:) !< netcdf chunksize to use for this variable
                                                  !! This feature is only
                                                  !! available for netcdf4 files
@@ -412,14 +379,14 @@ subroutine netcdf_add_restart_variable_5d(fileobj, variable_name, vdata, &
       call error("rank mismatch between vdata and dimensions arrays.")
     endif
     call netcdf_add_variable(fileobj, variable_name, buf, dimensions, &
-                             deflate_level=deflate_level, chunksizes=chunksizes)
+                              chunksizes=chunksizes)
   endif
 end subroutine netcdf_add_restart_variable_5d
 
 
 !> @brief Wrapper to distinguish interfaces.
 subroutine netcdf_add_restart_variable_5d_wrap(fileobj, variable_name, vdata, &
-                                               dimensions, is_optional, deflate_level, &
+                                               dimensions, is_optional,  &
                                                chunksizes)
   type(FmsNetcdfFile_t), intent(inout) :: fileobj !< File object.
   character(len=*), intent(in) :: variable_name !< Variable name.
@@ -428,15 +395,12 @@ subroutine netcdf_add_restart_variable_5d_wrap(fileobj, variable_name, vdata, &
   character(len=*), dimension(:), intent(in), optional :: dimensions !< Dimension names.
   logical, intent(in), optional :: is_optional !< Prevent errors in read-only files
                                                !! if a variable does not exist.
-  integer, intent(in), optional :: deflate_level !< The netcdf deflate level
-                                                 !! This feature is only
-                                                 !! available for netcdf4 files
   integer, intent(in), optional :: chunksizes(:) !< netcdf chunksize to use for this variable
                                                  !! This feature is only
                                                  !! available for netcdf4 files
-  
+
  call netcdf_add_restart_variable(fileobj, variable_name, vdata, dimensions, is_optional, &
-                                   deflate_level=deflate_level, chunksizes=chunksizes)
+                                    chunksizes=chunksizes)
 end subroutine netcdf_add_restart_variable_5d_wrap
 
 !> @brief Registers a regional 2D variable and stores the information needed

--- a/fms2_io/include/register_domain_restart_variable.inc
+++ b/fms2_io/include/register_domain_restart_variable.inc
@@ -25,7 +25,7 @@
 
 !> @brief Add a domain decomposed variable.
 subroutine register_domain_restart_variable_0d(fileobj, variable_name, vdata, &
-                                               dimensions, is_optional, deflate_level, &
+                                               dimensions, is_optional,  &
                                                chunksizes)
 
   type(FmsNetcdfDomainFile_t), intent(inout) :: fileobj !< File object.
@@ -34,21 +34,18 @@ subroutine register_domain_restart_variable_0d(fileobj, variable_name, vdata, &
   character(len=*), dimension(:), intent(in), optional :: dimensions !< Dimension names.
   logical, intent(in), optional :: is_optional !< Prevent errors in read-only files
                                                !! if a variable does not exist.
-  integer, intent(in), optional :: deflate_level !< The netcdf deflate level
-                                                 !! This feature is only
-                                                 !! available for netcdf4 files
   integer, intent(in), optional :: chunksizes(:) !< netcdf chunksize to use for this variable
                                                  !! This feature is only
                                                  !! available for netcdf4 files
 
   call netcdf_add_restart_variable(fileobj, variable_name, vdata, dimensions, is_optional, &
-                                   deflate_level=deflate_level, chunksizes=chunksizes)
+                                    chunksizes=chunksizes)
 end subroutine register_domain_restart_variable_0d
 
 
 !> @brief Add a domain decomposed variable.
 subroutine register_domain_restart_variable_1d(fileobj, variable_name, vdata, &
-                                               dimensions, is_optional, deflate_level, &
+                                               dimensions, is_optional,  &
                                                chunksizes)
 
   type(FmsNetcdfDomainFile_t), intent(inout) :: fileobj !< File object.
@@ -57,15 +54,12 @@ subroutine register_domain_restart_variable_1d(fileobj, variable_name, vdata, &
   character(len=*), dimension(:), intent(in), optional :: dimensions !< Dimension names.
   logical, intent(in), optional :: is_optional !< Prevent errors in read-only files
                                                !! if a variable does not exist.
-  integer, intent(in), optional :: deflate_level !< The netcdf deflate level
-                                                 !! This feature is only
-                                                 !! available for netcdf4 files
   integer, intent(in), optional :: chunksizes(:) !< netcdf chunksize to use for this variable
                                                  !! This feature is only
                                                  !! available for netcdf4 files
 
   call netcdf_add_restart_variable(fileobj, variable_name, vdata, dimensions, is_optional, &
-                                   deflate_level=deflate_level, chunksizes=chunksizes)
+                                    chunksizes=chunksizes)
   if (.not. fileobj%is_readonly) then
     call add_domain_attribute(fileobj, variable_name)
   endif
@@ -74,7 +68,7 @@ end subroutine register_domain_restart_variable_1d
 
 !> @brief Add a domain decomposed variable.
 subroutine register_domain_restart_variable_2d(fileobj, variable_name, vdata, &
-                                               dimensions, is_optional, deflate_level, &
+                                               dimensions, is_optional,  &
                                                chunksizes)
 
   type(FmsNetcdfDomainFile_t), intent(inout) :: fileobj !< File object.
@@ -83,21 +77,18 @@ subroutine register_domain_restart_variable_2d(fileobj, variable_name, vdata, &
   character(len=*), dimension(:), intent(in), optional :: dimensions !< Dimension names.
   logical, intent(in), optional :: is_optional !< Prevent errors in read-only files
                                                !! if a variable does not exist.
-  integer, intent(in), optional :: deflate_level !< The netcdf deflate level
-                                                 !! This feature is only
-                                                 !! available for netcdf4 files
   integer, intent(in), optional :: chunksizes(:) !< netcdf chunksize to use for this variable
                                                  !! This feature is only
                                                  !! available for netcdf4 files
 
   call netcdf_add_restart_variable(fileobj, variable_name, vdata, dimensions, is_optional, &
-                                   deflate_level=deflate_level, chunksizes=chunksizes)
+                                    chunksizes=chunksizes)
 end subroutine register_domain_restart_variable_2d
 
 
 !> @brief Add a domain decomposed variable.
 subroutine register_domain_restart_variable_3d(fileobj, variable_name, vdata, &
-                                               dimensions, is_optional, deflate_level, &
+                                               dimensions, is_optional,  &
                                                chunksizes)
 
   type(FmsNetcdfDomainFile_t), intent(inout) :: fileobj !< File object.
@@ -106,21 +97,18 @@ subroutine register_domain_restart_variable_3d(fileobj, variable_name, vdata, &
   character(len=*), dimension(:), intent(in), optional :: dimensions !< Dimension names.
   logical, intent(in), optional :: is_optional !< Prevent errors in read-only files
                                                !! if a variable does not exist.
-  integer, intent(in), optional :: deflate_level !< The netcdf deflate level
-                                                 !! This feature is only
-                                                 !! available for netcdf4 files
   integer, intent(in), optional :: chunksizes(:) !< netcdf chunksize to use for this variable
                                                  !! This feature is only
                                                  !! available for netcdf4 files
 
   call netcdf_add_restart_variable(fileobj, variable_name, vdata, dimensions, is_optional, &
-                                   deflate_level=deflate_level, chunksizes=chunksizes)
+                                    chunksizes=chunksizes)
 end subroutine register_domain_restart_variable_3d
 
 
 !> @brief Add a domain decomposed variable.
 subroutine register_domain_restart_variable_4d(fileobj, variable_name, vdata, &
-                                               dimensions, is_optional, deflate_level, &
+                                               dimensions, is_optional,  &
                                                 chunksizes)
 
   type(FmsNetcdfDomainFile_t), intent(inout) :: fileobj !< File object.
@@ -129,21 +117,18 @@ subroutine register_domain_restart_variable_4d(fileobj, variable_name, vdata, &
   character(len=*), dimension(:), intent(in), optional :: dimensions !< Dimension names.
   logical, intent(in), optional :: is_optional !< Prevent errors in read-only files
                                                !! if a variable does not exist.
-  integer, intent(in), optional :: deflate_level !< The netcdf deflate level
-                                                 !! This feature is only
-                                                 !! available for netcdf4 files
   integer, intent(in), optional :: chunksizes(:) !< netcdf chunksize to use for this variable
                                                  !! This feature is only
                                                  !! available for netcdf4 files
 
   call netcdf_add_restart_variable(fileobj, variable_name, vdata, dimensions, is_optional, &
-                                   deflate_level=deflate_level, chunksizes=chunksizes)
+                                    chunksizes=chunksizes)
 end subroutine register_domain_restart_variable_4d
 
 
 !> @brief Add a domain decomposed variable.
 subroutine register_domain_restart_variable_5d(fileobj, variable_name, vdata, &
-                                               dimensions, is_optional, deflate_level, &
+                                               dimensions, is_optional,  &
                                                chunksizes)
 
   type(FmsNetcdfDomainFile_t), intent(inout) :: fileobj !< File object.
@@ -152,14 +137,11 @@ subroutine register_domain_restart_variable_5d(fileobj, variable_name, vdata, &
   character(len=*), dimension(:), intent(in), optional :: dimensions !< Dimension names.
   logical, intent(in), optional :: is_optional !< Prevent errors in read-only files
                                                !! if a variable does not exist.
-  integer, intent(in), optional :: deflate_level !< The netcdf deflate level
-                                                 !! This feature is only
-                                                 !! available for netcdf4 files
   integer, intent(in), optional :: chunksizes(:) !< netcdf chunksize to use for this variable
                                                  !! This feature is only
                                                  !! available for netcdf4 files
-  
+
   call netcdf_add_restart_variable(fileobj, variable_name, vdata, dimensions, is_optional, &
-                                   deflate_level=deflate_level, chunksizes=chunksizes)
+                                    chunksizes=chunksizes)
 end subroutine register_domain_restart_variable_5d
 !> @}

--- a/fms2_io/include/register_unstructured_domain_restart_variable.inc
+++ b/fms2_io/include/register_unstructured_domain_restart_variable.inc
@@ -25,7 +25,7 @@
 
 !> @brief Add a domain decomposed variable.
 subroutine register_unstructured_domain_restart_variable_0d(fileobj, variable_name, vdata, &
-                                                            dimensions, is_optional, deflate_level, &
+                                                            dimensions, is_optional,  &
                                                             chunksizes)
 
   type(FmsNetcdfUnstructuredDomainFile_t), intent(inout) :: fileobj !< File object.
@@ -34,21 +34,18 @@ subroutine register_unstructured_domain_restart_variable_0d(fileobj, variable_na
   character(len=*), dimension(:), intent(in), optional :: dimensions !< Dimension names.
   logical, intent(in), optional :: is_optional !< Prevent errors in read-only files
                                                !! if a variable does not exist.
-  integer, intent(in), optional :: deflate_level !< The netcdf deflate level
-                                                 !! This feature is only
-                                                 !! available for netcdf4 files
   integer, intent(in), optional :: chunksizes(:) !< netcdf chunksize to use for this variable
                                                  !! This feature is only
                                                  !! available for netcdf4 files
 
   call netcdf_add_restart_variable(fileobj, variable_name, vdata, dimensions, is_optional, &
-                                   deflate_level=deflate_level, chunksizes=chunksizes)
+                                    chunksizes=chunksizes)
 end subroutine register_unstructured_domain_restart_variable_0d
 
 
 !> @brief Add a domain decomposed variable.
 subroutine register_unstructured_domain_restart_variable_1d(fileobj, variable_name, vdata, &
-                                                            dimensions, is_optional, deflate_level, &
+                                                            dimensions, is_optional,  &
                                                             chunksizes)
 
   type(FmsNetcdfUnstructuredDomainFile_t), intent(inout) :: fileobj !< File object.
@@ -57,21 +54,18 @@ subroutine register_unstructured_domain_restart_variable_1d(fileobj, variable_na
   character(len=*), dimension(:), intent(in), optional :: dimensions !< Dimension names.
   logical, intent(in), optional :: is_optional !< Prevent errors in read-only files
                                                !! if a variable does not exist.
-  integer, intent(in), optional :: deflate_level !< The netcdf deflate level
-                                                 !! This feature is only
-                                                 !! available for netcdf4 files
   integer, intent(in), optional :: chunksizes(:) !< netcdf chunksize to use for this variable
                                                  !! This feature is only
                                                  !! available for netcdf4 files
 
   call netcdf_add_restart_variable(fileobj, variable_name, vdata, dimensions, is_optional, &
-                                   deflate_level=deflate_level, chunksizes=chunksizes)
+                                    chunksizes=chunksizes)
 end subroutine register_unstructured_domain_restart_variable_1d
 
 
 !> @brief Add a domain decomposed variable.
 subroutine register_unstructured_domain_restart_variable_2d(fileobj, variable_name, vdata, &
-                                                            dimensions, is_optional, deflate_level, &
+                                                            dimensions, is_optional,  &
                                                             chunksizes )
 
   type(FmsNetcdfUnstructuredDomainFile_t), intent(inout) :: fileobj !< File object.
@@ -80,21 +74,18 @@ subroutine register_unstructured_domain_restart_variable_2d(fileobj, variable_na
   character(len=*), dimension(:), intent(in), optional :: dimensions !< Dimension names.
   logical, intent(in), optional :: is_optional !< Prevent errors in read-only files
                                                !! if a variable does not exist.
-  integer, intent(in), optional :: deflate_level !< The netcdf deflate level
-                                                 !! This feature is only
-                                                 !! available for netcdf4 files
   integer, intent(in), optional :: chunksizes(:) !< netcdf chunksize to use for this variable
                                                  !! This feature is only
                                                  !! available for netcdf4 files
 
   call netcdf_add_restart_variable(fileobj, variable_name, vdata, dimensions, is_optional, &
-                                   deflate_level=deflate_level, chunksizes=chunksizes)
+                                    chunksizes=chunksizes)
 end subroutine register_unstructured_domain_restart_variable_2d
 
 
 !> @brief Add a domain decomposed variable.
 subroutine register_unstructured_domain_restart_variable_3d(fileobj, variable_name, vdata, &
-                                                            dimensions, is_optional, deflate_level, &
+                                                            dimensions, is_optional,  &
                                                             chunksizes)
 
   type(FmsNetcdfUnstructuredDomainFile_t), intent(inout) :: fileobj !< File object.
@@ -103,21 +94,18 @@ subroutine register_unstructured_domain_restart_variable_3d(fileobj, variable_na
   character(len=*), dimension(:), intent(in), optional :: dimensions !< Dimension names.
   logical, intent(in), optional :: is_optional !< Prevent errors in read-only files
                                                !! if a variable does not exist.
-  integer, intent(in), optional :: deflate_level !< The netcdf deflate level
-                                                 !! This feature is only
-                                                 !! available for netcdf4 files
   integer, intent(in), optional :: chunksizes(:) !< netcdf chunksize to use for this variable
                                                  !! This feature is only
                                                  !! available for netcdf4 files
 
   call netcdf_add_restart_variable(fileobj, variable_name, vdata, dimensions, is_optional, &
-                                   deflate_level=deflate_level, chunksizes=chunksizes)
+                                    chunksizes=chunksizes)
 end subroutine register_unstructured_domain_restart_variable_3d
 
 
 !> @brief Add a domain decomposed variable.
 subroutine register_unstructured_domain_restart_variable_4d(fileobj, variable_name, vdata, &
-                                                            dimensions, is_optional, deflate_level, &
+                                                            dimensions, is_optional,  &
                                                             chunksizes)
 
   type(FmsNetcdfUnstructuredDomainFile_t), intent(inout) :: fileobj !< File object.
@@ -126,21 +114,18 @@ subroutine register_unstructured_domain_restart_variable_4d(fileobj, variable_na
   character(len=*), dimension(:), intent(in), optional :: dimensions !< Dimension names.
   logical, intent(in), optional :: is_optional !< Prevent errors in read-only files
                                                !! if a variable does not exist.
-  integer, intent(in), optional :: deflate_level !< The netcdf deflate level
-                                                 !! This feature is only
-                                                 !! available for netcdf4 files
   integer, intent(in), optional :: chunksizes(:) !< netcdf chunksize to use for this variable
                                                  !! This feature is only
                                                  !! available for netcdf4 files
 
   call netcdf_add_restart_variable(fileobj, variable_name, vdata, dimensions, is_optional, &
-                                   deflate_level=deflate_level, chunksizes=chunksizes)
+                                    chunksizes=chunksizes)
 end subroutine register_unstructured_domain_restart_variable_4d
 
 
 !> @brief Add a domain decomposed variable.
 subroutine register_unstructured_domain_restart_variable_5d(fileobj, variable_name, vdata, &
-                                                            dimensions, is_optional, deflate_level, &
+                                                            dimensions, is_optional,  &
                                                             chunksizes)
 
   type(FmsNetcdfUnstructuredDomainFile_t), intent(inout) :: fileobj !< File object.
@@ -149,14 +134,11 @@ subroutine register_unstructured_domain_restart_variable_5d(fileobj, variable_na
   character(len=*), dimension(:), intent(in), optional :: dimensions !< Dimension names.
   logical, intent(in), optional :: is_optional !< Prevent errors in read-only files
                                                !! if a variable does not exist.
-  integer, intent(in), optional :: deflate_level !< The netcdf deflate level
-                                                 !! This feature is only
-                                                 !! available for netcdf4 files
   integer, intent(in), optional :: chunksizes(:) !< netcdf chunksize to use for this variable
                                                  !! This feature is only
                                                  !! available for netcdf4 files
- 
+
   call netcdf_add_restart_variable(fileobj, variable_name, vdata, dimensions, is_optional, &
-                                   deflate_level=deflate_level, chunksizes=chunksizes)
+                                    chunksizes=chunksizes)
 end subroutine register_unstructured_domain_restart_variable_5d
 !> @}

--- a/fms2_io/netcdf_io.F90
+++ b/fms2_io/netcdf_io.F90
@@ -54,6 +54,9 @@ integer, private :: fms2_ncchksz = -1 !< Chunksize (bytes) used in nc_open and n
 integer, private :: fms2_nc_format_param = -1 !< Netcdf format type param used in nc_create
 character (len = 10), private :: fms2_nc_format !< Netcdf format type used in netcdf_file_open
 integer, private :: fms2_header_buffer_val = -1  !< value used in NF__ENDDEF
+integer, private :: fms2_deflate_level = 0
+logical, private :: fms2_shuffle = .false.
+logical, private :: fms2_allow_netcdf4 = .false.
 
 !> @}
 
@@ -332,12 +335,17 @@ end interface is_valid
 contains
 
 !> @brief Accepts the namelist fms2_io_nml variables relevant to netcdf_io_mod
-subroutine netcdf_io_init (chksz, header_buffer_val, netcdf_default_format)
+subroutine netcdf_io_init (chksz, header_buffer_val, netcdf_default_format, deflate_level, shuffle)
 integer, intent(in) :: chksz
 character (len = 10), intent(in) :: netcdf_default_format
 integer, intent(in) :: header_buffer_val
+integer, intent(in) :: deflate_level
+logical, intent(in) :: shuffle
 
  fms2_ncchksz = chksz
+ fms2_deflate_level = deflate_level
+ fms2_shuffle = shuffle
+ fms2_allow_netcdf4 = .false.
  fms2_header_buffer_val = header_buffer_val
  if (string_compare(netcdf_default_format, "64bit", .true.)) then
      fms2_nc_format_param = nf90_64bit_offset
@@ -347,6 +355,7 @@ integer, intent(in) :: header_buffer_val
      call string_copy(fms2_nc_format, "classic")
  elseif (string_compare(netcdf_default_format, "netcdf4", .true.)) then
      fms2_nc_format_param = nf90_netcdf4
+     fms2_allow_netcdf4 = .true.
      call string_copy(fms2_nc_format, "netcdf4")
  else
      call error("unrecognized netcdf file format "//trim(netcdf_default_format)// &
@@ -628,6 +637,7 @@ function netcdf_file_open(fileobj, path, mode, nc_format, pelist, is_restart, do
     else
       call string_copy(fileobj%nc_format, trim(fms2_nc_format))
       nc_format_param = fms2_nc_format_param
+      fileobj%is_netcdf4 = fms2_allow_netcdf4
     endif
 
     if (string_compare(mode, "read", .true.)) then
@@ -893,7 +903,7 @@ end subroutine register_compressed_dimension
 
 
 !> @brief Add a variable to a file.
-subroutine netcdf_add_variable(fileobj, variable_name, variable_type, dimensions, deflate_level, chunksizes)
+subroutine netcdf_add_variable(fileobj, variable_name, variable_type, dimensions, chunksizes)
 
   class(FmsNetcdfFile_t), intent(in) :: fileobj !< File object.
   character(len=*), intent(in) :: variable_name !< Variable name.
@@ -901,12 +911,9 @@ subroutine netcdf_add_variable(fileobj, variable_name, variable_type, dimensions
                                                 !! values are: "char", "int", "int64",
                                                 !! "float", or "double".
   character(len=*), dimension(:), intent(in), optional :: dimensions !< Dimension names.
-  integer, optional, intent(in) :: deflate_level !< The netcdf deflate level
-                                                 !! This feature is only
-                                                 !! available for netcdf4 files
   integer, optional, intent(in) :: chunksizes(:) !< netcdf chunksize to use for this variable
                                                  !! This feature is only
-                                                 !! available for netcdf4 files  
+                                                 !! available for netcdf4 files
   integer :: err
   integer, dimension(:), allocatable :: dimids
   integer :: vtype
@@ -945,9 +952,9 @@ subroutine netcdf_add_variable(fileobj, variable_name, variable_type, dimensions
       enddo
       if (fileobj%is_netcdf4) then
         err = nf90_def_var(fileobj%ncid, trim(variable_name), vtype, dimids, varid, &
-          &deflate_level=deflate_level, chunksizes=chunksizes)
+          &deflate_level=fms2_deflate_level, shuffle=fms2_shuffle, chunksizes=chunksizes)
       else
-        if (present(deflate_level) .or. present(chunksizes)) &
+        if (fms2_deflate_level .ne. -1 .or. fms2_shuffle .or. present(chunksizes)) &
           &call mpp_error(NOTE,"Not able to use deflate_level or chunksizes if not using netcdf4"// &
           & " ignoring them")
         err = nf90_def_var(fileobj%ncid, trim(variable_name), vtype, dimids, varid)

--- a/fms2_io/netcdf_io.F90
+++ b/fms2_io/netcdf_io.F90
@@ -37,6 +37,7 @@ private
 
 
 !Module constants.
+integer, parameter, public :: default_deflate_level = 0 !< The default (no compression) deflate level to use
 integer, parameter :: variable_missing = -1
 integer, parameter :: dimension_missing = -1
 integer, parameter, public :: no_unlimited_dimension = -1 !> No unlimited dimension in file.
@@ -54,7 +55,8 @@ integer, private :: fms2_ncchksz = -1 !< Chunksize (bytes) used in nc_open and n
 integer, private :: fms2_nc_format_param = -1 !< Netcdf format type param used in nc_create
 character (len = 10), private :: fms2_nc_format !< Netcdf format type used in netcdf_file_open
 integer, private :: fms2_header_buffer_val = -1  !< value used in NF__ENDDEF
-integer, private :: fms2_deflate_level = 0 !< Netcdf deflate level to use in nf90_def_var (integer between 1 to 9)
+integer, private :: fms2_deflate_level = default_deflate_level !< Netcdf deflate level to use in
+                                                               !! nf90_def_var (integer between 1 to 9)
 logical, private :: fms2_shuffle = .false. !< Flag indicating whether to use the netcdf shuffle filter
 logical, private :: fms2_is_netcdf4 = .false. !< Flag indicating whether the default netcdf file format is netcdf4
 
@@ -955,7 +957,7 @@ subroutine netcdf_add_variable(fileobj, variable_name, variable_type, dimensions
         err = nf90_def_var(fileobj%ncid, trim(variable_name), vtype, dimids, varid, &
           &deflate_level=fms2_deflate_level, shuffle=fms2_shuffle, chunksizes=chunksizes)
       else
-        if (fms2_deflate_level .ne. -1 .or. fms2_shuffle .or. present(chunksizes)) &
+        if (fms2_deflate_level .ne. default_deflate_level .or. fms2_shuffle .or. present(chunksizes)) &
           &call mpp_error(NOTE,"Not able to use deflate_level or chunksizes if not using netcdf4"// &
           & " ignoring them")
         err = nf90_def_var(fileobj%ncid, trim(variable_name), vtype, dimids, varid)

--- a/fms2_io/readme.md
+++ b/fms2_io/readme.md
@@ -614,7 +614,7 @@ deallocate(restart_file)
 - **ncchksz:** Sets chunksize (in bytes) argument in netcdf file creation calls. The default is `64*1024`.
 - **netcdf_default_format:** Sets the netcdf file type. The acceptable values are  "64bit", "classic", "netcdf4". This can be overwritten per file if you specify `nc_format` in the open_file call. The default is 64bit.
 - **header_buffer_val:** Sets the netCDF header buffer size(in bytes). The default is 16384 bytes.
-- **deflate_level:** Determines how much to compress the variable. Chosen by an integer of 1 through 9. The higher the number the more compression will take place, but will take longer to write the file. NOTE: the higher the number, the more time it will take to write the file. The default is no compression. This is loseless compression so that every bit of the original data can be recovered.
+- **deflate_level:** Determines how much to compress the variable. Chosen by an integer of 1 through 9. The higher the number the more compression will take place, but will take longer to write the file. The default is no compression. This is loseless compression so that every bit of the original data can be recovered. See the NETCDF user guide for more information: https://www.unidata.ucar.edu/blogs/developer/en/entry/netcdf_compression
 - **shuffle:** Flag indicating whether to use the netcdf shuffle filter.
 
 ### I. Chunking

--- a/fms2_io/readme.md
+++ b/fms2_io/readme.md
@@ -614,12 +614,12 @@ deallocate(restart_file)
 - **ncchksz:** Sets chunksize (in bytes) argument in netcdf file creation calls. The default is `64*1024`.
 - **netcdf_default_format:** Sets the netcdf file type. The acceptable values are  "64bit", "classic", "netcdf4". This can be overwritten per file if you specify `nc_format` in the open_file call. The default is 64bit.
 - **header_buffer_val:** Sets the netCDF header buffer size(in bytes). The default is 16384 bytes.
-- **deflate_level:** Determines how much to compress the variable. Chosen by an integer of 1 through 9. The higher the number, the more compression will take place, but will take longer to write the file. NOTE: the smaller the size, the more time it will take to write the file. The default is no compression.
+- **deflate_level:** Determines how much to compress the variable. Chosen by an integer of 1 through 9. The higher the number the more compression will take place, but will take longer to write the file. NOTE: the higher the number, the more time it will take to write the file. The default is no compression. This is loseless compression so that every bit of the original data can be recovered.
 - **shuffle:** Flag indicating whether to use the netcdf shuffle filter.
 
 ### I. Chunking
 
-In release 2022.04, "chunksize" was added as an optional arguments to the register_diag_field:
+In release 2022.04, "chunksize" was added as an optional argument to the register_diag_field:
 
 ```F90
 call register_restart_field(fileobj, 'variable_name', variable_data,
@@ -627,6 +627,6 @@ dim_names, chunsizes=chunksizes)
 ```
 - **chunksizes:** Is an array defining the chunksize of each dimension of the variable. Chunksizes can be used to improve performance. Default chunks are chosen by the library.
 
-- **NOTE: This argument can only be used in "NETCDF4" file formats. You can set the netcdf file format for all files using the 'netcdf_default_format' namelist or in a per file basis by using the 'nc_format' argument in the 'open_file' call**
+- **NOTE: This argument is only valid with "NETCDF4" file formats, otherwise it will be ignored. You can set the netcdf file format for all files using the 'netcdf_default_format' namelist or in a per file basis by using the 'nc_format' argument in the 'open_file' call**
 
 - See the NETCDF user guide for more information: (https://cluster.earlham.edu/bccd-ng/testing/mobeen/GALAXSEEHPC/netcdf-4.1.3/man4/netcdf.html#Chunking)

--- a/fms2_io/readme.md
+++ b/fms2_io/readme.md
@@ -627,6 +627,6 @@ dim_names, chunsizes=chunksizes)
 ```
 - **chunksizes:** Is an array defining the chunksize of each dimension of the variable. Chunksizes can be used to improve performance. Default chunks are chosen by the library.
 
-- **NOTE: This arguments can only be used in "NETCDF4" file formats. You can set the netcdf file format for all files using the 'netcdf_default_format' namelist or in a per file basis by using the 'nc_format' argument in the 'open_file' call**
+- **NOTE: This argument can only be used in "NETCDF4" file formats. You can set the netcdf file format for all files using the 'netcdf_default_format' namelist or in a per file basis by using the 'nc_format' argument in the 'open_file' call**
 
 - See the NETCDF user guide for more information: (https://cluster.earlham.edu/bccd-ng/testing/mobeen/GALAXSEEHPC/netcdf-4.1.3/man4/netcdf.html#Chunking)

--- a/fms2_io/readme.md
+++ b/fms2_io/readme.md
@@ -4,6 +4,17 @@
 
 Before introducing the FMS2_io module, subroutines and functions in fms_io and mpp_io modules were used to mainly handle read/writes to NetCDF files. However, there were duplicate routines present in both modules that led to redundancy, and the blackbox-like I/O processes restricted user flexibility. The FMS2_io module has thus been implemented for a cleaner set of I/O tools and to give users more control over the information being written/read to NetCDF files. This guide helps convert fms_io/mpp_io code to FMS2_io
 
+### Contents
+- [A. FMS2_io Fileobjs](readme.md#a-fms2_io-fileobjs)
+- [B. Writing Restarts](readme.md#b-writing-restarts)
+- [C. Reading Restarts](readme.md#c-reading-restarts)
+- [D. Reading/Writting Non-restarts](readme.md#d-readingwritting-non-restarts)
+- [E. Coupler Type Restarts](readme.md#e-coupler-type-restarts)
+- [F. Boundary Conditions Restarts](readme.md#f-boundary-conditions-restarts)
+- [G. Ascii_io](readme.md#g-ascii_io)
+- [H. FMS2_io namelist](readme.md#h-fms2_io-namelist)
+- [I. Chunking](readme.md#i-chunking)
+
 ### A. FMS2_io Fileobjs
 FMS2_io provides three new derived types, which target the different I/O paradigms used in GFDL models.
 
@@ -603,20 +614,19 @@ deallocate(restart_file)
 - **ncchksz:** Sets chunksize (in bytes) argument in netcdf file creation calls. The default is `64*1024`.
 - **netcdf_default_format:** Sets the netcdf file type. The acceptable values are  "64bit", "classic", "netcdf4". This can be overwritten per file if you specify `nc_format` in the open_file call. The default is 64bit.
 - **header_buffer_val:** Sets the netCDF header buffer size(in bytes). The default is 16384 bytes.
+- **deflate_level:** Determines how much to compress the variable. Chosen by an integer of 1 through 9. The higher the number, the more compression will take place, but will take longer to write the file. NOTE: the smaller the size, the more time it will take to write the file. The default is no compression.
+- **shuffle:** Flag indicating whether to use the netcdf shuffle filter.
 
-### I. Compression and Chunking
+### I. Chunking
 
-In release 2022.04, "deflate_level" and the "chunksize" were added as optional arguments to the register_diag_field:
+In release 2022.04, "chunksize" was added as an optional arguments to the register_diag_field:
 
 ```F90
 call register_restart_field(fileobj, 'variable_name', variable_data,
-dim_names, deflate_level=deflate_level, chunsizes=chunksizes)
+dim_names, chunsizes=chunksizes)
 ```
-
-- **deflate_level:** Determines how much to compress the variable. Chosen by an integer of 1 through 9. The higher the number, the more compression will take place, but will take longer to write the file. NOTE: the smaller the size, the more time it will take to write the file.
-
 - **chunksizes:** Is an array defining the chunksize of each dimension of the variable. Chunksizes can be used to improve performance. Default chunks are chosen by the library.
 
-- **NOTE: These arguments can only be used in "NETCDF4" file formats. You can set the netcdf file format for all files using the 'netcdf_default_format' namelist or in a per file basis by using the 'nc_format' argument in the 'open_file' call**
+- **NOTE: This arguments can only be used in "NETCDF4" file formats. You can set the netcdf file format for all files using the 'netcdf_default_format' namelist or in a per file basis by using the 'nc_format' argument in the 'open_file' call**
 
 - See the NETCDF user guide for more information: (https://cluster.earlham.edu/bccd-ng/testing/mobeen/GALAXSEEHPC/netcdf-4.1.3/man4/netcdf.html#Chunking)

--- a/test_fms/fms2_io/Makefile.am
+++ b/test_fms/fms2_io/Makefile.am
@@ -65,10 +65,16 @@ test_fms2_io.$(OBJEXT): argparse.mod
 # Run the test program.
 TESTS = test_bc_restart.sh test_fms2_io.sh test_atmosphere_io.sh test_io_simple.sh test_io_with_mask.sh test_global_att.sh test_read_ascii_file.sh
 
+if SKIP_NCDUMP_CHECKS
+skipflag="skip"
+else
+skipflag=""
+endif
+
 # Set srcdir as evironment variable to be reference in the job script
 TEST_EXTENSIONS = .sh
 SH_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
                   $(abs_top_srcdir)/test_fms/tap-driver.sh
-TESTS_ENVIRONMENT = srcdir="$(abs_top_srcdir)"
+TESTS_ENVIRONMENT = srcdir="$(abs_top_srcdir)" ncdump_skip=${skipflag}
 
 CLEANFILES = *.mod *.nc *.nc.* input.nml logfile.000000.out the_mask ascii_test1 *.dpi *.spi *.dyn *.spl *-files/*

--- a/test_fms/fms2_io/Makefile.am
+++ b/test_fms/fms2_io/Makefile.am
@@ -30,7 +30,7 @@ LDADD = $(top_builddir)/libFMS/libFMS.la
 
 # Build this test program.
 check_PROGRAMS = test_get_is_valid test_file_appendix test_fms2_io test_atmosphere_io test_io_simple test_io_with_mask test_global_att \
-                 test_bc_restart test_get_mosaic_tile_grid test_read_ascii_file test_unlimit_compressed
+                 test_bc_restart test_get_mosaic_tile_grid test_read_ascii_file test_unlimit_compressed test_chunksizes
 
 # This is the source code for the test.
 test_get_is_valid_SOURCES = test_get_is_valid.F90
@@ -48,6 +48,7 @@ test_get_mosaic_tile_grid_SOURCES=test_get_mosaic_tile_grid.F90
 test_read_ascii_file_SOURCES=test_read_ascii_file.F90
 test_file_appendix_SOURCES=test_file_appendix.F90
 test_unlimit_compressed_SOURCES=test_unlimit_compressed.F90
+test_chunksizes_SOURCES = test_chunksizes.F90
 
 EXTRA_DIST = test_bc_restart.sh test_fms2_io.sh test_atmosphere_io.sh test_io_simple.sh test_global_att.sh test_io_with_mask.sh test_read_ascii_file.sh
 

--- a/test_fms/fms2_io/test_atmosphere_io.F90
+++ b/test_fms/fms2_io/test_atmosphere_io.F90
@@ -322,9 +322,6 @@ names(3) = "lev"
 names(4) = "time"
 call create_data(var11, (/nxd, nyd, test_params%nz/))
 call register_restart_field(fileobj, "var11", var11, names(1:4))
-call register_restart_field(fileobj, "var12", var11, names(1:4),chunksizes &
- =(/10, 10, 10, 1 /), deflate_level=5)
-
 
 !Perform a "simulation" and write restart data.
 do i = 1, nt

--- a/test_fms/fms2_io/test_chunksizes.F90
+++ b/test_fms/fms2_io/test_chunksizes.F90
@@ -18,22 +18,22 @@
 !***********************************************************************
 
 program test_chunksizes
-  use fms2_io_mod, only: open_file, close_file, register_axis, register_restart_field, write_restart, &
-                         unlimited, fmsnetcdffile_t, read_restart
-  use mpp_mod,     only: mpp_error, FATAL
-  use fms_mod,     only: fms_init, fms_end
+  use fms2_io_mod,  only: open_file, close_file, register_axis, register_restart_field, write_restart, &
+                          unlimited, fmsnetcdffile_t, read_restart
+  use mpp_mod,      only: mpp_error, FATAL
+  use fms_mod,      only: fms_init, fms_end
   use platform_mod, only: r8_kind
 
   implicit none
 
-  integer, parameter :: dim_len = 24
-  integer               :: i, j, k !< For do loops
-  type(fmsnetcdffile_t) :: fileobj
-  character (len = 120), dimension(3) :: my_format !< Array of formats to try.
-  character (len = 120), dimension(4) :: dimnames
-  integer, dimension(4) :: chunksizes
-  real(kind=r8_kind) :: vardata_in(dim_len, dim_len, dim_len)
-  real(kind=r8_kind) :: vardata_out(dim_len, dim_len, dim_len)
+  integer, parameter     :: dim_len = 24                           !< The dimension length
+  integer                :: i, j, k                                !< For do loops
+  type(fmsnetcdffile_t)  :: fileobj                                !< FMS2_io fileobj
+  character (len = 120), :: my_format(3)                           !< Array of formats to try.
+  character (len = 120), :: dimnames(4)                            !< Array of dimension names
+  integer, dimension(4)  :: chunksizes                             !< The chunksizes to use
+  real(kind=r8_kind)     :: vardata_in(dim_len, dim_len, dim_len)  !< The data to write
+  real(kind=r8_kind)     :: vardata_out(dim_len, dim_len, dim_len) !< The data read in
 
   call fms_init()
 
@@ -53,6 +53,7 @@ program test_chunksizes
     enddo
   enddo
 
+  !< Loop through each of the file formats and write out a file
   do i = 1, 4
     if (i .ne. 4) then
       if (.not. open_file(fileobj, "test_chunksizes_"//trim(my_format(i))//".nc", "overwrite", &
@@ -67,11 +68,13 @@ program test_chunksizes
     call register_axis(fileobj, "dim2", dim_len)
     call register_axis(fileobj, "dim3", dim_len)
     call register_axis(fileobj, "dim4", unlimited)
+    !< The chunksizes will ignored for non netcdf4 file formats
     call register_restart_field(fileobj, "var1", vardata_in, dimnames, chunksizes=chunksizes)
     call write_restart(fileobj)
     call close_file(fileobj)
   enddo
 
+  !< Loop through each of the file formats and read out a file
   do i = 1, 4
     if (i .ne. 4) then
       if (.not. open_file(fileobj, "test_chunksizes_"//trim(my_format(i))//".nc", "read", &

--- a/test_fms/fms2_io/test_chunksizes.F90
+++ b/test_fms/fms2_io/test_chunksizes.F90
@@ -1,0 +1,96 @@
+!***********************************************************************
+!*                   GNU Lesser General Public License
+!*
+!* This file is part of the GFDL Flexible Modeling System (FMS).
+!*
+!* FMS is free software: you can redistribute it and/or modify it under
+!* the terms of the GNU Lesser General Public License as published by
+!* the Free Software Foundation, either version 3 of the License, or (at
+!* your option) any later version.
+!*
+!* FMS is distributed in the hope that it will be useful, but WITHOUT
+!* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+!* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+!* for more details.
+!*
+!* You should have received a copy of the GNU Lesser General Public
+!* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
+!***********************************************************************
+
+program test_chunksizes
+  use fms2_io_mod, only: open_file, close_file, register_axis, register_restart_field, write_restart, &
+                         unlimited, fmsnetcdffile_t, read_restart
+  use mpp_mod,     only: mpp_error, FATAL
+  use fms_mod,     only: fms_init, fms_end
+  use platform_mod, only: r8_kind
+
+  implicit none
+
+  integer, parameter :: dim_len = 24
+  integer               :: i, j, k !< For do loops
+  type(fmsnetcdffile_t) :: fileobj
+  character (len = 120), dimension(3) :: my_format !< Array of formats to try.
+  character (len = 120), dimension(4) :: dimnames
+  integer, dimension(4) :: chunksizes
+  real(kind=r8_kind) :: vardata_in(dim_len, dim_len, dim_len)
+  real(kind=r8_kind) :: vardata_out(dim_len, dim_len, dim_len)
+
+  call fms_init()
+
+  my_format(1) = '64bit'
+  my_format(2) = 'classic'
+  my_format(3) = 'netcdf4'
+
+  dimnames = (/"dim1", "dim2", "dim3", "dim4"/)
+
+  chunksizes = (/dim_len, dim_len, dim_len, 1/)
+
+  do i = 1, dim_len
+    do j = 1, dim_len
+      do k = 1, dim_len
+        vardata_in(i, j, k) = real(k, kind=r8_kind)/13.
+      enddo
+    enddo
+  enddo
+
+  do i = 1, 4
+    if (i .ne. 4) then
+      if (.not. open_file(fileobj, "test_chunksizes_"//trim(my_format(i))//".nc", "overwrite", &
+        is_restart=.true., nc_format=my_format(i))) &
+      call mpp_error(FATAL, "Error opening the file to write:test_chunksizes_"//trim(my_format(i))//".nc")
+    else
+      if (.not. open_file(fileobj, "test_chunksizes.nc", "overwrite", is_restart=.true.)) &
+      call mpp_error(FATAL, "Error opening the file to write:test_chunksizes.nc")
+    endif
+
+    call register_axis(fileobj, "dim1", dim_len)
+    call register_axis(fileobj, "dim2", dim_len)
+    call register_axis(fileobj, "dim3", dim_len)
+    call register_axis(fileobj, "dim4", unlimited)
+    call register_restart_field(fileobj, "var1", vardata_in, dimnames, chunksizes=chunksizes)
+    call write_restart(fileobj)
+    call close_file(fileobj)
+  enddo
+
+  do i = 1, 4
+    if (i .ne. 4) then
+      if (.not. open_file(fileobj, "test_chunksizes_"//trim(my_format(i))//".nc", "read", &
+        is_restart=.true., nc_format=my_format(i))) &
+      call mpp_error(FATAL, "Error opening the file to read:test_chunksizes_"//trim(my_format(i))//".nc")
+    else
+      if (.not. open_file(fileobj, "test_chunksizes.nc", "read", is_restart=.true.)) &
+      call mpp_error(FATAL, "Error opening the file to read:test_chunksizes.nc")
+    endif
+
+    vardata_out = -999.
+    call register_restart_field(fileobj, "var1", vardata_out, dimnames, chunksizes=chunksizes)
+    call read_restart(fileobj)
+    call close_file(fileobj)
+
+    if (sum(vardata_out) .ne. sum(vardata_in)) &
+      call mpp_error(FATAL, "Error reading the data back from file")
+  enddo
+
+  call fms_end()
+
+end program

--- a/test_fms/fms2_io/test_chunksizes.F90
+++ b/test_fms/fms2_io/test_chunksizes.F90
@@ -29,8 +29,8 @@ program test_chunksizes
   integer, parameter     :: dim_len = 24                           !< The dimension length
   integer                :: i, j, k                                !< For do loops
   type(fmsnetcdffile_t)  :: fileobj                                !< FMS2_io fileobj
-  character (len = 120), :: my_format(3)                           !< Array of formats to try.
-  character (len = 120), :: dimnames(4)                            !< Array of dimension names
+  character (len = 120) :: my_format(3)                            !< Array of formats to try.
+  character (len = 120) :: dimnames(4)                             !< Array of dimension names
   integer, dimension(4)  :: chunksizes                             !< The chunksizes to use
   real(kind=r8_kind)     :: vardata_in(dim_len, dim_len, dim_len)  !< The data to write
   real(kind=r8_kind)     :: vardata_out(dim_len, dim_len, dim_len) !< The data read in

--- a/test_fms/fms2_io/test_io_simple.F90
+++ b/test_fms/fms2_io/test_io_simple.F90
@@ -104,7 +104,7 @@ program test_io_simple
   call mpp_get_compute_domain(io_domain, xbegin=isc_east, xend=iec_east, xsize=nx_east, position=east)
   call mpp_get_compute_domain(io_domain, ybegin=jsc_north, yend=jec_north, ysize=ny_north, position=north)
 
-  call netcdf_io_init(ncchksz, header_buffer_val, netcdf_default_format)
+  call fms2_io_init
 
   do i = 1, 3
      write(testfile,'(a,a,a)') 'test_io_simple_', trim(my_format(i)), '.nc'

--- a/test_fms/fms2_io/test_io_simple.sh
+++ b/test_fms/fms2_io/test_io_simple.sh
@@ -56,6 +56,9 @@ test_expect_success "Test the unlimited compressed axis functionality" '
 test_expect_success "Test the chunksizes functionality with the default behavior" '
   mpirun -n 1 ../test_chunksizes
 '
+
+ncdump -hsv var1 test_chunksizes_netcdf4.res.nc 
+
 test_expect_success "test_chunksizes_netcdf4.res.nc should be chunked" '
   ncdump -hsv var1 test_chunksizes_netcdf4.res.nc | grep "ChunkSizes"
 '

--- a/test_fms/fms2_io/test_io_simple.sh
+++ b/test_fms/fms2_io/test_io_simple.sh
@@ -53,4 +53,85 @@ test_expect_success "Test the unlimited compressed axis functionality" '
   mpirun -n 6 ../test_unlimit_compressed
 '
 
+test_expect_success "Test the chunksizes functionality with the default behavior" '
+  mpirun -n 1 ../test_chunksizes
+'
+test_expect_success "test_chunksizes_netcdf4.res.nc should be chunked" '
+  ncdump -hsv var1 test_chunksizes_netcdf4.res.nc | grep "ChunkSizes"
+'
+test_expect_failure "test_chunksizes_classic.res.nc should not be chunked" '
+  ncdump -hsv var1 test_chunksizes_classic.res.nc | grep "ChunkSizes"
+'
+test_expect_failure "test_chunksizes_64bit.res.nc should not be chunked" '
+  ncdump -hsv var1 test_chunksizes_64bit.res.nc | grep "ChunkSizes"
+'
+test_expect_failure "test_chunksizes.res.nc should not be chunked" '
+  ncdump -hsv var1 test_chunksizes.res.nc | grep "ChunkSizes"
+'
+
+cat <<_EOF > input.nml
+&fms2_io_nml
+  netcdf_default_format = "netcdf4"
+/
+_EOF
+test_expect_success "Test the chunksizes functionality with netcdf4 as the default file format" '
+  mpirun -n 1 ../test_chunksizes
+'
+test_expect_success "test_chunksizes_netcdf4.res.nc should be chunked" '
+  ncdump -hsv var1 test_chunksizes_netcdf4.res.nc | grep "ChunkSizes"
+'
+test_expect_failure "test_chunksizes_classic.res.nc should not be chunked" '
+  ncdump -hsv var1 test_chunksizes_classic.res.nc | grep "ChunkSizes"
+'
+test_expect_failure "test_chunksizes_64bit.res.nc should not be chunked" '
+  ncdump -hsv var1 test_chunksizes_64bit.res.nc | grep "ChunkSizes"
+'
+test_expect_success "test_chunksizes.res.nc should be chunked" '
+  ncdump -hsv var1 test_chunksizes.res.nc | grep "ChunkSizes"
+'
+
+cat <<_EOF > input.nml
+&fms2_io_nml
+  deflate_level = 3
+  shuffle = .true.
+/
+_EOF
+test_expect_success "Test the deflate level and shuffle functionality with the default behavior" '
+  mpirun -n 1 ../test_chunksizes
+'
+test_expect_success "test_chunksizes_netcdf4.res.nc should be compressed" '
+  ncdump -hsv var1 test_chunksizes_netcdf4.res.nc | grep "DeflateLevel"
+'
+test_expect_failure "test_chunksizes_classic.res.nc should not be compressed" '
+  ncdump -hsv var1 test_chunksizes_classic.res.nc | grep "DeflateLevel"
+'
+test_expect_failure "test_chunksizes_64bit.res.nc should not be compressed" '
+  ncdump -hsv var1 test_chunksizes_64bit.res.nc | grep "DeflateLevel"
+'
+test_expect_failure "test_chunksizes.res.nc should not be compressed" '
+  ncdump -hsv var1 test_chunksizes.res.nc | grep "DeflateLevel"
+'
+
+cat <<_EOF > input.nml
+&fms2_io_nml
+  deflate_level = 3
+  shuffle = .true.
+  netcdf_default_format = "netcdf4"
+/
+_EOF
+test_expect_success "Test the deflate level and shuffle functionality with netcdf4 as the default file format" '
+  mpirun -n 1 ../test_chunksizes
+'
+test_expect_success "test_chunksizes_netcdf4.res.nc should be compressed" '
+  ncdump -hsv var1 test_chunksizes_netcdf4.res.nc | grep "DeflateLevel"
+'
+test_expect_failure "test_chunksizes_classic.res.nc should not be compressed" '
+  ncdump -hsv var1 test_chunksizes_classic.res.nc | grep "DeflateLevel"
+'
+test_expect_failure "test_chunksizes_64bit.res.nc should not be compressed" '
+  ncdump -hsv var1 test_chunksizes_64bit.res.nc | grep "DeflateLevel"
+'
+test_expect_success "test_chunksizes.res.nc should be compressed" '
+  ncdump -hsv var1 test_chunksizes.res.nc | grep "DeflateLevel"
+'
 test_done

--- a/test_fms/fms2_io/test_io_simple.sh
+++ b/test_fms/fms2_io/test_io_simple.sh
@@ -57,20 +57,20 @@ test_expect_success "Test the chunksizes functionality with the default behavior
   mpirun -n 1 ../test_chunksizes
 '
 
-ncdump -hsv var1 test_chunksizes_netcdf4.res.nc 
-
-test_expect_success "test_chunksizes_netcdf4.res.nc should be chunked" '
-  ncdump -hsv var1 test_chunksizes_netcdf4.res.nc | grep "ChunkSizes"
-'
-test_expect_failure "test_chunksizes_classic.res.nc should not be chunked" '
-  ncdump -hsv var1 test_chunksizes_classic.res.nc | grep "ChunkSizes"
-'
-test_expect_failure "test_chunksizes_64bit.res.nc should not be chunked" '
-  ncdump -hsv var1 test_chunksizes_64bit.res.nc | grep "ChunkSizes"
-'
-test_expect_failure "test_chunksizes.res.nc should not be chunked" '
-  ncdump -hsv var1 test_chunksizes.res.nc | grep "ChunkSizes"
-'
+if test ! -z "$ncdump_skip" ; then
+  test_expect_success "test_chunksizes_netcdf4.res.nc should be chunked" '
+    ncdump -hsv var1 test_chunksizes_netcdf4.res.nc | grep "ChunkSizes"
+  '
+  test_expect_failure "test_chunksizes_classic.res.nc should not be chunked" '
+    ncdump -hsv var1 test_chunksizes_classic.res.nc | grep "ChunkSizes"
+  '
+  test_expect_failure "test_chunksizes_64bit.res.nc should not be chunked" '
+    ncdump -hsv var1 test_chunksizes_64bit.res.nc | grep "ChunkSizes"
+  '
+  test_expect_failure "test_chunksizes.res.nc should not be chunked" '
+    ncdump -hsv var1 test_chunksizes.res.nc | grep "ChunkSizes"
+  '
+fi
 
 cat <<_EOF > input.nml
 &fms2_io_nml
@@ -80,19 +80,20 @@ _EOF
 test_expect_success "Test the chunksizes functionality with netcdf4 as the default file format" '
   mpirun -n 1 ../test_chunksizes
 '
-test_expect_success "test_chunksizes_netcdf4.res.nc should be chunked" '
-  ncdump -hsv var1 test_chunksizes_netcdf4.res.nc | grep "ChunkSizes"
-'
-test_expect_failure "test_chunksizes_classic.res.nc should not be chunked" '
-  ncdump -hsv var1 test_chunksizes_classic.res.nc | grep "ChunkSizes"
-'
-test_expect_failure "test_chunksizes_64bit.res.nc should not be chunked" '
-  ncdump -hsv var1 test_chunksizes_64bit.res.nc | grep "ChunkSizes"
-'
-test_expect_success "test_chunksizes.res.nc should be chunked" '
-  ncdump -hsv var1 test_chunksizes.res.nc | grep "ChunkSizes"
-'
-
+if test ! -z "$ncdump_skip" ; then
+  test_expect_success "test_chunksizes_netcdf4.res.nc should be chunked" '
+    ncdump -hsv var1 test_chunksizes_netcdf4.res.nc | grep "ChunkSizes"
+  '
+  test_expect_failure "test_chunksizes_classic.res.nc should not be chunked" '
+    ncdump -hsv var1 test_chunksizes_classic.res.nc | grep "ChunkSizes"
+  '
+  test_expect_failure "test_chunksizes_64bit.res.nc should not be chunked" '
+    ncdump -hsv var1 test_chunksizes_64bit.res.nc | grep "ChunkSizes"
+  '
+  test_expect_success "test_chunksizes.res.nc should be chunked" '
+    ncdump -hsv var1 test_chunksizes.res.nc | grep "ChunkSizes"
+  '
+fi
 cat <<_EOF > input.nml
 &fms2_io_nml
   deflate_level = 3
@@ -102,19 +103,20 @@ _EOF
 test_expect_success "Test the deflate level and shuffle functionality with the default behavior" '
   mpirun -n 1 ../test_chunksizes
 '
-test_expect_success "test_chunksizes_netcdf4.res.nc should be compressed" '
-  ncdump -hsv var1 test_chunksizes_netcdf4.res.nc | grep "DeflateLevel"
-'
-test_expect_failure "test_chunksizes_classic.res.nc should not be compressed" '
-  ncdump -hsv var1 test_chunksizes_classic.res.nc | grep "DeflateLevel"
-'
-test_expect_failure "test_chunksizes_64bit.res.nc should not be compressed" '
-  ncdump -hsv var1 test_chunksizes_64bit.res.nc | grep "DeflateLevel"
-'
-test_expect_failure "test_chunksizes.res.nc should not be compressed" '
-  ncdump -hsv var1 test_chunksizes.res.nc | grep "DeflateLevel"
-'
-
+if test ! -z "$ncdump_skip" ; then
+  test_expect_success "test_chunksizes_netcdf4.res.nc should be compressed" '
+    ncdump -hsv var1 test_chunksizes_netcdf4.res.nc | grep "DeflateLevel"
+  '
+  test_expect_failure "test_chunksizes_classic.res.nc should not be compressed" '
+    ncdump -hsv var1 test_chunksizes_classic.res.nc | grep "DeflateLevel"
+  '
+  test_expect_failure "test_chunksizes_64bit.res.nc should not be compressed" '
+    ncdump -hsv var1 test_chunksizes_64bit.res.nc | grep "DeflateLevel"
+  '
+  test_expect_failure "test_chunksizes.res.nc should not be compressed" '
+    ncdump -hsv var1 test_chunksizes.res.nc | grep "DeflateLevel"
+  '
+fi
 cat <<_EOF > input.nml
 &fms2_io_nml
   deflate_level = 3
@@ -125,16 +127,18 @@ _EOF
 test_expect_success "Test the deflate level and shuffle functionality with netcdf4 as the default file format" '
   mpirun -n 1 ../test_chunksizes
 '
-test_expect_success "test_chunksizes_netcdf4.res.nc should be compressed" '
-  ncdump -hsv var1 test_chunksizes_netcdf4.res.nc | grep "DeflateLevel"
-'
-test_expect_failure "test_chunksizes_classic.res.nc should not be compressed" '
-  ncdump -hsv var1 test_chunksizes_classic.res.nc | grep "DeflateLevel"
-'
-test_expect_failure "test_chunksizes_64bit.res.nc should not be compressed" '
-  ncdump -hsv var1 test_chunksizes_64bit.res.nc | grep "DeflateLevel"
-'
-test_expect_success "test_chunksizes.res.nc should be compressed" '
-  ncdump -hsv var1 test_chunksizes.res.nc | grep "DeflateLevel"
-'
+if test ! -z "$ncdump_skip" ; then
+  test_expect_success "test_chunksizes_netcdf4.res.nc should be compressed" '
+    ncdump -hsv var1 test_chunksizes_netcdf4.res.nc | grep "DeflateLevel"
+  '
+  test_expect_failure "test_chunksizes_classic.res.nc should not be compressed" '
+    ncdump -hsv var1 test_chunksizes_classic.res.nc | grep "DeflateLevel"
+  '
+  test_expect_failure "test_chunksizes_64bit.res.nc should not be compressed" '
+    ncdump -hsv var1 test_chunksizes_64bit.res.nc | grep "DeflateLevel"
+  '
+  test_expect_success "test_chunksizes.res.nc should be compressed" '
+    ncdump -hsv var1 test_chunksizes.res.nc | grep "DeflateLevel"
+  '
+fi
 test_done


### PR DESCRIPTION
**Description**
- Removes `deflate level` as an optional argument to `register_restart_field`
- Adds `deflate_level` and `shuffle` as arguments to `fms2_io_nml` and uses them to define the variable
- Adds a test to test the `chunksizes` feature in `register_restart_field` and these two namelist parameter
- Checks if ncdump is available and if it is, it uses it to determine if the chunksizes, deflate_level, and shuffle were added correctly
- Updates documentation

Fixes #1073 
Fixes #1045 

**How Has This Been Tested?**
CI including new tests

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

