### PR TITLE
Removing unused arguments within FMS

### DIFF
--- a/amip_interp/amip_interp.F90
+++ b/amip_interp/amip_interp.F90
@@ -774,11 +774,11 @@ endif
 !#######################################################################
 
  !> @return A newly created @ref amip_interp_type
- function amip_interp_new_1d ( lon , lat , mask , use_climo, use_annual, &
+ function amip_interp_new_1d ( lon , lat , use_climo, use_annual, &
                                 interp_method ) result (Interp)
 
  real,    intent(in), dimension(:)   :: lon, lat
- logical, intent(in), dimension(:,:) :: mask
+ !logical, intent(in), dimension(:,:) :: mask
  character(len=*), intent(in), optional       :: interp_method
  logical, intent(in), optional       :: use_climo, use_annual
 
@@ -814,11 +814,11 @@ endif
    end function amip_interp_new_1d
 
  !> @return A newly created @ref amip_interp_type
- function amip_interp_new_2d ( lon , lat , mask , use_climo, use_annual, &
+ function amip_interp_new_2d ( lon , lat , use_climo, use_annual, &
                                 interp_method ) result (Interp)
 
  real,    intent(in), dimension(:,:)   :: lon, lat
- logical, intent(in), dimension(:,:) :: mask
+ !logical, intent(in), dimension(:,:) :: mask
  character(len=*), intent(in), optional :: interp_method
  logical, intent(in), optional       :: use_climo, use_annual
 

--- a/amip_interp/amip_interp.F90
+++ b/amip_interp/amip_interp.F90
@@ -778,7 +778,6 @@ endif
                                 interp_method ) result (Interp)
 
  real,    intent(in), dimension(:)   :: lon, lat
- !logical, intent(in), dimension(:,:) :: mask
  character(len=*), intent(in), optional       :: interp_method
  logical, intent(in), optional       :: use_climo, use_annual
 
@@ -818,7 +817,6 @@ endif
                                 interp_method ) result (Interp)
 
  real,    intent(in), dimension(:,:)   :: lon, lat
- !logical, intent(in), dimension(:,:) :: mask
  character(len=*), intent(in), optional :: interp_method
  logical, intent(in), optional       :: use_climo, use_annual
 

--- a/astronomy/astronomy.F90
+++ b/astronomy/astronomy.F90
@@ -1744,7 +1744,6 @@ subroutine annual_mean_solar_2d (lat, cosz, solar, fracday,  &
                                  rrsun)
 
 !--------------------------------------------------------------------
-!integer,                 intent(in)    :: js, je
 real, dimension(:,:),    intent(in)    :: lat
 real, dimension(:,:),    intent(out)   :: solar, cosz, fracday
 real,                    intent(out)   :: rrsun

--- a/astronomy/astronomy.F90
+++ b/astronomy/astronomy.F90
@@ -1740,7 +1740,7 @@ end subroutine daily_mean_solar_cal_0d
 !! (earth-sun distance squared)
 !! @param [out] <fracday> Daylight fraction of time interval
 !! @param [out] <rrsun> Earth-Sun distance (r) relative to semi-major axis of orbital ellipse (a):(a/r)**2
