### PR TITLE
mixed mode sat_vapor_pres part 1

### DIFF
--- a/sat_vapor_pres/sat_vapor_pres_k.F90
+++ b/sat_vapor_pres/sat_vapor_pres_k.F90
@@ -233,7 +233,7 @@
       dtres = (tcmax - tcmin)/real(table_size-1)
       tminl = real(tcmin)+TFREEZE  ! minimum valid temp in table
       dtinvl = one/dtres
-      tepsl = zp5*dtres
+      tepsl = p5*dtres
       tinrc = .1*dtres
       if(present(teps )) teps =tepsl
       if(present(tmin )) tmin =tminl

--- a/sat_vapor_pres/sat_vapor_pres_k.F90
+++ b/sat_vapor_pres/sat_vapor_pres_k.F90
@@ -191,6 +191,10 @@
  character(len=*), intent(out) :: err_msg
  real, intent(out), optional :: teps, tmin, dtinv
 
+  real, parameter :: one=1.0
+  real, parameter :: p5=0.5
+  real, parameter :: p25=0.25
+
 ! increment used to generate derivative table
   real, dimension(3) :: tem(3), es(3)
   real :: hdtinv, tinrc, tfact
@@ -228,8 +232,8 @@
       table_siz = table_size
       dtres = (tcmax - tcmin)/real(table_size-1)
       tminl = real(tcmin)+TFREEZE  ! minimum valid temp in table
-      dtinvl = 1./dtres
-      tepsl = .5*dtres
+      dtinvl = one/dtres
+      tepsl = zp5*dtres
       tinrc = .1*dtres
       if(present(teps )) teps =tepsl
       if(present(tmin )) tmin =tminl
@@ -240,7 +244,7 @@
 ! it is necessary to compute ftact differently than it is in memphis.
       tfact = 5.0*dtinvl
 
-      hdtinv = dtinvl*0.5
+      hdtinv = dtinvl*p5
 
 ! compute es tables from tcmin to tcmax
 ! estimate es derivative with small +/- difference
@@ -249,7 +253,7 @@
 
         do i = 1, table_size
           tem(1) = tminl + dtres*real(i-1)
-          TABLE(i) = ES0*610.78*exp(-hlv/rvgas*(1./tem(1) - 1./tfreeze))
+          TABLE(i) = ES0*real(610.78,FMS_SP_KIND_)*exp(-hlv/rvgas*(one/tem(1) - one/tfreeze))
           DTABLE(i) = hlv*TABLE(i)/rvgas/tem(1)**2.
         enddo
 
@@ -270,13 +274,13 @@
 ! differencing des values in the table
 
       do i = 2, table_size-1
-         D2TABLE(i) = 0.25*dtinvl*(DTABLE(i+1)-DTABLE(i-1))
+         D2TABLE(i) = p25*dtinvl*(DTABLE(i+1)-DTABLE(i-1))
       enddo
     ! one-sided derivatives at boundaries
 
-         D2TABLE(1) = 0.50*dtinvl*(DTABLE(2)-DTABLE(1))
+         D2TABLE(1) = p5*dtinvl*(DTABLE(2)-DTABLE(1))
 
-         D2TABLE(table_size) = 0.50*dtinvl*&
+         D2TABLE(table_size) = p5*dtinvl*&
               (DTABLE(table_size)-DTABLE(table_size-1))
 
    if (construct_table_wrt_liq) then
@@ -297,13 +301,13 @@
 ! differencing des values in the table
 
      do i = 2, table_size-1
-       D2TABLE2(i) = 0.25*dtinvl*(DTABLE2(i+1)-DTABLE2(i-1))
+       D2TABLE2(i) = p25*dtinvl*(DTABLE2(i+1)-DTABLE2(i-1))
      enddo
 ! one-sided derivatives at boundaries
 
-     D2TABLE2(1) = 0.50*dtinvl*(DTABLE2(2)-DTABLE2(1))
+     D2TABLE2(1) = p5*dtinvl*(DTABLE2(2)-DTABLE2(1))
 
