### PR TITLE
Fix misspellings and rename variable in yaml_parser.F90

### DIFF
--- a/parser/yaml_parser.F90
+++ b/parser/yaml_parser.F90
@@ -266,11 +266,11 @@ subroutine get_value_from_key_0d(file_id, block_id, key_name, key_value, is_opti
 
    type(c_ptr) :: c_buffer !< c pointer with the value
    integer(kind=c_int) :: success !< Flag indicating if the value was obtained successfully
-   logical :: optional !< Flag indicating that the key was optional
+   logical :: optional_flag !< Flag indicating that the key was optional
    integer :: err_unit !< integer with io error
 
-   optional = .false.
-   if (present(is_optional)) optional = is_optional
+   optional_flag = .false.
+   if (present(is_optional)) optional_flag = is_optional
 
    if (.not. is_valid_file_id(file_id)) call mpp_error(FATAL, &
        &  "The file id in your get_value_from_key call is invalid! Check your call.")
@@ -313,7 +313,7 @@ subroutine get_value_from_key_0d(file_id, block_id, key_name, key_value, is_opti
                             &" is not supported. Only i4, i8, r4, r8 and strings are supported.")
      end select
    else
-     if(.not. optional) call mpp_error(FATAL, "Error getting the value for key:"//trim(key_name))
+     if(.not. optional_flag) call mpp_error(FATAL, "Error getting the value for key:"//trim(key_name))
    endif
 
 end subroutine get_value_from_key_0d
@@ -332,11 +332,11 @@ subroutine get_value_from_key_1d(file_id, block_id, key_name, key_value, is_opti
 
    type(c_ptr) :: c_buffer !< c pointer with the value
    integer(kind=c_int) :: success !< Flag indicating if the value was obtained successfully
-   logical :: optional !< Flag indicating that the key was optional
+   logical :: optional_flag !< Flag indicating that the key was optional
    integer :: err_unit !< integer with io error
 
-   optional=.false.
-   if (present(is_optional)) optional = is_optional
+   optional_flag=.false.
+   if (present(is_optional)) optional_flag = is_optional
 
    if (.not. is_valid_file_id(file_id)) call mpp_error(FATAL, &
        &  "The file id in your get_value_from_key call is invalid! Check your call.")
@@ -371,7 +371,7 @@ subroutine get_value_from_key_1d(file_id, block_id, key_name, key_value, is_opti
                             &" is not supported. Only i4, i8, r4, r8 and strings are supported.")
      end select
    else
-     if(.not. optional) call mpp_error(FATAL, "Error getting the value for key:"//trim(key_name))
+     if(.not. optional_flag) call mpp_error(FATAL, "Error getting the value for key:"//trim(key_name))
    endif
 end subroutine get_value_from_key_1d
 

--- a/parser/yaml_parser.F90
+++ b/parser/yaml_parser.F90
@@ -61,13 +61,13 @@ end interface get_value_from_key
 interface
 
 !> @brief Private c function that opens and parses a yaml file (see yaml_parser_binding.c)
-!! @return Flag indicating if the read was sucessful
+!! @return Flag indicating if the read was successful
 function open_and_parse_file_wrap(filename, file_id) bind(c) &
-   result(sucess)
+   result(success)
    use iso_c_binding, only: c_char, c_int, c_bool
    character(kind=c_char), intent(in) :: filename(*) !< Filename of the yaml file
    integer(kind=c_int), intent(out) :: file_id !< File id corresponding to the yaml file that was opened
-   logical(kind=c_bool) :: sucess !< Flag indicating if the read was sucessful
+   logical(kind=c_bool) :: success !< Flag indicating if the read was successful
 end function open_and_parse_file_wrap
 
 !> @brief Private c function that checks if a file_id is valid (see yaml_parser_binding.c)
@@ -129,14 +129,14 @@ end function get_value
 
 !> @brief Private c function that determines they value of a key in yaml_file (see yaml_parser_binding.c)
 !! @return c pointer with the value obtained
-function get_value_from_key_wrap(file_id, block_id, key_name, sucess) bind(c) &
+function get_value_from_key_wrap(file_id, block_id, key_name, success) bind(c) &
    result(key_value2)
 
    use iso_c_binding, only: c_ptr, c_char, c_int, c_bool
    integer(kind=c_int), intent(in) :: file_id !< File id of the yaml file to search
    integer(kind=c_int), intent(in) :: block_id !< ID corresponding to the block you want the key for
    character(kind=c_char), intent(in) :: key_name(*) !< Name of the key you want the value for
-   integer(kind=c_int), intent(out) :: sucess !< Flag indicating if the call was sucessful
+   integer(kind=c_int), intent(out) :: success !< Flag indicating if the call was successful
    type(c_ptr) :: key_value2
 end function get_value_from_key_wrap
 
@@ -206,7 +206,7 @@ function open_and_parse_file(filename) &
    result(file_id)
 
    character(len=*), intent(in) :: filename !< Filename of the yaml file
-   logical :: sucess !< Flag indicating if the read was sucessful
+   logical :: success !< Flag indicating if the read was successful
    logical :: yaml_exists !< Flag indicating whether the yaml exists
 
    integer :: file_id
@@ -217,8 +217,8 @@ function open_and_parse_file(filename) &
       call mpp_error(NOTE, "The yaml file:"//trim(filename)//" does not exist, hopefully this is your intent!")
       return
    end if
-   sucess = open_and_parse_file_wrap(trim(filename)//c_null_char, file_id)
-   if (.not. sucess) call mpp_error(FATAL, "Error opening the yaml file:"//trim(filename)//". Check the file!")
+   success = open_and_parse_file_wrap(trim(filename)//c_null_char, file_id)
+   if (.not. success) call mpp_error(FATAL, "Error opening the yaml file:"//trim(filename)//". Check the file!")
 
 end function open_and_parse_file
 
@@ -265,7 +265,7 @@ subroutine get_value_from_key_0d(file_id, block_id, key_name, key_value, is_opti
    character(len=255) :: buffer !< String buffer with the value
 
    type(c_ptr) :: c_buffer !< c pointer with the value
-   integer(kind=c_int) :: sucess !< Flag indicating if the value was obtained sucessfully
+   integer(kind=c_int) :: success !< Flag indicating if the value was obtained successfully
    logical :: optional !< Flag indicating that the key was optional
    integer :: err_unit !< integer with io error
 
@@ -277,8 +277,8 @@ subroutine get_value_from_key_0d(file_id, block_id, key_name, key_value, is_opti
    if (.not. is_valid_block_id(file_id, block_id)) call mpp_error(FATAL, &
        &  "The block id in your get_value_from_key call is invalid! Check your call.")
 
-   c_buffer = get_value_from_key_wrap(file_id, block_id, trim(key_name)//c_null_char, sucess)
-   if (sucess == 1) then
+   c_buffer = get_value_from_key_wrap(file_id, block_id, trim(key_name)//c_null_char, success)
+   if (success == 1) then
      buffer = fms_c2f_string(c_buffer)
 
      select type (key_value)
@@ -331,7 +331,7 @@ subroutine get_value_from_key_1d(file_id, block_id, key_name, key_value, is_opti
    character(len=255) :: buffer !< String buffer with the value
 
    type(c_ptr) :: c_buffer !< c pointer with the value
-   integer(kind=c_int) :: sucess !< Flag indicating if the value was obtained sucessfully
+   integer(kind=c_int) :: success !< Flag indicating if the value was obtained successfully
    logical :: optional !< Flag indicating that the key was optional
    integer :: err_unit !< integer with io error
 
@@ -343,8 +343,8 @@ subroutine get_value_from_key_1d(file_id, block_id, key_name, key_value, is_opti
    if (.not. is_valid_block_id(file_id, block_id)) call mpp_error(FATAL, &
        &  "The block id in your get_value_from_key call is invalid! Check your call.")
 
-   c_buffer = get_value_from_key_wrap(file_id, block_id, trim(key_name)//c_null_char, sucess)
-   if (sucess == 1) then
+   c_buffer = get_value_from_key_wrap(file_id, block_id, trim(key_name)//c_null_char, success)
+   if (success == 1) then
      buffer = fms_c2f_string(c_buffer)
 
      select type (key_value)

--- a/parser/yaml_parser.F90
+++ b/parser/yaml_parser.F90
@@ -127,7 +127,7 @@ function get_value(file_id, key_id) bind(c) &
    type(c_ptr) :: key_value
 end function get_value
 
-!> @brief Private c function that determines they value of a key in yaml_file (see yaml_parser_binding.c)
+!> @brief Private c function that determines the value of a key in yaml_file (see yaml_parser_binding.c)
 !! @return c pointer with the value obtained
 function get_value_from_key_wrap(file_id, block_id, key_name, success) bind(c) &
    result(key_value2)
@@ -258,7 +258,7 @@ subroutine get_value_from_key_0d(file_id, block_id, key_name, key_value, is_opti
    integer, intent(in) :: block_id !< ID corresponding to the block you want the key for
    character(len=*), intent(in) :: key_name !< Name of the key you want the value for
    class(*), intent(inout):: key_value !< Value of the key
-   logical, intent(in), optional :: is_optional !< Flag indicating if it is okay for they key to not exist.
+   logical, intent(in), optional :: is_optional !< Flag indicating if it is okay for the key to not exist.
                                                 !! If the key does not exist key_value will not be set, so it
                                                 !! is the user's responsibility to initialize it before the call
 
@@ -324,7 +324,7 @@ subroutine get_value_from_key_1d(file_id, block_id, key_name, key_value, is_opti
    integer, intent(in) :: block_id !< ID corresponding to the block you want the key for
    character(len=*), intent(in) :: key_name !< Name of the key you want the value for
    class(*), intent(inout):: key_value(:) !< Value of the key
-   logical, intent(in), optional :: is_optional !< Flag indicating if it is okay for they key' to not exist.
+   logical, intent(in), optional :: is_optional !< Flag indicating if it is okay for the key' to not exist.
                                                 !! If the key does not exist key_value will not be set, so it
                                                 !! is the user's responsibility to initialize it before the call
 


### PR DESCRIPTION
**Description**
A handful of misspellings in `yaml_parser.F90` have been fixed. The variable name `optional` has been changed to `optional_flag`, because `optional` is a Fortran keyword.

Fixes #974

**How Has This Been Tested?**
Project was configured with the `--with-yaml=yes` flag and compiled successfully.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] `make distcheck` passes