-subroutine annual_mean_solar_2d (js, je, lat, cosz, solar, fracday,  &
+subroutine annual_mean_solar_2d (lat, cosz, solar, fracday,  &
                                  rrsun)
 
 !--------------------------------------------------------------------

--- a/astronomy/astronomy.F90
+++ b/astronomy/astronomy.F90
@@ -1744,7 +1744,7 @@ subroutine annual_mean_solar_2d (lat, cosz, solar, fracday,  &
                                  rrsun)
 
 !--------------------------------------------------------------------
-integer,                 intent(in)    :: js, je
+!integer,                 intent(in)    :: js, je
 real, dimension(:,:),    intent(in)    :: lat
 real, dimension(:,:),    intent(out)   :: solar, cosz, fracday
 real,                    intent(out)   :: rrsun
@@ -1878,7 +1878,7 @@ real,               intent(out)    :: rrsun_out
 !--------------------------------------------------------------------
 !>    call annual_mean_solar_2d to calculate the astronomy fields.
 !--------------------------------------------------------------------
-        call annual_mean_solar_2d (jst, jnd, lat_2d, cosz_2d,   &
+        call annual_mean_solar_2d (lat_2d, cosz_2d,   &
                                    solar_2d, fracday_2d, rrsun)
 
 !-------------------------------------------------------------------
@@ -1941,7 +1941,7 @@ real, dimension(:), intent(out)    :: solar !< shortwave flux factor: cosine of 
 !--------------------------------------------------------------------
 !>    call annual_mean_solar_2d to calculate the astronomy fields.
 !--------------------------------------------------------------------
-        call annual_mean_solar_2d (jst, jnd, lat_2d, cosz_2d,   &
+        call annual_mean_solar_2d (lat_2d, cosz_2d,   &
                                    solar_2d, fracday_2d, rrsun)
 
 !-------------------------------------------------------------------

--- a/axis_utils/axis_utils.F90
+++ b/axis_utils/axis_utils.F90
@@ -145,8 +145,6 @@ contains
 
     type(axistype), intent(in) :: axis
     type(axistype), intent(inout) :: axis_bound
-    !type(axistype), intent(in), dimension(:) :: axes
-    !character(len=*), intent(inout), optional :: bnd_name
     character(len=*), intent(out), optional :: err_msg
 
     real, dimension(:), allocatable :: data, tmp

--- a/axis_utils/axis_utils.F90
+++ b/axis_utils/axis_utils.F90
@@ -141,12 +141,12 @@ contains
   end subroutine get_axis_cart
 
   !> @brief Return axis_bound either from an array of available axes, or defined based on axis mid-points
-  subroutine get_axis_bounds(axis,axis_bound,axes,bnd_name,err_msg)
+  subroutine get_axis_bounds(axis,axis_bound,err_msg)
 
     type(axistype), intent(in) :: axis
     type(axistype), intent(inout) :: axis_bound
-    type(axistype), intent(in), dimension(:) :: axes
-    character(len=*), intent(inout), optional :: bnd_name
+    !type(axistype), intent(in), dimension(:) :: axes
+    !character(len=*), intent(inout), optional :: bnd_name
     character(len=*), intent(out), optional :: err_msg
 
     real, dimension(:), allocatable :: data, tmp

--- a/diag_manager/diag_output.F90
+++ b/diag_manager/diag_output.F90
@@ -724,7 +724,6 @@ character(len=128),dimension(size(axes)) :: axis_names
   !!
   !! Write out the attribute meta data to file, for field and axes
   SUBROUTINE write_attribute_meta(num_attributes, attributes, time_method, err_msg, varname, fileob)
-    !INTEGER, INTENT(in) :: file_unit !< File unit number
     INTEGER, INTENT(in) :: num_attributes !< Number of attributes to write
     TYPE(diag_atttype), DIMENSION(:), INTENT(in) :: attributes !< Array of attributes
     CHARACTER(len=*), INTENT(in), OPTIONAL :: time_method !< To include in cell_methods attribute if present

--- a/diag_manager/diag_output.F90
+++ b/diag_manager/diag_output.F90
@@ -361,7 +361,7 @@ CONTAINS
        endif
 
        !> Write additional axis attributes, from diag_axis_add_attribute calls
-       CALL write_attribute_meta(file_unit, num_attributes, attributes, err_msg, varname=axis_name, fileob=fileob)
+       CALL write_attribute_meta(num_attributes, attributes, err_msg, varname=axis_name, fileob=fileob)
        IF ( LEN_TRIM(err_msg) .GT. 0 ) THEN
           CALL error_mesg('diag_output_mod::write_axis_meta_data', TRIM(err_msg), FATAL)
        END IF
@@ -660,7 +660,7 @@ character(len=128),dimension(size(axes)) :: axis_names
     IF ( PRESENT(num_attributes) ) THEN
        IF ( PRESENT(attributes) ) THEN
           IF ( num_attributes .GT. 0 .AND. allocated(attributes) ) THEN
-             CALL write_attribute_meta(file_unit, num_attributes, attributes, time_method, err_msg, &
+             CALL write_attribute_meta(num_attributes, attributes, time_method, err_msg, &
                                      & fileob=fileob, varname=name)
              IF ( LEN_TRIM(err_msg) .GT. 0 ) THEN
                 CALL error_mesg('diag_output_mod::write_field_meta_data',&
@@ -723,8 +723,8 @@ character(len=128),dimension(size(axes)) :: axis_names
   !> \brief Write out attribute meta data to file
   !!
   !! Write out the attribute meta data to file, for field and axes
-  SUBROUTINE write_attribute_meta(file_unit, num_attributes, attributes, time_method, err_msg, varname, fileob)
-    INTEGER, INTENT(in) :: file_unit !< File unit number
+  SUBROUTINE write_attribute_meta(num_attributes, attributes, time_method, err_msg, varname, fileob)
+    !INTEGER, INTENT(in) :: file_unit !< File unit number
     INTEGER, INTENT(in) :: num_attributes !< Number of attributes to write
     TYPE(diag_atttype), DIMENSION(:), INTENT(in) :: attributes !< Array of attributes
     CHARACTER(len=*), INTENT(in), OPTIONAL :: time_method !< To include in cell_methods attribute if present

--- a/exchange/xgrid.F90
+++ b/exchange/xgrid.F90
@@ -1987,11 +1987,11 @@ subroutine setup_xmap(xmap, grid_ids, grid_domains, grid_file, atm_grid, lnd_ug_
   call mpp_clock_begin(id_conservation_check)
 
   if(lnd_ug_id ==0) then
-     xxx = conservation_check(grid1%area*0.0+1.0, grid1%id, xmap)
+     xxx = conservation_check(grid1%area*0.0+1.0, xmap)
   else
      allocate(tmp_2d(grid1%is_me:grid1%ie_me, grid1%js_me:grid1%je_me))
      tmp_2d = 1.0
-     xxx = conservation_check_ug(tmp_2d, grid1%id, xmap)
+     xxx = conservation_check_ug(tmp_2d, xmap)
      deallocate(tmp_2d)
   endif
   write(out_unit,* )"Checked data is array of constant 1"
@@ -2019,9 +2019,9 @@ subroutine setup_xmap(xmap, grid_ids, grid_domains, grid_file, atm_grid, lnd_ug_
 
      !--- second order along both zonal and meridinal direction
      if(lnd_ug_id ==0) then
-        xxx = conservation_check(check_data, grid1%id, xmap,  remap_method = remapping_method )
+        xxx = conservation_check(check_data, xmap,  remap_method = remapping_method )
      else
-        xxx = conservation_check_ug(check_data, grid1%id, xmap,  remap_method = remapping_method )
+        xxx = conservation_check_ug(check_data, xmap,  remap_method = remapping_method )
      endif
      write( out_unit,* ) &
           "Checked data is array of random number between 0 and 1 using "//trim(interp_method)
@@ -3991,9 +3991,9 @@ end subroutine get_1_from_xgrid_repro
 !!   variable (1) on its home model grid, (2) after interpolation to the other
 !!   side grid(s), and (3) after re_interpolation back onto its home side grid(s).
 !! @return real(r8_kind) conservation_check_side1
-function conservation_check_side1(d, grid_id, xmap,remap_method) ! this one for 1->2->1
+function conservation_check_side1(d, xmap,remap_method) ! this one for 1->2->1
 real(r8_kind), dimension(:,:),    intent(in   ) :: d !< model data to check
-character(len=3),        intent(in   ) :: grid_id !< 3 character grid id
+!character(len=3),        intent(in   ) :: grid_id !< 3 character grid id
 type (xmap_type),        intent(inout) :: xmap !< exchange grid
 real(r8_kind), dimension(3)                     :: conservation_check_side1
 integer, intent(in), optional :: remap_method
@@ -4094,9 +4094,9 @@ end function conservation_check_side2
 !!   variable (1) on its home model grid, (2) after interpolation to the other
 !!   side grid(s), and (3) after re_interpolation back onto its home side grid(s).
 !! @return real(r8_kind) conservation_check_ug_side1
-function conservation_check_ug_side1(d, grid_id, xmap,remap_method) ! this one for 1->2->1
+function conservation_check_ug_side1(d, xmap,remap_method) ! this one for 1->2->1
 real(r8_kind), dimension(:,:),    intent(in   ) :: d !< model data to check
-character(len=3),        intent(in   ) :: grid_id !< 3 character grid ID
+!character(len=3),        intent(in   ) :: grid_id !< 3 character grid ID
 type (xmap_type),        intent(inout) :: xmap !< exchange grid
 real(r8_kind), dimension(3)                     :: conservation_check_ug_side1
 integer, intent(in), optional :: remap_method

--- a/exchange/xgrid.F90
+++ b/exchange/xgrid.F90
@@ -3993,7 +3993,6 @@ end subroutine get_1_from_xgrid_repro
 !! @return real(r8_kind) conservation_check_side1
 function conservation_check_side1(d, xmap,remap_method) ! this one for 1->2->1
 real(r8_kind), dimension(:,:),    intent(in   ) :: d !< model data to check
-!character(len=3),        intent(in   ) :: grid_id !< 3 character grid id
 type (xmap_type),        intent(inout) :: xmap !< exchange grid
 real(r8_kind), dimension(3)                     :: conservation_check_side1
 integer, intent(in), optional :: remap_method
@@ -4096,7 +4095,6 @@ end function conservation_check_side2
 !! @return real(r8_kind) conservation_check_ug_side1
 function conservation_check_ug_side1(d, xmap,remap_method) ! this one for 1->2->1
 real(r8_kind), dimension(:,:),    intent(in   ) :: d !< model data to check
-!character(len=3),        intent(in   ) :: grid_id !< 3 character grid ID
 type (xmap_type),        intent(inout) :: xmap !< exchange grid
 real(r8_kind), dimension(3)                     :: conservation_check_ug_side1
 integer, intent(in), optional :: remap_method

--- a/field_manager/field_manager.F90
+++ b/field_manager/field_manager.F90
@@ -3476,7 +3476,7 @@ call find_base(name_loc, path, base)
 
 if (associated(temp_list_p)) then
 ! Find the entry values for the list.
-  success = query_method(temp_list_p, recursive_t, base, method_name, method_control)
+  success = query_method(temp_list_p, recursive_t, method_name, method_control)
 else
 ! This is not a list but it may be a parameter with a value
 ! If so put the parameter value in method_name.
@@ -3510,12 +3510,12 @@ end function  fm_query_method
 !! associated with a field.
 !> @return A flag to indicate whether the function operated with (FALSE) or
 !! without (TRUE) errors
-recursive function query_method(list_p, recursive, name, method_name, method_control) &
+recursive function query_method(list_p, recursive, method_name, method_control) &
           result (success)
 logical :: success
 type (field_def), pointer     :: list_p !< A pointer to the field that is of interest
 logical,          intent(in)  :: recursive !< A flag to enable recursive searching if true
-character(len=*), intent(in)  :: name !<  name of a list that the user wishes to change to
+!character(len=*), intent(in)  :: name !<  name of a list that the user wishes to change to
 character(len=*), intent(out) :: method_name !< name of a parameter associated with the named field
 character(len=*), intent(out) :: method_control !< value of parameters associated with the named field
 
@@ -3541,7 +3541,7 @@ else
     case(list_type)
       ! If this is a list, then this is the method name
       if (recursive) then
-        if (.not. query_method(this_field_p, .true., this_field_p%name, method_name, method_control)) then
+        if (.not. query_method(this_field_p, .true., method_name, method_control)) then
           success = .false.
           exit
         else
@@ -3743,7 +3743,7 @@ else
 endif
 !        Find the list
 if (success) then
-  success = find_method(temp_list_p, recursive_t, num_meth, methods, control)
+  success = find_method(temp_list_p, num_meth, methods, control)
 endif
 
 end function fm_find_methods
@@ -3752,11 +3752,11 @@ end function fm_find_methods
 !! associated parameters for the field list.
 !! @returns A flag to indicate whether the function operated with (FALSE) or
 !!     without (TRUE) errors.
-recursive function find_method(list_p, recursive, num_meth, method, control)   &
+recursive function find_method(list_p, num_meth, method, control)   &
           result (success)
 logical                                     :: success
 type (field_def), pointer                   :: list_p !< A pointer to the field of interest
-logical,          intent(in)                :: recursive !< If true, search recursively for fields
+!logical,          intent(in)                :: recursive !< If true, search recursively for fields
 integer,          intent(inout)             :: num_meth !< The number of methods found
 character(len=*), intent(out), dimension(:) :: method !< The methods associated with the field pointed to by list_p
 character(len=*), intent(out), dimension(:) :: control !< The control parameters for the methods found
@@ -3792,7 +3792,7 @@ else
            write (method(num_meth),'(a,a,a,$)') trim(method(num_meth)), &
                                                 trim(this_field_p%name), list_sep
         endif
-        success = find_method(this_field_p, .true., num_meth, method, control)
+        success = find_method(this_field_p, num_meth, method, control)
 
     case(integer_type)
         write (scratch,*) this_field_p%i_value

--- a/field_manager/field_manager.F90
+++ b/field_manager/field_manager.F90
@@ -3515,7 +3515,6 @@ recursive function query_method(list_p, recursive, method_name, method_control) 
 logical :: success
 type (field_def), pointer     :: list_p !< A pointer to the field that is of interest
 logical,          intent(in)  :: recursive !< A flag to enable recursive searching if true
-!character(len=*), intent(in)  :: name !<  name of a list that the user wishes to change to
 character(len=*), intent(out) :: method_name !< name of a parameter associated with the named field
 character(len=*), intent(out) :: method_control !< value of parameters associated with the named field
 
@@ -3756,7 +3755,6 @@ recursive function find_method(list_p, num_meth, method, control)   &
           result (success)
 logical                                     :: success
 type (field_def), pointer                   :: list_p !< A pointer to the field of interest
-!logical,          intent(in)                :: recursive !< If true, search recursively for fields
 integer,          intent(inout)             :: num_meth !< The number of methods found
 character(len=*), intent(out), dimension(:) :: method !< The methods associated with the field pointed to by list_p
 character(len=*), intent(out), dimension(:) :: control !< The control parameters for the methods found

--- a/fms/fms_io.F90
+++ b/fms/fms_io.F90
@@ -1270,7 +1270,7 @@ end subroutine write_data_3d_new
 !-------------------------------------------------------------------------------
 subroutine register_restart_axis_r1d(fileObj,fieldname,data,cartesian,units,longname,sense,min,calendar)
   type(restart_file_type),    intent(inout)      :: fileObj
-  character(len=*),           intent(in)         :: fieldname  !filename,
+  character(len=*),           intent(in)         :: fieldname
   real,                       intent(in), target :: data(:)
   character(len=*),           intent(in)         :: cartesian
   character(len=*), optional, intent(in)         :: units, longname
@@ -1331,7 +1331,7 @@ end subroutine register_restart_axis_r1d
 subroutine register_restart_axis_i1d(fileObj,fieldname,data,compressed, &
                                      compressed_axis,dimlen,dimlen_name,dimlen_lname,units,longname,imin)
   type(restart_file_type),    intent(inout)      :: fileObj
-  character(len=*),           intent(in)         :: fieldname   !filename,
+  character(len=*),           intent(in)         :: fieldname
   integer,                    intent(in)         :: data(:)
   character(len=*),           intent(in)         :: compressed
   character(len=*),           intent(in)         :: compressed_axis !< which compressed axis (C or H)
@@ -1401,7 +1401,7 @@ end subroutine register_restart_axis_i1d
 
 subroutine register_restart_axis_unlimited(fileObj,fieldname,nelem,units,longname)
   type(restart_file_type),    intent(inout)      :: fileObj
-  character(len=*),           intent(in)         :: fieldname  !filename,
+  character(len=*),           intent(in)         :: fieldname
   integer                                        :: nelem  ! Number of elements on rank
   character(len=*), optional, intent(in)         :: units, longname
 

--- a/fms/fms_io.F90
+++ b/fms/fms_io.F90
@@ -1401,7 +1401,7 @@ end subroutine register_restart_axis_i1d
 
 subroutine register_restart_axis_unlimited(fileObj,fieldname,nelem,units,longname)
   type(restart_file_type),    intent(inout)      :: fileObj
-  character(len=*),           intent(in)         :: fieldname  !filename, 
+  character(len=*),           intent(in)         :: fieldname  !filename,
   integer                                        :: nelem  ! Number of elements on rank
   character(len=*), optional, intent(in)         :: units, longname
 

--- a/fms/fms_io.F90
+++ b/fms/fms_io.F90
@@ -1268,9 +1268,9 @@ end subroutine write_data_3d_new
 !   This routine will register an integer restart file axis
 !
 !-------------------------------------------------------------------------------
-subroutine register_restart_axis_r1d(fileObj,filename,fieldname,data,cartesian,units,longname,sense,min,calendar)
+subroutine register_restart_axis_r1d(fileObj,fieldname,data,cartesian,units,longname,sense,min,calendar)
   type(restart_file_type),    intent(inout)      :: fileObj
-  character(len=*),           intent(in)         :: filename, fieldname
+  character(len=*),           intent(in)         :: fieldname  !filename,
   real,                       intent(in), target :: data(:)
   character(len=*),           intent(in)         :: cartesian
   character(len=*), optional, intent(in)         :: units, longname
@@ -1328,10 +1328,10 @@ end subroutine register_restart_axis_r1d
 !   This routine will register the compressed index restart file axis
 !
 !-------------------------------------------------------------------------------
-subroutine register_restart_axis_i1d(fileObj,filename,fieldname,data,compressed, &
+subroutine register_restart_axis_i1d(fileObj,fieldname,data,compressed, &
                                      compressed_axis,dimlen,dimlen_name,dimlen_lname,units,longname,imin)
   type(restart_file_type),    intent(inout)      :: fileObj
-  character(len=*),           intent(in)         :: filename, fieldname
+  character(len=*),           intent(in)         :: fieldname   !filename,
   integer,                    intent(in)         :: data(:)
   character(len=*),           intent(in)         :: compressed
   character(len=*),           intent(in)         :: compressed_axis !< which compressed axis (C or H)
@@ -1399,9 +1399,9 @@ end subroutine register_restart_axis_i1d
 
 !-------------------------------------------------------------------------------
 
-subroutine register_restart_axis_unlimited(fileObj,filename,fieldname,nelem,units,longname)
+subroutine register_restart_axis_unlimited(fileObj,fieldname,nelem,units,longname)
   type(restart_file_type),    intent(inout)      :: fileObj
-  character(len=*),           intent(in)         :: filename, fieldname
+  character(len=*),           intent(in)         :: fieldname  !filename, 
   integer                                        :: nelem  ! Number of elements on rank
   character(len=*), optional, intent(in)         :: units, longname
 

--- a/horiz_interp/horiz_interp.F90
+++ b/horiz_interp/horiz_interp.F90
@@ -252,7 +252,7 @@ contains
   !> @brief Creates a 1D @ref horiz_interp_type with the given parameters
   subroutine horiz_interp_new_1d (Interp, lon_in, lat_in, lon_out, lat_out, verbose, &
                                   interp_method, num_nbrs, max_dist, src_modulo,     &
-                                  grid_at_center, mask_in, mask_out)
+                                  grid_at_center)
 
     !-----------------------------------------------------------------------
     type(horiz_interp_type), intent(inout)        :: Interp
@@ -264,8 +264,8 @@ contains
     real,    intent(in),                 optional :: max_dist
     logical, intent(in),                 optional :: src_modulo
     logical, intent(in),                 optional :: grid_at_center
-    real, intent(in), dimension(:,:),    optional :: mask_in  !< dummy variable
-    real, intent(inout),dimension(:,:),  optional :: mask_out !< dummy variable
+    !real, intent(in), dimension(:,:),    optional :: mask_in  !< dummy variable
+    !real, intent(inout),dimension(:,:),  optional :: mask_out !< dummy variable
     !-----------------------------------------------------------------------
     real, dimension(:,:), allocatable :: lon_src, lat_src, lon_dst, lat_dst
     real, dimension(:),   allocatable :: lon_src_1d, lat_src_1d, lon_dst_1d, lat_dst_1d
@@ -430,7 +430,7 @@ contains
               verbose=verbose )
       else
          call horiz_interp_conserve_new ( Interp, lon_in, lat_in, lon_out, lat_out, &
-              verbose=verbose, mask_in=mask_in, mask_out=mask_out )
+              mask_in=mask_in, mask_out=mask_out )
       end if
    case ("bilinear")
       Interp%interp_method = BILINEAR
@@ -542,13 +542,13 @@ contains
               verbose=verbose )
       else if(src_is_latlon) then
          call horiz_interp_conserve_new ( Interp, lon_in(:,1), lat_in(1,:), lon_out, lat_out, &
-              verbose=verbose, mask_in=mask_in, mask_out=mask_out )
+              mask_in=mask_in, mask_out=mask_out )
       else if(dst_is_latlon) then
          call horiz_interp_conserve_new ( Interp, lon_in, lat_in, lon_out(:,1), lat_out(1,:), &
-              verbose=verbose, mask_in=mask_in, mask_out=mask_out )
+              mask_in=mask_in, mask_out=mask_out )
       else
          call horiz_interp_conserve_new ( Interp, lon_in, lat_in, lon_out, lat_out, &
-              verbose=verbose, mask_in=mask_in, mask_out=mask_out )
+              mask_in=mask_in, mask_out=mask_out )
       end if
 
    case ("spherical")
@@ -623,7 +623,7 @@ contains
               verbose=verbose)
       else
          call horiz_interp_conserve_new ( Interp, lon_in, lat_in, lon_out, lat_out, &
-              verbose=verbose, mask_in=mask_in, mask_out=mask_out )
+              mask_in=mask_in, mask_out=mask_out )
       end if
    case ("bilinear")
       Interp%interp_method = BILINEAR