-     D2TABLE2(table_size) = 0.50*dtinvl*&
+     D2TABLE2(table_size) = p5*dtinvl*&
           (DTABLE2(table_size)-DTABLE2(table_size-1))
    endif
 
@@ -326,13 +330,13 @@
 ! differencing des values in the table
 
      do i = 2, table_size-1
-       D2TABLE3(i) = 0.25*dtinvl*(DTABLE3(i+1)-DTABLE3(i-1))
+       D2TABLE3(i) = p25*dtinvl*(DTABLE3(i+1)-DTABLE3(i-1))
      enddo
 ! one-sided derivatives at boundaries
 
-     D2TABLE3(1) = 0.50*dtinvl*(DTABLE3(2)-DTABLE3(1))
+     D2TABLE3(1) = p5*dtinvl*(DTABLE3(2)-DTABLE3(1))
 
-     D2TABLE3(table_size) = 0.50*dtinvl*&
+     D2TABLE3(table_size) = p5*dtinvl*&
           (DTABLE3(table_size)-DTABLE3(table_size-1))
    endif
 

--- a/sat_vapor_pres/sat_vapor_pres_k.F90
+++ b/sat_vapor_pres/sat_vapor_pres_k.F90
@@ -486,6 +486,9 @@
  logical,intent(in),                  optional :: es_over_liq
  logical,intent(in),                  optional :: es_over_liq_and_ice
 
+ real, parameter :: zero=0.0
+ real, parameter :: one=1.0
+
  real, dimension(size(temp,1), size(temp,2), size(temp,3)) ::   &
                                                   esloc, desat, denom
  integer :: i, j, k
@@ -494,7 +497,7 @@
    if (present(hc)) then
      hc_loc = hc
    else
-     hc_loc = 1.0
+     hc_loc = one
    endif
  if (present(es_over_liq)) then
    if (present (dqsdT)) then
@@ -524,16 +527,16 @@
    endif
    if (nbad == 0) then
      if (present (q) .and. use_exact_qs) then
-       qs = (1.0 + zvir*q)*eps*esloc/press
+       qs = (one + zvir*q)*eps*esloc/press
        if (present (dqsdT)) then
-         dqsdT = (1.0 + zvir*q)*eps*desat/press
+         dqsdT = (one + zvir*q)*eps*desat/press
        endif
      else  ! (present(q))
-       denom = press - (1.0 - eps)*esloc
+       denom = press - (one - eps)*esloc
        do k=1,size(qs,3)
          do j=1,size(qs,2)
            do i=1,size(qs,1)
-             if (denom(i,j,k) > 0.0) then
+             if (denom(i,j,k) > zero) then
                qs(i,j,k) = eps*esloc(i,j,k)/denom(i,j,k)
              else
                qs(i,j,k) = eps
@@ -573,6 +576,9 @@
  logical,intent(in),                optional :: es_over_liq
  logical,intent(in),                  optional :: es_over_liq_and_ice
 
+ real, parameter :: zero=0.0
+ real, parameter :: one=1.0
+
  real, dimension(size(temp,1), size(temp,2)) :: esloc, desat, denom
  integer :: i, j
  real    :: hc_loc
@@ -580,7 +586,7 @@
    if (present(hc)) then
      hc_loc = hc
    else
-     hc_loc = 1.0
+     hc_loc = one
    endif
 
  if (present(es_over_liq)) then
@@ -611,15 +617,15 @@
    endif
    if (nbad == 0) then
      if (present (q) .and. use_exact_qs) then
-       qs = (1.0 + zvir*q)*eps*esloc/press
+       qs = (one + zvir*q)*eps*esloc/press
        if (present (dqsdT)) then
-         dqsdT = (1.0 + zvir*q)*eps*desat/press
+         dqsdT = (one + zvir*q)*eps*desat/press
        endif
      else  ! (present(q))
-       denom = press - (1.0 - eps)*esloc
+       denom = press - (one - eps)*esloc
       do j=1,size(qs,2)
         do i=1,size(qs,1)
