### PR TITLE
Insert OpenMP directive, single, around allocation region of module level variables

### DIFF
--- a/tridiagonal/tridiagonal.F90
+++ b/tridiagonal/tridiagonal.F90
@@ -80,8 +80,6 @@ subroutine tri_invert(x,d,a,b,c)
 
 implicit none
 
-real, allocatable, dimension(:,:,:) :: e,g,cc !< Local instead of global to the module
-real, allocatable, dimension(:,:)   :: bb     !< Local instead of global to the module
 real, intent(out), dimension(:,:,:) :: x !< Solution to the tridiagonal system of equations
 real, intent(in),  dimension(:,:,:) :: d !< The right-hand side term, see the schematic above.
 real, optional,    dimension(:,:,:) :: a,b,c !< Left hand side terms(see schematic above).

--- a/tridiagonal/tridiagonal.F90
+++ b/tridiagonal/tridiagonal.F90
@@ -60,8 +60,8 @@
 module tridiagonal_mod
 
 !--------------------------------------------------------------------------
-real,    private, allocatable, dimension(:,:,:) :: e,g,cc
-real,    private, allocatable, dimension(:,:)   :: bb
+!real,    private, allocatable, dimension(:,:,:) :: e,g,cc !< Make local to subroutine below
+!real,    private, allocatable, dimension(:,:)   :: bb     !< Make local to subroutine below
 logical, private :: init_tridiagonal = .false.
 !--------------------------------------------------------------------------
 
@@ -80,6 +80,8 @@ subroutine tri_invert(x,d,a,b,c)
 
 implicit none
 
+real, allocatable, dimension(:,:,:) :: e,g,cc !< Local instead of global to the module
+real, allocatable, dimension(:,:)   :: bb     !< Local instead of global to the module
 real, intent(out), dimension(:,:,:) :: x !< Solution to the tridiagonal system of equations
 real, intent(in),  dimension(:,:,:) :: d !< The right-hand side term, see the schematic above.
 real, optional,    dimension(:,:,:) :: a,b,c !< Left hand side terms(see schematic above).
