### PR TITLE
update doc site deployment

### DIFF
--- a/.github/workflows/update_docs.yml
+++ b/.github/workflows/update_docs.yml
@@ -6,7 +6,7 @@ on:
     types: [published]
   workflow_dispatch:
 jobs:
-  update_docs:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -23,8 +23,26 @@ jobs:
         run: |
           sudo apt -y install doxygen graphviz
           doxygen gen_docs/Doxyfile
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Upload Pages Artifact
+        uses: actions/upload-pages-artifact@v1
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./gen_docs/html
+          path: 'gen_docs/html'
+  deploy:
+    needs: build
+    
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    # Specify runner + deployment step
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/.github/workflows/update_docs.yml
+++ b/.github/workflows/update_docs.yml
@@ -29,7 +29,7 @@ jobs:
           path: 'gen_docs/html'
   deploy:
     needs: build
-    
+
     # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
     permissions:
       pages: write      # to deploy to Pages


### PR DESCRIPTION
**Description**
updates the docs workflow to use github's own action for deployment instead of the third party one I had used. I used a more recent [example from seth](https://github.com/NOAA-RDHPCS/noaa-rdhpcs.github.io/blob/main/.github/workflows/publish_docs.yml) with the current github recommended way to deploy.

It used to be required that you had an explicit branch (gh-pages) to deploy to the site, but this update will change it to an artifact (saved in the action) instead.

Fixes # (issue)

**How Has This Been Tested?**
testing on my fork

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