-          if (denom(i,j) > 0.0) then
+          if (denom(i,j) > zero) then
             qs(i,j) = eps*esloc(i,j)/denom(i,j)
           else
             qs(i,j) = eps
@@ -657,6 +663,9 @@
  real, intent(out), dimension(:), optional :: dqsdT, esat
  logical,intent(in),              optional :: es_over_liq
  logical,intent(in),                  optional :: es_over_liq_and_ice
+
+ real, parameter :: zero=0.0
+ real, parameter :: one=1.0
 
  real, dimension(size(temp,1)) :: esloc, desat, denom
  integer :: i
@@ -696,14 +705,14 @@
    endif
    if (nbad == 0) then
      if (present (q) .and. use_exact_qs) then
-       qs = (1.0 + zvir*q)*eps*esloc/press
+       qs = (one + zvir*q)*eps*esloc/press
        if (present (dqsdT)) then
-         dqsdT = (1.0 + zvir*q)*eps*desat/press
+         dqsdT = (one + zvir*q)*eps*desat/press
        endif
      else  ! (present(q))
-       denom = press - (1.0 - eps)*esloc
+       denom = press - (one - eps)*esloc
        do i=1,size(qs,1)
-         if (denom(i) >  0.0) then
+         if (denom(i) >  zero) then
            qs(i) = eps*esloc(i)/denom(i)
          else
            qs(i) = eps
@@ -740,6 +749,9 @@
  real, intent(out),     optional :: dqsdT, esat
  logical,intent(in),    optional :: es_over_liq
  logical,intent(in),                  optional :: es_over_liq_and_ice
+
+ real, parameter :: zero=0.0
+ real, parameter :: one=1.0
 
  real    :: esloc, desat, denom
  real    :: hc_loc
@@ -778,13 +790,13 @@
    endif
    if (nbad == 0) then
      if (present (q) .and. use_exact_qs) then
-       qs = (1.0 + zvir*q)*eps*esloc/press
+       qs = (one + zvir*q)*eps*esloc/press
        if (present (dqsdT)) then
-         dqsdT = (1.0 + zvir*q)*eps*desat/press
+         dqsdT = (one + zvir*q)*eps*desat/press
        endif
      else  ! (present(q))
-       denom = press - (1.0 - eps)*esloc
-       if (denom > 0.0) then
+       denom = press - (one - eps)*esloc
+       if (denom > zero) then
          qs = eps*esloc/denom
        else
          qs = eps
@@ -825,13 +837,16 @@
 
  real, dimension(size(temp,1), size(temp,2), size(temp,3)) ::    &
                                                     esloc, desat, denom
+ real, parameter :: zero=0.0
+ real, parameter :: one=1.0
+
  integer :: i, j, k
  real    :: hc_loc
 
    if (present(hc)) then
      hc_loc = hc
    else
-     hc_loc = 1.0
+     hc_loc = one
    endif
 
  if (present (es_over_liq)) then
@@ -871,7 +886,7 @@
        do k=1,size(mrs,3)
          do j=1,size(mrs,2)
            do i=1,size(mrs,1)
-             if (denom(i,j,k) > 0.0) then
+             if (denom(i,j,k) > zero) then
                mrs(i,j,k) = eps*esloc(i,j,k)/denom(i,j,k)
              else
                mrs(i,j,k) = eps
@@ -911,6 +926,9 @@
  logical,intent(in),               optional :: es_over_liq
  logical,intent(in),                  optional :: es_over_liq_and_ice
 
+ real, parameter :: zero=0.0
+ real, parameter :: one=1.0
+
  real, dimension(size(temp,1), size(temp,2)) :: esloc, desat, denom
  integer :: i, j
  real    :: hc_loc
@@ -918,7 +936,7 @@
    if (present(hc)) then
      hc_loc = hc
    else
-     hc_loc = 1.0
+     hc_loc = one
    endif
 
  if (present (es_over_liq)) then
@@ -957,7 +975,7 @@
        denom = press - esloc
        do j=1,size(mrs,2)
          do i=1,size(mrs,1)
-           if (denom(i,j) > 0.0) then
+           if (denom(i,j) > zero) then
              mrs(i,j) = eps*esloc(i,j)/denom(i,j)
            else
              mrs(i,j) = eps
@@ -996,6 +1014,9 @@
  logical,intent(in),              optional :: es_over_liq
  logical,intent(in),                  optional :: es_over_liq_and_ice
 
+ real, parameter :: zero=0.0
+ real, parameter :: one=1.0
+
  real, dimension(size(temp,1)) :: esloc, desat, denom
  integer :: i
  real    :: hc_loc
@@ -1003,7 +1024,7 @@
    if (present(hc)) then
      hc_loc = hc
    else
-     hc_loc = 1.0
+     hc_loc = one
    endif
 
  if (present (es_over_liq)) then
@@ -1041,7 +1062,7 @@
      else ! (present (mr))
        denom = press - esloc
        do i=1,size(mrs,1)
-         if (denom(i) > 0.0) then
+         if (denom(i) > zero) then
            mrs(i) = eps*esloc(i)/denom(i)
          else
            mrs(i) = eps
@@ -1079,13 +1100,16 @@
  logical,intent(in),                  optional :: es_over_liq
  logical,intent(in),                  optional :: es_over_liq_and_ice
 
+ real, parameter :: zero=0.0
+ real, parameter :: one=1.0
+
  real    :: esloc, desat, denom
  real    :: hc_loc
 
    if (present(hc)) then
      hc_loc = hc
    else
-     hc_loc = 1.0
+     hc_loc = one
    endif
 
  if (present (es_over_liq)) then
@@ -1122,7 +1146,7 @@
        endif
      else ! (present (mr))
        denom = press - esloc
-       if (denom > 0.0) then
+       if (denom > zero) then
          mrs = eps*esloc/denom
        else
          mrs = eps
@@ -1153,6 +1177,8 @@
  real, intent(out), dimension(:,:,:)  :: esat, desat
  integer, intent(out)                 :: nbad
 
+ real, parameter :: two=2.0
+
  real    :: tmp, del
  integer :: ind, i, j, k
 
@@ -1168,7 +1194,7 @@
        del = tmp-dtres*real(ind)
        esat(i,j,k) = TABLE(ind+1) +  &
                      del*(DTABLE(ind+1) + del*D2TABLE(ind+1))
-       desat(i,j,k) = DTABLE(ind+1) + 2.*del*D2TABLE(ind+1)
+       desat(i,j,k) = DTABLE(ind+1) + two*del*D2TABLE(ind+1)
      endif
    enddo
    enddo
@@ -1182,6 +1208,8 @@
  real, intent(in),  dimension(:,:)  :: temp
  real, intent(out), dimension(:,:)  :: esat, desat
  integer, intent(out)               :: nbad
+
+ real, parameter :: two=2.0
 
  real    :: tmp, del
  integer :: ind, i, j
@@ -1197,7 +1225,7 @@
        del = tmp-dtres*real(ind)
        esat(i,j) = TABLE(ind+1) + &
                    del*(DTABLE(ind+1) + del*D2TABLE(ind+1))
-       desat(i,j) = DTABLE(ind+1) + 2.*del*D2TABLE(ind+1)
+       desat(i,j) = DTABLE(ind+1) + two*del*D2TABLE(ind+1)
      endif
    enddo
    enddo
@@ -1210,6 +1238,8 @@
  real, intent(in),  dimension(:)  :: temp
  real, intent(out), dimension(:)  :: esat, desat
  integer, intent(out)             :: nbad
+
+ real, parameter :: two=2.0
 
  real    :: tmp, del
  integer :: ind, i
@@ -1224,7 +1254,7 @@
        del = tmp-dtres*real(ind)
        esat(i) = TABLE(ind+1) + &
                    del*(DTABLE(ind+1) + del*D2TABLE(ind+1))