@@ -673,8 +673,7 @@ contains
       call horiz_interp_bilinear(Interp,data_in, data_out, verbose, mask_in, mask_out, &
                              missing_value, missing_permit, new_missing_handle )
    case(BICUBIC)
-      call horiz_interp_bicubic(Interp,data_in, data_out, verbose, mask_in, mask_out, &
-                             missing_value, missing_permit )
+      call horiz_interp_bicubic(Interp,data_in, data_out, verbose, mask_out)
    case(SPHERICA)
       call horiz_interp_spherical(Interp,data_in, data_out, verbose, mask_in, mask_out, &
                              missing_value )

--- a/horiz_interp/horiz_interp.F90
+++ b/horiz_interp/horiz_interp.F90
@@ -264,8 +264,6 @@ contains
     real,    intent(in),                 optional :: max_dist
     logical, intent(in),                 optional :: src_modulo
     logical, intent(in),                 optional :: grid_at_center
-    !real, intent(in), dimension(:,:),    optional :: mask_in  !< dummy variable
-    !real, intent(inout),dimension(:,:),  optional :: mask_out !< dummy variable
     !-----------------------------------------------------------------------
     real, dimension(:,:), allocatable :: lon_src, lat_src, lon_dst, lat_dst
     real, dimension(:),   allocatable :: lon_src_1d, lat_src_1d, lon_dst_1d, lat_dst_1d

--- a/horiz_interp/horiz_interp_bicubic.F90
+++ b/horiz_interp/horiz_interp_bicubic.F90
@@ -426,16 +426,15 @@ module horiz_interp_bicubic_mod
   end subroutine horiz_interp_bicubic_new_1d
 
   !> @brief Perform bicubic horizontal interpolation
-  subroutine horiz_interp_bicubic( Interp, data_in, data_out, verbose, mask_in, mask_out, missing_value, &
-                                 &  missing_permit)
+  subroutine horiz_interp_bicubic( Interp, data_in, data_out, verbose, mask_out)
     type (horiz_interp_type), intent(in)        :: Interp
     real, intent(in),  dimension(:,:)           :: data_in
     real, intent(out), dimension(:,:)           :: data_out
     integer, intent(in),               optional :: verbose
-    real, intent(in),  dimension(:,:), optional :: mask_in
+    !real, intent(in),  dimension(:,:), optional :: mask_in
     real, intent(out), dimension(:,:), optional :: mask_out
-    real, intent(in),                  optional :: missing_value
-    integer, intent(in),               optional :: missing_permit
+    !real, intent(in),                  optional :: missing_value
+    !integer, intent(in),               optional :: missing_permit
     real :: yz, ycu, ycl
     real :: xz, xcu, xcl
     real :: val, val1, val2

--- a/horiz_interp/horiz_interp_bicubic.F90
+++ b/horiz_interp/horiz_interp_bicubic.F90
@@ -431,10 +431,7 @@ module horiz_interp_bicubic_mod
     real, intent(in),  dimension(:,:)           :: data_in
     real, intent(out), dimension(:,:)           :: data_out
     integer, intent(in),               optional :: verbose
-    !real, intent(in),  dimension(:,:), optional :: mask_in
     real, intent(out), dimension(:,:), optional :: mask_out
-    !real, intent(in),                  optional :: missing_value
-    !integer, intent(in),               optional :: missing_permit
     real :: yz, ycu, ycl
     real :: xz, xcu, xcl
     real :: val, val1, val2

--- a/horiz_interp/horiz_interp_conserve.F90
+++ b/horiz_interp/horiz_interp_conserve.F90
@@ -328,13 +328,13 @@ contains
   !#######################################################################
 
   subroutine horiz_interp_conserve_new_1dx2d ( Interp, lon_in, lat_in, lon_out, lat_out, &
-                                               mask_in, mask_out, verbose)
+                                               mask_in, mask_out)
     type(horiz_interp_type),        intent(inout) :: Interp
     real, intent(in),              dimension(:)   :: lon_in , lat_in
     real, intent(in),              dimension(:,:) :: lon_out, lat_out
     real, intent(in),    optional, dimension(:,:) :: mask_in
     real, intent(inout), optional, dimension(:,:) :: mask_out
-    integer, intent(in), optional                 :: verbose
+    !integer, intent(in), optional                 :: verbose
 
 
     integer :: create_xgrid_1DX2D_order1, get_maxxgrid, maxxgrid
@@ -495,13 +495,13 @@ contains
   !#######################################################################
 
   subroutine horiz_interp_conserve_new_2dx1d ( Interp, lon_in, lat_in, lon_out, lat_out, &
-                                               mask_in, mask_out, verbose)
+                                               mask_in, mask_out)
     type(horiz_interp_type),        intent(inout) :: Interp
     real, intent(in),              dimension(:,:) :: lon_in , lat_in
     real, intent(in),              dimension(:)   :: lon_out, lat_out
     real, intent(in),    optional, dimension(:,:) :: mask_in
     real, intent(inout), optional, dimension(:,:) :: mask_out
-    integer, intent(in), optional                 :: verbose
+    !integer, intent(in), optional                 :: verbose
 
     integer :: create_xgrid_2DX1D_order1, get_maxxgrid, maxxgrid
     integer :: create_xgrid_great_circle
@@ -602,13 +602,13 @@ contains
   !#######################################################################
 
   subroutine horiz_interp_conserve_new_2dx2d ( Interp, lon_in, lat_in, lon_out, lat_out, &
-                                               mask_in, mask_out, verbose)
+                                               mask_in, mask_out)
     type(horiz_interp_type),        intent(inout) :: Interp
     real, intent(in),              dimension(:,:) :: lon_in , lat_in
     real, intent(in),              dimension(:,:) :: lon_out, lat_out
     real, intent(in),    optional, dimension(:,:) :: mask_in
     real, intent(inout), optional, dimension(:,:) :: mask_out
-    integer, intent(in), optional                 :: verbose
+    !integer, intent(in), optional                 :: verbose
 
     integer :: create_xgrid_2DX2D_order1, get_maxxgrid, maxxgrid
     integer :: create_xgrid_great_circle
@@ -741,7 +741,7 @@ contains
     case (2)
        if(present(mask_in) .OR. present(mask_out) ) call mpp_error(FATAL, 'horiz_interp_conserve:'// &
             & ' for version 2, mask_in and mask_out must be passed in horiz_interp_new, not in horiz_interp')
-       call horiz_interp_conserve_version2(Interp, data_in, data_out, verbose)
+       call horiz_interp_conserve_version2(Interp, data_in, data_out)
     end select
 
   end subroutine horiz_interp_conserve
@@ -895,12 +895,12 @@ contains
   end subroutine horiz_interp_conserve_version1
 
   !#############################################################################
-  subroutine horiz_interp_conserve_version2 ( Interp, data_in, data_out, verbose )
+  subroutine horiz_interp_conserve_version2 ( Interp, data_in, data_out )
     !-----------------------------------------------------------------------
     type (horiz_interp_type), intent(in) :: Interp
     real,    intent(in),  dimension(:,:) :: data_in
     real,    intent(out), dimension(:,:) :: data_out
-    integer, intent(in),        optional :: verbose
+    !integer, intent(in),        optional :: verbose
     integer :: i, i_src, j_src, i_dst, j_dst
 
     data_out = 0.0

--- a/horiz_interp/horiz_interp_conserve.F90
+++ b/horiz_interp/horiz_interp_conserve.F90
@@ -334,7 +334,6 @@ contains
     real, intent(in),              dimension(:,:) :: lon_out, lat_out
     real, intent(in),    optional, dimension(:,:) :: mask_in
     real, intent(inout), optional, dimension(:,:) :: mask_out
-    !integer, intent(in), optional                 :: verbose
 
 
     integer :: create_xgrid_1DX2D_order1, get_maxxgrid, maxxgrid
@@ -501,8 +500,6 @@ contains
     real, intent(in),              dimension(:)   :: lon_out, lat_out
     real, intent(in),    optional, dimension(:,:) :: mask_in
     real, intent(inout), optional, dimension(:,:) :: mask_out
-    !integer, intent(in), optional                 :: verbose
-
     integer :: create_xgrid_2DX1D_order1, get_maxxgrid, maxxgrid
     integer :: create_xgrid_great_circle
     integer :: nlon_in, nlat_in, nlon_out, nlat_out, nxgrid, i, j
@@ -608,8 +605,6 @@ contains
     real, intent(in),              dimension(:,:) :: lon_out, lat_out
     real, intent(in),    optional, dimension(:,:) :: mask_in
     real, intent(inout), optional, dimension(:,:) :: mask_out
-    !integer, intent(in), optional                 :: verbose
-
     integer :: create_xgrid_2DX2D_order1, get_maxxgrid, maxxgrid
     integer :: create_xgrid_great_circle
     integer :: nlon_in, nlat_in, nlon_out, nlat_out, nxgrid, i
@@ -900,7 +895,6 @@ contains
     type (horiz_interp_type), intent(in) :: Interp
     real,    intent(in),  dimension(:,:) :: data_in
     real,    intent(out), dimension(:,:) :: data_out
-    !integer, intent(in),        optional :: verbose
     integer :: i, i_src, j_src, i_dst, j_dst
 
     data_out = 0.0

--- a/horiz_interp/horiz_interp_spherical.F90
+++ b/horiz_interp/horiz_interp_spherical.F90
@@ -415,8 +415,6 @@ end subroutine horiz_interp_spherical_init
     real, intent(out), dimension(:,:,:)         :: wt
     integer, intent(in),               optional :: verbose
     real, intent(in), dimension(:,:),  optional :: mask_in
-    !real, intent(inout), dimension(:,:), optional :: mask_out
-    !real, intent(in),                  optional :: missing_value
 
     !--- some local variables ----------------------------------------
     real, dimension(Interp%nlon_src, Interp%nlat_src) :: mask_src

--- a/horiz_interp/horiz_interp_spherical.F90
+++ b/horiz_interp/horiz_interp_spherical.F90
@@ -410,13 +410,13 @@ end subroutine horiz_interp_spherical_init
   end subroutine horiz_interp_spherical
 
   !#######################################################################
-  subroutine horiz_interp_spherical_wght( Interp, wt, verbose, mask_in, mask_out, missing_value)
+  subroutine horiz_interp_spherical_wght( Interp, wt, verbose, mask_in)
     type (horiz_interp_type), intent(in)        :: Interp
     real, intent(out), dimension(:,:,:)         :: wt
     integer, intent(in),               optional :: verbose
     real, intent(in), dimension(:,:),  optional :: mask_in
-    real, intent(inout), dimension(:,:), optional :: mask_out
-    real, intent(in),                  optional :: missing_value
+    !real, intent(inout), dimension(:,:), optional :: mask_out
+    !real, intent(in),                  optional :: missing_value
 
     !--- some local variables ----------------------------------------
     real, dimension(Interp%nlon_src, Interp%nlat_src) :: mask_src

--- a/monin_obukhov/monin_obukhov.F90
+++ b/monin_obukhov/monin_obukhov.F90
@@ -254,14 +254,14 @@ if(present(avail)) then
 
    call monin_obukhov_profile_1d(vonkarm, &
         & neutral, stable_option, new_mo_option,rich_crit, zeta_trans, &
-        & n, zref, zref_t, z, z0, zt, zq, u_star, b_star, q_star, &
+        & n, zref, zref_t, z, z0, zt, zq, u_star, b_star, &
         & del_m, del_t, del_q, .true., avail, ier)
 
 else
 
    call monin_obukhov_profile_1d(vonkarm, &
         & neutral, stable_option, new_mo_option,rich_crit, zeta_trans, &
-        & n, zref, zref_t, z, z0, zt, zq, u_star, b_star, q_star, &
+        & n, zref, zref_t, z, z0, zt, zq, u_star, b_star, &
         & del_m, del_t, del_q, .false., dummy_avail, ier)
 
 endif

--- a/monin_obukhov/monin_obukhov.F90
+++ b/monin_obukhov/monin_obukhov.F90
@@ -231,11 +231,11 @@ end subroutine mo_drag_1d
 
 !=======================================================================
 
-subroutine mo_profile_1d(zref, zref_t, z, z0, zt, zq, u_star, b_star, q_star, &
+subroutine mo_profile_1d(zref, zref_t, z, z0, zt, zq, u_star, b_star, &
                          del_m, del_t, del_q, avail)
 
 real,    intent(in)                :: zref, zref_t
-real,    intent(in) , dimension(:) :: z, z0, zt, zq, u_star, b_star, q_star
+real,    intent(in) , dimension(:) :: z, z0, zt, zq, u_star, b_star  !, q_star
 real,    intent(out), dimension(:) :: del_m, del_t, del_q
 logical, intent(in) , optional, dimension(:) :: avail
 
@@ -709,7 +709,7 @@ integer :: j
 
 do j = 1, size(z,2)
   call mo_profile_1d (zref, zref_t, z(:,j), z0(:,j), zt(:,j),         &
-                      zq(:,j), u_star(:,j), b_star(:,j), q_star(:,j), &
+                      zq(:,j), u_star(:,j), b_star(:,j),              &
                       del_m(:,j), del_h (:,j), del_q (:,j))
 enddo
 
@@ -737,7 +737,7 @@ b_star_1(1) = b_star
 q_star_1(1) = q_star
 
 call mo_profile_1d (zref, zref_t, z_1, z0_1, zt_1, zq_1, &
-                    u_star_1, b_star_1, q_star_1,        &
+                    u_star_1, b_star_1,                  &
                     del_m_1, del_h_1, del_q_1)
 
 del_m = del_m_1(1)
@@ -763,10 +763,10 @@ integer :: k
 do k = 1, size(zref(:))
   if(present(avail)) then
     call mo_profile_1d (zref(k), zref(k), z, z0, zt, zq, &
-       u_star, b_star, q_star, del_m(:,k), del_t(:,k), del_q(:,k), avail)
+       u_star, b_star, del_m(:,k), del_t(:,k), del_q(:,k), avail)
   else
       call mo_profile_1d (zref(k), zref(k), z, z0, zt, zq, &
-       u_star, b_star, q_star, del_m(:,k), del_t(:,k), del_q(:,k))
+       u_star, b_star, del_m(:,k), del_t(:,k), del_q(:,k))
   endif
 enddo
 

--- a/monin_obukhov/monin_obukhov.F90
+++ b/monin_obukhov/monin_obukhov.F90
@@ -235,7 +235,7 @@ subroutine mo_profile_1d(zref, zref_t, z, z0, zt, zq, u_star, b_star, &
                          del_m, del_t, del_q, avail)
 
 real,    intent(in)                :: zref, zref_t
-real,    intent(in) , dimension(:) :: z, z0, zt, zq, u_star, b_star  !, q_star
+real,    intent(in) , dimension(:) :: z, z0, zt, zq, u_star, b_star
 real,    intent(out), dimension(:) :: del_m, del_t, del_q
 logical, intent(in) , optional, dimension(:) :: avail
 

--- a/monin_obukhov/monin_obukhov.F90
+++ b/monin_obukhov/monin_obukhov.F90
@@ -698,11 +698,11 @@ return
 end subroutine mo_drag_0d
 !=======================================================================
 
