### PR TITLE
Modern diag_manager: Store the current_model_time in the diag_object

### DIFF
--- a/diag_manager/fms_diag_file_object.F90
+++ b/diag_manager/fms_diag_file_object.F90
@@ -728,9 +728,12 @@ end subroutine add_axes
 !> @brief adds the start time to the fileobj
 !! @note This should be called from the register field calls. It can be called multiple times (one for each variable)
 !! So it needs to make sure that the start_time is the same for each variable. The initial value is the base_time
-subroutine add_start_time(this, start_time)
-  class(fmsDiagFile_type), intent(inout)       :: this            !< The file object
+subroutine add_start_time(this, start_time, model_time)
+  class(fmsDiagFile_type), intent(inout)       :: this           !< The file object
   TYPE(time_type),         intent(in)          :: start_time     !< Start time to add to the fileobj
+  TYPE(time_type),         intent(out)         :: model_time     !< The current model time
+                                                                 !! this will be set to the start_time
+                                                                 !! at the begining of the run
 
   !< If the start_time sent in is equal to the base_time return because
   !! this%start_time was already set to the base_time
@@ -745,6 +748,7 @@ subroutine add_start_time(this, start_time)
   else
     !> If the this%start_time is equal to the base_time,
     !! simply update it with the start_time and set up the *_output variables
+    model_time = start_time
     this%start_time = start_time
     this%last_output = start_time
     this%next_output = diag_time_inc(start_time, this%get_file_freq(), this%get_file_frequnit())

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -19,7 +19,8 @@
 module fms_diag_object_mod
 use mpp_mod, only: fatal, note, warning, mpp_error, mpp_pe, mpp_root_pe, stdout
 use diag_data_mod,  only: diag_null, diag_not_found, diag_not_registered, diag_registered_id, &
-                         &DIAG_FIELD_NOT_FOUND, diag_not_registered, max_axes, TWO_D_DOMAIN
+                         &DIAG_FIELD_NOT_FOUND, diag_not_registered, max_axes, TWO_D_DOMAIN, &
+                         &get_base_time
   USE time_manager_mod, ONLY: set_time, set_date, get_time, time_type, OPERATOR(>=), OPERATOR(>),&
        & OPERATOR(<), OPERATOR(==), OPERATOR(/=), OPERATOR(/), OPERATOR(+), ASSIGNMENT(=), get_date, &
        & get_ticks_per_second
@@ -51,6 +52,7 @@ private
   type(fmsDiagBufferContainer_type), allocatable :: FMS_diag_buffers(:) !< array of buffer objects
   integer, private :: registered_buffers = 0 !< number of registered buffers, per dimension
   class(fmsDiagAxisContainer_type), allocatable :: diag_axis(:) !< Array of diag_axis
+  type(time_type)  :: current_model_time !< The current model time
   integer, private :: registered_variables !< Number of registered variables
   integer, private :: registered_axis !< Number of registered axis
   logical, private :: initialized=.false. !< True if the fmsDiagObject is initialized
@@ -114,6 +116,7 @@ subroutine fms_diag_object_init (this,diag_subset_output)
   this%buffers_initialized = fms_diag_buffer_init(this%FMS_diag_buffers, SIZE(diag_yaml%get_diag_fields()))
   this%registered_variables = 0
   this%registered_axis = 0