-       desat(i) = DTABLE(ind+1) + 2.*del*D2TABLE(ind+1)
+       desat(i) = DTABLE(ind+1) + two*del*D2TABLE(ind+1)
      endif
    enddo
 
@@ -1236,6 +1266,8 @@
  real, intent(in)     :: temp
  real, intent(out)    :: esat, desat
  integer, intent(out) :: nbad
+
+ real, parameter :: two=2.0
 
  real    :: tmp, del
  integer :: ind
@@ -1249,7 +1281,7 @@
      del = tmp-dtres*real(ind)
      esat = TABLE(ind+1) + &
             del*(DTABLE(ind+1) + del*D2TABLE(ind+1))
-     desat = DTABLE(ind+1) + 2.*del*D2TABLE(ind+1)
+     desat = DTABLE(ind+1) + two*del*D2TABLE(ind+1)
    endif
 
  end subroutine lookup_es_des_k_0d
@@ -1288,6 +1320,9 @@
  real, intent(in),  dimension(:,:,:)  :: temp
  real, intent(out), dimension(:,:,:)  :: desat
  integer, intent(out) :: nbad
+
+ real, parameter :: two=2.0
+
  real    :: tmp, del
  integer :: ind, i, j, k
 
@@ -1301,7 +1336,7 @@
        nbad = nbad+1
      else
        del = tmp-dtres*real(ind)
-       desat(i,j,k) = DTABLE(ind+1) + 2.*del*D2TABLE(ind+1)
+       desat(i,j,k) = DTABLE(ind+1) + two*del*D2TABLE(ind+1)
      endif
    enddo
    enddo
@@ -1314,6 +1349,9 @@
  real, intent(in),  dimension(:,:)  :: temp
  real, intent(out), dimension(:,:)  :: desat
  integer, intent(out) :: nbad
+
+ real, parameter :: two=2.0
+
  real    :: tmp, del
  integer :: ind, i, j
 
@@ -1326,7 +1364,7 @@
        nbad = nbad+1
      else
        del = tmp-dtres*real(ind)
-       desat(i,j) = DTABLE(ind+1) + 2.*del*D2TABLE(ind+1)
+       desat(i,j) = DTABLE(ind+1) + two*del*D2TABLE(ind+1)
      endif
    enddo
    enddo
@@ -1361,6 +1399,9 @@
  real, intent(in),  dimension(:)  :: temp
  real, intent(out), dimension(:)  :: desat
  integer, intent(out) :: nbad
+
+ real, parameter :: two=2.0
+
  real    :: tmp, del
  integer :: ind, i
 
@@ -1372,7 +1413,7 @@
        nbad = nbad+1
      else
        del = tmp-dtres*real(ind)
-       desat(i) = DTABLE(ind+1) + 2.*del*D2TABLE(ind+1)
+       desat(i) = DTABLE(ind+1) + two*del*D2TABLE(ind+1)
      endif
    enddo
 
@@ -1403,6 +1444,9 @@
  real, intent(in)     :: temp
  real, intent(out)    :: desat
  integer, intent(out) :: nbad
+
+ real, parameter :: two=2.0
+
  real    :: tmp, del
  integer :: ind
 
@@ -1413,7 +1457,7 @@
      nbad = nbad+1
    else
      del = tmp-dtres*real(ind)
-     desat = DTABLE(ind+1) + 2.*del*D2TABLE(ind+1)
+     desat = DTABLE(ind+1) + two*del*D2TABLE(ind+1)
    endif
 
  end subroutine lookup_des_k_0d
@@ -1443,6 +1487,8 @@
  real, intent(out), dimension(:,:,:)  :: esat, desat
  integer, intent(out)                 :: nbad
 
+ real, parameter :: two=2.0
+
  real    :: tmp, del
  integer :: ind, i, j, k
 
@@ -1458,7 +1504,7 @@
        del = tmp-dtres*real(ind)
        esat(i,j,k) = TABLE2(ind+1) +  &
                      del*(DTABLE2(ind+1) + del*D2TABLE2(ind+1))