-subroutine mo_profile_2d(zref, zref_t, z, z0, zt, zq, u_star, b_star, q_star, &
+subroutine mo_profile_2d(zref, zref_t, z, z0, zt, zq, u_star, b_star, &
                          del_m, del_h, del_q)
 
 real, intent(in)                  :: zref, zref_t
-real, intent(in) , dimension(:,:) :: z, z0, zt, zq, u_star, b_star, q_star
+real, intent(in) , dimension(:,:) :: z, z0, zt, zq, u_star, b_star
 real, intent(out), dimension(:,:) :: del_m, del_h, del_q
 
 integer :: j
@@ -750,11 +750,11 @@ end subroutine mo_profile_0d
 
 !=======================================================================
 
-subroutine mo_profile_1d_n(zref, z, z0, zt, zq, u_star, b_star, q_star, &
+subroutine mo_profile_1d_n(zref, z, z0, zt, zq, u_star, b_star, &
                          del_m, del_t, del_q, avail)
 
 real,    intent(in),  dimension(:)   :: zref
-real,    intent(in) , dimension(:)   :: z, z0, zt, zq, u_star, b_star, q_star
+real,    intent(in) , dimension(:)   :: z, z0, zt, zq, u_star, b_star
 real,    intent(out), dimension(:,:) :: del_m, del_t, del_q
 logical, intent(in) , optional, dimension(:) :: avail
 
@@ -805,7 +805,7 @@ integer :: k
 
 do k = 1, size(zref(:))
   call mo_profile_2d (zref(k), zref(k), z, z0, zt, zq, &
-       u_star, b_star, q_star, del_m(:,:,k), del_t(:,:,k), del_q(:,:,k))
+       u_star, b_star, del_m(:,:,k), del_t(:,:,k), del_q(:,:,k))
 enddo
 
 return

--- a/monin_obukhov/monin_obukhov_inter.F90
+++ b/monin_obukhov/monin_obukhov_inter.F90
@@ -178,7 +178,7 @@ pure subroutine monin_obukhov_drag_1d(grav, vonkarm,               &
         end if
      enddo
 
-     call monin_obukhov_solve_zeta (error, zeta_min, max_iter, small, &
+     call monin_obukhov_solve_zeta (error, zeta_min, max_iter, &
           & stable_option, new_mo_option, rich_crit, zeta_trans,      &
           & n, rich, zz, z0, zt, zq, fm, ft, fq, mask_1, ier)
 
@@ -200,14 +200,14 @@ pure subroutine monin_obukhov_drag_1d(grav, vonkarm,               &
 end subroutine monin_obukhov_drag_1d
 
 
-pure subroutine monin_obukhov_solve_zeta(error, zeta_min, max_iter, small,  &
+pure subroutine monin_obukhov_solve_zeta(error, zeta_min, max_iter,  &
      & stable_option, new_mo_option, rich_crit, zeta_trans,        & !miz
      & n, rich, z, z0, zt, zq, f_m, f_t, f_q, mask, ier)
 
   real   , intent(in   )                :: error    !< = 1.e-04
   real   , intent(in   )                :: zeta_min !< = 1.e-06
   integer, intent(in   )                :: max_iter !< = 20
-  real   , intent(in   )                :: small    !< = 1.e-04
+  !real   , intent(in   )                :: small    !< = 1.e-04
   integer, intent(in   )                :: stable_option
   logical, intent(in   )                :: new_mo_option
   real   , intent(in   )                :: rich_crit, zeta_trans
@@ -423,7 +423,7 @@ end subroutine monin_obukhov_derivative_m
 
 pure subroutine monin_obukhov_profile_1d(vonkarm, &
      & neutral, stable_option, new_mo_option, rich_crit, zeta_trans, &
-     & n, zref, zref_t, z, z0, zt, zq, u_star, b_star, q_star, &
+     & n, zref, zref_t, z, z0, zt, zq, u_star, b_star, &
      & del_m, del_t, del_q, lavail, avail, ier)
 
   real   , intent(in   )                :: vonkarm
@@ -433,7 +433,7 @@ pure subroutine monin_obukhov_profile_1d(vonkarm, &
   real   , intent(in   )                :: rich_crit, zeta_trans
   integer, intent(in   )                :: n
   real,    intent(in   )                :: zref, zref_t
-  real,    intent(in   ), dimension(n)  :: z, z0, zt, zq, u_star, b_star, q_star
+  real,    intent(in   ), dimension(n)  :: z, z0, zt, zq, u_star, b_star  !, q_star
   real,    intent(  out), dimension(n)  :: del_m, del_t, del_q
   logical, intent(in   )                :: lavail !< whether to use provided mask or not
   logical, intent(in   ), dimension(n)  :: avail  !< provided mask

--- a/monin_obukhov/monin_obukhov_inter.F90
+++ b/monin_obukhov/monin_obukhov_inter.F90
@@ -207,7 +207,6 @@ pure subroutine monin_obukhov_solve_zeta(error, zeta_min, max_iter,  &
   real   , intent(in   )                :: error    !< = 1.e-04
   real   , intent(in   )                :: zeta_min !< = 1.e-06
   integer, intent(in   )                :: max_iter !< = 20
-  !real   , intent(in   )                :: small    !< = 1.e-04
   integer, intent(in   )                :: stable_option
   logical, intent(in   )                :: new_mo_option
   real   , intent(in   )                :: rich_crit, zeta_trans
@@ -433,7 +432,7 @@ pure subroutine monin_obukhov_profile_1d(vonkarm, &
   real   , intent(in   )                :: rich_crit, zeta_trans
   integer, intent(in   )                :: n
   real,    intent(in   )                :: zref, zref_t
-  real,    intent(in   ), dimension(n)  :: z, z0, zt, zq, u_star, b_star  !, q_star
+  real,    intent(in   ), dimension(n)  :: z, z0, zt, zq, u_star, b_star
   real,    intent(  out), dimension(n)  :: del_m, del_t, del_q
   logical, intent(in   )                :: lavail !< whether to use provided mask or not
   logical, intent(in   ), dimension(n)  :: avail  !< provided mask

--- a/sat_vapor_pres/sat_vapor_pres.F90
+++ b/sat_vapor_pres/sat_vapor_pres.F90
@@ -2248,7 +2248,7 @@ contains
      endif
    endif
 
-   call compute_mrs_k (temp, press, EPSILO, ZVIR, mrsat, nbad, mr,  &
+   call compute_mrs_k (temp, press, EPSILO, mrsat, nbad, mr,  &
                      hc, dmrsdT, esat, es_over_liq, es_over_liq_and_ice)
 
    if ( nbad == 0 ) then
@@ -2310,7 +2310,7 @@ contains
 
 !  call compute_mrs_k (temp, press, EPSILO, ZVIR, mrsat,  &
 !                                                     nbad, mr, dmrsdT)
-   call compute_mrs_k (temp, press, EPSILO, ZVIR, mrsat, nbad, mr,  &
+   call compute_mrs_k (temp, press, EPSILO, mrsat, nbad, mr,  &
                      hc, dmrsdT, esat, es_over_liq, es_over_liq_and_ice)
 
    if ( nbad == 0 ) then
@@ -2372,7 +2372,7 @@ contains
 
 !  call compute_mrs_k (temp, press, EPSILO, ZVIR, mrsat,  &
 !                                                     nbad, mr, dmrsdT)
-   call compute_mrs_k (temp, press, EPSILO, ZVIR, mrsat, nbad, mr,  &
+   call compute_mrs_k (temp, press, EPSILO, mrsat, nbad, mr,  &
                      hc, dmrsdT, esat, es_over_liq, es_over_liq_and_ice)
 
    if ( nbad == 0 ) then
@@ -2434,7 +2434,7 @@ contains
 
 !  call compute_mrs_k (temp, press, EPSILO, ZVIR, mrsat,   &
 !                                                    nbad, mr, dmrsdT)
-   call compute_mrs_k (temp, press, EPSILO, ZVIR, mrsat, nbad, mr,  &
+   call compute_mrs_k (temp, press, EPSILO, mrsat, nbad, mr,  &
                      hc, dmrsdT, esat, es_over_liq, es_over_liq_and_ice)
 
    if ( nbad == 0 ) then

--- a/sat_vapor_pres/sat_vapor_pres_k.F90
+++ b/sat_vapor_pres/sat_vapor_pres_k.F90
@@ -1761,7 +1761,7 @@
                  mr, hc, dmrsdT, esat,es_over_liq, es_over_liq_and_ice)
 
  real, intent(in),  dimension(:,:,:)           :: temp, press
- real, intent(in)                              :: eps  !, zvir
+ real, intent(in)                              :: eps
  real, intent(out), dimension(:,:,:)           :: mrs
  integer, intent(out)                          :: nbad
  real, intent(in),  dimension(:,:,:), optional :: mr
@@ -1934,7 +1934,7 @@
                  mr, hc, dmrsdT, esat,es_over_liq, es_over_liq_and_ice)
 
  real, intent(in),  dimension(:)           :: temp, press
- real, intent(in)                          :: eps   !, zvir
+ real, intent(in)                          :: eps
  real, intent(out), dimension(:)           :: mrs
  integer, intent(out)                      :: nbad
  real, intent(in),  dimension(:), optional :: mr
@@ -2017,7 +2017,7 @@
                  mr, hc, dmrsdT, esat,es_over_liq, es_over_liq_and_ice)
 
  real, intent(in)                              :: temp, press
- real, intent(in)                              :: eps   !, zvir
+ real, intent(in)                              :: eps
  real, intent(out)                             :: mrs
  integer, intent(out)                          :: nbad
  real, intent(in),                    optional :: mr

--- a/sat_vapor_pres/sat_vapor_pres_k.F90
+++ b/sat_vapor_pres/sat_vapor_pres_k.F90
@@ -1757,11 +1757,11 @@
 
 !#######################################################################
 
- subroutine compute_mrs_k_3d (temp, press, eps, zvir, mrs, nbad,   &
+ subroutine compute_mrs_k_3d (temp, press, eps, mrs, nbad,   &
                  mr, hc, dmrsdT, esat,es_over_liq, es_over_liq_and_ice)
 
  real, intent(in),  dimension(:,:,:)           :: temp, press
- real, intent(in)                              :: eps, zvir
+ real, intent(in)                              :: eps  !, zvir
  real, intent(out), dimension(:,:,:)           :: mrs
  integer, intent(out)                          :: nbad
  real, intent(in),  dimension(:,:,:), optional :: mr
@@ -1845,11 +1845,11 @@
 
 !#######################################################################
 
- subroutine compute_mrs_k_2d (temp, press, eps, zvir, mrs, nbad,  &
+ subroutine compute_mrs_k_2d (temp, press, eps, mrs, nbad,  &
                  mr, hc, dmrsdT, esat,es_over_liq, es_over_liq_and_ice)
 
  real, intent(in),  dimension(:,:)           :: temp, press
- real, intent(in)                            :: eps, zvir
+ real, intent(in)                            :: eps  !, zvir
  real, intent(out), dimension(:,:)           :: mrs
  integer, intent(out)                        :: nbad
  real, intent(in), dimension(:,:), optional  :: mr
@@ -1930,11 +1930,11 @@
 
 !#######################################################################
 
- subroutine compute_mrs_k_1d (temp, press, eps, zvir, mrs, nbad,  &
+ subroutine compute_mrs_k_1d (temp, press, eps, mrs, nbad,  &
                  mr, hc, dmrsdT, esat,es_over_liq, es_over_liq_and_ice)
 
  real, intent(in),  dimension(:)           :: temp, press
- real, intent(in)                          :: eps, zvir
+ real, intent(in)                          :: eps   !, zvir
  real, intent(out), dimension(:)           :: mrs
  integer, intent(out)                      :: nbad
  real, intent(in),  dimension(:), optional :: mr
@@ -2013,11 +2013,11 @@
 
 !#######################################################################
 
- subroutine compute_mrs_k_0d (temp, press, eps, zvir, mrs, nbad,   &
+ subroutine compute_mrs_k_0d (temp, press, eps, mrs, nbad,   &
                  mr, hc, dmrsdT, esat,es_over_liq, es_over_liq_and_ice)
 
  real, intent(in)                              :: temp, press
- real, intent(in)                              :: eps, zvir
+ real, intent(in)                              :: eps   !, zvir
  real, intent(out)                             :: mrs
  integer, intent(out)                          :: nbad
  real, intent(in),                    optional :: mr

--- a/test_fms/monin_obukhov/test_monin_obukhov.F90
+++ b/test_fms/monin_obukhov/test_monin_obukhov.F90
@@ -242,7 +242,7 @@ program test_monin_obukhov
 
       call monin_obukhov_profile_1d(vonkarm, &
            & neutral, stable_option, new_mo_option, rich_crit, zeta_trans, &
-           & n, zref, zref_t, z, z0, zt, zq, u_star, b_star, q_star, &
+           & n, zref, zref_t, z, z0, zt, zq, u_star, b_star,               &
            & del_m, del_t, del_q, .true., avail, ier_l)
 
       ! check sum results

--- a/time_manager/time_manager.F90
+++ b/time_manager/time_manager.F90
@@ -2696,7 +2696,7 @@ if(present(err_msg)) err_msg = ''
 
 select case(calendar_type)
 case(THIRTY_DAY_MONTHS)
-   days_in_month = days_in_month_thirty(Time)
+   days_in_month = days_in_month_thirty()
 case(GREGORIAN)
    days_in_month = days_in_month_gregorian(Time)
 case(JULIAN)
@@ -2744,13 +2744,13 @@ if(leap_year_julian(Time) .and. month == 2) days_in_month_julian = 29
 end function days_in_month_julian
 
 !--------------------------------------------------------------------------
-function days_in_month_thirty(Time)
+function days_in_month_thirty()
 
 ! Returns the number of days in a thirty day month (needed for transparent
 ! changes to calendar type).
 
 integer :: days_in_month_thirty
-type(time_type), intent(in) :: Time
+!type(time_type), intent(in) :: Time
 
 days_in_month_thirty = 30
 
@@ -2809,7 +2809,7 @@ case(GREGORIAN)
 case(JULIAN)
    leap_year = leap_year_julian(Time)
 case(NOLEAP)
-   leap_year = leap_year_no_leap(Time)
+   leap_year = leap_year_no_leap()
 case default
    if(error_handler('function leap_year', 'Invalid calendar type in leap_year', err_msg)) return
 end select
@@ -2873,12 +2873,12 @@ end function leap_year_thirty
 
 !--------------------------------------------------------------------------
 
-function leap_year_no_leap(Time)
+function leap_year_no_leap()
 
 ! Another tough one; no leap year returns false for leap year inquiry.
 
 logical :: leap_year_no_leap
-type(time_type), intent(in) :: Time
+!type(time_type), intent(in) :: Time
 
 leap_year_no_leap = .FALSE.
 
@@ -2990,13 +2990,13 @@ if(.not.module_is_initialized) call time_manager_init
 
 select case(calendar_type)
 case(THIRTY_DAY_MONTHS)
-   days_in_year = days_in_year_thirty(Time)
+   days_in_year = days_in_year_thirty()
 case(GREGORIAN)
    days_in_year = days_in_year_gregorian(Time)
 case(JULIAN)
    days_in_year = days_in_year_julian(Time)
 case(NOLEAP)
-   days_in_year = days_in_year_no_leap(Time)
+   days_in_year = days_in_year_no_leap()
 case default
    call error_mesg('days_in_year','Invalid calendar type in days_in_year',FATAL)
 end select
@@ -3005,10 +3005,10 @@ end function days_in_year
 
 !--------------------------------------------------------------------------
 
-function days_in_year_thirty(Time)
+function days_in_year_thirty()
 
 integer :: days_in_year_thirty
-type(time_type), intent(in) :: Time
+!type(time_type), intent(in) :: Time
 
 days_in_year_thirty = 360
 
@@ -3045,10 +3045,10 @@ end function days_in_year_julian
 
 !--------------------------------------------------------------------------
 
-function days_in_year_no_leap(Time)
+function days_in_year_no_leap()
 
 integer :: days_in_year_no_leap
-type(time_type), intent(in) :: Time
+!type(time_type), intent(in) :: Time
 
 days_in_year_no_leap = 365
 

--- a/time_manager/time_manager.F90
+++ b/time_manager/time_manager.F90
@@ -2750,7 +2750,6 @@ function days_in_month_thirty()
 ! changes to calendar type).
 
 integer :: days_in_month_thirty
-!type(time_type), intent(in) :: Time
 
 days_in_month_thirty = 30
 
@@ -2878,7 +2877,6 @@ function leap_year_no_leap()
 ! Another tough one; no leap year returns false for leap year inquiry.
 
 logical :: leap_year_no_leap
-!type(time_type), intent(in) :: Time
 
 leap_year_no_leap = .FALSE.
 
@@ -3008,7 +3006,6 @@ end function days_in_year
 function days_in_year_thirty()
 
 integer :: days_in_year_thirty
-!type(time_type), intent(in) :: Time
 
 days_in_year_thirty = 360
 
@@ -3048,7 +3045,6 @@ end function days_in_year_julian
 function days_in_year_no_leap()
 
 integer :: days_in_year_no_leap
-!type(time_type), intent(in) :: Time
 
 days_in_year_no_leap = 365
 

--- a/tracer_manager/tracer_manager.F90
+++ b/tracer_manager/tracer_manager.F90
@@ -1319,7 +1319,6 @@ subroutine set_tracer_method(model, name, method_type, method_control)
 integer, intent(in)                    :: model !< A parameter representing component model in use
 character(len=*), intent(in)           :: name !< Tracer name
 character(len=*), intent(in)           :: method_type !< type of method to be set
-!character(len=*), intent(in)           :: method_name !< name of method to be set
 character(len=*), intent(in)           :: method_control !< control parameters of the given method
 
 integer :: n, num_method, index

--- a/tracer_manager/tracer_manager.F90
+++ b/tracer_manager/tracer_manager.F90
@@ -1314,12 +1314,12 @@ endif
 end subroutine set_tracer_atts
 
 !> @brief A subroutine to allow the user to set some tracer specific methods.
-subroutine set_tracer_method(model, name, method_type, method_name, method_control)
+subroutine set_tracer_method(model, name, method_type, method_control)
 
 integer, intent(in)                    :: model !< A parameter representing component model in use
 character(len=*), intent(in)           :: name !< Tracer name
 character(len=*), intent(in)           :: method_type !< type of method to be set
-character(len=*), intent(in)           :: method_name !< name of method to be set
+!character(len=*), intent(in)           :: method_name !< name of method to be set
 character(len=*), intent(in)           :: method_control !< control parameters of the given method
 
 integer :: n, num_method, index


### PR DESCRIPTION
**Description**
Removes unused arguments that are called by using the flag `-Wunused-dummy-argument`when compiling with GCC
Arguments that were flagged as unused in mpp or coupler were not removed and a majority of the unused arguments in old IO were also left

Fixes # (820)

**How Has This Been Tested?**
Autotools compiled with oneapi and gcc

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