+  this%current_model_time = get_base_time()
   this%initialized = .true.
 #else
   call mpp_error("fms_diag_object_init",&
@@ -134,7 +137,7 @@ subroutine fms_diag_object_end (this, time)
   !TODO: loop through files and force write
   if (.not. this%initialized) return
 
-  call this%fms_diag_do_io(time, is_end_of_run=.true.)
+  call this%fms_diag_do_io(is_end_of_run=.true.)
   !TODO: Deallocate diag object arrays and clean up all memory
   do i=1, size(this%FMS_diag_buffers)
     if(allocated(this%FMS_diag_buffers(i)%diag_buffer_obj)) then
@@ -226,7 +229,7 @@ CALL MPP_ERROR(FATAL,"You can not use the modern diag manager without compiling 
      call fileptr%set_file_domain(fieldptr%get_domain(), fieldptr%get_type_of_domain())
      call fileptr%init_diurnal_axis(this%diag_axis, this%registered_axis, diag_field_indices(i))
      call fileptr%add_axes(axes, this%diag_axis, this%registered_axis)
-     call fileptr%add_start_time(init_time)
+     call fileptr%add_start_time(init_time, this%current_model_time)
      call fileptr%set_file_time_ops (fieldptr%diag_field(i), fieldptr%is_static())
     enddo
   elseif (present(axes)) then !only axes present
@@ -242,7 +245,7 @@ CALL MPP_ERROR(FATAL,"You can not use the modern diag manager without compiling 
     do i = 1, size(file_ids)
      fileptr => this%FMS_diag_files(file_ids(i))%FMS_diag_file
      call fileptr%add_field_and_yaml_id(fieldptr%get_id(), diag_field_indices(i))
-     call fileptr%add_start_time(init_time)
+     call fileptr%add_start_time(init_time, this%current_model_time)
      call fileptr%set_file_time_ops (fieldptr%diag_field(i), fieldptr%is_static())
     enddo
   else !no axis or init time present
@@ -514,7 +517,7 @@ end function fms_diag_accept_data
 !! variable metadata and data when necessary.
 subroutine fms_diag_send_complete(this, time_step)
   class(fmsDiagObject_type), target, intent (inout) :: this      !< The diag object
-  TYPE (time_type),                  INTENT(in)     :: time_step !< The current model time
+  TYPE (time_type),                  INTENT(in)     :: time_step !< The time_step
 
   integer :: i !< For do loops
 
@@ -529,6 +532,9 @@ CALL MPP_ERROR(FATAL,"You can not use the modern diag manager without compiling 
   logical :: math !< True if the math functions need to be called using the data buffer,
   !! False if the math functions were done in accept_data
   integer, dimension(:), allocatable :: file_field_ids !< Array of field IDs for a file
+
+  !< Update the current model time by adding the time_step
+  this%current_model_time = this%current_model_time + time_step
 
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   !! In the future, this may be parallelized for offloading
@@ -553,22 +559,21 @@ CALL MPP_ERROR(FATAL,"You can not use the modern diag manager without compiling 
     endif field_outer_if
   enddo file_loop
 
-  call this%fms_diag_do_io(time_step)
+  call this%fms_diag_do_io()
 #endif
 
 end subroutine fms_diag_send_complete
 
 !> @brief Loops through all the files, open the file, writes out axis and
 !! variable metadata and data when necessary.
-subroutine fms_diag_do_io(this, time_step, is_end_of_run)
-  class(fmsDiagObject_type), target, intent (inout) :: this          !< The diag object
-  TYPE (time_type),                  INTENT(in)     :: time_step     !< The current model time
+subroutine fms_diag_do_io(this, is_end_of_run)
+  class(fmsDiagObject_type), target, intent(inout)  :: this          !< The diag object
   logical,                 optional, intent(in)     :: is_end_of_run !< If .true. this is the end of the run,
                                                                      !! so force write
 #ifdef use_yaml
   integer :: i !< For do loops
   class(fmsDiagFileContainer_type), pointer :: diag_file !< Pointer to this%FMS_diag_files(i) (for convenience)
-
+  TYPE (time_type),                 pointer :: model_time!< The current model time
 
   logical :: file_is_opened_this_time_step !< True if the file was opened in this time_step
                                            !! If true the metadata will need to be written
@@ -577,13 +582,15 @@ subroutine fms_diag_do_io(this, time_step, is_end_of_run)
   force_write = .false.
   if (present (is_end_of_run)) force_write = .true.
 
+  model_time => this%current_model_time
+
   do i = 1, size(this%FMS_diag_files)
     diag_file => this%FMS_diag_files(i)
 
     !< Go away if the file is a subregional file and the current PE does not have any data for it
     if (.not. diag_file%writing_on_this_pe()) cycle
 
-    call diag_file%open_diag_file(time_step, file_is_opened_this_time_step)
+    call diag_file%open_diag_file(model_time, file_is_opened_this_time_step)
     if (file_is_opened_this_time_step) then
       call diag_file%write_time_metadata()
       call diag_file%write_axis_metadata(this%diag_axis)
@@ -591,13 +598,13 @@ subroutine fms_diag_do_io(this, time_step, is_end_of_run)
       call diag_file%write_axis_data(this%diag_axis)
     endif
 
-    if (diag_file%is_time_to_write(time_step)) then
+    if (diag_file%is_time_to_write(model_time)) then
       call diag_file%increase_unlimited_dimension()
       call diag_file%write_time_data()
       !TODO call diag_file%add_variable_data()
-      call diag_file%update_next_write(time_step)
-      call diag_file%update_current_new_file_freq_index(time_step)
-      if (diag_file%is_time_to_close_file(time_step)) call diag_file%close_diag_file()
+      call diag_file%update_next_write(model_time)
+      call diag_file%update_current_new_file_freq_index(model_time)
+      if (diag_file%is_time_to_close_file(model_time)) call diag_file%close_diag_file()
     else if (force_write .and. .not. diag_file%is_file_static()) then
       call diag_file%increase_unlimited_dimension()
       call diag_file%write_time_data()

--- a/test_fms/diag_manager/test_flexible_time.F90
+++ b/test_fms/diag_manager/test_flexible_time.F90
@@ -21,7 +21,7 @@
 program test_flexible_time
 use   fms_mod,          only: fms_init, fms_end
 use   time_manager_mod, only: set_date, time_type, increment_date, set_calendar_type, &
-                              JULIAN
+                              JULIAN, set_time
 use   diag_manager_mod, only: diag_manager_init, diag_axis_init, register_diag_field, &
                               diag_manager_set_time_end, diag_send_complete, diag_manager_end
 use   mpp_mod,          only: FATAL, mpp_error
@@ -51,9 +51,7 @@ call diag_manager_set_time_end(End_Time)
 
 !< Set up the simulation
 do i=1,48
-  !< Increase the time by 1 hour
-  Time = increment_date(Start_Time, 0, 0, 0, i, 0, 0)
-  call diag_send_complete(Time)
+  call diag_send_complete(set_time(3600,0))
 enddo
 
 call diag_manager_end(End_Time)

--- a/test_fms/diag_manager/test_modern_diag.F90
+++ b/test_fms/diag_manager/test_modern_diag.F90
@@ -30,7 +30,7 @@ use   diag_manager_mod, only: diag_manager_init, diag_manager_end, diag_axis_ini
 use   platform_mod,     only: r8_kind, r4_kind
 use   fms_mod,          only: fms_init, fms_end
 use   mpp_mod,          only: FATAL, mpp_error, mpp_npes, mpp_pe, mpp_root_pe, mpp_broadcast, input_nml_file
-use   time_manager_mod, only: time_type, set_calendar_type, set_date, JULIAN, set_time
+use   time_manager_mod, only: time_type, set_calendar_type, set_date, JULIAN, set_time, OPERATOR(+)
 use fms_diag_object_mod,only: dump_diag_obj
 
 implicit none
@@ -46,6 +46,7 @@ type data_type
 end type data_type
 
 type(time_type)                   :: Time             !< Time of the simulation
+type(time_type)                   :: Time_step        !< Time_step of the simulation
 integer, dimension(2)             :: layout           !< Layout to use when setting up the domain
 integer, dimension(2)             :: io_layout        !< io layout to use when setting up the io domain
 integer                           :: nx               !< Number of x points
@@ -193,8 +194,9 @@ call diag_manager_set_time_end(Time)
 call diag_manager_set_time_end(set_date(2,1,2,0,0,0))
 
 call allocate_dummy_data(var_data, domain, Domain_cube_sph, land_domain, nz)
+Time_step = set_time (3600,0) !< 1 hour
 do i=1,23
-  Time = set_date(2,1,1,i,0,0)
+  Time = Time + Time_step
   call set_dummy_data(var_data, i)
   used = send_data(id_var1, var_data%var1, Time)
   used = send_data(id_var2, var_data%var2, Time)
@@ -207,7 +209,7 @@ do i=1,23
   !TODO I don't know about this (scalar field) or how this is suppose to work #WUT
   used = send_data(id_var8, var_data%var6, Time)
 
-  call diag_send_complete(Time)
+  call diag_send_complete(Time_step)
 enddo
 call deallocate_dummy_data(var_data)
 


### PR DESCRIPTION
**Description**
Adds a variable to the diag_object to store the current model time (which gets updated using the time_step in diag_send_complete) + updates tests

Fixes # (issue)

**How Has This Been Tested?**
CI

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

