### PR TITLE
Extend `string` interface in `fms_string_utils_mod`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -296,6 +296,7 @@ foreach(kind ${kinds})
   target_include_directories(${libTgt}_f PRIVATE include
                                                  fms
                                                  fms2_io/include
+                                                 string_utils/include
                                                  mpp/include
                                                  diag_manager/include
                                                  constants4
@@ -334,6 +335,7 @@ foreach(kind ${kinds})
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/fms>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/fms2_io/include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/string_utils/include>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/mpp/include>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/diag_manager/include>)
 

--- a/parser/yaml_parser.F90
+++ b/parser/yaml_parser.F90
@@ -266,11 +266,11 @@ subroutine get_value_from_key_0d(file_id, block_id, key_name, key_value, is_opti
 
    type(c_ptr) :: c_buffer !< c pointer with the value
    integer(kind=c_int) :: success !< Flag indicating if the value was obtained successfully
-   logical :: optional !< Flag indicating that the key was optional
+   logical :: optional_flag !< Flag indicating that the key was optional
    integer :: err_unit !< integer with io error
 
-   optional = .false.
-   if (present(is_optional)) optional = is_optional
+   optional_flag = .false.
+   if (present(is_optional)) optional_flag = is_optional
 
    if (.not. is_valid_file_id(file_id)) call mpp_error(FATAL, &
        &  "The file id in your get_value_from_key call is invalid! Check your call.")
@@ -313,7 +313,7 @@ subroutine get_value_from_key_0d(file_id, block_id, key_name, key_value, is_opti
                             &" is not supported. Only i4, i8, r4, r8 and strings are supported.")
      end select
    else
-     if(.not. optional) call mpp_error(FATAL, "Error getting the value for key:"//trim(key_name))
+     if(.not. optional_flag) call mpp_error(FATAL, "Error getting the value for key:"//trim(key_name))
    endif
 
 end subroutine get_value_from_key_0d
@@ -332,11 +332,11 @@ subroutine get_value_from_key_1d(file_id, block_id, key_name, key_value, is_opti
 
    type(c_ptr) :: c_buffer !< c pointer with the value
    integer(kind=c_int) :: success !< Flag indicating if the value was obtained successfully
-   logical :: optional !< Flag indicating that the key was optional
+   logical :: optional_flag !< Flag indicating that the key was optional
    integer :: err_unit !< integer with io error
 
-   optional=.false.
-   if (present(is_optional)) optional = is_optional
+   optional_flag=.false.
+   if (present(is_optional)) optional_flag = is_optional
 
    if (.not. is_valid_file_id(file_id)) call mpp_error(FATAL, &
        &  "The file id in your get_value_from_key call is invalid! Check your call.")
@@ -371,7 +371,7 @@ subroutine get_value_from_key_1d(file_id, block_id, key_name, key_value, is_opti
                             &" is not supported. Only i4, i8, r4, r8 and strings are supported.")
      end select
    else
-     if(.not. optional) call mpp_error(FATAL, "Error getting the value for key:"//trim(key_name))
+     if(.not. optional_flag) call mpp_error(FATAL, "Error getting the value for key:"//trim(key_name))
    endif
 end subroutine get_value_from_key_1d
 

--- a/parser/yaml_parser.F90
+++ b/parser/yaml_parser.F90
@@ -61,13 +61,13 @@ end interface get_value_from_key
 interface
 
 !> @brief Private c function that opens and parses a yaml file (see yaml_parser_binding.c)
-!! @return Flag indicating if the read was sucessful
+!! @return Flag indicating if the read was successful
 function open_and_parse_file_wrap(filename, file_id) bind(c) &
-   result(sucess)
+   result(success)
    use iso_c_binding, only: c_char, c_int, c_bool
    character(kind=c_char), intent(in) :: filename(*) !< Filename of the yaml file
    integer(kind=c_int), intent(out) :: file_id !< File id corresponding to the yaml file that was opened
-   logical(kind=c_bool) :: sucess !< Flag indicating if the read was sucessful
+   logical(kind=c_bool) :: success !< Flag indicating if the read was successful
 end function open_and_parse_file_wrap
 
 !> @brief Private c function that checks if a file_id is valid (see yaml_parser_binding.c)
@@ -129,14 +129,14 @@ end function get_value
 
 !> @brief Private c function that determines they value of a key in yaml_file (see yaml_parser_binding.c)
 !! @return c pointer with the value obtained
-function get_value_from_key_wrap(file_id, block_id, key_name, sucess) bind(c) &
+function get_value_from_key_wrap(file_id, block_id, key_name, success) bind(c) &
    result(key_value2)
 
    use iso_c_binding, only: c_ptr, c_char, c_int, c_bool
    integer(kind=c_int), intent(in) :: file_id !< File id of the yaml file to search
    integer(kind=c_int), intent(in) :: block_id !< ID corresponding to the block you want the key for
    character(kind=c_char), intent(in) :: key_name(*) !< Name of the key you want the value for
-   integer(kind=c_int), intent(out) :: sucess !< Flag indicating if the call was sucessful
+   integer(kind=c_int), intent(out) :: success !< Flag indicating if the call was successful
    type(c_ptr) :: key_value2
 end function get_value_from_key_wrap
 
@@ -206,7 +206,7 @@ function open_and_parse_file(filename) &
    result(file_id)
 
    character(len=*), intent(in) :: filename !< Filename of the yaml file
-   logical :: sucess !< Flag indicating if the read was sucessful
+   logical :: success !< Flag indicating if the read was successful
    logical :: yaml_exists !< Flag indicating whether the yaml exists
 
    integer :: file_id
@@ -217,8 +217,8 @@ function open_and_parse_file(filename) &
       call mpp_error(NOTE, "The yaml file:"//trim(filename)//" does not exist, hopefully this is your intent!")
       return
    end if
-   sucess = open_and_parse_file_wrap(trim(filename)//c_null_char, file_id)
-   if (.not. sucess) call mpp_error(FATAL, "Error opening the yaml file:"//trim(filename)//". Check the file!")
+   success = open_and_parse_file_wrap(trim(filename)//c_null_char, file_id)
+   if (.not. success) call mpp_error(FATAL, "Error opening the yaml file:"//trim(filename)//". Check the file!")
 
 end function open_and_parse_file
 
@@ -265,7 +265,7 @@ subroutine get_value_from_key_0d(file_id, block_id, key_name, key_value, is_opti
    character(len=255) :: buffer !< String buffer with the value
 
    type(c_ptr) :: c_buffer !< c pointer with the value
-   integer(kind=c_int) :: sucess !< Flag indicating if the value was obtained sucessfully
+   integer(kind=c_int) :: success !< Flag indicating if the value was obtained successfully
    logical :: optional !< Flag indicating that the key was optional
    integer :: err_unit !< integer with io error
 
@@ -277,8 +277,8 @@ subroutine get_value_from_key_0d(file_id, block_id, key_name, key_value, is_opti
    if (.not. is_valid_block_id(file_id, block_id)) call mpp_error(FATAL, &
        &  "The block id in your get_value_from_key call is invalid! Check your call.")
 
-   c_buffer = get_value_from_key_wrap(file_id, block_id, trim(key_name)//c_null_char, sucess)
-   if (sucess == 1) then
+   c_buffer = get_value_from_key_wrap(file_id, block_id, trim(key_name)//c_null_char, success)
+   if (success == 1) then
      buffer = fms_c2f_string(c_buffer)
 
      select type (key_value)
@@ -331,7 +331,7 @@ subroutine get_value_from_key_1d(file_id, block_id, key_name, key_value, is_opti
    character(len=255) :: buffer !< String buffer with the value
 
    type(c_ptr) :: c_buffer !< c pointer with the value
-   integer(kind=c_int) :: sucess !< Flag indicating if the value was obtained sucessfully
+   integer(kind=c_int) :: success !< Flag indicating if the value was obtained successfully
    logical :: optional !< Flag indicating that the key was optional
    integer :: err_unit !< integer with io error
 
@@ -343,8 +343,8 @@ subroutine get_value_from_key_1d(file_id, block_id, key_name, key_value, is_opti
    if (.not. is_valid_block_id(file_id, block_id)) call mpp_error(FATAL, &
        &  "The block id in your get_value_from_key call is invalid! Check your call.")
 
-   c_buffer = get_value_from_key_wrap(file_id, block_id, trim(key_name)//c_null_char, sucess)
-   if (sucess == 1) then
+   c_buffer = get_value_from_key_wrap(file_id, block_id, trim(key_name)//c_null_char, success)
+   if (success == 1) then
      buffer = fms_c2f_string(c_buffer)
 
      select type (key_value)

--- a/parser/yaml_parser.F90
+++ b/parser/yaml_parser.F90
@@ -127,7 +127,7 @@ function get_value(file_id, key_id) bind(c) &
    type(c_ptr) :: key_value
 end function get_value
 
-!> @brief Private c function that determines they value of a key in yaml_file (see yaml_parser_binding.c)
+!> @brief Private c function that determines the value of a key in yaml_file (see yaml_parser_binding.c)
 !! @return c pointer with the value obtained
 function get_value_from_key_wrap(file_id, block_id, key_name, success) bind(c) &
    result(key_value2)
@@ -258,7 +258,7 @@ subroutine get_value_from_key_0d(file_id, block_id, key_name, key_value, is_opti
    integer, intent(in) :: block_id !< ID corresponding to the block you want the key for
    character(len=*), intent(in) :: key_name !< Name of the key you want the value for
    class(*), intent(inout):: key_value !< Value of the key
-   logical, intent(in), optional :: is_optional !< Flag indicating if it is okay for they key to not exist.
+   logical, intent(in), optional :: is_optional !< Flag indicating if it is okay for the key to not exist.
                                                 !! If the key does not exist key_value will not be set, so it
                                                 !! is the user's responsibility to initialize it before the call
 
@@ -324,7 +324,7 @@ subroutine get_value_from_key_1d(file_id, block_id, key_name, key_value, is_opti
    integer, intent(in) :: block_id !< ID corresponding to the block you want the key for
    character(len=*), intent(in) :: key_name !< Name of the key you want the value for
    class(*), intent(inout):: key_value(:) !< Value of the key
-   logical, intent(in), optional :: is_optional !< Flag indicating if it is okay for they key' to not exist.
+   logical, intent(in), optional :: is_optional !< Flag indicating if it is okay for the key' to not exist.
                                                 !! If the key does not exist key_value will not be set, so it
                                                 !! is the user's responsibility to initialize it before the call
 

--- a/string_utils/Makefile.am
+++ b/string_utils/Makefile.am
@@ -30,6 +30,9 @@ noinst_LTLIBRARIES = libstring_utils.la
 # The convenience library depends on its source.
 libstring_utils_la_SOURCES = \
   fms_string_utils.F90 \
+  include/fms_string_utils.inc \
+  include/fms_string_utils_r4.fh \
+  include/fms_string_utils_r8.fh \
   fms_string_utils_binding.c
 
 MODFILES = \

--- a/string_utils/Makefile.am
+++ b/string_utils/Makefile.am
@@ -21,7 +21,7 @@
 # package.
 
 # Include .h and .mod files.
-AM_CPPFLAGS = -I$(top_srcdir)/include
+AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/string_utils/include
 AM_FCFLAGS = $(FC_MODINC). $(FC_MODOUT)$(MODDIR)
 
 # Build this uninstalled convenience library.

--- a/string_utils/fms_string_utils.F90
+++ b/string_utils/fms_string_utils.F90
@@ -116,6 +116,7 @@ end interface
 !> Converts a number or a real array to a string
 !> @ingroup fms_mod
 interface string
+  module procedure string_from_logical
   module procedure string_from_integer
   module procedure string_from_r4, string_from_r8
   module procedure string_from_array_1d_r4, string_from_array_1d_r8
@@ -241,6 +242,18 @@ contains
     enddo
 end subroutine fms_f2c_string
 
+  !> @brief Converts a Boolean value to a string
+  !> @return The Boolean value as a string
+  function string_from_logical(v)
+    logical, intent(in) :: v !< Boolean value to be converted to a string
+    character(:), allocatable :: string_from_logical
+
+    if (v) then
+      string_from_logical = "True"
+    else
+      string_from_logical = "False"
+    endif
+  end function
 
   !> @brief Converts an integer to a string
   !> @return The integer as a string

--- a/string_utils/fms_string_utils.F90
+++ b/string_utils/fms_string_utils.F90
@@ -251,8 +251,29 @@ end subroutine fms_f2c_string
     write(tmp,'(i0)') i
     res = trim(tmp)
    return
-
   end function string_from_integer
+
+  !> @brief Converts a real number (r4_kind) to a string
+  !> @return The real number as a string
+  function string_from_r4(r)
+    real(r4_kind), intent(in) :: r !< Real number to be converted to a string
+    character(:), allocatable :: string_from_r4
+    character(15) :: s
+
+    write(s, "(ES15.7E2)") r
+    string_from_r4 = trim(adjustl(s))
+  end function
+
+  !> @brief Converts a real number (r8_kind) to a string
+  !> @return The real number as a string
+  function string_from_r8(r)
+    real(r8_kind), intent(in) :: r !< Real number to be converted to a string
+    character(:), allocatable :: string_from_r8
+    character(25) :: s
+
+    write(s, "(ES25.16E2)") r
+    string_from_r8 = trim(adjustl(s))
+  end function
 
   !> @brief Safely copy a string from one buffer to another.
   subroutine string_copy(dest, source, check_for_null)

--- a/string_utils/fms_string_utils.F90
+++ b/string_utils/fms_string_utils.F90
@@ -272,28 +272,6 @@ end subroutine fms_f2c_string
    return
   end function string_from_integer
 
-  !> @brief Converts a real number (r4_kind) to a string
-  !> @return The real number as a string
-  function string_from_r4(r)
-    real(r4_kind), intent(in) :: r !< Real number to be converted to a string
-    character(:), allocatable :: string_from_r4
-    character(15) :: s
-
-    write(s, "(ES15.7E2)") r
-    string_from_r4 = trim(adjustl(s))
-  end function
-
-  !> @brief Converts a real number (r8_kind) to a string
-  !> @return The real number as a string
-  function string_from_r8(r)
-    real(r8_kind), intent(in) :: r !< Real number to be converted to a string
-    character(:), allocatable :: string_from_r8
-    character(25) :: s
-
-    write(s, "(ES25.16E2)") r
-    string_from_r8 = trim(adjustl(s))
-  end function
-
   !> @brief Safely copy a string from one buffer to another.
   subroutine string_copy(dest, source, check_for_null)
     character(len=*), intent(inout) :: dest !< Destination string.

--- a/string_utils/fms_string_utils.F90
+++ b/string_utils/fms_string_utils.F90
@@ -44,6 +44,7 @@ module fms_string_utils_mod
   public :: fms_cstring2cpointer
   public :: string
   public :: string_copy
+  public :: stringify
 !> @}
 
   interface
@@ -113,15 +114,20 @@ interface fms_c2f_string
   module procedure cpointer_fortran_conversion
 end interface
 
-!> Converts a number or a real array to a string
+!> Converts a number or a Boolean value to a string
 !> @ingroup fms_mod
 interface string
   module procedure string_from_logical
   module procedure string_from_integer
   module procedure string_from_r4, string_from_r8
-  module procedure string_from_array_1d_r4, string_from_array_1d_r8
-  module procedure string_from_array_2d_r4, string_from_array_2d_r8
-  module procedure string_from_array_3d_r4, string_from_array_3d_r8
+end interface
+
+!> Converts an array of real numbers to a string
+!> @ingroup fms_mod
+interface stringify
+  module procedure stringify_1d_r4, stringify_1d_r8
+  module procedure stringify_2d_r4, stringify_2d_r8
+  module procedure stringify_3d_r4, stringify_3d_r8
 end interface
 
 !> @addtogroup fms_string_utils_mod

--- a/string_utils/fms_string_utils.F90
+++ b/string_utils/fms_string_utils.F90
@@ -28,6 +28,7 @@
 !> @{
 module fms_string_utils_mod
   use, intrinsic :: iso_c_binding
+  use platform_mod, only: r4_kind, r8_kind
   use mpp_mod
 
   implicit none
@@ -112,11 +113,14 @@ interface fms_c2f_string
   module procedure cpointer_fortran_conversion
 end interface
 
-!> Converts a number to a string
+!> Converts a number or a real array to a string
 !> @ingroup fms_mod
 interface string
-   module procedure string_from_integer
-   module procedure string_from_real
+  module procedure string_from_integer
+  module procedure string_from_r4, string_from_r8
+  module procedure string_from_array_1d_r4, string_from_array_1d_r8
+  module procedure string_from_array_2d_r4, string_from_array_2d_r8
+  module procedure string_from_array_3d_r4, string_from_array_3d_r8
 end interface
 
 !> @addtogroup fms_string_utils_mod
@@ -250,19 +254,6 @@ end subroutine fms_f2c_string
 
   end function string_from_integer
 
-  !#######################################################################
-  !> @brief Converts a real to a string
-  !> @return The real number as a string
-  function string_from_real(r)
-    real, intent(in) :: r !< Real number to be converted to a string
-    character(len=32) :: string_from_real
-
-    write(string_from_real,*) r
-
-    return
-
-  end function string_from_real
-
   !> @brief Safely copy a string from one buffer to another.
   subroutine string_copy(dest, source, check_for_null)
     character(len=*), intent(inout) :: dest !< Destination string.
@@ -289,6 +280,9 @@ end subroutine fms_f2c_string
     dest = ""
     dest = adjustl(trim(source(1:i)))
   end subroutine string_copy
+
+#include "fms_string_utils_r4.fh"
+#include "fms_string_utils_r8.fh"
 
 end module fms_string_utils_mod
 !> @}

--- a/string_utils/include/fms_string_utils.inc
+++ b/string_utils/include/fms_string_utils.inc
@@ -1,0 +1,95 @@
+!***********************************************************************
+!*                   GNU Lesser General Public License
+!*
+!* This file is part of the GFDL Flexible Modeling System (FMS).
+!*
+!* FMS is free software: you can redistribute it and/or modify it under
+!* the terms of the GNU Lesser General Public License as published by
+!* the Free Software Foundation, either version 3 of the License, or (at
+!* your option) any later version.
+!*
+!* FMS is distributed in the hope that it will be useful, but WITHOUT
+!* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+!* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+!* for more details.
+!*
+!* You should have received a copy of the GNU Lesser General Public
+!* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
+!***********************************************************************
+
+!> @brief Converts a real number to a string
+!> @return The real number as a string
+function STRING_FROM_REAL_(r)
+  real(STRING_UTILS_KIND_), intent(in) :: r !< Real number to be converted to a string
+  character(:), allocatable :: STRING_FROM_REAL_
+  character(32) :: s
+
+  write(s, *) r
+  STRING_FROM_REAL_ = trim(adjustl(s))
+end function
+
+!> @brief Converts a 1D array of real numbers to a string
+!> @return The 1D array as a string
+function STRING_FROM_ARRAY_1D_(arr)
+  real(STRING_UTILS_KIND_), dimension(:), intent(in) :: arr
+  character(:), allocatable :: STRING_FROM_ARRAY_1D_
+  integer :: i, n
+
+  n = size(arr)
+
+  if (n .gt. 0) then
+    STRING_FROM_ARRAY_1D_ = "[" // STRING_FROM_REAL_(arr(1))
+  else
+    STRING_FROM_ARRAY_1D_ = "["
+  endif
+
+  do i = 2,n
+    STRING_FROM_ARRAY_1D_ = STRING_FROM_ARRAY_1D_ // ", " // STRING_FROM_REAL_(arr(i))
+  enddo
+
+  STRING_FROM_ARRAY_1D_ = STRING_FROM_ARRAY_1D_ // "]"
+end function
+
+!> @brief Converts a 2D array of real numbers to a string
+!> @return The 2D array as a string
+function STRING_FROM_ARRAY_2D_(arr)
+  real(STRING_UTILS_KIND_), dimension(:,:), intent(in) :: arr
+  character(:), allocatable :: STRING_FROM_ARRAY_2D_
+  integer :: i, n
+
+  n = size(arr, 2)
+
+  if (n .gt. 0) then
+    STRING_FROM_ARRAY_2D_ = "[" // STRING_FROM_ARRAY_1D_(arr(:,1))
+  else
+    STRING_FROM_ARRAY_2D_ = "["
+  endif
+
+  do i = 2,n
+    STRING_FROM_ARRAY_2D_ = STRING_FROM_ARRAY_2D_ // ", " // STRING_FROM_ARRAY_1D_(arr(:,i))
+  enddo
+
+  STRING_FROM_ARRAY_2D_ = STRING_FROM_ARRAY_2D_ // "]"
+end function
+
+!> @brief Converts a 3D array of real numbers to a string
+!> @return The 3D array as a string
+function STRING_FROM_ARRAY_3D_(arr)
+  real(STRING_UTILS_KIND_), dimension(:,:,:), intent(in) :: arr
+  character(:), allocatable :: STRING_FROM_ARRAY_3D_
+  integer :: i, n
+
+  n = size(arr, 3)
+
+  if (n .gt. 0) then
+    STRING_FROM_ARRAY_3D_ = "[" // STRING_FROM_ARRAY_2D_(arr(:,:,1))
+  else
+    STRING_FROM_ARRAY_3D_ = "["
+  endif
+
+  do i = 2,n
+    STRING_FROM_ARRAY_3D_ = STRING_FROM_ARRAY_3D_ // ", " // STRING_FROM_ARRAY_2D_(arr(:,:,i))
+  enddo
+
+  STRING_FROM_ARRAY_3D_ = STRING_FROM_ARRAY_3D_ // "]"
+end function

--- a/string_utils/include/fms_string_utils.inc
+++ b/string_utils/include/fms_string_utils.inc
@@ -17,23 +17,6 @@
 !* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
 !***********************************************************************
 
-!> @brief Converts a real number to a string
-!> @return The real number as a string
-function STRING_FROM_REAL_(r, fmt)
-  real(STRING_UTILS_KIND_), intent(in) :: r !< Real number to be converted to a string
-  character(*), intent(in), optional :: fmt !< Optional format string for the real number
-  character(:), allocatable :: STRING_FROM_REAL_
-  character(32) :: s
-
-  if (present(fmt)) then
-    write(s, "(" // fmt // ")") r
-  else
-    write(s, *) r
-  endif
-
-  STRING_FROM_REAL_ = trim(adjustl(s))
-end function
-
 !> @brief Converts a 1D array of real numbers to a string
 !> @return The 1D array as a string
 function STRINGIFY_1D_(arr, fmt)

--- a/string_utils/include/fms_string_utils.inc
+++ b/string_utils/include/fms_string_utils.inc
@@ -17,17 +17,6 @@
 !* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
 !***********************************************************************
 
-!> @brief Converts a real number to a string
-!> @return The real number as a string
-function STRING_FROM_REAL_(r)
-  real(STRING_UTILS_KIND_), intent(in) :: r !< Real number to be converted to a string
-  character(:), allocatable :: STRING_FROM_REAL_
-  character(32) :: s
-
-  write(s, *) r
-  STRING_FROM_REAL_ = trim(adjustl(s))
-end function
-
 !> @brief Converts a 1D array of real numbers to a string
 !> @return The 1D array as a string
 function STRING_FROM_ARRAY_1D_(arr)
@@ -38,13 +27,13 @@ function STRING_FROM_ARRAY_1D_(arr)
   n = size(arr)
 
   if (n .gt. 0) then
-    STRING_FROM_ARRAY_1D_ = "[" // STRING_FROM_REAL_(arr(1))
+    STRING_FROM_ARRAY_1D_ = "[" // string(arr(1))
   else
     STRING_FROM_ARRAY_1D_ = "["
   endif
 
   do i = 2,n
-    STRING_FROM_ARRAY_1D_ = STRING_FROM_ARRAY_1D_ // ", " // STRING_FROM_REAL_(arr(i))
+    STRING_FROM_ARRAY_1D_ = STRING_FROM_ARRAY_1D_ // ", " // string(arr(i))
   enddo
 
   STRING_FROM_ARRAY_1D_ = STRING_FROM_ARRAY_1D_ // "]"

--- a/string_utils/include/fms_string_utils.inc
+++ b/string_utils/include/fms_string_utils.inc
@@ -23,7 +23,7 @@ function STRING_FROM_REAL_(r, fmt)
   real(STRING_UTILS_KIND_), intent(in) :: r !< Real number to be converted to a string
   character(*), intent(in), optional :: fmt !< Optional format string for the real number
   character(:), allocatable :: STRING_FROM_REAL_
-  character(25) :: s
+  character(32) :: s
 
   if (present(fmt)) then
     write(s, "(" // fmt // ")") r

--- a/string_utils/include/fms_string_utils.inc
+++ b/string_utils/include/fms_string_utils.inc
@@ -19,66 +19,66 @@
 
 !> @brief Converts a 1D array of real numbers to a string
 !> @return The 1D array as a string
-function STRING_FROM_ARRAY_1D_(arr)
+function STRINGIFY_1D_(arr)
   real(STRING_UTILS_KIND_), dimension(:), intent(in) :: arr
-  character(:), allocatable :: STRING_FROM_ARRAY_1D_
+  character(:), allocatable :: STRINGIFY_1D_
   integer :: i, n
 
   n = size(arr)
 
   if (n .gt. 0) then
-    STRING_FROM_ARRAY_1D_ = "[" // string(arr(1))
+    STRINGIFY_1D_ = "[" // string(arr(1))
   else
-    STRING_FROM_ARRAY_1D_ = "["
+    STRINGIFY_1D_ = "["
   endif
 
   do i = 2,n
-    STRING_FROM_ARRAY_1D_ = STRING_FROM_ARRAY_1D_ // ", " // string(arr(i))
+    STRINGIFY_1D_ = STRINGIFY_1D_ // ", " // string(arr(i))
   enddo
 
-  STRING_FROM_ARRAY_1D_ = STRING_FROM_ARRAY_1D_ // "]"
+  STRINGIFY_1D_ = STRINGIFY_1D_ // "]"
 end function
 
 !> @brief Converts a 2D array of real numbers to a string
 !> @return The 2D array as a string
-function STRING_FROM_ARRAY_2D_(arr)
+function STRINGIFY_2D_(arr)
   real(STRING_UTILS_KIND_), dimension(:,:), intent(in) :: arr
-  character(:), allocatable :: STRING_FROM_ARRAY_2D_
+  character(:), allocatable :: STRINGIFY_2D_
   integer :: i, n
 
   n = size(arr, 2)
 
   if (n .gt. 0) then
-    STRING_FROM_ARRAY_2D_ = "[" // STRING_FROM_ARRAY_1D_(arr(:,1))
+    STRINGIFY_2D_ = "[" // STRINGIFY_1D_(arr(:,1))
   else
-    STRING_FROM_ARRAY_2D_ = "["
+    STRINGIFY_2D_ = "["
   endif
 
   do i = 2,n
-    STRING_FROM_ARRAY_2D_ = STRING_FROM_ARRAY_2D_ // ", " // STRING_FROM_ARRAY_1D_(arr(:,i))
+    STRINGIFY_2D_ = STRINGIFY_2D_ // ", " // STRINGIFY_1D_(arr(:,i))
   enddo
 
-  STRING_FROM_ARRAY_2D_ = STRING_FROM_ARRAY_2D_ // "]"
+  STRINGIFY_2D_ = STRINGIFY_2D_ // "]"
 end function
 
 !> @brief Converts a 3D array of real numbers to a string
 !> @return The 3D array as a string
-function STRING_FROM_ARRAY_3D_(arr)
+function STRINGIFY_3D_(arr)
   real(STRING_UTILS_KIND_), dimension(:,:,:), intent(in) :: arr
-  character(:), allocatable :: STRING_FROM_ARRAY_3D_
+  character(:), allocatable :: STRINGIFY_3D_
   integer :: i, n
 
   n = size(arr, 3)
 
   if (n .gt. 0) then
-    STRING_FROM_ARRAY_3D_ = "[" // STRING_FROM_ARRAY_2D_(arr(:,:,1))
+    STRINGIFY_3D_ = "[" // STRINGIFY_2D_(arr(:,:,1))
   else
-    STRING_FROM_ARRAY_3D_ = "["
+    STRINGIFY_3D_ = "["
   endif
 
   do i = 2,n
-    STRING_FROM_ARRAY_3D_ = STRING_FROM_ARRAY_3D_ // ", " // STRING_FROM_ARRAY_2D_(arr(:,:,i))
+    STRINGIFY_3D_ = STRINGIFY_3D_ // ", " // STRINGIFY_2D_(arr(:,:,i))
   enddo
 
-  STRING_FROM_ARRAY_3D_ = STRING_FROM_ARRAY_3D_ // "]"
+  STRINGIFY_3D_ = STRINGIFY_3D_ // "]"
 end function

--- a/string_utils/include/fms_string_utils.inc
+++ b/string_utils/include/fms_string_utils.inc
@@ -17,23 +17,41 @@
 !* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
 !***********************************************************************
 
+!> @brief Converts a real number to a string
+!> @return The real number as a string
+function STRING_FROM_REAL_(r, fmt)
+  real(STRING_UTILS_KIND_), intent(in) :: r !< Real number to be converted to a string
+  character(*), intent(in), optional :: fmt !< Optional format string for the real number
+  character(:), allocatable :: STRING_FROM_REAL_
+  character(25) :: s
+
+  if (present(fmt)) then
+    write(s, "(" // fmt // ")") r
+  else
+    write(s, *) r
+  endif
+
+  STRING_FROM_REAL_ = trim(adjustl(s))
+end function
+
 !> @brief Converts a 1D array of real numbers to a string
 !> @return The 1D array as a string
-function STRINGIFY_1D_(arr)
-  real(STRING_UTILS_KIND_), dimension(:), intent(in) :: arr
+function STRINGIFY_1D_(arr, fmt)
+  real(STRING_UTILS_KIND_), dimension(:), intent(in) :: arr !< Real array to be converted to a string
+  character(*), intent(in), optional :: fmt !< Optional format string for the real array entries
   character(:), allocatable :: STRINGIFY_1D_
   integer :: i, n
 
   n = size(arr)
 
   if (n .gt. 0) then
-    STRINGIFY_1D_ = "[" // string(arr(1))
+    STRINGIFY_1D_ = "[" // string(arr(1), fmt)
   else
     STRINGIFY_1D_ = "["
   endif
 
   do i = 2,n
-    STRINGIFY_1D_ = STRINGIFY_1D_ // ", " // string(arr(i))
+    STRINGIFY_1D_ = STRINGIFY_1D_ // ", " // string(arr(i), fmt)
   enddo
 
   STRINGIFY_1D_ = STRINGIFY_1D_ // "]"
@@ -41,21 +59,22 @@ end function
 
 !> @brief Converts a 2D array of real numbers to a string
 !> @return The 2D array as a string
-function STRINGIFY_2D_(arr)
-  real(STRING_UTILS_KIND_), dimension(:,:), intent(in) :: arr
+function STRINGIFY_2D_(arr, fmt)
+  real(STRING_UTILS_KIND_), dimension(:,:), intent(in) :: arr !< Real array to be converted to a string
+  character(*), intent(in), optional :: fmt !< Optional format string for the real array entries
   character(:), allocatable :: STRINGIFY_2D_
   integer :: i, n
 
   n = size(arr, 2)
 
   if (n .gt. 0) then
-    STRINGIFY_2D_ = "[" // STRINGIFY_1D_(arr(:,1))
+    STRINGIFY_2D_ = "[" // STRINGIFY_1D_(arr(:,1), fmt)
   else
     STRINGIFY_2D_ = "["
   endif
 
   do i = 2,n
-    STRINGIFY_2D_ = STRINGIFY_2D_ // ", " // STRINGIFY_1D_(arr(:,i))
+    STRINGIFY_2D_ = STRINGIFY_2D_ // ", " // STRINGIFY_1D_(arr(:,i), fmt)
   enddo
 
   STRINGIFY_2D_ = STRINGIFY_2D_ // "]"
@@ -63,21 +82,22 @@ end function
 
 !> @brief Converts a 3D array of real numbers to a string
 !> @return The 3D array as a string
-function STRINGIFY_3D_(arr)
-  real(STRING_UTILS_KIND_), dimension(:,:,:), intent(in) :: arr
+function STRINGIFY_3D_(arr, fmt)
+  real(STRING_UTILS_KIND_), dimension(:,:,:), intent(in) :: arr !< Real array to be converted to a string
+  character(*), intent(in), optional :: fmt !< Optional format string for the real array entries
   character(:), allocatable :: STRINGIFY_3D_
   integer :: i, n
 
   n = size(arr, 3)
 
   if (n .gt. 0) then
-    STRINGIFY_3D_ = "[" // STRINGIFY_2D_(arr(:,:,1))
+    STRINGIFY_3D_ = "[" // STRINGIFY_2D_(arr(:,:,1), fmt)
   else
     STRINGIFY_3D_ = "["
   endif
 
   do i = 2,n
-    STRINGIFY_3D_ = STRINGIFY_3D_ // ", " // STRINGIFY_2D_(arr(:,:,i))
+    STRINGIFY_3D_ = STRINGIFY_3D_ // ", " // STRINGIFY_2D_(arr(:,:,i), fmt)
   enddo
 
   STRINGIFY_3D_ = STRINGIFY_3D_ // "]"

--- a/string_utils/include/fms_string_utils_r4.fh
+++ b/string_utils/include/fms_string_utils_r4.fh
@@ -18,6 +18,7 @@
 !***********************************************************************
 
 #define STRING_UTILS_KIND_ r4_kind
+#define STRING_FROM_REAL_ string_from_r4
 #define STRINGIFY_1D_ stringify_1d_r4
 #define STRINGIFY_2D_ stringify_2d_r4
 #define STRINGIFY_3D_ stringify_3d_r4
@@ -25,6 +26,7 @@
 #include "fms_string_utils.inc"
 
 #undef STRING_UTILS_KIND_
+#undef STRING_FROM_REAL_
 #undef STRINGIFY_1D_
 #undef STRINGIFY_2D_
 #undef STRINGIFY_3D_

--- a/string_utils/include/fms_string_utils_r4.fh
+++ b/string_utils/include/fms_string_utils_r4.fh
@@ -18,7 +18,6 @@
 !***********************************************************************
 
 #define STRING_UTILS_KIND_ r4_kind
-#define STRING_FROM_REAL_ string_from_r4
 #define STRING_FROM_ARRAY_1D_ string_from_array_1d_r4
 #define STRING_FROM_ARRAY_2D_ string_from_array_2d_r4
 #define STRING_FROM_ARRAY_3D_ string_from_array_3d_r4
@@ -26,7 +25,6 @@
 #include "fms_string_utils.inc"
 
 #undef STRING_UTILS_KIND_
-#undef STRING_FROM_REAL_
 #undef STRING_FROM_ARRAY_1D_
 #undef STRING_FROM_ARRAY_2D_
 #undef STRING_FROM_ARRAY_3D_

--- a/string_utils/include/fms_string_utils_r4.fh
+++ b/string_utils/include/fms_string_utils_r4.fh
@@ -18,7 +18,6 @@
 !***********************************************************************
 
 #define STRING_UTILS_KIND_ r4_kind
-#define STRING_FROM_REAL_ string_from_r4
 #define STRINGIFY_1D_ stringify_1d_r4
 #define STRINGIFY_2D_ stringify_2d_r4
 #define STRINGIFY_3D_ stringify_3d_r4
@@ -26,7 +25,6 @@
 #include "fms_string_utils.inc"
 
 #undef STRING_UTILS_KIND_
-#undef STRING_FROM_REAL_
 #undef STRINGIFY_1D_
 #undef STRINGIFY_2D_
 #undef STRINGIFY_3D_

--- a/string_utils/include/fms_string_utils_r4.fh
+++ b/string_utils/include/fms_string_utils_r4.fh
@@ -18,13 +18,13 @@
 !***********************************************************************
 
 #define STRING_UTILS_KIND_ r4_kind
-#define STRING_FROM_ARRAY_1D_ string_from_array_1d_r4
-#define STRING_FROM_ARRAY_2D_ string_from_array_2d_r4
-#define STRING_FROM_ARRAY_3D_ string_from_array_3d_r4
+#define STRINGIFY_1D_ stringify_1d_r4
+#define STRINGIFY_2D_ stringify_2d_r4
+#define STRINGIFY_3D_ stringify_3d_r4
 
 #include "fms_string_utils.inc"
 
 #undef STRING_UTILS_KIND_
-#undef STRING_FROM_ARRAY_1D_
-#undef STRING_FROM_ARRAY_2D_
-#undef STRING_FROM_ARRAY_3D_
+#undef STRINGIFY_1D_
+#undef STRINGIFY_2D_
+#undef STRINGIFY_3D_

--- a/string_utils/include/fms_string_utils_r4.fh
+++ b/string_utils/include/fms_string_utils_r4.fh
@@ -1,0 +1,32 @@
+!***********************************************************************
+!*                   GNU Lesser General Public License
+!*
+!* This file is part of the GFDL Flexible Modeling System (FMS).
+!*
+!* FMS is free software: you can redistribute it and/or modify it under
+!* the terms of the GNU Lesser General Public License as published by
+!* the Free Software Foundation, either version 3 of the License, or (at
+!* your option) any later version.
+!*
+!* FMS is distributed in the hope that it will be useful, but WITHOUT
+!* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+!* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+!* for more details.
+!*
+!* You should have received a copy of the GNU Lesser General Public
+!* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
+!***********************************************************************
+
+#define STRING_UTILS_KIND_ r4_kind
+#define STRING_FROM_REAL_ string_from_r4
+#define STRING_FROM_ARRAY_1D_ string_from_array_1d_r4
+#define STRING_FROM_ARRAY_2D_ string_from_array_2d_r4
+#define STRING_FROM_ARRAY_3D_ string_from_array_3d_r4
+
+#include "fms_string_utils.inc"
+
+#undef STRING_UTILS_KIND_
+#undef STRING_FROM_REAL_
+#undef STRING_FROM_ARRAY_1D_
+#undef STRING_FROM_ARRAY_2D_
+#undef STRING_FROM_ARRAY_3D_

--- a/string_utils/include/fms_string_utils_r8.fh
+++ b/string_utils/include/fms_string_utils_r8.fh
@@ -18,7 +18,6 @@
 !***********************************************************************
 
 #define STRING_UTILS_KIND_ r8_kind
-#define STRING_FROM_REAL_ string_from_r8
 #define STRING_FROM_ARRAY_1D_ string_from_array_1d_r8
 #define STRING_FROM_ARRAY_2D_ string_from_array_2d_r8
 #define STRING_FROM_ARRAY_3D_ string_from_array_3d_r8
@@ -26,7 +25,6 @@
 #include "fms_string_utils.inc"
 
 #undef STRING_UTILS_KIND_
-#undef STRING_FROM_REAL_
 #undef STRING_FROM_ARRAY_1D_
 #undef STRING_FROM_ARRAY_2D_
 #undef STRING_FROM_ARRAY_3D_

--- a/string_utils/include/fms_string_utils_r8.fh
+++ b/string_utils/include/fms_string_utils_r8.fh
@@ -1,0 +1,32 @@
+!***********************************************************************
+!*                   GNU Lesser General Public License
+!*
+!* This file is part of the GFDL Flexible Modeling System (FMS).
+!*
+!* FMS is free software: you can redistribute it and/or modify it under
+!* the terms of the GNU Lesser General Public License as published by
+!* the Free Software Foundation, either version 3 of the License, or (at
+!* your option) any later version.
+!*
+!* FMS is distributed in the hope that it will be useful, but WITHOUT
+!* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+!* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+!* for more details.
+!*
+!* You should have received a copy of the GNU Lesser General Public
+!* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
+!***********************************************************************
+
+#define STRING_UTILS_KIND_ r8_kind
+#define STRING_FROM_REAL_ string_from_r8
+#define STRING_FROM_ARRAY_1D_ string_from_array_1d_r8
+#define STRING_FROM_ARRAY_2D_ string_from_array_2d_r8
+#define STRING_FROM_ARRAY_3D_ string_from_array_3d_r8
+
+#include "fms_string_utils.inc"
+
+#undef STRING_UTILS_KIND_
+#undef STRING_FROM_REAL_
+#undef STRING_FROM_ARRAY_1D_
+#undef STRING_FROM_ARRAY_2D_
+#undef STRING_FROM_ARRAY_3D_

--- a/string_utils/include/fms_string_utils_r8.fh
+++ b/string_utils/include/fms_string_utils_r8.fh
@@ -18,7 +18,6 @@
 !***********************************************************************
 
 #define STRING_UTILS_KIND_ r8_kind
-#define STRING_FROM_REAL_ string_from_r8
 #define STRINGIFY_1D_ stringify_1d_r8
 #define STRINGIFY_2D_ stringify_2d_r8
 #define STRINGIFY_3D_ stringify_3d_r8
@@ -26,7 +25,6 @@
 #include "fms_string_utils.inc"
 
 #undef STRING_UTILS_KIND_
-#undef STRING_FROM_REAL_
 #undef STRINGIFY_1D_
 #undef STRINGIFY_2D_
 #undef STRINGIFY_3D_

--- a/string_utils/include/fms_string_utils_r8.fh
+++ b/string_utils/include/fms_string_utils_r8.fh
@@ -18,13 +18,13 @@
 !***********************************************************************
 
 #define STRING_UTILS_KIND_ r8_kind
-#define STRING_FROM_ARRAY_1D_ string_from_array_1d_r8
-#define STRING_FROM_ARRAY_2D_ string_from_array_2d_r8
-#define STRING_FROM_ARRAY_3D_ string_from_array_3d_r8
+#define STRINGIFY_1D_ stringify_1d_r8
+#define STRINGIFY_2D_ stringify_2d_r8
+#define STRINGIFY_3D_ stringify_3d_r8
 
 #include "fms_string_utils.inc"
 
 #undef STRING_UTILS_KIND_
-#undef STRING_FROM_ARRAY_1D_
-#undef STRING_FROM_ARRAY_2D_
-#undef STRING_FROM_ARRAY_3D_
+#undef STRINGIFY_1D_
+#undef STRINGIFY_2D_
+#undef STRINGIFY_3D_

--- a/string_utils/include/fms_string_utils_r8.fh
+++ b/string_utils/include/fms_string_utils_r8.fh
@@ -18,6 +18,7 @@
 !***********************************************************************
 
 #define STRING_UTILS_KIND_ r8_kind
+#define STRING_FROM_REAL_ string_from_r8
 #define STRINGIFY_1D_ stringify_1d_r8
 #define STRINGIFY_2D_ stringify_2d_r8
 #define STRINGIFY_3D_ stringify_3d_r8
@@ -25,6 +26,7 @@
 #include "fms_string_utils.inc"
 
 #undef STRING_UTILS_KIND_
+#undef STRING_FROM_REAL_
 #undef STRINGIFY_1D_
 #undef STRINGIFY_2D_
 #undef STRINGIFY_3D_

--- a/test_fms/string_utils/test_string_utils.F90
+++ b/test_fms/string_utils/test_string_utils.F90
@@ -22,7 +22,7 @@
 program test_fms_string_utils
   use fms_string_utils_mod
   use fms_mod, only: fms_init, fms_end
-  use platform_mod, only: r4_kind, r8_kind
+  use platform_mod, only: r4_kind, r8_kind, i4_kind, i8_kind
   use mpp_mod
   use, intrinsic :: iso_c_binding
 
@@ -178,32 +178,36 @@ program test_fms_string_utils
       call mpp_error(FATAL, "string() unit test failed for Boolean false value")
     endif
 
-    if (string(0) .ne. "0") then
-      call mpp_error(FATAL, "string() unit test failed for zero integer")
+    if (string(12345_i4_kind) .ne. "12345") then
+      call mpp_error(FATAL, "string() unit test failed for positive integer(4)")
     endif
 
-    if (string(12345) .ne. "12345") then
-      call mpp_error(FATAL, "string() unit test failed for positive integer")
+    if (string(-12345_i4_kind) .ne. "-12345") then
+      call mpp_error(FATAL, "string() unit test failed for negative integer(4)")
     endif
 
-    if (string(-12345) .ne. "-12345") then
-      call mpp_error(FATAL, "string() unit test failed for negative integer")
+    if (string(12345_i8_kind) .ne. "12345") then
+      call mpp_error(FATAL, "string() unit test failed for positive integer(8)")
+    endif
+
+    if (string(-12345_i8_kind) .ne. "-12345") then
+      call mpp_error(FATAL, "string() unit test failed for negative integer(8)")
     endif
 
     if (string(1._r4_kind, "F15.7") .ne. "1.0000000") then
-      call mpp_error(FATAL, "string() unit test failed for positive r4 real")
+      call mpp_error(FATAL, "string() unit test failed for positive real(4)")
     endif
 
     if (string(-1._r4_kind, "F15.7") .ne. "-1.0000000") then
-      call mpp_error(FATAL, "string() unit test failed for negative r4 real")
+      call mpp_error(FATAL, "string() unit test failed for negative real(4)")
     endif
 
     if (string(1._r8_kind, "F25.16") .ne. "1.0000000000000000") then
-      call mpp_error(FATAL, "string() unit test failed for positive r8 real")
+      call mpp_error(FATAL, "string() unit test failed for positive real(8)")
     endif
 
     if (string(-1._r8_kind, "F25.16") .ne. "-1.0000000000000000") then
-      call mpp_error(FATAL, "string() unit test failed for negative r8 real")
+      call mpp_error(FATAL, "string() unit test failed for negative real(8)")
     endif
   end subroutine
 

--- a/test_fms/string_utils/test_string_utils.F90
+++ b/test_fms/string_utils/test_string_utils.F90
@@ -22,6 +22,7 @@
 program test_fms_string_utils
   use fms_string_utils_mod
   use fms_mod, only: fms_init, fms_end
+  use platform_mod, only: r4_kind, r8_kind
   use mpp_mod
   use, intrinsic :: iso_c_binding
 
@@ -110,6 +111,8 @@ program test_fms_string_utils
   print *, "Checking if fms_find_unique determines the correct number of unique strings"
   if (nunique .ne. 7) call mpp_error(FATAL, "The number of unique strings in your array is not correct")
 
+  call check_string
+
   call fms_end()
 
   deallocate(my_array)
@@ -164,5 +167,76 @@ program test_fms_string_utils
       endif
     end do
   end subroutine check_my_indices
+
+  subroutine check_string
+    real(r4_kind) :: arr_1d_r4(3), arr_2d_r4(2, 2), arr_3d_r4(2, 2, 2)
+    real(r8_kind) :: arr_1d_r8(3), arr_2d_r8(2, 2), arr_3d_r8(2, 2, 2)
+
+    if (string(12345) .ne. "12345") then
+      call mpp_error(FATAL, "string() unit test failed for positive integer")
+    endif
+
+    if (string(-12345) .ne. "-12345") then
+      call mpp_error(FATAL, "string() unit test failed for negative integer")
+    endif
+
+    if (string(1.2345_ r4_kind) .ne. "1.23450005") then
+      call mpp_error(FATAL, "string() unit test failed for positive r4 real")
+    endif
+
+    if (string(-1.2345_ r4_kind) .ne. "-1.23450005") then
+      call mpp_error(FATAL, "string() unit test failed for negative r4 real")
+    endif
+
+    if (string(1.2345_ r8_kind) .ne. "1.2344999999999999") then
+      call mpp_error(FATAL, "string() unit test failed for positive r8 real")
+    endif
+
+    if (string(-1.2345_ r8_kind) .ne. "-1.2344999999999999") then
+      call mpp_error(FATAL, "string() unit test failed for negative r8 real")
+    endif
+
+    arr_1d_r4 = [0._ r4_kind, 1._ r4_kind, 2._ r4_kind]
+    if (string(arr_1d_r4) .ne. "[0.00000000, 1.00000000, 2.00000000]") then
+      call mpp_error(FATAL, "string() unit test failed for 1D r4 array")
+    endif
+
+    arr_1d_r8 = [0._ r8_kind, 1._ r8_kind, 2._ r8_kind]
+    if (string(arr_1d_r8) .ne. "[0.0000000000000000, 1.0000000000000000, 2.0000000000000000]") then
+      call mpp_error(FATAL, "string() unit test failed for 1D r8 array")
+    endif
+
+    arr_2d_r4 = reshape([[0._ r4_kind, 1._ r4_kind], [2._ r4_kind, 3._ r4_kind]], [2, 2])
+    if (string(arr_2d_r4) .ne. &
+    & "[[0.00000000, 1.00000000], [2.00000000, 3.00000000]]") then
+      call mpp_error(FATAL, "string() unit test failed for 2D r4 array")
+    endif
+
+    arr_2d_r8 = reshape([[0._ r8_kind, 1._ r8_kind], [2._ r8_kind, 3._ r8_kind]], [2, 2])
+    if (string(arr_2d_r8) .ne. &
+    & "[[0.0000000000000000, 1.0000000000000000], [2.0000000000000000, 3.0000000000000000]]") then
+      call mpp_error(FATAL, "string() unit test failed for 2D r8 array")
+    endif
+
+    arr_3d_r4 = reshape([ &
+      & [[0._ r4_kind, 1._ r4_kind], [2._ r4_kind, 3._ r4_kind]], &
+      & [[4._ r4_kind, 5._ r4_kind], [6._ r4_kind, 7._ r4_kind]] &
+    & ], [2, 2, 2])
+    if (string(arr_3d_r4) .ne. &
+    & "[[[0.00000000, 1.00000000], [2.00000000, 3.00000000]],&
+      & [[4.00000000, 5.00000000], [6.00000000, 7.00000000]]]") then
+      call mpp_error(FATAL, "string() unit test failed for 3D r4 array")
+    endif
+
+    arr_3d_r8 = reshape([ &
+      & [[0._ r8_kind, 1._ r8_kind], [2._ r8_kind, 3._ r8_kind]], &
+      & [[4._ r8_kind, 5._ r8_kind], [6._ r8_kind, 7._ r8_kind]] &
+    & ], [2, 2, 2])
+    if (string(arr_3d_r8) .ne. &
+    & "[[[0.0000000000000000, 1.0000000000000000], [2.0000000000000000, 3.0000000000000000]],&
+      & [[4.0000000000000000, 5.0000000000000000], [6.0000000000000000, 7.0000000000000000]]]") then
+      call mpp_error(FATAL, "string() unit test failed for 3D r8 array")
+    endif
+  end subroutine
 
 end program test_fms_string_utils

--- a/test_fms/string_utils/test_string_utils.F90
+++ b/test_fms/string_utils/test_string_utils.F90
@@ -190,19 +190,19 @@ program test_fms_string_utils
       call mpp_error(FATAL, "string() unit test failed for negative integer")
     endif
 
-    if (string(1._r4_kind) .ne. "1.0000000E+00") then
+    if (string(1._r4_kind, "F15.7") .ne. "1.0000000") then
       call mpp_error(FATAL, "string() unit test failed for positive r4 real")
     endif
 
-    if (string(-1._r4_kind) .ne. "-1.0000000E+00") then
+    if (string(-1._r4_kind, "F15.7") .ne. "-1.0000000") then
       call mpp_error(FATAL, "string() unit test failed for negative r4 real")
     endif
 
-    if (string(1._r8_kind) .ne. "1.0000000000000000E+00") then
+    if (string(1._r8_kind, "F25.16") .ne. "1.0000000000000000") then
       call mpp_error(FATAL, "string() unit test failed for positive r8 real")
     endif
 
-    if (string(-1._r8_kind) .ne. "-1.0000000000000000E+00") then
+    if (string(-1._r8_kind, "F25.16") .ne. "-1.0000000000000000") then
       call mpp_error(FATAL, "string() unit test failed for negative r8 real")
     endif
   end subroutine
@@ -212,24 +212,24 @@ program test_fms_string_utils
     real(r8_kind) :: arr_1d_r8(3), arr_2d_r8(2, 2), arr_3d_r8(2, 2, 2)
 
     arr_1d_r4 = [0._r4_kind, 1._r4_kind, 2._r4_kind]
-    if (stringify(arr_1d_r4) .ne. "[0.0000000E+00, 1.0000000E+00, 2.0000000E+00]") then
+    if (stringify(arr_1d_r4, "F15.7") .ne. "[0.0000000, 1.0000000, 2.0000000]") then
       call mpp_error(FATAL, "stringify() unit test failed for 1D r4 array")
     endif
 
     arr_1d_r8 = [0._r8_kind, 1._r8_kind, 2._r8_kind]
-    if (stringify(arr_1d_r8) .ne. "[0.0000000000000000E+00, 1.0000000000000000E+00, 2.0000000000000000E+00]") then
+    if (stringify(arr_1d_r8, "F25.16") .ne. "[0.0000000000000000, 1.0000000000000000, 2.0000000000000000]") then
       call mpp_error(FATAL, "stringify() unit test failed for 1D r8 array")
     endif
 
     arr_2d_r4 = reshape([[0._r4_kind, 1._r4_kind], [2._r4_kind, 3._r4_kind]], [2, 2])
-    if (stringify(arr_2d_r4) .ne. &
-    & "[[0.0000000E+00, 1.0000000E+00], [2.0000000E+00, 3.0000000E+00]]") then
+    if (stringify(arr_2d_r4, "F15.7") .ne. &
+    & "[[0.0000000, 1.0000000], [2.0000000, 3.0000000]]") then
       call mpp_error(FATAL, "stringify() unit test failed for 2D r4 array")
     endif
 
     arr_2d_r8 = reshape([[0._r8_kind, 1._r8_kind], [2._r8_kind, 3._r8_kind]], [2, 2])
-    if (stringify(arr_2d_r8) .ne. &
-    & "[[0.0000000000000000E+00, 1.0000000000000000E+00], [2.0000000000000000E+00, 3.0000000000000000E+00]]") then
+    if (stringify(arr_2d_r8, "F25.16") .ne. &
+    & "[[0.0000000000000000, 1.0000000000000000], [2.0000000000000000, 3.0000000000000000]]") then
       call mpp_error(FATAL, "stringify() unit test failed for 2D r8 array")
     endif
 
@@ -237,9 +237,9 @@ program test_fms_string_utils
       & [[0._r4_kind, 1._r4_kind], [2._r4_kind, 3._r4_kind]], &
       & [[4._r4_kind, 5._r4_kind], [6._r4_kind, 7._r4_kind]] &
     & ], [2, 2, 2])
-    if (stringify(arr_3d_r4) .ne. &
-    & "[[[0.0000000E+00, 1.0000000E+00], [2.0000000E+00, 3.0000000E+00]],&
-      & [[4.0000000E+00, 5.0000000E+00], [6.0000000E+00, 7.0000000E+00]]]") then
+    if (stringify(arr_3d_r4, "F15.7") .ne. &
+    & "[[[0.0000000, 1.0000000], [2.0000000, 3.0000000]],&
+      & [[4.0000000, 5.0000000], [6.0000000, 7.0000000]]]") then
       call mpp_error(FATAL, "stringify() unit test failed for 3D r4 array")
     endif
 
@@ -247,9 +247,9 @@ program test_fms_string_utils
       & [[0._r8_kind, 1._r8_kind], [2._r8_kind, 3._r8_kind]], &
       & [[4._r8_kind, 5._r8_kind], [6._r8_kind, 7._r8_kind]] &
     & ], [2, 2, 2])
-    if (stringify(arr_3d_r8) .ne. &
-    & "[[[0.0000000000000000E+00, 1.0000000000000000E+00], [2.0000000000000000E+00, 3.0000000000000000E+00]],&
-      & [[4.0000000000000000E+00, 5.0000000000000000E+00], [6.0000000000000000E+00, 7.0000000000000000E+00]]]") then
+    if (stringify(arr_3d_r8, "F25.16") .ne. &
+    & "[[[0.0000000000000000, 1.0000000000000000], [2.0000000000000000, 3.0000000000000000]],&
+      & [[4.0000000000000000, 5.0000000000000000], [6.0000000000000000, 7.0000000000000000]]]") then
       call mpp_error(FATAL, "stringify() unit test failed for 3D r8 array")
     endif
   end subroutine

--- a/test_fms/string_utils/test_string_utils.F90
+++ b/test_fms/string_utils/test_string_utils.F90
@@ -180,41 +180,41 @@ program test_fms_string_utils
       call mpp_error(FATAL, "string() unit test failed for negative integer")
     endif
 
-    if (string(1.2345_r4_kind) .ne. "1.23450005") then
+    if (string(1._r4_kind) .ne. "1.0000000E+00") then
       call mpp_error(FATAL, "string() unit test failed for positive r4 real")
     endif
 
-    if (string(-1.2345_r4_kind) .ne. "-1.23450005") then
+    if (string(-1._r4_kind) .ne. "-1.0000000E+00") then
       call mpp_error(FATAL, "string() unit test failed for negative r4 real")
     endif
 
-    if (string(1.2345_r8_kind) .ne. "1.2344999999999999") then
+    if (string(1._r8_kind) .ne. "1.0000000000000000E+00") then
       call mpp_error(FATAL, "string() unit test failed for positive r8 real")
     endif
 
-    if (string(-1.2345_r8_kind) .ne. "-1.2344999999999999") then
+    if (string(-1._r8_kind) .ne. "-1.0000000000000000E+00") then
       call mpp_error(FATAL, "string() unit test failed for negative r8 real")
     endif
 
     arr_1d_r4 = [0._r4_kind, 1._r4_kind, 2._r4_kind]
-    if (string(arr_1d_r4) .ne. "[0.00000000, 1.00000000, 2.00000000]") then
+    if (string(arr_1d_r4) .ne. "[0.0000000E+00, 1.0000000E+00, 2.0000000E+00]") then
       call mpp_error(FATAL, "string() unit test failed for 1D r4 array")
     endif
 
     arr_1d_r8 = [0._r8_kind, 1._r8_kind, 2._r8_kind]
-    if (string(arr_1d_r8) .ne. "[0.0000000000000000, 1.0000000000000000, 2.0000000000000000]") then
+    if (string(arr_1d_r8) .ne. "[0.0000000000000000E+00, 1.0000000000000000E+00, 2.0000000000000000E+00]") then
       call mpp_error(FATAL, "string() unit test failed for 1D r8 array")
     endif
 
     arr_2d_r4 = reshape([[0._r4_kind, 1._r4_kind], [2._r4_kind, 3._r4_kind]], [2, 2])
     if (string(arr_2d_r4) .ne. &
-    & "[[0.00000000, 1.00000000], [2.00000000, 3.00000000]]") then
+    & "[[0.0000000E+00, 1.0000000E+00], [2.0000000E+00, 3.0000000E+00]]") then
       call mpp_error(FATAL, "string() unit test failed for 2D r4 array")
     endif
 
     arr_2d_r8 = reshape([[0._r8_kind, 1._r8_kind], [2._r8_kind, 3._r8_kind]], [2, 2])
     if (string(arr_2d_r8) .ne. &
-    & "[[0.0000000000000000, 1.0000000000000000], [2.0000000000000000, 3.0000000000000000]]") then
+    & "[[0.0000000000000000E+00, 1.0000000000000000E+00], [2.0000000000000000E+00, 3.0000000000000000E+00]]") then
       call mpp_error(FATAL, "string() unit test failed for 2D r8 array")
     endif
 
@@ -223,8 +223,8 @@ program test_fms_string_utils
       & [[4._r4_kind, 5._r4_kind], [6._r4_kind, 7._r4_kind]] &
     & ], [2, 2, 2])
     if (string(arr_3d_r4) .ne. &
-    & "[[[0.00000000, 1.00000000], [2.00000000, 3.00000000]],&
-      & [[4.00000000, 5.00000000], [6.00000000, 7.00000000]]]") then
+    & "[[[0.0000000E+00, 1.0000000E+00], [2.0000000E+00, 3.0000000E+00]],&
+      & [[4.0000000E+00, 5.0000000E+00], [6.0000000E+00, 7.0000000E+00]]]") then
       call mpp_error(FATAL, "string() unit test failed for 3D r4 array")
     endif
 
@@ -233,8 +233,8 @@ program test_fms_string_utils
       & [[4._r8_kind, 5._r8_kind], [6._r8_kind, 7._r8_kind]] &
     & ], [2, 2, 2])
     if (string(arr_3d_r8) .ne. &
-    & "[[[0.0000000000000000, 1.0000000000000000], [2.0000000000000000, 3.0000000000000000]],&
-      & [[4.0000000000000000, 5.0000000000000000], [6.0000000000000000, 7.0000000000000000]]]") then
+    & "[[[0.0000000000000000E+00, 1.0000000000000000E+00], [2.0000000000000000E+00, 3.0000000000000000E+00]],&
+      & [[4.0000000000000000E+00, 5.0000000000000000E+00], [6.0000000000000000E+00, 7.0000000000000000E+00]]]") then
       call mpp_error(FATAL, "string() unit test failed for 3D r8 array")
     endif
   end subroutine

--- a/test_fms/string_utils/test_string_utils.F90
+++ b/test_fms/string_utils/test_string_utils.F90
@@ -172,6 +172,18 @@ program test_fms_string_utils
     real(r4_kind) :: arr_1d_r4(3), arr_2d_r4(2, 2), arr_3d_r4(2, 2, 2)
     real(r8_kind) :: arr_1d_r8(3), arr_2d_r8(2, 2), arr_3d_r8(2, 2, 2)
 
+    if (string(.true.) .ne. "True") then
+      call mpp_error(FATAL, "string() unit test failed for Boolean true value")
+    endif
+
+    if (string(.false.) .ne. "False") then
+      call mpp_error(FATAL, "string() unit test failed for Boolean false value")
+    endif
+
+    if (string(0) .ne. "0") then
+      call mpp_error(FATAL, "string() unit test failed for zero integer")
+    endif
+
     if (string(12345) .ne. "12345") then
       call mpp_error(FATAL, "string() unit test failed for positive integer")
     endif

--- a/test_fms/string_utils/test_string_utils.F90
+++ b/test_fms/string_utils/test_string_utils.F90
@@ -180,47 +180,47 @@ program test_fms_string_utils
       call mpp_error(FATAL, "string() unit test failed for negative integer")
     endif
 
-    if (string(1.2345_ r4_kind) .ne. "1.23450005") then
+    if (string(1.2345_r4_kind) .ne. "1.23450005") then
       call mpp_error(FATAL, "string() unit test failed for positive r4 real")
     endif
 
-    if (string(-1.2345_ r4_kind) .ne. "-1.23450005") then
+    if (string(-1.2345_r4_kind) .ne. "-1.23450005") then
       call mpp_error(FATAL, "string() unit test failed for negative r4 real")
     endif
 
-    if (string(1.2345_ r8_kind) .ne. "1.2344999999999999") then
+    if (string(1.2345_r8_kind) .ne. "1.2344999999999999") then
       call mpp_error(FATAL, "string() unit test failed for positive r8 real")
     endif
 
-    if (string(-1.2345_ r8_kind) .ne. "-1.2344999999999999") then
+    if (string(-1.2345_r8_kind) .ne. "-1.2344999999999999") then
       call mpp_error(FATAL, "string() unit test failed for negative r8 real")
     endif
 
-    arr_1d_r4 = [0._ r4_kind, 1._ r4_kind, 2._ r4_kind]
+    arr_1d_r4 = [0._r4_kind, 1._r4_kind, 2._r4_kind]
     if (string(arr_1d_r4) .ne. "[0.00000000, 1.00000000, 2.00000000]") then
       call mpp_error(FATAL, "string() unit test failed for 1D r4 array")
     endif
 
-    arr_1d_r8 = [0._ r8_kind, 1._ r8_kind, 2._ r8_kind]
+    arr_1d_r8 = [0._r8_kind, 1._r8_kind, 2._r8_kind]
     if (string(arr_1d_r8) .ne. "[0.0000000000000000, 1.0000000000000000, 2.0000000000000000]") then
       call mpp_error(FATAL, "string() unit test failed for 1D r8 array")
     endif
 
-    arr_2d_r4 = reshape([[0._ r4_kind, 1._ r4_kind], [2._ r4_kind, 3._ r4_kind]], [2, 2])
+    arr_2d_r4 = reshape([[0._r4_kind, 1._r4_kind], [2._r4_kind, 3._r4_kind]], [2, 2])
     if (string(arr_2d_r4) .ne. &
     & "[[0.00000000, 1.00000000], [2.00000000, 3.00000000]]") then
       call mpp_error(FATAL, "string() unit test failed for 2D r4 array")
     endif
 
-    arr_2d_r8 = reshape([[0._ r8_kind, 1._ r8_kind], [2._ r8_kind, 3._ r8_kind]], [2, 2])
+    arr_2d_r8 = reshape([[0._r8_kind, 1._r8_kind], [2._r8_kind, 3._r8_kind]], [2, 2])
     if (string(arr_2d_r8) .ne. &
     & "[[0.0000000000000000, 1.0000000000000000], [2.0000000000000000, 3.0000000000000000]]") then
       call mpp_error(FATAL, "string() unit test failed for 2D r8 array")
     endif
 
     arr_3d_r4 = reshape([ &
-      & [[0._ r4_kind, 1._ r4_kind], [2._ r4_kind, 3._ r4_kind]], &
-      & [[4._ r4_kind, 5._ r4_kind], [6._ r4_kind, 7._ r4_kind]] &
+      & [[0._r4_kind, 1._r4_kind], [2._r4_kind, 3._r4_kind]], &
+      & [[4._r4_kind, 5._r4_kind], [6._r4_kind, 7._r4_kind]] &
     & ], [2, 2, 2])
     if (string(arr_3d_r4) .ne. &
     & "[[[0.00000000, 1.00000000], [2.00000000, 3.00000000]],&
@@ -229,8 +229,8 @@ program test_fms_string_utils
     endif
 
     arr_3d_r8 = reshape([ &
-      & [[0._ r8_kind, 1._ r8_kind], [2._ r8_kind, 3._ r8_kind]], &
-      & [[4._ r8_kind, 5._ r8_kind], [6._ r8_kind, 7._ r8_kind]] &
+      & [[0._r8_kind, 1._r8_kind], [2._r8_kind, 3._r8_kind]], &
+      & [[4._r8_kind, 5._r8_kind], [6._r8_kind, 7._r8_kind]] &
     & ], [2, 2, 2])
     if (string(arr_3d_r8) .ne. &
     & "[[[0.0000000000000000, 1.0000000000000000], [2.0000000000000000, 3.0000000000000000]],&

--- a/test_fms/string_utils/test_string_utils.F90
+++ b/test_fms/string_utils/test_string_utils.F90
@@ -112,6 +112,7 @@ program test_fms_string_utils
   if (nunique .ne. 7) call mpp_error(FATAL, "The number of unique strings in your array is not correct")
 
   call check_string
+  call check_stringify
 
   call fms_end()
 
@@ -169,9 +170,6 @@ program test_fms_string_utils
   end subroutine check_my_indices
 
   subroutine check_string
-    real(r4_kind) :: arr_1d_r4(3), arr_2d_r4(2, 2), arr_3d_r4(2, 2, 2)
-    real(r8_kind) :: arr_1d_r8(3), arr_2d_r8(2, 2), arr_3d_r8(2, 2, 2)
-
     if (string(.true.) .ne. "True") then
       call mpp_error(FATAL, "string() unit test failed for Boolean true value")
     endif
@@ -207,47 +205,52 @@ program test_fms_string_utils
     if (string(-1._r8_kind) .ne. "-1.0000000000000000E+00") then
       call mpp_error(FATAL, "string() unit test failed for negative r8 real")
     endif
+  end subroutine
+
+  subroutine check_stringify
+    real(r4_kind) :: arr_1d_r4(3), arr_2d_r4(2, 2), arr_3d_r4(2, 2, 2)
+    real(r8_kind) :: arr_1d_r8(3), arr_2d_r8(2, 2), arr_3d_r8(2, 2, 2)
 
     arr_1d_r4 = [0._r4_kind, 1._r4_kind, 2._r4_kind]
-    if (string(arr_1d_r4) .ne. "[0.0000000E+00, 1.0000000E+00, 2.0000000E+00]") then
-      call mpp_error(FATAL, "string() unit test failed for 1D r4 array")
+    if (stringify(arr_1d_r4) .ne. "[0.0000000E+00, 1.0000000E+00, 2.0000000E+00]") then
+      call mpp_error(FATAL, "stringify() unit test failed for 1D r4 array")
     endif
 
     arr_1d_r8 = [0._r8_kind, 1._r8_kind, 2._r8_kind]
-    if (string(arr_1d_r8) .ne. "[0.0000000000000000E+00, 1.0000000000000000E+00, 2.0000000000000000E+00]") then
-      call mpp_error(FATAL, "string() unit test failed for 1D r8 array")
+    if (stringify(arr_1d_r8) .ne. "[0.0000000000000000E+00, 1.0000000000000000E+00, 2.0000000000000000E+00]") then
+      call mpp_error(FATAL, "stringify() unit test failed for 1D r8 array")
     endif
 
     arr_2d_r4 = reshape([[0._r4_kind, 1._r4_kind], [2._r4_kind, 3._r4_kind]], [2, 2])
-    if (string(arr_2d_r4) .ne. &
+    if (stringify(arr_2d_r4) .ne. &
     & "[[0.0000000E+00, 1.0000000E+00], [2.0000000E+00, 3.0000000E+00]]") then
-      call mpp_error(FATAL, "string() unit test failed for 2D r4 array")
+      call mpp_error(FATAL, "stringify() unit test failed for 2D r4 array")
     endif
 
     arr_2d_r8 = reshape([[0._r8_kind, 1._r8_kind], [2._r8_kind, 3._r8_kind]], [2, 2])
-    if (string(arr_2d_r8) .ne. &
+    if (stringify(arr_2d_r8) .ne. &
     & "[[0.0000000000000000E+00, 1.0000000000000000E+00], [2.0000000000000000E+00, 3.0000000000000000E+00]]") then
-      call mpp_error(FATAL, "string() unit test failed for 2D r8 array")
+      call mpp_error(FATAL, "stringify() unit test failed for 2D r8 array")
     endif
 
     arr_3d_r4 = reshape([ &
       & [[0._r4_kind, 1._r4_kind], [2._r4_kind, 3._r4_kind]], &
       & [[4._r4_kind, 5._r4_kind], [6._r4_kind, 7._r4_kind]] &
     & ], [2, 2, 2])
-    if (string(arr_3d_r4) .ne. &
+    if (stringify(arr_3d_r4) .ne. &
     & "[[[0.0000000E+00, 1.0000000E+00], [2.0000000E+00, 3.0000000E+00]],&
       & [[4.0000000E+00, 5.0000000E+00], [6.0000000E+00, 7.0000000E+00]]]") then
-      call mpp_error(FATAL, "string() unit test failed for 3D r4 array")
+      call mpp_error(FATAL, "stringify() unit test failed for 3D r4 array")
     endif
 
     arr_3d_r8 = reshape([ &
       & [[0._r8_kind, 1._r8_kind], [2._r8_kind, 3._r8_kind]], &
       & [[4._r8_kind, 5._r8_kind], [6._r8_kind, 7._r8_kind]] &
     & ], [2, 2, 2])
-    if (string(arr_3d_r8) .ne. &
+    if (stringify(arr_3d_r8) .ne. &
     & "[[[0.0000000000000000E+00, 1.0000000000000000E+00], [2.0000000000000000E+00, 3.0000000000000000E+00]],&
       & [[4.0000000000000000E+00, 5.0000000000000000E+00], [6.0000000000000000E+00, 7.0000000000000000E+00]]]") then
-      call mpp_error(FATAL, "string() unit test failed for 3D r8 array")
+      call mpp_error(FATAL, "stringify() unit test failed for 3D r8 array")
     endif
   end subroutine
 


### PR DESCRIPTION
**Description**
The `string` interface in `fms_string_utils_mod` has been extended to support the following types of input:
* `r4_kind` and `r8_kind` reals
* 1D, 2D, and 3D arrays of reals

Additionally, leading and trailing whitespace is now stripped from the output for real arguments.

Fixes #1141

**How Has This Been Tested?**
A unit test has been implemented. The test passes on the AMD box with `gcc 12.2.0`.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes