### PR TITLE
add compiler support to readme and fix some compiler bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,26 @@ The following external libraries are required when building libFMS
 Please see the [Build and Installation page](http://noaa-gfdl.github.io/FMS/build.html)
 for more information on building with each build system.
 
+## Compiler Support
+
+For most production environments and large scale regression testing, FMS is currently compiled with the
+Intel classic compiler (ifort) but will be transitioning to the llvm-based ifx intel compiler when it is
+available for production.
+
+Below shows the status of our compiler support for various compilers and versions. Testing was done on
+CentOS 8, with additional testing on Gaea using a cray SLES system.
+Compilers used in our Github continuous integration testing are in bold.
+
+|Compiler                | Version |Builds Successfully | Unit Testing |
+|------------------------|---------|--------------------|---------------------|
+|**intel classic(ifort)**| 2021.6.0| yes                | passes              |
+|**GNU (gfortran)**      | 9.3.0   | yes                | passes              |
+|intel oneapi (ifx)      | 2021.6.0| yes                | passes              |
+|GNU (gfortran)          | 11.2.0  | yes                | passes              |
+|HP/Cray (cce)           | 9.1.1   | yes                | not passing         |
+|Nvidia/PGI(nvfortran)   | 22.9-0  | no                 | not passing         |
+|AMD (aocc)              | 3.2.0   | yes                | TODO                |
+
 ## Documentation
 
 Source code documentation for the FMS code base is available at http://noaa-gfdl.github.io/FMS.

--- a/README.md
+++ b/README.md
@@ -84,17 +84,18 @@ Intel classic compiler (ifort) but will be transitioning to the llvm-based ifx i
 available for production.
 
 Below shows the status of our compiler support for various compilers and versions. Testing was done on
-CentOS 8, with additional testing on Gaea using a cray SLES system.
+CentOS 8, with additional testing using a larger cray SLES system. MPICH is used as the MPI library
+except for the intel compilers, which use intel's mpi library.
 Compilers used in our Github continuous integration testing are in bold.
 
-|Compiler                | Version |Builds Successfully        | Unit Testing |
+|Compiler                | Version |Builds Successfully        | Unit Testing        |
 |------------------------|---------|---------------------------|---------------------|
 |**intel classic(ifort)**| 2021.6.0| yes                       | passes              |
 |**GNU (gfortran)**      | 9.3.0   | yes                       | passes              |
 |intel oneapi (ifx)      | 2021.6.0| yes                       | passes              |
 |GNU (gfortran)          | 11.2.0  | yes                       | passes              |
 |HP/Cray (cce)           | 9.1.1   | yes                       | not passing         |
-|Nvidia/PGI(nvfortran)   | 22.9-0  | no                        | not passing         |
+|Nvidia/PGI(nvfortran)   | 22.9    | no                        | not passing         |
 |AMD (aocc)              | 3.2.0   | no(compiles,fails to link)| not passing         |
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -87,15 +87,15 @@ Below shows the status of our compiler support for various compilers and version
 CentOS 8, with additional testing on Gaea using a cray SLES system.
 Compilers used in our Github continuous integration testing are in bold.
 
-|Compiler                | Version |Builds Successfully | Unit Testing |
-|------------------------|---------|--------------------|---------------------|
-|**intel classic(ifort)**| 2021.6.0| yes                | passes              |
-|**GNU (gfortran)**      | 9.3.0   | yes                | passes              |
-|intel oneapi (ifx)      | 2021.6.0| yes                | passes              |
-|GNU (gfortran)          | 11.2.0  | yes                | passes              |
-|HP/Cray (cce)           | 9.1.1   | yes                | not passing         |
-|Nvidia/PGI(nvfortran)   | 22.9-0  | no                 | not passing         |
-|AMD (aocc)              | 3.2.0   | yes                | TODO                |
+|Compiler                | Version |Builds Successfully        | Unit Testing |
+|------------------------|---------|---------------------------|---------------------|
+|**intel classic(ifort)**| 2021.6.0| yes                       | passes              |
+|**GNU (gfortran)**      | 9.3.0   | yes                       | passes              |
+|intel oneapi (ifx)      | 2021.6.0| yes                       | passes              |
+|GNU (gfortran)          | 11.2.0  | yes                       | passes              |
+|HP/Cray (cce)           | 9.1.1   | yes                       | not passing         |
+|Nvidia/PGI(nvfortran)   | 22.9-0  | no                        | not passing         |
+|AMD (aocc)              | 3.2.0   | no(compiles,fails to link)| not passing         |
 
 ## Documentation
 

--- a/parser/yaml_output_functions.c
+++ b/parser/yaml_output_functions.c
@@ -395,7 +395,8 @@ void write_yaml_from_struct_3 (char *yamlname, int asize, struct fmsyamloutkeys 
   char* curr_topkey = topkeys->level2key;
 
   /* loop through the top level 2 keys */
-  for (int top_ind=0; top_ind < topkeys->level2key_offset; top_ind++) {
+  int top_ind;
+  for (top_ind=0; top_ind < topkeys->level2key_offset; top_ind++) {
     /* Start the secodn level event */
     yaml_scalar_event_initialize(&event, NULL, (yaml_char_t *)YAML_STR_TAG,
       				 (yaml_char_t *)curr_topkey, strlen(curr_topkey), 1, 0,
@@ -412,7 +413,8 @@ void write_yaml_from_struct_3 (char *yamlname, int asize, struct fmsyamloutkeys 
 	    return;
     }
     /* loop through the structs for this key*/
-    for (int s2 = 0 ; s2 < lvl2keyeach[top_ind]; s2++){
+    int s2;
+    for (s2 = 0 ; s2 < lvl2keyeach[top_ind]; s2++){
       yaml_mapping_start_event_initialize(&event, NULL, (yaml_char_t *)YAML_MAP_TAG,
         				  1, YAML_ANY_MAPPING_STYLE);
       if (!yaml_emitter_emit(&emitter, &event)){
@@ -424,7 +426,8 @@ void write_yaml_from_struct_3 (char *yamlname, int asize, struct fmsyamloutkeys 
 
       /* Next level keys */
       char * curr_l2key = (&l2keys[s2count])->level2key;
-      for (int l2_ind = 0; l2_ind < (&l2keys[s2count])->level2key_offset; l2_ind++) {
+      int l2_ind;
+      for (l2_ind = 0; l2_ind < (&l2keys[s2count])->level2key_offset; l2_ind++) {
         /* Start the third level event */
      	  yaml_scalar_event_initialize(&event, NULL, (yaml_char_t *)YAML_STR_TAG,
      		                            (yaml_char_t *)curr_l2key, strlen(curr_l2key), 1, 0,
@@ -444,7 +447,8 @@ void write_yaml_from_struct_3 (char *yamlname, int asize, struct fmsyamloutkeys 
         int s3start = s3count;
         int s3end = s3start + n3each[i_n3];
         i_n3++;
-        for (int s3 = s3start ; s3 < s3end ; s3++){
+        int s3;
+        for (s3 = s3start ; s3 < s3end ; s3++){
           yaml_mapping_start_event_initialize(&event, NULL, (yaml_char_t *)YAML_MAP_TAG,
                     1, YAML_ANY_MAPPING_STYLE);
           if (!yaml_emitter_emit(&emitter, &event)){

--- a/test_fms/mpp/test_mpp_chksum.F90
+++ b/test_fms/mpp/test_mpp_chksum.F90
@@ -53,7 +53,7 @@ program test_mpp_chksum
     call mpp_error(FATAL, 'test_mpp_chksum: invalid test number given')
   endif
 
-  call MPI_FINALIZE
+  call mpp_exit
 
   contains
   !> tests mixed precision checksums with ints


### PR DESCRIPTION
**Description**
Adds a little compiler support section to the readme with a chart for whether fms builds and tests without error on different compilers. Let me know if you think it needs any more info

Also puts in two small fixes for compiler bugs:
- one line fix for failures coming from the mpp_checksum test with more recent gnu versions
- fixes a compilation error with intel's llvm based c compiler (var declarations in for loops typically aren't allowed in c, not sure why the other compilers allowed it)

**How Has This Been Tested?**
amd box + on gaea

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

