### PR TITLE
[WIP] Proposed fix Gnu and Pgi issue with class(*) in send_data3d

### DIFF
--- a/diag_manager/diag_manager.F90
+++ b/diag_manager/diag_manager.F90
@@ -1315,7 +1315,7 @@ CONTAINS
             & 'The field is not one of the supported types of real(kind=4) or real(kind=8)', FATAL)
     END SELECT
 
-    send_data_0d = send_data_3d(diag_field_id, field_out, time, err_msg=err_msg)
+    send_data_0d = send_data_3d_class(diag_field_id, field_out, time, err_msg=err_msg)
   END FUNCTION send_data_0d
 
   !> @return true if send is successful
@@ -1370,18 +1370,18 @@ CONTAINS
 
     IF ( PRESENT(mask) .OR. PRESENT(rmask) ) THEN
        IF ( PRESENT(is_in) .OR. PRESENT(ie_in) ) THEN
-          send_data_1d = send_data_3d(diag_field_id, field_out, time, is_in=is_in, js_in=1, ks_in=1,&
+          send_data_1d = send_data_3d_class(diag_field_id, field_out, time, is_in=is_in, js_in=1, ks_in=1,&
                & mask=mask_out, ie_in=ie_in, je_in=1, ke_in=1, weight=weight, err_msg=err_msg)
        ELSE
-          send_data_1d = send_data_3d(diag_field_id, field_out, time, mask=mask_out,&
+          send_data_1d = send_data_3d_class(diag_field_id, field_out, time, mask=mask_out,&
                & weight=weight, err_msg=err_msg)
        END IF
     ELSE
        IF ( PRESENT(is_in) .OR. PRESENT(ie_in) ) THEN
-          send_data_1d = send_data_3d(diag_field_id, field_out, time, is_in=is_in, js_in=1, ks_in=1,&
+          send_data_1d = send_data_3d_class(diag_field_id, field_out, time, is_in=is_in, js_in=1, ks_in=1,&
                & ie_in=ie_in, je_in=1, ke_in=1, weight=weight, err_msg=err_msg)
        ELSE
-          send_data_1d = send_data_3d(diag_field_id, field_out, time, weight=weight, err_msg=err_msg)
+          send_data_1d = send_data_3d_class(diag_field_id, field_out, time, weight=weight, err_msg=err_msg)
        END IF
     END IF
   END FUNCTION send_data_1d
@@ -1438,16 +1438,40 @@ CONTAINS
     END IF
 
     IF ( PRESENT(mask) .OR. PRESENT(rmask) ) THEN
-       send_data_2d = send_data_3d(diag_field_id, field_out, time, is_in=is_in, js_in=js_in, ks_in=1, mask=mask_out,&
+       send_data_2d = send_data_3d_class(diag_field_id, field_out, time, is_in=is_in, js_in=js_in, ks_in=1, mask=mask_out,&
             & ie_in=ie_in, je_in=je_in, ke_in=1, weight=weight, err_msg=err_msg)
     ELSE
-       send_data_2d = send_data_3d(diag_field_id, field_out, time, is_in=is_in, js_in=js_in, ks_in=1,&
+       send_data_2d = send_data_3d_class(diag_field_id, field_out, time, is_in=is_in, js_in=js_in, ks_in=1,&
             & ie_in=ie_in, je_in=je_in, ke_in=1, weight=weight, err_msg=err_msg)
     END IF
   END FUNCTION send_data_2d
 
   !> @return true if send is successful
   LOGICAL FUNCTION send_data_3d(diag_field_id, field, time, is_in, js_in, ks_in, &
+             & mask, rmask, ie_in, je_in, ke_in, weight, err_msg)
+    INTEGER, INTENT(in) :: diag_field_id
+    REAL, DIMENSION(:,:,:), INTENT(in) :: field
+    REAL, INTENT(in), OPTIONAL :: weight
+    TYPE (time_type), INTENT(in), OPTIONAL :: time
+    INTEGER, INTENT(in), OPTIONAL :: is_in, js_in, ks_in,ie_in,je_in, ke_in
+    LOGICAL, DIMENSION(:,:,:), INTENT(in), OPTIONAL :: mask
+    REAL, DIMENSION(:,:,:), INTENT(in), OPTIONAL :: rmask
+    CHARACTER(len=*), INTENT(out), OPTIONAL :: err_msg
+
+    if (present(mask) .and. present(rmask)) then
+      send_data_3d = send_data_3d_class(diag_field_id, field, time=time, is_in=is_in, js_in=js_in, ks_in=ks_in, &
+                               mask=mask, rmask=rmask, ie_in=ie_in, je_in=je_in, ke_in=ke_in, weight=weight, &
+                               err_msg=err_msg)
+    elseif (present(rmask)) then
+      send_data_3d = send_data_3d_class(diag_field_id, field, time=time, is_in=is_in, js_in=js_in, ks_in=ks_in, &
+                               rmask=rmask, ie_in=ie_in, je_in=je_in, ke_in=ke_in, weight=weight, err_msg=err_msg)
+    else
+      send_data_3d = send_data_3d_class(diag_field_id, field, time=time, is_in=is_in, js_in=js_in, ks_in=ks_in, &
+                               ie_in=ie_in, je_in=je_in, ke_in=ke_in, weight=weight, err_msg=err_msg)
+    endif
+  END FUNCTION send_data_3d
+  !> @return true if send is successful
+  LOGICAL FUNCTION send_data_3d_class(diag_field_id, field, time, is_in, js_in, ks_in, &
              & mask, rmask, ie_in, je_in, ke_in, weight, err_msg)
     INTEGER, INTENT(in) :: diag_field_id
     CLASS(*), DIMENSION(:,:,:), INTENT(in) :: field
@@ -1503,10 +1527,10 @@ CONTAINS
 
     ! If diag_field_id is < 0 it means that this field is not registered, simply return
     IF ( diag_field_id <= 0 ) THEN
-       send_data_3d = .FALSE.
+       send_data_3d_class = .FALSE.
        RETURN
     ELSE
-       send_data_3d = .TRUE.
+       send_data_3d_class = .TRUE.
     END IF
 
     IF ( PRESENT(err_msg) ) err_msg = ''
@@ -3219,7 +3243,7 @@ CONTAINS
 
     DEALLOCATE(field_out)
     DEALLOCATE(oor_mask)
-  END FUNCTION send_data_3d
+  END FUNCTION send_data_3d_class
 
   !> @return true if send is successful
   LOGICAL FUNCTION send_tile_averaged_data1d ( id, field, area, time, mask )

--- a/diag_manager/diag_manager.F90
+++ b/diag_manager/diag_manager.F90
@@ -1438,8 +1438,8 @@ CONTAINS
     END IF
 
     IF ( PRESENT(mask) .OR. PRESENT(rmask) ) THEN
-       send_data_2d = send_data_3d_class(diag_field_id, field_out, time, is_in=is_in, js_in=js_in, ks_in=1, mask=mask_out,&
-            & ie_in=ie_in, je_in=je_in, ke_in=1, weight=weight, err_msg=err_msg)
+       send_data_2d = send_data_3d_class(diag_field_id, field_out, time, is_in=is_in, js_in=js_in, ks_in=1,&
+            & mask=mask_out, ie_in=ie_in, je_in=je_in, ke_in=1, weight=weight, err_msg=err_msg)
     ELSE
        send_data_2d = send_data_3d_class(diag_field_id, field_out, time, is_in=is_in, js_in=js_in, ks_in=1,&
             & ie_in=ie_in, je_in=je_in, ke_in=1, weight=weight, err_msg=err_msg)

--- a/diag_manager/diag_manager.F90
+++ b/diag_manager/diag_manager.F90
@@ -1450,12 +1450,12 @@ CONTAINS
   LOGICAL FUNCTION send_data_3d(diag_field_id, field, time, is_in, js_in, ks_in, &
              & mask, rmask, ie_in, je_in, ke_in, weight, err_msg)
     INTEGER, INTENT(in) :: diag_field_id
-    REAL, DIMENSION(:,:,:), INTENT(in) :: field
-    REAL, INTENT(in), OPTIONAL :: weight
+    CLASS(*), DIMENSION(:,:,:), INTENT(in) :: field
+    CLASS(*), INTENT(in), OPTIONAL :: weight
     TYPE (time_type), INTENT(in), OPTIONAL :: time
     INTEGER, INTENT(in), OPTIONAL :: is_in, js_in, ks_in,ie_in,je_in, ke_in
     LOGICAL, DIMENSION(:,:,:), INTENT(in), OPTIONAL :: mask
-    REAL, DIMENSION(:,:,:), INTENT(in), OPTIONAL :: rmask
+    CLASS(*), DIMENSION(:,:,:), INTENT(in), OPTIONAL :: rmask
     CHARACTER(len=*), INTENT(out), OPTIONAL :: err_msg
 
     if (present(mask) .and. present(rmask)) then

--- a/diag_manager/diag_manager.F90
+++ b/diag_manager/diag_manager.F90
@@ -1315,7 +1315,7 @@ CONTAINS
             & 'The field is not one of the supported types of real(kind=4) or real(kind=8)', FATAL)
     END SELECT
 
-    send_data_0d = send_data_3d_class(diag_field_id, field_out, time, err_msg=err_msg)
+    send_data_0d = diag_send_data(diag_field_id, field_out, time, err_msg=err_msg)
   END FUNCTION send_data_0d
 
   !> @return true if send is successful
@@ -1370,18 +1370,18 @@ CONTAINS
 
     IF ( PRESENT(mask) .OR. PRESENT(rmask) ) THEN
        IF ( PRESENT(is_in) .OR. PRESENT(ie_in) ) THEN
-          send_data_1d = send_data_3d_class(diag_field_id, field_out, time, is_in=is_in, js_in=1, ks_in=1,&
+          send_data_1d = diag_send_data(diag_field_id, field_out, time, is_in=is_in, js_in=1, ks_in=1,&
                & mask=mask_out, ie_in=ie_in, je_in=1, ke_in=1, weight=weight, err_msg=err_msg)
        ELSE
-          send_data_1d = send_data_3d_class(diag_field_id, field_out, time, mask=mask_out,&
+          send_data_1d = diag_send_data(diag_field_id, field_out, time, mask=mask_out,&
                & weight=weight, err_msg=err_msg)
        END IF
     ELSE
        IF ( PRESENT(is_in) .OR. PRESENT(ie_in) ) THEN
-          send_data_1d = send_data_3d_class(diag_field_id, field_out, time, is_in=is_in, js_in=1, ks_in=1,&
+          send_data_1d = diag_send_data(diag_field_id, field_out, time, is_in=is_in, js_in=1, ks_in=1,&
                & ie_in=ie_in, je_in=1, ke_in=1, weight=weight, err_msg=err_msg)
        ELSE
-          send_data_1d = send_data_3d_class(diag_field_id, field_out, time, weight=weight, err_msg=err_msg)
+          send_data_1d = diag_send_data(diag_field_id, field_out, time, weight=weight, err_msg=err_msg)
        END IF
     END IF
   END FUNCTION send_data_1d
@@ -1438,10 +1438,10 @@ CONTAINS
     END IF
 
     IF ( PRESENT(mask) .OR. PRESENT(rmask) ) THEN
-       send_data_2d = send_data_3d_class(diag_field_id, field_out, time, is_in=is_in, js_in=js_in, ks_in=1,&
+       send_data_2d = diag_send_data(diag_field_id, field_out, time, is_in=is_in, js_in=js_in, ks_in=1,&
             & mask=mask_out, ie_in=ie_in, je_in=je_in, ke_in=1, weight=weight, err_msg=err_msg)
     ELSE
-       send_data_2d = send_data_3d_class(diag_field_id, field_out, time, is_in=is_in, js_in=js_in, ks_in=1,&
+       send_data_2d = diag_send_data(diag_field_id, field_out, time, is_in=is_in, js_in=js_in, ks_in=1,&
             & ie_in=ie_in, je_in=je_in, ke_in=1, weight=weight, err_msg=err_msg)
     END IF
   END FUNCTION send_data_2d
@@ -1459,19 +1459,19 @@ CONTAINS
     CHARACTER(len=*), INTENT(out), OPTIONAL :: err_msg
 
     if (present(mask) .and. present(rmask)) then
-      send_data_3d = send_data_3d_class(diag_field_id, field, time=time, is_in=is_in, js_in=js_in, ks_in=ks_in, &
+      send_data_3d = diag_send_data(diag_field_id, field, time=time, is_in=is_in, js_in=js_in, ks_in=ks_in, &
                                mask=mask, rmask=rmask, ie_in=ie_in, je_in=je_in, ke_in=ke_in, weight=weight, &
                                err_msg=err_msg)
     elseif (present(rmask)) then
-      send_data_3d = send_data_3d_class(diag_field_id, field, time=time, is_in=is_in, js_in=js_in, ks_in=ks_in, &
+      send_data_3d = diag_send_data(diag_field_id, field, time=time, is_in=is_in, js_in=js_in, ks_in=ks_in, &
                                rmask=rmask, ie_in=ie_in, je_in=je_in, ke_in=ke_in, weight=weight, err_msg=err_msg)
     else
-      send_data_3d = send_data_3d_class(diag_field_id, field, time=time, is_in=is_in, js_in=js_in, ks_in=ks_in, &
+      send_data_3d = diag_send_data(diag_field_id, field, time=time, is_in=is_in, js_in=js_in, ks_in=ks_in, &
                                ie_in=ie_in, je_in=je_in, ke_in=ke_in, weight=weight, err_msg=err_msg)
     endif
   END FUNCTION send_data_3d
   !> @return true if send is successful
-  LOGICAL FUNCTION send_data_3d_class(diag_field_id, field, time, is_in, js_in, ks_in, &
+  LOGICAL FUNCTION diag_send_data(diag_field_id, field, time, is_in, js_in, ks_in, &
              & mask, rmask, ie_in, je_in, ke_in, weight, err_msg)
     INTEGER, INTENT(in) :: diag_field_id
     CLASS(*), DIMENSION(:,:,:), INTENT(in) :: field
@@ -1527,10 +1527,10 @@ CONTAINS
 
     ! If diag_field_id is < 0 it means that this field is not registered, simply return
     IF ( diag_field_id <= 0 ) THEN
-       send_data_3d_class = .FALSE.
+       diag_send_data = .FALSE.
        RETURN
     ELSE
-       send_data_3d_class = .TRUE.
+       diag_send_data = .TRUE.
     END IF
 
     IF ( PRESENT(err_msg) ) err_msg = ''
@@ -3243,7 +3243,7 @@ CONTAINS
 
     DEALLOCATE(field_out)
     DEALLOCATE(oor_mask)
-  END FUNCTION send_data_3d_class
+  END FUNCTION diag_send_data
 
   !> @return true if send is successful
   LOGICAL FUNCTION send_tile_averaged_data1d ( id, field, area, time, mask )


### PR DESCRIPTION
**Description**
Fixes gnu and pgi issue with class(*) in send_data3d
- MOM6 gnu tests seg fault when calling send_data3d under FMS2023.01-beta2
- These tests were passing under FMS2023.01-alpha4
- Slight changes in send_data3d has probably tickled some bugs in the Gnu compiler
- It is clear that both gnu and pgi have issues with optional arguments declared as class(*)
- Rather than having component models add kludge code to avoid these
issues (probably compiler bugs) we can limit the kludge to a minimum by
putting them inside FMS where these  already exists (in send_data_1d and
send_data_2d interfaces).
- We may even be able to get rid of some old kludge we put in the component models to avoid these compiler issues.
- With this commit MOM6 tests passed under compilers Intel22, gnu11 and Nvhpc22.7 on c5

Fixes # (issue)

**How Has This Been Tested?**
MOM6_solo test cases with Intel, Gnu and Pgi 

**Checklist:**
- [ *] My code follows the style guidelines of this project
- [ *] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] `make distcheck` passes