@@ -88,17 +90,13 @@ real, optional,    dimension(:,:,:) :: a,b,c !< Left hand side terms(see schemat
 real, dimension(size(x,1),size(x,2),size(x,3)) :: f
 integer :: k
 
+allocate(e (size(x,1),size(x,2),size(x,3)))
+allocate(g (size(x,1),size(x,2),size(x,3)))
+allocate(bb(size(x,1),size(x,2)))
+allocate(cc(size(x,1),size(x,2),size(x,3)))
+
 if(present(a)) then
   init_tridiagonal = .true.
-
-  if(allocated(e))     deallocate(e)
-  if(allocated(g))     deallocate(g)
-  if(allocated(bb))    deallocate(bb)
-  if(allocated(cc))    deallocate(cc)
-  allocate(e (size(x,1),size(x,2),size(x,3)))
-  allocate(g (size(x,1),size(x,2),size(x,3)))
-  allocate(bb(size(x,1),size(x,2)))
-  allocate(cc(size(x,1),size(x,2),size(x,3)))
 
   e(:,:,1) = - a(:,:,1)/b(:,:,1)
   a(:,:,size(x,3)) = 0.0
@@ -124,6 +122,11 @@ do k = size(x,3)-1,1,-1
   x(:,:,k) = e(:,:,k)*x(:,:,k+1)+f(:,:,k)
 end do
 
+if(allocated(e)) deallocate(e)
+if(allocated(g)) deallocate(g)
+if(allocated(bb)) deallocate(bb)
+if(allocated(cc)) deallocate(cc)
+
 return
 end subroutine tri_invert
 
@@ -133,11 +136,6 @@ end subroutine tri_invert
 subroutine close_tridiagonal
 
 implicit none
-
-deallocate(e)
-deallocate(g)
-deallocate(bb)
-deallocate(cc)
 
 return
 end subroutine close_tridiagonal

--- a/tridiagonal/tridiagonal.F90
+++ b/tridiagonal/tridiagonal.F90
@@ -59,9 +59,11 @@
 !> @{
 module tridiagonal_mod
 
+use OMP_LIB
+
 !--------------------------------------------------------------------------
 real,    private, allocatable, dimension(:,:,:) :: e,g,cc
-real,    private, allocatable, dimension(:,:)   :: bb 
+real,    private, allocatable, dimension(:,:)   :: bb
 logical, private :: init_tridiagonal = .false.
 !--------------------------------------------------------------------------
 
@@ -90,7 +92,7 @@ integer :: k
 
 if(present(a)) then
   init_tridiagonal = .true.
-  
+
   if(allocated(e))     deallocate(e)
   if(allocated(g))     deallocate(g)
   if(allocated(bb))    deallocate(bb)
@@ -134,11 +136,14 @@ subroutine close_tridiagonal
 
 implicit none
 
-!> @brief Check if module variables are allocated
+!$OMP BARRIER
+!< Check if module variables are allocated
+!$OMP CRITICAL
 if(allocated(e)) deallocate(e)
 if(allocated(g)) deallocate(g)
 if(allocated(bb)) deallocate(bb)
 if(allocated(cc)) deallocate(cc)
+!$OMP END CRITICAL
 
 return
 end subroutine close_tridiagonal

--- a/tridiagonal/tridiagonal.F90
+++ b/tridiagonal/tridiagonal.F90
@@ -143,7 +143,7 @@ if(allocated(e)) deallocate(e)
 if(allocated(g)) deallocate(g)
 if(allocated(bb)) deallocate(bb)
 if(allocated(cc)) deallocate(cc)
-!$OMP END SINGLE !< There is an implicit barrier 
+!$OMP END SINGLE !< There is an implicit barrier
 
 return
 end subroutine close_tridiagonal

--- a/tridiagonal/tridiagonal.F90
+++ b/tridiagonal/tridiagonal.F90
@@ -60,8 +60,8 @@
 module tridiagonal_mod
 
 !--------------------------------------------------------------------------
-real,    private, allocatable, dimension(:,:,:) :: e,g,cc !< Make local to subroutine below
-real,    private, allocatable, dimension(:,:)   :: bb     !< Make local to subroutine below
+real,    private, allocatable, dimension(:,:,:) :: e,g,cc 
+real,    private, allocatable, dimension(:,:)   :: bb     
 logical, private :: init_tridiagonal = .false.
 !--------------------------------------------------------------------------
 
@@ -91,6 +91,10 @@ integer :: k
 if(present(a)) then
   init_tridiagonal = .true.
   
+  if(allocated(e))     deallocate(e)
+  if(allocated(g))     deallocate(g)
+  if(allocated(bb))    deallocate(bb)
+  if(allocated(cc))    deallocate(cc)
   allocate(e (size(x,1),size(x,2),size(x,3)))
   allocate(g (size(x,1),size(x,2),size(x,3)))
   allocate(bb(size(x,1),size(x,2)))

--- a/tridiagonal/tridiagonal.F90
+++ b/tridiagonal/tridiagonal.F90
@@ -60,8 +60,8 @@
 module tridiagonal_mod
 
 !--------------------------------------------------------------------------
-real,    private, allocatable, dimension(:,:,:) :: e,g,cc 
-real,    private, allocatable, dimension(:,:)   :: bb     
+real,    private, allocatable, dimension(:,:,:) :: e,g,cc
+real,    private, allocatable, dimension(:,:)   :: bb 
 logical, private :: init_tridiagonal = .false.
 !--------------------------------------------------------------------------
 

--- a/tridiagonal/tridiagonal.F90
+++ b/tridiagonal/tridiagonal.F90
@@ -90,7 +90,7 @@ integer :: k
 
 if(present(a)) then
   init_tridiagonal = .true.
-  
+
   !< Check if module variables are allocated
   !$OMP SINGLE
   if(allocated(e))     deallocate(e)
@@ -101,7 +101,7 @@ if(present(a)) then
   allocate(g (size(x,1),size(x,2),size(x,3)))
   allocate(bb(size(x,1),size(x,2)))
   allocate(cc(size(x,1),size(x,2),size(x,3)))
-  !$OMP END SINGLE !< There is an implicit barrier
+  !$OMP END SINGLE !< There is an implicit barrier.
 
   e(:,:,1) = - a(:,:,1)/b(:,:,1)
   a(:,:,size(x,3)) = 0.0
@@ -135,15 +135,15 @@ end subroutine tri_invert
 !> @brief Releases memory used by the solver
 subroutine close_tridiagonal
 
-implicit none
+  implicit none
 
-!< Check if module variables are allocated
-!$OMP SINGLE
-if(allocated(e)) deallocate(e)
-if(allocated(g)) deallocate(g)
-if(allocated(bb)) deallocate(bb)
-if(allocated(cc)) deallocate(cc)
-!$OMP END SINGLE !< There is an implicit barrier
+  !< Check if module variables are allocated
+  !$OMP SINGLE
+  if(allocated(e)) deallocate(e)
+  if(allocated(g)) deallocate(g)
+  if(allocated(bb)) deallocate(bb)
+  if(allocated(cc)) deallocate(cc)
+  !$OMP END SINGLE !< There is an implicit barrier.
 
 return
 end subroutine close_tridiagonal

--- a/tridiagonal/tridiagonal.F90
+++ b/tridiagonal/tridiagonal.F90
@@ -59,8 +59,6 @@
 !> @{
 module tridiagonal_mod
 
-use OMP_LIB
-
 !--------------------------------------------------------------------------
 real,    private, allocatable, dimension(:,:,:) :: e,g,cc
 real,    private, allocatable, dimension(:,:)   :: bb

--- a/tridiagonal/tridiagonal.F90
+++ b/tridiagonal/tridiagonal.F90
@@ -60,8 +60,8 @@
 module tridiagonal_mod
 
 !--------------------------------------------------------------------------
-!real,    private, allocatable, dimension(:,:,:) :: e,g,cc !< Make local to subroutine below
-!real,    private, allocatable, dimension(:,:)   :: bb     !< Make local to subroutine below
+real,    private, allocatable, dimension(:,:,:) :: e,g,cc !< Make local to subroutine below
+real,    private, allocatable, dimension(:,:)   :: bb     !< Make local to subroutine below
 logical, private :: init_tridiagonal = .false.
 !--------------------------------------------------------------------------
 
@@ -90,13 +90,13 @@ real, optional,    dimension(:,:,:) :: a,b,c !< Left hand side terms(see schemat
 real, dimension(size(x,1),size(x,2),size(x,3)) :: f
 integer :: k
 
-allocate(e (size(x,1),size(x,2),size(x,3)))
-allocate(g (size(x,1),size(x,2),size(x,3)))
-allocate(bb(size(x,1),size(x,2)))
-allocate(cc(size(x,1),size(x,2),size(x,3)))
-
 if(present(a)) then
   init_tridiagonal = .true.
+  
+  allocate(e (size(x,1),size(x,2),size(x,3)))
+  allocate(g (size(x,1),size(x,2),size(x,3)))
+  allocate(bb(size(x,1),size(x,2)))
+  allocate(cc(size(x,1),size(x,2),size(x,3)))
 
   e(:,:,1) = - a(:,:,1)/b(:,:,1)
   a(:,:,size(x,3)) = 0.0
@@ -122,11 +122,6 @@ do k = size(x,3)-1,1,-1
   x(:,:,k) = e(:,:,k)*x(:,:,k+1)+f(:,:,k)
 end do
 
-if(allocated(e)) deallocate(e)
-if(allocated(g)) deallocate(g)
-if(allocated(bb)) deallocate(bb)
-if(allocated(cc)) deallocate(cc)
-
 return
 end subroutine tri_invert
 
@@ -136,6 +131,12 @@ end subroutine tri_invert
 subroutine close_tridiagonal
 
 implicit none
+
+!> @brief Check if module variables are allocated
+if(allocated(e)) deallocate(e)
+if(allocated(g)) deallocate(g)
+if(allocated(bb)) deallocate(bb)
+if(allocated(cc)) deallocate(cc)
 
 return
 end subroutine close_tridiagonal

--- a/tridiagonal/tridiagonal.F90
+++ b/tridiagonal/tridiagonal.F90
@@ -91,6 +91,9 @@ integer :: k
 if(present(a)) then
   init_tridiagonal = .true.
 
+  !$OMP BARRIER
+  !< Check if module variables are allocated
+  !$OMP CRITICAL
   if(allocated(e))     deallocate(e)
   if(allocated(g))     deallocate(g)
   if(allocated(bb))    deallocate(bb)
@@ -99,6 +102,7 @@ if(present(a)) then
   allocate(g (size(x,1),size(x,2),size(x,3)))
   allocate(bb(size(x,1),size(x,2)))
   allocate(cc(size(x,1),size(x,2),size(x,3)))
+  !$OMP END CRITICAL
 
   e(:,:,1) = - a(:,:,1)/b(:,:,1)
   a(:,:,size(x,3)) = 0.0

--- a/tridiagonal/tridiagonal.F90
+++ b/tridiagonal/tridiagonal.F90
@@ -90,10 +90,9 @@ integer :: k
 
 if(present(a)) then
   init_tridiagonal = .true.
-
-  !$OMP BARRIER
+  
   !< Check if module variables are allocated
-  !$OMP CRITICAL
+  !$OMP SINGLE
   if(allocated(e))     deallocate(e)
   if(allocated(g))     deallocate(g)
   if(allocated(bb))    deallocate(bb)
@@ -102,7 +101,7 @@ if(present(a)) then
   allocate(g (size(x,1),size(x,2),size(x,3)))
   allocate(bb(size(x,1),size(x,2)))
   allocate(cc(size(x,1),size(x,2),size(x,3)))
-  !$OMP END CRITICAL
+  !$OMP END SINGLE !< There is an implicit barrier
 
   e(:,:,1) = - a(:,:,1)/b(:,:,1)
   a(:,:,size(x,3)) = 0.0
@@ -138,14 +137,13 @@ subroutine close_tridiagonal
 
 implicit none
 
-!$OMP BARRIER
 !< Check if module variables are allocated
-!$OMP CRITICAL
+!$OMP SINGLE
 if(allocated(e)) deallocate(e)
 if(allocated(g)) deallocate(g)
 if(allocated(bb)) deallocate(bb)
 if(allocated(cc)) deallocate(cc)
-!$OMP END CRITICAL
+!$OMP END SINGLE !< There is an implicit barrier 
 
 return
 end subroutine close_tridiagonal

--- a/tridiagonal/tridiagonal.F90
+++ b/tridiagonal/tridiagonal.F90
@@ -89,10 +89,10 @@ real, dimension(size(x,1),size(x,2),size(x,3)) :: f
 integer :: k
 
 if(present(a)) then
-  init_tridiagonal = .true.
 
   !< Check if module variables are allocated
   !$OMP SINGLE
+  init_tridiagonal = .true.
   if(allocated(e))     deallocate(e)
   if(allocated(g))     deallocate(g)
   if(allocated(bb))    deallocate(bb)


### PR DESCRIPTION
**Description**
This update relates to race condition due to multiple threads accessing module level variables, 'e', 'g', 'cc', and 'bb' at the same time. The OpenMP directive, 'single', is inserted around the deallocation/allocation regions to avoid the race condition.

Fixes #1108 

**How Has This Been Tested?**
The update was tested with 'make check' and 'make distcheck' without any issues on OS, 'CentOS Stream 8'. The following setup was used for compiler, MPI wrapper, and required packages:
- oneapi v2022.2
- hdf5 v1.12.0
- tbb v2021.6.0
- oclfpga v2022.1.0
- netcdf v4.8.0
- mpi v2021.6.0 (Intel(R) MPI Library 2021.6)
- compiler-rt v2022.1.0
- compiler v2022.1.0

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