-       desat(i,j,k) = DTABLE2(ind+1) + 2.*del*D2TABLE2(ind+1)
+       desat(i,j,k) = DTABLE2(ind+1) + two*del*D2TABLE2(ind+1)
      endif
    enddo
    enddo
@@ -1472,6 +1518,8 @@
  real, intent(in),  dimension(:,:)  :: temp
  real, intent(out), dimension(:,:)  :: esat, desat
  integer, intent(out)               :: nbad
+
+ real, parameter :: two=2.0
 
  real    :: tmp, del
  integer :: ind, i, j
@@ -1487,7 +1535,7 @@
        del = tmp-dtres*real(ind)
        esat(i,j) = TABLE2(ind+1) + &
                    del*(DTABLE2(ind+1) + del*D2TABLE2(ind+1))
-       desat(i,j) = DTABLE2(ind+1) + 2.*del*D2TABLE2(ind+1)
+       desat(i,j) = DTABLE2(ind+1) + two*del*D2TABLE2(ind+1)
      endif
    enddo
    enddo
@@ -1500,6 +1548,8 @@
  real, intent(in),  dimension(:)  :: temp
  real, intent(out), dimension(:)  :: esat, desat
  integer, intent(out)             :: nbad
+
+ real, parameter :: two=2.0
 
  real    :: tmp, del
  integer :: ind, i
@@ -1514,7 +1564,7 @@
        del = tmp-dtres*real(ind)
        esat(i) = TABLE2(ind+1) + &
                    del*(DTABLE2(ind+1) + del*D2TABLE2(ind+1))
-       desat(i) = DTABLE2(ind+1) + 2.*del*D2TABLE2(ind+1)
+       desat(i) = DTABLE2(ind+1) + two*del*D2TABLE2(ind+1)
      endif
    enddo
 
@@ -1526,6 +1576,8 @@
  real, intent(in)     :: temp
  real, intent(out)    :: esat, desat
  integer, intent(out) :: nbad
+
+ real, parameter :: two=2.0
 
  real    :: tmp, del
  integer :: ind
@@ -1539,7 +1591,7 @@
      del = tmp-dtres*real(ind)
      esat = TABLE2(ind+1) + &
             del*(DTABLE2(ind+1) + del*D2TABLE2(ind+1))
-     desat = DTABLE2(ind+1) + 2.*del*D2TABLE2(ind+1)
+     desat = DTABLE2(ind+1) + two*del*D2TABLE2(ind+1)
    endif
 
  end subroutine lookup_es2_des2_k_0d
@@ -1578,6 +1630,9 @@
  real, intent(in),  dimension(:,:,:)  :: temp
  real, intent(out), dimension(:,:,:)  :: desat
  integer, intent(out) :: nbad
+
+ real, parameter :: two=2.0
+
  real    :: tmp, del
  integer :: ind, i, j, k
 
@@ -1591,7 +1646,7 @@
        nbad = nbad+1
      else
        del = tmp-dtres*real(ind)
-       desat(i,j,k) = DTABLE2(ind+1) + 2.*del*D2TABLE2(ind+1)
+       desat(i,j,k) = DTABLE2(ind+1) + two*del*D2TABLE2(ind+1)
      endif
    enddo
    enddo
@@ -1604,6 +1659,9 @@
  real, intent(in),  dimension(:,:)  :: temp
  real, intent(out), dimension(:,:)  :: desat
  integer, intent(out) :: nbad
+
+ real, parameter :: two=2.0
+
  real    :: tmp, del
  integer :: ind, i, j
 
@@ -1616,7 +1674,7 @@
        nbad = nbad+1
      else
        del = tmp-dtres*real(ind)
-       desat(i,j) = DTABLE2(ind+1) + 2.*del*D2TABLE2(ind+1)
+       desat(i,j) = DTABLE2(ind+1) + two*del*D2TABLE2(ind+1)
      endif
    enddo
    enddo
