### PR TITLE
Modern diag manager: check if field is registered

### DIFF
--- a/diag_manager/fms_diag_file_object.F90
+++ b/diag_manager/fms_diag_file_object.F90
@@ -93,6 +93,7 @@ type :: fmsDiagFile_type
 
  contains
   procedure, public :: add_field_and_yaml_id
+  procedure, public :: is_field_registered
   procedure, public :: init_diurnal_axis
   procedure, public :: has_file_metadata_from_model
   procedure, public :: has_fileobj
@@ -254,6 +255,15 @@ logical function fms_diag_files_object_init (files_array)
 !    FATAL)
   endif
 end function fms_diag_files_object_init
+
+!< @brief Determine if the field corresponding to the field_id was registered to the file
+!! @return .True. if the field was registed to the file
+logical function is_field_registered(this, field_id)
+  class(fmsDiagFile_type), intent(inout) :: this         !< The file object
+  integer,                 intent(in)    :: field_id     !< Id of the field to check
+
+  is_field_registered = this%field_registered(field_id)
+end function is_field_registered
 
 !> \brief Adds a field and yaml ID to the file
 subroutine add_field_and_yaml_id (this, new_field_id, yaml_id)

--- a/diag_manager/fms_diag_file_object.F90
+++ b/diag_manager/fms_diag_file_object.F90
@@ -260,7 +260,7 @@ end function fms_diag_files_object_init
 !< @brief Determine if the field corresponding to the field_id was registered to the file
 !! @return .True. if the field was registed to the file
 pure logical function is_field_registered(this, field_id)
-  class(fmsDiagFile_type), intent(inout) :: this         !< The file object
+  class(fmsDiagFile_type), intent(in)    :: this         !< The file object
   integer,                 intent(in)    :: field_id     !< Id of the field to check
 
   is_field_registered = this%field_registered(field_id)

--- a/diag_manager/fms_diag_file_object.F90
+++ b/diag_manager/fms_diag_file_object.F90
@@ -259,7 +259,7 @@ end function fms_diag_files_object_init
 
 !< @brief Determine if the field corresponding to the field_id was registered to the file
 !! @return .True. if the field was registed to the file
-logical function is_field_registered(this, field_id)
+pure logical function is_field_registered(this, field_id)
   class(fmsDiagFile_type), intent(inout) :: this         !< The file object
   integer,                 intent(in)    :: field_id     !< Id of the field to check
 

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -539,7 +539,7 @@ CALL MPP_ERROR(FATAL,"You can not use the modern diag manager without compiling 
       file_field_ids = diag_file%FMS_diag_file%get_field_ids()
       field_loop: do ifield = 1, size(file_field_ids)
         ! If the field is not registered go away
-        if (diag_file%FMS_diag_field%is_field_registered(ifield)) cycle
+        if (diag_file%FMS_diag_file%is_field_registered(ifield)) cycle
 
         diag_field => this%FMS_diag_fields(file_field_ids(ifield))
         !> Check if math needs to be done

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -539,7 +539,7 @@ CALL MPP_ERROR(FATAL,"You can not use the modern diag manager without compiling 
       file_field_ids = diag_file%FMS_diag_file%get_field_ids()
       field_loop: do ifield = 1, size(file_field_ids)
         ! If the field is not registered go away
-        if (diag_file%FMS_diag_file%is_field_registered(ifield)) cycle
+        if (.not. diag_file%FMS_diag_file%is_field_registered(ifield)) cycle
 
         diag_field => this%FMS_diag_fields(file_field_ids(ifield))
         !> Check if math needs to be done

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -538,6 +538,9 @@ CALL MPP_ERROR(FATAL,"You can not use the modern diag manager without compiling 
       allocate (file_field_ids(size(diag_file%FMS_diag_file%get_field_ids() )))
       file_field_ids = diag_file%FMS_diag_file%get_field_ids()
       field_loop: do ifield = 1, size(file_field_ids)
+        ! If the field is not registered go away
+        if (diag_file%FMS_diag_field%is_field_registered(ifield)) cycle
+
         diag_field => this%FMS_diag_fields(file_field_ids(ifield))
         !> Check if math needs to be done
         ! math = diag_field%get_math_needs_to_be_done()


### PR DESCRIPTION
**Description**
Adds a function to the file_object to check if a field in the file object was registered
Updates `send_diag_complete` to skip fields that were not registered

This was causing out of bounds issues when a variable was not registered since `file_field_ids(ifield)` will be -1 so
it will try to do
```F90
 diag_field => this%FMS_diag_fields(-1)
```

Fixes # (issue)

**How Has This Been Tested?**
CI

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

