### PR TITLE
log_diag_field_info updates for main

### DIFF
--- a/diag_manager/diag_manager.F90
+++ b/diag_manager/diag_manager.F90
@@ -3667,7 +3667,7 @@ CONTAINS
          & max_input_fields, max_axes, do_diag_field_log, write_bytes_in_file, debug_diag_manager,&
          & max_num_axis_sets, max_files, use_cmor, issue_oor_warnings,&
          & oor_warnings_fatal, max_out_per_in_field, flush_nc_files, region_out_use_alt_value, max_field_attributes,&
-         & max_file_attributes, max_axis_attributes, prepend_date, field_log_separator
+         & max_file_attributes, max_axis_attributes, prepend_date, use_mpp_io, field_log_separator
 
     ! If the module was already initialized do nothing
     IF ( module_is_initialized ) RETURN
@@ -3758,13 +3758,13 @@ CONTAINS
     END DO
     ALLOCATE(files(max_files))
     if (.not.use_mpp_io) then
-    ALLOCATE(fileobjU(max_files))
-    ALLOCATE(fileobj(max_files))
-    ALLOCATE(fileobjND(max_files))
-    ALLOCATE(fnum_for_domain(max_files))
-    !> Initialize fnum_for_domain with "dn" which stands for done
-    fnum_for_domain(:) = "dn"
-       CALL error_mesg('diag_manager_mod::diag_manager_init',&
+      ALLOCATE(fileobjU(max_files))
+      ALLOCATE(fileobj(max_files))
+      ALLOCATE(fileobjND(max_files))
+      ALLOCATE(fnum_for_domain(max_files))
+      !> Initialize fnum_for_domain with "dn" which stands for done
+      fnum_for_domain(:) = "dn"
+      CALL error_mesg('diag_manager_mod::diag_manager_init',&
                & 'diag_manager is using fms2_io', NOTE)
     else
        CALL error_mesg('diag_manager_mod::diag_manager_init',&
@@ -3787,11 +3787,11 @@ CONTAINS
        END IF
     END IF
 
-     CALL parse_diag_table(DIAG_SUBSET=diag_subset_output, ISTAT=mystat, ERR_MSG=err_msg_local)
-     IF ( mystat /= 0 ) THEN
+   CALL parse_diag_table(DIAG_SUBSET=diag_subset_output, ISTAT=mystat, ERR_MSG=err_msg_local)
+   IF ( mystat /= 0 ) THEN
        IF ( fms_error_handler('diag_manager_mod::diag_manager_init',&
             & 'Error parsing diag_table. '//TRIM(err_msg_local), err_msg) ) RETURN
-     END IF
+   END IF
 
     !initialize files%bytes_written to zero
     files(:)%bytes_written = 0
@@ -4080,7 +4080,7 @@ CONTAINS
     CHARACTER(len=*), INTENT(in) :: att_name !< new attribute name
     REAL, INTENT(in) :: att_value !< new attribute value
 
-      CALL diag_field_add_attribute_r1d(diag_field_id, att_name, (/ att_value /))
+    CALL diag_field_add_attribute_r1d(diag_field_id, att_name, (/ att_value /))
   END SUBROUTINE diag_field_add_attribute_scalar_r
 
   !> @brief Add a scalar integer attribute to the diag field corresponding to a given id
@@ -4089,7 +4089,7 @@ CONTAINS
     CHARACTER(len=*), INTENT(in) :: att_name !< new attribute name
     INTEGER, INTENT(in) :: att_value !< new attribute value
 
-      CALL diag_field_add_attribute_i1d(diag_field_id, att_name, (/ att_value /))
+    CALL diag_field_add_attribute_i1d(diag_field_id, att_name, (/ att_value /))
   END SUBROUTINE diag_field_add_attribute_scalar_i
 
   !> @brief Add a scalar character attribute to the diag field corresponding to a given id
@@ -4098,7 +4098,7 @@ CONTAINS
     CHARACTER(len=*), INTENT(in) :: att_name !< new attribute name
     CHARACTER(len=*), INTENT(in) :: att_value !< new attribute value
 
-      CALL diag_field_attribute_init(diag_field_id, att_name, NF90_CHAR, cval=att_value)
+    CALL diag_field_attribute_init(diag_field_id, att_name, NF90_CHAR, cval=att_value)
   END SUBROUTINE diag_field_add_attribute_scalar_c
 
   !> @brief Add a real 1D array attribute to the diag field corresponding to a given id
@@ -4107,7 +4107,7 @@ CONTAINS
     CHARACTER(len=*), INTENT(in) :: att_name !< new attribute name
     REAL, DIMENSION(:), INTENT(in) :: att_value !< new attribute value
 
-      CALL diag_field_attribute_init(diag_field_id, att_name, NF90_FLOAT, rval=att_value)
+    CALL diag_field_attribute_init(diag_field_id, att_name, NF90_FLOAT, rval=att_value)
   END SUBROUTINE diag_field_add_attribute_r1d
 
   !> @brief Add an integer 1D array attribute to the diag field corresponding to a given id
@@ -4116,7 +4116,7 @@ CONTAINS
     CHARACTER(len=*), INTENT(in) :: att_name !< new attribute name
     INTEGER, DIMENSION(:), INTENT(in) :: att_value !< new attribute value
 
-      CALL diag_field_attribute_init(diag_field_id, att_name, NF90_INT, ival=att_value)
+    CALL diag_field_attribute_init(diag_field_id, att_name, NF90_INT, ival=att_value)
   END SUBROUTINE diag_field_add_attribute_i1d
 
   !> @brief Add the cell_measures attribute to a diag out field

--- a/diag_manager/diag_manager.F90
+++ b/diag_manager/diag_manager.F90
@@ -208,7 +208,7 @@ use platform_mod
        & get_ticks_per_second
   USE mpp_mod, ONLY: mpp_get_current_pelist, mpp_pe, mpp_npes, mpp_root_pe, mpp_sum
 
-  USE mpp_mod, ONLY: input_nml_file, mpp_error
+  USE mpp_mod, ONLY: input_nml_file
 
   USE fms_mod, ONLY: error_mesg, FATAL, WARNING, NOTE, stdout, stdlog, write_version_number,&
        & fms_error_handler, check_nml_error, lowercase
@@ -643,7 +643,7 @@ CONTAINS
     ! Fatal error if the module has not been initialized.
     IF ( .NOT.module_is_initialized ) THEN
        ! <ERROR STATUS="FATAL">diag_manager has NOT been initialized</ERROR>
-       CALL mpp_error(FATAL, 'diag_manager_mod::register_static_field_old. diag_manager has NOT been initialized')
+       CALL error_mesg ('diag_manager_mod::register_static_field', 'diag_manager has NOT been initialized', FATAL)
     END IF
 
     ! Check if OPTIONAL parameters were passed in.
@@ -657,8 +657,8 @@ CONTAINS
           TYPE IS (real(kind=r8_kind))
              missing_value_use = real(missing_value)
           CLASS DEFAULT
-             CALL mpp_error (FATAL, 'diag_manager_mod::register_static_field. The missing_value is not one of '// &
-                                    'the supported types of real(kind=4) or real(kind=8)', FATAL)
+             CALL error_mesg ('diag_manager_mod::register_static_field',&
+                  & 'The missing_value is not one of the supported types of real(kind=4) or real(kind=8)', FATAL)
           END SELECT
        END IF
     END IF
@@ -3799,6 +3799,12 @@ CONTAINS
     ! open diag field log file
     IF ( do_diag_field_log.AND.mpp_pe().EQ.mpp_root_pe() ) THEN
       open(newunit=diag_log_unit, file='diag_field_log.out', action='WRITE')
+      WRITE (diag_log_unit,'(777a)') &
+           & 'Module',         FIELD_LOG_SEPARATOR, 'Field',     FIELD_LOG_SEPARATOR, &
+           & 'Long Name',      FIELD_LOG_SEPARATOR, 'Units',     FIELD_LOG_SEPARATOR, &
+           & 'Number of Axis', FIELD_LOG_SEPARATOR, 'Time Axis', FIELD_LOG_SEPARATOR, &
+           & 'Missing Value',  FIELD_LOG_SEPARATOR, 'Min Value', FIELD_LOG_SEPARATOR,  &
+           & 'Max Value',      FIELD_LOG_SEPARATOR, 'AXES LIST'
     END IF
 
     module_is_initialized = .TRUE.

--- a/diag_manager/diag_util.F90
+++ b/diag_manager/diag_util.F90
@@ -634,7 +634,7 @@ CONTAINS
     CHARACTER(len=*), INTENT(in) :: module_name !< Module name
     CHARACTER(len=*), INTENT(in) :: field_name !< Field name
     INTEGER, DIMENSION(:), INTENT(in) :: axes !< Axis IDs
-    CHARACTER(len=*), INTENT(in) :: axes_list !< Comma seperated list of axes names 
+    CHARACTER(len=*), INTENT(in) :: axes_list !< Comma seperated list of axes names
     CHARACTER(len=*), OPTIONAL, INTENT(in) :: long_name !< Long name for field.
     CHARACTER(len=*), OPTIONAL, INTENT(in) :: units !< Unit of field.
     CLASS(*), OPTIONAL, INTENT(in) :: missing_value !< Missing value value.


### PR DESCRIPTION
**Description**
This takes the changes from #1090 and adds any applicable changes to main instead of dmUpdate.

- Changes the log routine to be able to take an alternative separator (default is `|`) via a nml flag
- adds the axes list as an argument rather than retrieving the list during the routine.
- moves header write to first call instead of in diag_manager_init (still opened during init)

**How Has This Been Tested?**
oneapi 23, amd box

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