@@ -1651,6 +1709,9 @@
  real, intent(in),  dimension(:)  :: temp
  real, intent(out), dimension(:)  :: desat
  integer, intent(out) :: nbad
+
+ real, parameter :: two=2.0
+
  real    :: tmp, del
  integer :: ind, i
 
@@ -1662,7 +1723,7 @@
        nbad = nbad+1
      else
        del = tmp-dtres*real(ind)
-       desat(i) = DTABLE2(ind+1) + 2.*del*D2TABLE2(ind+1)
+       desat(i) = DTABLE2(ind+1) + two*del*D2TABLE2(ind+1)
      endif
    enddo
 
@@ -1693,6 +1754,9 @@
  real, intent(in)     :: temp
  real, intent(out)    :: desat
  integer, intent(out) :: nbad
+
+ real, parameter :: two=2.0
+
  real    :: tmp, del
  integer :: ind
 
@@ -1703,7 +1767,7 @@
      nbad = nbad+1
    else
      del = tmp-dtres*real(ind)
-     desat = DTABLE2(ind+1) + 2.*del*D2TABLE2(ind+1)
+     desat = DTABLE2(ind+1) + two*del*D2TABLE2(ind+1)
    endif
 
  end subroutine lookup_des2_k_0d
@@ -1735,6 +1799,8 @@
  real, intent(out), dimension(:,:,:)  :: esat, desat
  integer, intent(out)                 :: nbad
 
+ real, parameter :: two=2.0
+
  real    :: tmp, del
  integer :: ind, i, j, k
 
@@ -1750,7 +1816,7 @@
        del = tmp-dtres*real(ind)
        esat(i,j,k) = TABLE3(ind+1) +  &
                      del*(DTABLE3(ind+1) + del*D2TABLE3(ind+1))
-       desat(i,j,k) = DTABLE3(ind+1) + 2.*del*D2TABLE3(ind+1)
+       desat(i,j,k) = DTABLE3(ind+1) + two*del*D2TABLE3(ind+1)
      endif
    enddo
    enddo
@@ -1764,6 +1830,8 @@
  real, intent(in),  dimension(:,:)  :: temp
  real, intent(out), dimension(:,:)  :: esat, desat
  integer, intent(out)               :: nbad
+
+ real, parameter :: two=2.0
 
  real    :: tmp, del
  integer :: ind, i, j
@@ -1779,7 +1847,7 @@
        del = tmp-dtres*real(ind)
        esat(i,j) = TABLE3(ind+1) + &
                    del*(DTABLE3(ind+1) + del*D2TABLE3(ind+1))
-       desat(i,j) = DTABLE3(ind+1) + 2.*del*D2TABLE3(ind+1)
+       desat(i,j) = DTABLE3(ind+1) + two*del*D2TABLE3(ind+1)
      endif
    enddo
    enddo
@@ -1792,6 +1860,8 @@
  real, intent(in),  dimension(:)  :: temp
  real, intent(out), dimension(:)  :: esat, desat
  integer, intent(out)             :: nbad
+
+ real, parameter :: two=2.0
 
  real    :: tmp, del
  integer :: ind, i
@@ -1806,7 +1876,7 @@
        del = tmp-dtres*real(ind)
        esat(i) = TABLE3(ind+1) + &
                    del*(DTABLE3(ind+1) + del*D2TABLE3(ind+1))
-       desat(i) = DTABLE3(ind+1) + 2.*del*D2TABLE3(ind+1)
+       desat(i) = DTABLE3(ind+1) + two*del*D2TABLE3(ind+1)
      endif
    enddo
 
@@ -1818,6 +1888,8 @@
  real, intent(in)     :: temp
  real, intent(out)    :: esat, desat
  integer, intent(out) :: nbad
+
+ real, parameter :: two=2.0
 
  real    :: tmp, del
  integer :: ind
@@ -1831,7 +1903,7 @@
      del = tmp-dtres*real(ind)
      esat = TABLE3(ind+1) + &
             del*(DTABLE3(ind+1) + del*D2TABLE3(ind+1))
-     desat = DTABLE3(ind+1) + 2.*del*D2TABLE3(ind+1)
+     desat = DTABLE3(ind+1) + two*del*D2TABLE3(ind+1)
    endif
 
  end subroutine lookup_es3_des3_k_0d
@@ -1870,6 +1942,9 @@
  real, intent(in),  dimension(:,:,:)  :: temp
  real, intent(out), dimension(:,:,:)  :: desat
  integer, intent(out) :: nbad
+
+ real, parameter :: two=2.0
+
  real    :: tmp, del
  integer :: ind, i, j, k
 
@@ -1883,7 +1958,7 @@
        nbad = nbad+1
      else
        del = tmp-dtres*real(ind)
-       desat(i,j,k) = DTABLE3(ind+1) + 2.*del*D2TABLE3(ind+1)
+       desat(i,j,k) = DTABLE3(ind+1) + two*del*D2TABLE3(ind+1)
      endif
    enddo
    enddo
@@ -1896,6 +1971,9 @@
  real, intent(in),  dimension(:,:)  :: temp
  real, intent(out), dimension(:,:)  :: desat
  integer, intent(out) :: nbad
+
+ real, parameter :: two=2.0
+
  real    :: tmp, del
  integer :: ind, i, j
 
@@ -1908,7 +1986,7 @@
        nbad = nbad+1
      else
        del = tmp-dtres*real(ind)
-       desat(i,j) = DTABLE3(ind+1) + 2.*del*D2TABLE3(ind+1)
+       desat(i,j) = DTABLE3(ind+1) + two*del*D2TABLE3(ind+1)
      endif
    enddo
    enddo
@@ -1943,6 +2021,9 @@
  real, intent(in),  dimension(:)  :: temp
  real, intent(out), dimension(:)  :: desat
  integer, intent(out) :: nbad
+
+ real, parameter :: two=2.0
+
  real    :: tmp, del
  integer :: ind, i
 
@@ -1954,7 +2035,7 @@
        nbad = nbad+1
      else
        del = tmp-dtres*real(ind)
-       desat(i) = DTABLE3(ind+1) + 2.*del*D2TABLE3(ind+1)
+       desat(i) = DTABLE3(ind+1) + two*del*D2TABLE3(ind+1)
      endif
    enddo
 
@@ -1985,6 +2066,9 @@
  real, intent(in)     :: temp
  real, intent(out)    :: desat
  integer, intent(out) :: nbad
+
+ real, parameter :: two=2.0
+
  real    :: tmp, del
  integer :: ind
 
@@ -1995,7 +2079,7 @@
      nbad = nbad+1
    else
      del = tmp-dtres*real(ind)
-     desat = DTABLE3(ind+1) + 2.*del*D2TABLE3(ind+1)
+     desat = DTABLE3(ind+1) + two*del*D2TABLE3(ind+1)
    endif
 
  end subroutine lookup_des3_k_0d

--- a/sat_vapor_pres/sat_vapor_pres_k.F90
+++ b/sat_vapor_pres/sat_vapor_pres_k.F90
@@ -253,7 +253,7 @@
 
         do i = 1, table_size
           tem(1) = tminl + dtres*real(i-1)
-          TABLE(i) = ES0*real(610.78,FMS_SP_KIND_)*exp(-hlv/rvgas*(one/tem(1) - one/tfreeze))
+          TABLE(i) = ES0*610.78*exp(-hlv/rvgas*(one/tem(1) - one/tfreeze))
           DTABLE(i) = hlv*TABLE(i)/rvgas/tem(1)**2.
         enddo
 


### PR DESCRIPTION
**Description**
In this PR, several numerical values used frequently in `sat_vapor_pres_k.F90` (e.g., 0.0, 1.0, 0.5, 0.25, 2.0.) are replaced with variables that are declared as real parameters.  It is expected that these changes will make the code  easier to comprehend with the mixed-mode updates.  

Fixes # (issue)

**How Has This Been Tested?**
make run successfully with Intel and GCC

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

