### PR TITLE
Checks placed before allocating pointers passed into routines

### DIFF
--- a/exchange/xgrid.F90
+++ b/exchange/xgrid.F90
@@ -1087,6 +1087,7 @@ logical,        intent(in)             :: use_higher_order
         grid%x(1:size_prev) = x_local
         deallocate(x_local)
      else
+      if(ASSOCIATED(grid%x)) deallocate(grid%x) !< Check if allocated
         allocate( grid%x( grid%size ) )
         grid%x%di = 0.0; grid%x%dj = 0.0
      end if
@@ -1248,6 +1249,7 @@ logical,        intent(in)             :: use_higher_order
         grid%x_repro(1:ll_repro) = x_local
         deallocate(x_local)
      else
+      if(ASSOCIATED(grid%x_repro)) deallocate(grid%x_repro) !< Check if allocated
         allocate( grid%x_repro( grid%size_repro ) )
         grid%x_repro%di = 0.0; grid%x_repro%dj = 0.0
      end if
@@ -1318,7 +1320,8 @@ subroutine get_grid_version1(grid, grid_id, grid_file)
   endif
 
   call mpp_get_compute_domain(grid%domain, is, ie, js, je)
-
+  if (associated(grid%lon)) deallocate(grid%lon) !< Check if allocated
+￼ if (associated(grid%lat)) deallocate(grid%lat) !< Check if allocated
   allocate(grid%lon(grid%im), grid%lat(grid%jm))
   if(grid_id == 'ATM') then
      call read_data(fileobj, 'xta', lonb)
@@ -1413,6 +1416,8 @@ subroutine get_grid_version2(grid, grid_id, grid_file)
         start(2) = 2; nread(1) = nlon*2+1
         allocate(tmpx(nlon*2+1, 1), tmpy(1, nlat*2+1))
         call read_data(fileobj, "x", tmpx, corner=start, edge_lengths=nread)
+        if (associated(grid%lon)) deallocate(grid%lon) !< Check if allocated
+￼       if (associated(grid%lat)) deallocate(grid%lat) !< Check if allocated
         allocate(grid%lon(grid%im), grid%lat(grid%jm))
         do i = 1, grid%im
            grid%lon(i) = tmpx(2*i,1) * d2r
@@ -1425,6 +1430,8 @@ subroutine get_grid_version2(grid, grid_id, grid_file)
         end do
         grid%is_latlon = .true.
      else
+        if (associated(grid%geolon)) deallocate(grid%geolon) !< Check if allocated
+￼       if (associated(grid%geolat)) deallocate(grid%geolat) !< Check if allocated
         allocate(grid%geolon(grid%isd_me:grid%ied_me, grid%jsd_me:grid%jed_me))
         allocate(grid%geolat(grid%isd_me:grid%ied_me, grid%jsd_me:grid%jed_me))
         grid%geolon = 1e10
@@ -1545,8 +1552,12 @@ subroutine setup_xmap(xmap, grid_ids, grid_domains, grid_file, atm_grid, lnd_ug_
   xmap%npes = mpp_npes()
   xmap%root_pe = mpp_root_pe()
 
+  if (associated(xmap%grids)) deallocate(xmap%grids) !< Check if allocated
   allocate( xmap%grids(1:size(grid_ids(:))) )
 
+  if (associated(xmap%your1my2)) deallocate(xmap%your1my2) !< Check if allocated
+  if (associated(xmap%your2my1)) deallocate(xmap%your2my1) !< Check if allocated
+  if (associated(xmap%your2my1_size)) deallocate(xmap%your2my1_size) !< Check if allocated
   allocate ( xmap%your1my2(0:xmap%npes-1), xmap%your2my1(0:xmap%npes-1) )
   allocate ( xmap%your2my1_size(0:xmap%npes-1) )
 
@@ -1589,6 +1600,11 @@ subroutine setup_xmap(xmap, grid_ids, grid_domains, grid_file, atm_grid, lnd_ug_
      grid%id     = grid_ids    (g)
      grid%domain = grid_domains(g)
      grid%on_this_pe = mpp_domain_is_initialized(grid_domains(g))
+     if (associated(grid%is)) deallocate(grid%is) !< Check if allocated
+     if (associated(grid%ie)) deallocate(grid%ie) !< Check if allocated
+     if (associated(grid%js)) deallocate(grid%js) !< Check if allocated
+     if (associated(grid%je)) deallocate(grid%je) !< Check if allocated
+     if (associated(grid%tile)) deallocate(grid%tile) !< Check if allocated
      allocate ( grid%is(0:xmap%npes-1), grid%ie(0:xmap%npes-1) )
      allocate ( grid%js(0:xmap%npes-1), grid%je(0:xmap%npes-1) )
      allocate ( grid%tile(0:xmap%npes-1) )
@@ -1624,6 +1640,7 @@ subroutine setup_xmap(xmap, grid_ids, grid_domains, grid_file, atm_grid, lnd_ug_
      endif
 
      npes = grid%npes
+     if (associated(grid%pelist)) deallocate(grid%pelist) !< Check if allocated
      allocate(grid%pelist(0:npes-1))
      call mpp_get_domain_pelist(grid%domain, grid%pelist)
      grid%root_pe = mpp_get_domain_root_pe(grid%domain)
@@ -1679,6 +1696,10 @@ subroutine setup_xmap(xmap, grid_ids, grid_domains, grid_file, atm_grid, lnd_ug_
                                      'does not support unstructured grid for VERSION1 grid' ,FATAL)
         grid%is_ug     = .true.
         grid%ug_domain = lnd_ug_domain
+        if (associated(grid%ls)) deallocate(grid%ls) !< Check if allocated
+        if (associated(grid%le)) deallocate(grid%le) !< Check if allocated
+        if (associated(grid%gs)) deallocate(grid%gs) !< Check if allocated
+        if (associated(grid%ge)) deallocate(grid%ge) !< Check if allocated
         allocate ( grid%ls(0:xmap%npes-1), grid%le(0:xmap%npes-1) )
         allocate ( grid%gs(0:xmap%npes-1), grid%ge(0:xmap%npes-1) )
         grid%ls = 0
@@ -1695,6 +1716,7 @@ subroutine setup_xmap(xmap, grid_ids, grid_domains, grid_file, atm_grid, lnd_ug_
         grid%gs_me => grid%gs(xmap%me-xmap%root_pe); grid%ge_me => grid%ge(xmap%me-xmap%root_pe)
         grid%tile_me => grid%tile(xmap%me-xmap%root_pe)
         grid%nxl_me = grid%le_me - grid%ls_me + 1
+        if (associated(grid%l_index)) deallocate(grid%l_index) !< Check if allocated
         allocate(grid%l_index(grid%gs_me:grid%ge_me))
         allocate(grid_index(grid%ls_me:grid%le_me))
         call mpp_get_UG_domain_grid_index(grid%ug_domain, grid_index)
@@ -1705,6 +1727,8 @@ subroutine setup_xmap(xmap, grid_ids, grid_domains, grid_file, atm_grid, lnd_ug_
         enddo
 
         if( grid%on_this_pe ) then
+           if (associated(grid%area)) deallocate(grid%area) !< Check if allocated
+           if (associated(grid%area_inv)) deallocate(grid%area_inv) !< Check if allocated
            allocate( grid%area    (grid%ls_me:grid%le_me,1) )
            allocate( grid%area_inv(grid%ls_me:grid%le_me,1) )
            grid%area       = 0.0
@@ -1712,6 +1736,8 @@ subroutine setup_xmap(xmap, grid_ids, grid_domains, grid_file, atm_grid, lnd_ug_
            grid%size_repro = 0
         endif
      else if( grid%on_this_pe ) then
+        if (associated(grid%area)) deallocate(grid%area) !< Check if allocated
+        if (associated(grid%area_inv)) deallocate(grid%area_inv) !< Check if allocated
         allocate( grid%area    (grid%is_me:grid%ie_me, grid%js_me:grid%je_me) )
         allocate( grid%area_inv(grid%is_me:grid%ie_me, grid%js_me:grid%je_me) )
         grid%area       = 0.0
@@ -1783,6 +1809,17 @@ subroutine setup_xmap(xmap, grid_ids, grid_domains, grid_file, atm_grid, lnd_ug_
                    call error_mesg('xgrid_mod', 'incorrect dimension size of atm_grid%vlon', FATAL)
               if(size(atm_grid%vlat,1) .NE. 3 .OR. size(atm_grid%vlat,2) .NE. nxc .OR. size(atm_grid%vlat,3) .NE. nyc)&
                    call error_mesg('xgrid_mod', 'incorrect dimension size of atm_grid%vlat', FATAL)
+              if (associated(grid%box%dx)) deallocate(grid%box%dx) !< Check if allocated
+              if (associated(grid%box%dy)) deallocate(grid%box%dy) !< Check if allocated
+              if (associated(grid%box%area)) deallocate(grid%box%area) !< Check if allocated
+              if (associated(grid%box%edge_w)) deallocate(grid%box%edge_w) !< Check if allocated
+              if (associated(grid%box%edge_e)) deallocate(grid%box%edge_e) !< Check if allocated
+              if (associated(grid%box%edge_s)) deallocate(grid%box%edge_s) !< Check if allocated
+              if (associated(grid%box%edge_n)) deallocate(grid%box%edge_n) !< Check if allocated
+              if (associated(grid%box%en1)) deallocate(grid%box%en1) !< Check if allocated
+              if (associated(grid%box%en2)) deallocate(grid%box%en2) !< Check if allocated
+              if (associated(grid%box%vlon)) deallocate(grid%box%vlon) !< Check if allocated
+              if (associated(grid%box%vlat)) deallocate(grid%box%vlat) !< Check if allocated
               allocate(grid%box%dx    (grid%is_me:grid%ie_me,   grid%js_me:grid%je_me+1 ))
               allocate(grid%box%dy    (grid%is_me:grid%ie_me+1, grid%js_me:grid%je_me   ))
               allocate(grid%box%area  (grid%is_me:grid%ie_me,   grid%js_me:grid%je_me   ))
@@ -1811,6 +1848,7 @@ subroutine setup_xmap(xmap, grid_ids, grid_domains, grid_file, atm_grid, lnd_ug_
      if(xmap%version==VERSION2) call close_file(mosaicfileobj)
      if (g>1) then
         if(grid%on_this_pe) then
+         if (associated(grid%frac_area)) deallocate(grid%frac_area) !< Check if allocated
            if(grid%is_ug) then
               allocate( grid%frac_area(grid%ls_me:grid%le_me, 1, grid%km) )
            else
@@ -1939,6 +1977,8 @@ subroutine setup_xmap(xmap, grid_ids, grid_domains, grid_file, atm_grid, lnd_ug_
   xmap%your2my1(xmap%me-xmap%root_pe) = .false. ! a PE from communicating with itself
 
   if (make_exchange_reproduce) then
+   if (associated(xmap%send_count_repro)) deallocate(xmap%send_count_repro) !< Check if allocated
+￼   if (associated(xmap%recv_count_repro)) deallocate(xmap%recv_count_repro) !< Check if allocated
      allocate( xmap%send_count_repro(0:xmap%npes-1) )
      allocate( xmap%recv_count_repro(0:xmap%npes-1) )
      xmap%send_count_repro = 0
@@ -1960,12 +2000,18 @@ subroutine setup_xmap(xmap, grid_ids, grid_domains, grid_file, atm_grid, lnd_ug_
      xmap%recv_count_repro_tot = 0
   end if
 
+  if (associated(xmap%x1)) deallocate(xmap%x1) !< Check if allocated
+  if (associated(xmap%x2)) deallocate(xmap%x2) !< Check if allocated
+  if (associated(xmap%x1_put)) deallocate(xmap%x1_put) !< Check if allocated
+  if (associated(xmap%x2_get)) deallocate(xmap%x2_get) !< Check if allocated
   allocate( xmap%x1(1:sum(xmap%grids(2:size(xmap%grids(:)))%size)) )
   allocate( xmap%x2(1:sum(xmap%grids(2:size(xmap%grids(:)))%size)) )
   allocate( xmap%x1_put(1:sum(xmap%grids(2:size(xmap%grids(:)))%size)) )
   allocate( xmap%x2_get(1:sum(xmap%grids(2:size(xmap%grids(:)))%size)) )
 
   !--- The following will setup indx to be used in regen
+  if (associated(xmap%get1)) deallocate(xmap%get1) !< Check if allocated
+  if (associated(xmap%put1)) deallocate(xmap%put1) !< Check if allocated
   allocate(xmap%get1, xmap%put1)
   call mpp_clock_begin(id_set_comm)
 
@@ -1974,6 +2020,7 @@ subroutine setup_xmap(xmap, grid_ids, grid_domains, grid_file, atm_grid, lnd_ug_
   call set_comm_put1(xmap)
 
   if(make_exchange_reproduce) then
+   if (associated(xmap%get1_repro)) deallocate(xmap%get1_repro) !< Check if allocated
     allocate(xmap%get1_repro)
     call set_comm_get1_repro(xmap)
   endif
@@ -2174,6 +2221,7 @@ subroutine set_comm_get1_repro(xmap)
 
   comm%nrecv = nrecv
   if( nrecv > 0 ) then
+   if (associated(comm%recv)) deallocate(comm%recv) !< Check if allocated
     allocate(comm%recv(nrecv))
     pos = 0
     do n = 1, nrecv
@@ -2200,6 +2248,7 @@ subroutine set_comm_get1_repro(xmap)
 
   comm%nsend = nsend
   if( nsend > 0 ) then
+   if (associated(comm%send)) deallocate(comm%send) !< Check if allocated
      allocate(comm%send(nsend))
      pos = 0
      cnt(:) = 0
@@ -2296,6 +2345,7 @@ subroutine set_comm_get1(xmap)
 
   if(max_size > 0) then
      allocate(pe_side1(max_size))
+     if (associated(xmap%ind_get1)) deallocate(xmap%ind_get1) !< Check if allocated
      allocate(xmap%ind_get1(max_size))
 
      !--- find the recv_indx
@@ -2399,6 +2449,7 @@ subroutine set_comm_get1(xmap)
   nsend = count( send_size> 0)
   comm%nsend = nsend
   if(nsend>0) then
+   if (associated(comm%send)) deallocate(comm%send) !< Check if allocated
      allocate(comm%send(nsend))
      comm%send(:)%count = 0
   endif
@@ -2474,6 +2525,7 @@ subroutine set_comm_get1(xmap)
   comm%recvsize = 0
 
   if(nrecv >0) then
+   if (associated(comm%recv)) deallocate(comm%recv) !< Check if allocated
      allocate(comm%recv(nrecv))
      comm%recv(:)%count = 0
      !--- set up the buffer pos for each receiving
@@ -2526,6 +2578,7 @@ subroutine set_comm_get1(xmap)
            endif
         endif
      enddo
+     if (associated(comm%unpack_ind)) deallocate(comm%unpack_ind) !< Check if allocated
      allocate(comm%unpack_ind(nrecv))
      pos = 0
      do p = 0, npes-1
@@ -2604,6 +2657,7 @@ subroutine set_comm_put1(xmap)
 
   if(max_size > 0) then
      allocate(pe_put1(max_size))
+     if (associated(xmap%ind_put1)) deallocate(xmap%ind_put1) !< Check if allocated
      allocate(xmap%ind_put1(max_size))
 
      !--- find the recv_indx
@@ -2724,6 +2778,7 @@ subroutine set_comm_put1(xmap)
   nrecv = count( send_size> 0)
   comm%nrecv = nrecv
   if(nrecv>0) then
+   if (associated(comm%recv)) deallocate(comm%recv) !< Check if allocated
      allocate(comm%recv(nrecv))
      comm%recv(:)%count = 0
   endif
@@ -2798,6 +2853,7 @@ subroutine set_comm_put1(xmap)
   comm%sendsize = 0
 
   if(nsend >0) then
+   if (associated(comm%send)) deallocate(comm%send) !< Check if allocated
      allocate(comm%send(nsend))
      comm%send(:)%count = 0
      pos = 0
@@ -2864,8 +2920,8 @@ type (xmap_type), intent(inout) :: xmap
   end do
 
   if (max_size>size(xmap%x1(:))) then
-    deallocate(xmap%x1)
-    deallocate(xmap%x2)
+    if (associated(xmap%x1)) deallocate(xmap%x1) !< Check x1 if allocated
+    if (associated(xmap%x2)) deallocate(xmap%x2) !< Check x2 if allocated
     allocate( xmap%x1(1:max_size) )
     allocate( xmap%x2(1:max_size) )
   endif
@@ -2933,11 +2989,11 @@ type (xmap_type), intent(inout) :: xmap
 
 
   if (max_size>size(xmap%x1_put(:))) then
-    deallocate(xmap%x1_put)
+   if (associated(xmap%x1_put)) deallocate(xmap%x1_put) !< Check if allocated
     allocate( xmap%x1_put(1:max_size) )
   endif
   if (max_size>size(xmap%x2_get(:))) then
-    deallocate(xmap%x2_get)
+    if (associated(xmap%x2_get)) deallocate(xmap%x2_get) !< Check if allocated
     allocate( xmap%x2_get(1:max_size) )
   endif
 
@@ -3067,7 +3123,7 @@ type (xmap_type),       intent(inout) :: xmap !< exchange grid with given grid I
     grid => xmap%grids(g)
     if (grid_id==grid%id) then
       if (size(f,3)/=size(grid%frac_area,3)) then
-        deallocate (grid%frac_area)
+        if (associated(grid%frac_area)) deallocate (grid%frac_area) !< Check if allocated
         grid%km = size(f,3);
         allocate( grid%frac_area(grid%is_me:grid%ie_me, grid%js_me:grid%je_me, &
                                                                       grid%km) )
@@ -3101,7 +3157,7 @@ type (xmap_type),       intent(inout) :: xmap !< exchange grid with given grid I
     grid => xmap%grids(g)
     if (grid_id==grid%id) then
       if (size(f,2)/=size(grid%frac_area,3)) then
-        deallocate (grid%frac_area)
+        if (associated(grid%frac_area)) deallocate (grid%frac_area) !< Check if allocated
         grid%km = size(f,2);
         allocate( grid%frac_area(grid%ls_me:grid%le_me, 1, grid%km) )
       end if

--- a/exchange/xgrid.F90
+++ b/exchange/xgrid.F90
@@ -1321,7 +1321,7 @@ subroutine get_grid_version1(grid, grid_id, grid_file)
 
   call mpp_get_compute_domain(grid%domain, is, ie, js, je)
   if (associated(grid%lon)) deallocate(grid%lon) !< Check if allocated
-￼ if (associated(grid%lat)) deallocate(grid%lat) !< Check if allocated
+  if (associated(grid%lat)) deallocate(grid%lat) !< Check if allocated
   allocate(grid%lon(grid%im), grid%lat(grid%jm))
   if(grid_id == 'ATM') then
      call read_data(fileobj, 'xta', lonb)
@@ -1417,7 +1417,7 @@ subroutine get_grid_version2(grid, grid_id, grid_file)
         allocate(tmpx(nlon*2+1, 1), tmpy(1, nlat*2+1))
         call read_data(fileobj, "x", tmpx, corner=start, edge_lengths=nread)
         if (associated(grid%lon)) deallocate(grid%lon) !< Check if allocated
-￼       if (associated(grid%lat)) deallocate(grid%lat) !< Check if allocated
+        if (associated(grid%lat)) deallocate(grid%lat) !< Check if allocated
         allocate(grid%lon(grid%im), grid%lat(grid%jm))
         do i = 1, grid%im
            grid%lon(i) = tmpx(2*i,1) * d2r
@@ -1431,7 +1431,7 @@ subroutine get_grid_version2(grid, grid_id, grid_file)
         grid%is_latlon = .true.
      else
         if (associated(grid%geolon)) deallocate(grid%geolon) !< Check if allocated
-￼       if (associated(grid%geolat)) deallocate(grid%geolat) !< Check if allocated
+        if (associated(grid%geolat)) deallocate(grid%geolat) !< Check if allocated
         allocate(grid%geolon(grid%isd_me:grid%ied_me, grid%jsd_me:grid%jed_me))
         allocate(grid%geolat(grid%isd_me:grid%ied_me, grid%jsd_me:grid%jed_me))
         grid%geolon = 1e10
@@ -1978,7 +1978,7 @@ subroutine setup_xmap(xmap, grid_ids, grid_domains, grid_file, atm_grid, lnd_ug_
 
   if (make_exchange_reproduce) then
    if (associated(xmap%send_count_repro)) deallocate(xmap%send_count_repro) !< Check if allocated
-￼   if (associated(xmap%recv_count_repro)) deallocate(xmap%recv_count_repro) !< Check if allocated
+   if (associated(xmap%recv_count_repro)) deallocate(xmap%recv_count_repro) !< Check if allocated
      allocate( xmap%send_count_repro(0:xmap%npes-1) )
      allocate( xmap%recv_count_repro(0:xmap%npes-1) )
      xmap%send_count_repro = 0

--- a/exchange/xgrid.F90
+++ b/exchange/xgrid.F90
@@ -1640,7 +1640,6 @@ subroutine setup_xmap(xmap, grid_ids, grid_domains, grid_file, atm_grid, lnd_ug_
      endif
 
      npes = grid%npes
-     if (associated(grid%pelist)) deallocate(grid%pelist) !< Check if allocated
      allocate(grid%pelist(0:npes-1))
      call mpp_get_domain_pelist(grid%domain, grid%pelist)
      grid%root_pe = mpp_get_domain_root_pe(grid%domain)

--- a/mpp/include/mpp_define_nest_domains.inc
+++ b/mpp/include/mpp_define_nest_domains.inc
@@ -189,6 +189,16 @@ subroutine mpp_define_nest_domains(nest_domain, domain, num_nest, nest_level, ti
   call mpp_get_current_pelist(pes)
 
   nest_domain%num_nest = num_nest
+   if (associated(nest_domain%tile_fine)) deallocate(nest_domain%tile_fine) !< Check if allocated
+   if (associated(nest_domain%tile_coarse)) deallocate(nest_domain%tile_coarse) !< Check if allocated
+   if (associated(nest_domain%istart_fine)) deallocate(nest_domain%istart_fine) !< Check if allocated
+   if (associated(nest_domain%iend_fine)) deallocate(nest_domain%iend_fine) !< Check if allocated
+   if (associated(nest_domain%jstart_fine)) deallocate(nest_domain%jstart_fine) !< Check if allocated
+   if (associated(nest_domain%jend_fine)) deallocate(nest_domain%jend_fine) !< Check if allocated
+   if (associated(nest_domain%istart_coarse)) deallocate(nest_domain%istart_coarse) !< Check if allocated
+   if (associated(nest_domain%iend_coarse)) deallocate(nest_domain%iend_coarse) !< Check if allocated
+   if (associated(nest_domain%jstart_coarse)) deallocate(nest_domain%jstart_coarse) !< Check if allocated
+   if (associated(nest_domain%jend_coarse)) deallocate(nest_domain%jend_coarse) !< Check if allocated
   allocate(nest_domain%tile_fine(num_nest), nest_domain%tile_coarse(num_nest) )
   allocate(nest_domain%istart_fine(num_nest), nest_domain%iend_fine(num_nest) )
   allocate(nest_domain%jstart_fine(num_nest), nest_domain%jend_fine(num_nest) )
@@ -196,6 +206,7 @@ subroutine mpp_define_nest_domains(nest_domain, domain, num_nest, nest_level, ti
   allocate(nest_domain%jstart_coarse(num_nest), nest_domain%jend_coarse(num_nest) )
 
   !---Added to enable moving nests
+  if (associated(nest_domain%nest_level)) deallocate(nest_domain%nest_level) !< Check if allocated
   allocate(nest_domain%nest_level(num_nest))
 
   nest_domain%tile_fine = tile_fine(1:num_nest)
@@ -253,6 +264,7 @@ subroutine mpp_define_nest_domains(nest_domain, domain, num_nest, nest_level, ti
   enddo
 
   nest_domain%num_level = nlevels
+  if (associated(nest_domain%nest)) deallocate(nest_domain%nest) !< Check if allocated
   allocate(nest_domain%nest(nlevels))
   allocate(pelist_level(mpp_npes()))
   allocate(is_nest_fine(nlevels))
@@ -297,6 +309,7 @@ subroutine mpp_define_nest_domains(nest_domain, domain, num_nest, nest_level, ti
         endif
      enddo
 
+     if (associated(nest_domain%nest(l)%pelist)) deallocate(nest_domain%nest(l)%pelist) !< Check if allocated
      allocate(nest_domain%nest(l)%pelist(npes_level))
      nest_domain%nest(l)%pelist(:) = pelist_level(1:npes_level)
 
@@ -490,7 +503,9 @@ subroutine define_nest_level_type(nest_domain, x_refine, y_refine, extra_halo)
      endif
   enddo
 
+  if (associated(nest_domain%pelist_fine)) deallocate(nest_domain%pelist_fine) !< Check if allocated
   allocate(nest_domain%pelist_fine(npes_fine))
+  if (associated(nest_domain%pelist_coarse)) deallocate(nest_domain%pelist_coarse) !< Check if allocated
   allocate(nest_domain%pelist_coarse(npes_coarse))
   nest_domain%pelist_fine = pes_fine
   nest_domain%pelist_coarse = pes_coarse
@@ -529,6 +544,7 @@ subroutine define_nest_level_type(nest_domain, x_refine, y_refine, extra_halo)
 
   nest_domain%my_num_nest = my_num_nest
   if(my_num_nest>0) then
+   if (associated(nest_domain%my_nest_id)) deallocate(nest_domain%my_nest_id) !< Check if allocated
      allocate(nest_domain%my_nest_id(my_num_nest))
      nest_domain%my_nest_id(:) = my_nest_id(1:my_num_nest)
   endif
@@ -564,11 +580,19 @@ subroutine define_nest_level_type(nest_domain, x_refine, y_refine, extra_halo)
   nest_domain%x_refine = x_refine
   nest_domain%y_refine = y_refine
 
+  if (associated(nest_domain%C2F_T)) deallocate(nest_domain%C2F_T) !< Check if allocated
+  if (associated(nest_domain%C2F_C)) deallocate(nest_domain%C2F_C) !< Check if allocated
+  if (associated(nest_domain%C2F_E)) deallocate(nest_domain%C2F_E) !< Check if allocated
+  if (associated(nest_domain%C2F_N)) deallocate(nest_domain%C2F_N) !< Check if allocated
   allocate( nest_domain%C2F_T, nest_domain%C2F_C, nest_domain%C2F_E, nest_domain%C2F_N )
   nest_domain%C2F_T%next => NULL()
   nest_domain%C2F_C%next => NULL()
   nest_domain%C2F_N%next => NULL()
   nest_domain%C2F_E%next => NULL()
+  if (associated(nest_domain%F2C_T)) deallocate(nest_domain%F2C_T) !< Check if allocated
+  if (associated(nest_domain%F2C_C)) deallocate(nest_domain%F2C_C) !< Check if allocated
+  if (associated(nest_domain%F2C_E)) deallocate(nest_domain%F2C_E) !< Check if allocated
+  if (associated(nest_domain%F2C_N)) deallocate(nest_domain%F2C_N) !< Check if allocated
   allocate( nest_domain%F2C_T, nest_domain%F2C_C, nest_domain%F2C_E, nest_domain%F2C_N )
 
   call compute_overlap_fine_to_coarse(nest_domain, nest_domain%F2C_T, CENTER, "F2C T-cell")
@@ -1029,6 +1053,7 @@ subroutine compute_overlap_coarse_to_fine(nest_domain, overlap, extra_halo, posi
   !--- copy the overlapping into nest_domain data.
   overlap%nrecv = nrecv
   if( nrecv > 0 ) then
+   if (associated(overlap%recv)) deallocate(overlap%recv) !< Check if allocated
      allocate(overlap%recv(nrecv))
      do n = 1, nrecv
         call copy_nest_overlap( overlap%recv(n), overLaplist(n) )
@@ -1039,6 +1064,7 @@ subroutine compute_overlap_coarse_to_fine(nest_domain, overlap, extra_halo, posi
 
   overlap%nsend = nsend
   if( nsend > 0 ) then
+   if (associated(overlap%send)) deallocate(overlap%send) !< Check if allocated
      allocate(overlap%send(nsend))
      do n = 1, nsend
         call copy_nest_overlap( overlap%send(n), overLaplist(n) )
@@ -1256,6 +1282,7 @@ subroutine compute_overlap_fine_to_coarse(nest_domain, overlap, position, name)
      enddo
      overlap%nsend = nsend
      if(nsend > 0) then
+      if (associated(overlap%send)) deallocate(overlap%send) !< Check if allocated
         allocate(overlap%send(nsend))
         do n = 1, nsend
            call copy_nest_overlap(overlap%send(n), overlaplist(n) )

--- a/mpp/include/mpp_define_nest_domains.inc
+++ b/mpp/include/mpp_define_nest_domains.inc
@@ -189,16 +189,6 @@ subroutine mpp_define_nest_domains(nest_domain, domain, num_nest, nest_level, ti
   call mpp_get_current_pelist(pes)
 
   nest_domain%num_nest = num_nest
-   if (associated(nest_domain%tile_fine)) deallocate(nest_domain%tile_fine) !< Check if allocated
-   if (associated(nest_domain%tile_coarse)) deallocate(nest_domain%tile_coarse) !< Check if allocated
-   if (associated(nest_domain%istart_fine)) deallocate(nest_domain%istart_fine) !< Check if allocated
-   if (associated(nest_domain%iend_fine)) deallocate(nest_domain%iend_fine) !< Check if allocated
-   if (associated(nest_domain%jstart_fine)) deallocate(nest_domain%jstart_fine) !< Check if allocated
-   !if (associated(nest_domain%jend_fine)) deallocate(nest_domain%jend_fine) !< Check if allocated
-   if (associated(nest_domain%istart_coarse)) deallocate(nest_domain%istart_coarse) !< Check if allocated
-   if (associated(nest_domain%iend_coarse)) deallocate(nest_domain%iend_coarse) !< Check if allocated
-   if (associated(nest_domain%jstart_coarse)) deallocate(nest_domain%jstart_coarse) !< Check if allocated
-   if (associated(nest_domain%jend_coarse)) deallocate(nest_domain%jend_coarse) !< Check if allocated
   allocate(nest_domain%tile_fine(num_nest), nest_domain%tile_coarse(num_nest) )
   allocate(nest_domain%istart_fine(num_nest), nest_domain%iend_fine(num_nest) )
   allocate(nest_domain%jstart_fine(num_nest), nest_domain%jend_fine(num_nest) )

--- a/mpp/include/mpp_define_nest_domains.inc
+++ b/mpp/include/mpp_define_nest_domains.inc
@@ -534,7 +534,6 @@ subroutine define_nest_level_type(nest_domain, x_refine, y_refine, extra_halo)
 
   nest_domain%my_num_nest = my_num_nest
   if(my_num_nest>0) then
-   if (associated(nest_domain%my_nest_id)) deallocate(nest_domain%my_nest_id) !< Check if allocated
      allocate(nest_domain%my_nest_id(my_num_nest))
      nest_domain%my_nest_id(:) = my_nest_id(1:my_num_nest)
   endif

--- a/mpp/include/mpp_define_nest_domains.inc
+++ b/mpp/include/mpp_define_nest_domains.inc
@@ -194,7 +194,7 @@ subroutine mpp_define_nest_domains(nest_domain, domain, num_nest, nest_level, ti
    if (associated(nest_domain%istart_fine)) deallocate(nest_domain%istart_fine) !< Check if allocated
    if (associated(nest_domain%iend_fine)) deallocate(nest_domain%iend_fine) !< Check if allocated
    if (associated(nest_domain%jstart_fine)) deallocate(nest_domain%jstart_fine) !< Check if allocated
-   if (associated(nest_domain%jend_fine)) deallocate(nest_domain%jend_fine) !< Check if allocated
+   !if (associated(nest_domain%jend_fine)) deallocate(nest_domain%jend_fine) !< Check if allocated
    if (associated(nest_domain%istart_coarse)) deallocate(nest_domain%istart_coarse) !< Check if allocated
    if (associated(nest_domain%iend_coarse)) deallocate(nest_domain%iend_coarse) !< Check if allocated
    if (associated(nest_domain%jstart_coarse)) deallocate(nest_domain%jstart_coarse) !< Check if allocated

--- a/mpp/include/mpp_domains_define.inc
+++ b/mpp/include/mpp_domains_define.inc
@@ -490,6 +490,7 @@
        "mpp_domains_define.inc(mpp_define_io_domain): "//trim(domain%name)// &
        ": multiple tile per pe is not supported yet for this routine")
 
+    if (associated(domain%io_domain)) deallocate(domain%io_domain) !< Check if associated
     allocate(domain%io_domain)
     domain%io_layout = io_layout
     io_domain => domain%io_domain
@@ -516,6 +517,7 @@
     io_domain%ntiles   = 1
     io_domain%pe       = domain%pe
     io_domain%symmetry = domain%symmetry
+    if (associated(io_domain%list)) deallocate(io_domain%list) !< Check if associated
     allocate(io_domain%list(0:npes_in_group-1))
     do i = 0, npes_in_group-1
        allocate( io_domain%list(i)%x(1), io_domain%list(i)%y(1), io_domain%list(i)%tile_id(1) )
@@ -550,6 +552,9 @@
     enddo
     deallocate(posarray)
 
+    if (associated(io_domain%x)) deallocate(io_domain%x) !< Check if associated
+    if (associated(io_domain%y)) deallocate(io_domain%y) !< Check if associated
+    if (associated(io_domain%tile_id)) deallocate(io_domain%tile_id) !< Check if associated
     allocate(io_domain%x(1), io_domain%y(1), io_domain%tile_id(1) )
     allocate(io_domain%x(1)%list(0:npes_x-1), io_domain%y(1)%list(0:npes_y-1) )
     n = -1
@@ -858,6 +863,7 @@
 
        !--- when tile is not equal to 1, the layout for that tile always ( 1, 1), so no need for pearray in domain
        if( tile == 1 ) then
+         if (associated(domain%pearray)) deallocate(domain%pearray) !< Check if allocated
           allocate( domain%pearray(0:ndivx-1,0:ndivy-1) )
           domain%pearray = pearray
        end if
@@ -1010,11 +1016,18 @@
     if(is_complete) then
        domain%whalo = whalosz; domain%ehalo = ehalosz
        domain%shalo = shalosz; domain%nhalo = nhalosz
+       if (associated(domain%update_T)) deallocate(domain%update_T) !< Check if associated
+       if (associated(domain%update_E)) deallocate(domain%update_E) !< Check if associated
+       if (associated(domain%update_C)) deallocate(domain%update_C) !< Check if associated
+       if (associated(domain%update_N)) deallocate(domain%update_N) !< Check if associated
        allocate(domain%update_T, domain%update_E, domain%update_C, domain%update_N)
        domain%update_T%next => NULL()
        domain%update_E%next => NULL()
        domain%update_C%next => NULL()
        domain%update_N%next => NULL()
+       if (associated(domain%check_E)) deallocate(domain%check_E) !< Check if associated
+       if (associated(domain%check_C)) deallocate(domain%check_C) !< Check if associated
+       if (associated(domain%check_N)) deallocate(domain%check_N) !< Check if associated
        allocate(domain%check_E,  domain%check_C,  domain%check_N )
        domain%update_T%nsend = 0
        domain%update_T%nrecv = 0
@@ -1061,6 +1074,9 @@
           call set_check_overlap( domain, CORNER )
           call set_check_overlap( domain, EAST   )
           call set_check_overlap( domain, NORTH  )
+          if (associated(domain%bound_E)) deallocate(domain%bound_E) !< Check if associated
+          if (associated(domain%bound_C)) deallocate(domain%bound_C) !< Check if associated
+          if (associated(domain%bound_N)) deallocate(domain%bound_N) !< Check if associated
           allocate(domain%bound_E,  domain%bound_C,  domain%bound_N )
           call set_bound_overlap( domain, CORNER )
           call set_bound_overlap( domain, EAST   )
@@ -1297,6 +1313,7 @@ end subroutine check_message_size
             'mpp_domains_define.inc: the third dimension of maskmap is not equal num_tile')
     end if
 
+    if (associated(domain%tileList)) deallocate(domain%tileList) !< Check if associated
     allocate(domain%tileList(num_tile))
     do n = 1, num_tile
        domain%tileList(n)%xbegin = global_indices(1,n)
@@ -1306,6 +1323,10 @@ end subroutine check_message_size
     enddo
     !--- define some mosaic information in domain type
     nt = ntile_per_pe(mpp_pe()-mpp_root_pe())
+    if (associated(domain%tile_id)) deallocate(domain%tile_id) !< Check if associated
+    if (associated(domain%x)) deallocate(domain%x) !< Check if associated
+    if (associated(domain%y)) deallocate(domain%y) !< Check if associated
+    if (associated(domain%list)) deallocate(domain%list) !< Check if associated
     allocate(domain%tile_id(nt), domain%x(nt), domain%y(nt) )
     allocate(domain%list(0:nlist-1))
 
@@ -1344,6 +1365,7 @@ end subroutine check_message_size
        end if
     end do
 
+    if (associated(domain%tile_id_all)) deallocate(domain%tile_id_all) !< Check if associated
     allocate(domain%tile_id_all(num_tile))
     domain%tile_id_all(:) = tile_id_local(:)
 
@@ -1518,6 +1540,9 @@ end subroutine check_message_size
        call set_check_overlap( domain, NORTH  )
     endif
     if(domain%symmetry) then
+      if (associated(domain%bound_E)) deallocate(domain%bound_E) !< Check if associated
+      if (associated(domain%bound_C)) deallocate(domain%bound_C) !< Check if associated
+      if (associated(domain%bound_N)) deallocate(domain%bound_N) !< Check if associated
        allocate(domain%bound_E,  domain%bound_C,  domain%bound_N )
        call set_bound_overlap( domain, CORNER )
        call set_bound_overlap( domain, EAST   )
@@ -2128,6 +2153,7 @@ end subroutine check_message_size
 
     ! copy the overlapping information into domain data structure
     if(nsend>0) then
+      if (associated(update%send)) deallocate(update%send) !< Check if associated
        allocate(update%send(nsend))
        update%nsend = nsend
        do m = 1, nsend
@@ -2137,6 +2163,7 @@ end subroutine check_message_size
 
     if(nsend_check>0) then
        check%nsend = nsend_check
+       if (associated(check%send)) deallocate(check%send) !< Check if associated
        allocate(check%send(nsend_check))
        do m = 1, nsend_check
           call add_check_overlap( check%send(m), checkList(m) )
@@ -2705,6 +2732,7 @@ end subroutine check_message_size
 
     ! copy the overlapping information into domain
     if(nrecv>0) then
+      if (associated(update%recv)) deallocate(update%recv) !< Check if associated
        allocate(update%recv(nrecv))
        update%nrecv = nrecv
        do m = 1, nrecv
@@ -2720,6 +2748,7 @@ end subroutine check_message_size
 
     if(nrecv_check>0) then
        check%nrecv = nrecv_check
+       if (associated(check%recv)) deallocate(check%recv) !< Check if associated
        allocate(check%recv(nrecv_check))
        do m = 1, nrecv_check
           call add_check_overlap( check%recv(m), checkList(m) )
@@ -3296,6 +3325,7 @@ end subroutine check_message_size
 
     ! copy the overlapping information into domain data structure
     if(nsend>0) then
+      if (associated(update%send)) deallocate(update%send) !< Check if associated
        allocate(update%send(nsend))
        update%nsend = nsend
        do m = 1, nsend
@@ -3304,6 +3334,7 @@ end subroutine check_message_size
     endif
 
     if(nsend_check>0) then
+      if (associated(check%send)) deallocate(check%send) !< Check if associated
        allocate(check%send(nsend_check))
        check%nsend = nsend_check
        do m = 1, nsend_check
@@ -3568,6 +3599,7 @@ end subroutine check_message_size
     ! copy the overlapping information into domain
     if(nrecv>0) then
        update%nrecv = nrecv
+       if (associated(update%recv)) deallocate(update%recv) !< Check if associated
        allocate(update%recv(nrecv))
        do m = 1, nrecv
           call add_update_overlap( update%recv(m), overlapList(m) )
@@ -3582,6 +3614,7 @@ end subroutine check_message_size
 
     if(nrecv_check>0) then
        check%nrecv = nrecv_check
+       if (associated(check%recv)) deallocate(check%recv) !< Check if associated
        allocate(check%recv(nrecv_check))
        do m = 1, nrecv_check
           call add_check_overlap( check%recv(m), checkList(m) )
@@ -3931,6 +3964,7 @@ end subroutine check_message_size
    ! copy the overlapping information into domain data structure
     if(nsend>0) then
        update%nsend = nsend
+       if (associated(update%send)) deallocate(update%send) !< Check if associated
        allocate(update%send(nsend))
        do m = 1, nsend
           call add_update_overlap( update%send(m), overlapList(m) )
@@ -3939,6 +3973,7 @@ end subroutine check_message_size
 
     if(nsend_check>0) then
        check%nsend = nsend_check
+       if (associated(check%send)) deallocate(check%send) !< Check if associated
        allocate(check%send(nsend_check))
        do m = 1, nsend_check
           call add_check_overlap( check%send(m), checkList(m) )
@@ -4195,6 +4230,7 @@ end subroutine check_message_size
     ! copy the overlapping information into domain
     if(nrecv>0) then
        update%nrecv = nrecv
+       if (associated(update%recv)) deallocate(update%recv) !< Check if associated
        allocate(update%recv(nrecv))
        do m = 1, nrecv
           call add_update_overlap( update%recv(m), overlapList(m) )
@@ -4209,6 +4245,7 @@ end subroutine check_message_size
 
     if(nrecv_check>0) then
        check%nrecv = nrecv_check
+       if (associated(check%recv)) deallocate(check%recv) !< Check if associated
        allocate(check%recv(nrecv_check))
        do m = 1, nrecv_check
           call add_check_overlap( check%recv(m), checkList(m) )
@@ -4543,6 +4580,7 @@ end subroutine check_message_size
     ! copy the overlapping information into domain data structure
     if(nsend>0) then
        update%nsend = nsend
+       if (associated(update%send)) deallocate(update%send) !< Check if associated
        allocate(update%send(nsend))
        do m = 1, nsend
           call add_update_overlap( update%send(m), overlapList(m) )
@@ -4551,6 +4589,7 @@ end subroutine check_message_size
 
    if(nsend_check>0) then
        check%nsend = nsend_check
+       if (associated(check%send)) deallocate(check%send) !< Check if associated
        allocate(check%send(nsend_check))
        do m = 1, nsend_check
           call add_check_overlap( check%send(m), checkList(m) )
@@ -4794,6 +4833,7 @@ end subroutine check_message_size
     ! copy the overlapping information into domain
     if(nrecv>0) then
        update%nrecv = nrecv
+       if (associated(update%recv)) deallocate(update%recv) !< Check if associated
        allocate(update%recv(nrecv))
        do m = 1, nrecv
           call add_update_overlap( update%recv(m), overlapList(m) )
@@ -4808,6 +4848,7 @@ end subroutine check_message_size
 
     if(nrecv_check>0) then
        check%nrecv = nrecv_check
+       if (associated(check%recv)) deallocate(check%recv) !< Check if associated
        allocate(check%recv(nrecv_check))
        do m = 1, nrecv_check
           call add_check_overlap( check%recv(m), checkList(m) )
@@ -5065,6 +5106,7 @@ end subroutine check_message_size
 
     if(nsend>0) then
        overlap_out%nsend = nsend
+       if (associated(overlap_out%send)) deallocate(overlap_out%send) !< Check if associated
        allocate(overlap_out%send(nsend));
        do n = 1, nsend
           call add_update_overlap(overlap_out%send(n), send(n) )
@@ -5154,6 +5196,7 @@ end subroutine check_message_size
 
     if(nrecv>0) then
        overlap_out%nrecv = nrecv
+       if (associated(overlap_out%recv)) deallocate(overlap_out%recv) !< Check if associated
        allocate(overlap_out%recv(nrecv));
        do n = 1, nrecv
           call add_update_overlap(overlap_out%recv(n), recv(n) )
@@ -6053,6 +6096,7 @@ subroutine set_contact_point(domain, position)
 
   update_out%nsend = nsend
   if(nsend>0) then
+   if (associated(update_out%send)) deallocate(update_out%send) !< Check if associated
      allocate(update_out%send(nsend))
      pos = 0
      do list = 0, nlist-1
@@ -6135,6 +6179,7 @@ subroutine set_contact_point(domain, position)
 
   update_out%nrecv = nrecv
   if(nrecv>0) then
+   if (associated(update_out%recv)) deallocate(update_out%recv) !< Check if associated
      allocate(update_out%recv(nrecv))
      pos = 0
      do list = 0, nlist-1
@@ -6204,6 +6249,7 @@ do m = 1, update%nsend
 enddo
 
 if(nsend>0) then
+   if (associated(check%send)) deallocate(check%send) !< Check if associated
    allocate(check%send(nsend))
    call allocate_check_overlap(overlap, maxsize)
 endif
@@ -6280,6 +6326,7 @@ enddo
 if(nsend>0) call deallocate_overlap_type(overlap)
 
 if(nrecv>0) then
+   if (associated(check%recv)) deallocate(check%recv) !< Check if associated
    allocate(check%recv(nrecv))
    call allocate_check_overlap(overlap, maxsize)
 endif
@@ -6378,10 +6425,12 @@ subroutine set_bound_overlap( domain, position )
   bound%nsend = nlist_send
   bound%nrecv = nlist_recv
   if(nlist_send >0) then
+   if (associated(bound%send)) deallocate(bound%send) !< Check if associated
      allocate(bound%send(nlist_send))
      bound%send(:)%count = 0
   endif
   if(nlist_recv >0) then
+   if (associated(bound%recv)) deallocate(bound%recv) !< Check if associated
      allocate(bound%recv(nlist_recv))
      bound%recv(:)%count = 0
   endif
@@ -6522,6 +6571,13 @@ subroutine set_bound_overlap( domain, position )
            if(nsend > nlist_send)  call mpp_error(FATAL, "set_bound_overlap: nsend > nlist_send")
            bound%send(nsend)%count = count
            bound%send(nsend)%pe    = my_pe
+           if (associated(bound%send(nsend)%is)) deallocate(bound%send(nsend)%is) !< Check if allocated
+           if (associated(bound%send(nsend)%ie)) deallocate(bound%send(nsend)%ie) !< Check if allocated
+           if (associated(bound%send(nsend)%js)) deallocate(bound%send(nsend)%js) !< Check if allocated
+           if (associated(bound%send(nsend)%je)) deallocate(bound%send(nsend)%je) !< Check if allocated
+           if (associated(bound%send(nsend)%dir)) deallocate(bound%send(nsend)%dir) !< Check if allocated
+           if (associated(bound%send(nsend)%rotation)) deallocate(bound%send(nsend)%rotation) !< Check if allocated
+           if (associated(bound%send(nsend)%tileMe)) deallocate(bound%send(nsend)%tileMe) !< Check if allocated
            allocate(bound%send(nsend)%is(count),  bound%send(nsend)%ie(count) )
            allocate(bound%send(nsend)%js(count),  bound%send(nsend)%je(count) )
            allocate(bound%send(nsend)%dir(count), bound%send(nsend)%rotation(count) )
@@ -6621,6 +6677,13 @@ subroutine set_bound_overlap( domain, position )
         nsend = nsend + 1
         bound%send(nsend)%count = count
         bound%send(nsend)%pe    = overlap%pe
+        if (associated(bound%send(nsend)%is)) deallocate(bound%send(nsend)%is) !< Check if allocated
+        if (associated(bound%send(nsend)%ie)) deallocate(bound%send(nsend)%ie) !< Check if allocated
+        if (associated(bound%send(nsend)%js)) deallocate(bound%send(nsend)%js) !< Check if allocated
+        if (associated(bound%send(nsend)%je)) deallocate(bound%send(nsend)%je) !< Check if allocated
+        if (associated(bound%send(nsend)%dir)) deallocate(bound%send(nsend)%dir) !< Check if allocated
+        if (associated(bound%send(nsend)%rotation)) deallocate(bound%send(nsend)%rotation) !< Check if allocated
+        if (associated(bound%send(nsend)%tileMe)) deallocate(bound%send(nsend)%tileMe) !< Check if allocated
         allocate(bound%send(nsend)%is(count),  bound%send(nsend)%ie(count) )
         allocate(bound%send(nsend)%js(count),  bound%send(nsend)%je(count) )
         allocate(bound%send(nsend)%dir(count), bound%send(nsend)%rotation(count) )
@@ -6770,6 +6833,14 @@ subroutine set_bound_overlap( domain, position )
            if(nrecv > nlist_recv) call mpp_error(FATAL, "set_bound_overlap: nrecv > nlist_recv")
            bound%recv(nrecv)%count = count
            bound%recv(nrecv)%pe    = my_pe
+           if (associated(bound%recv(nrecv)%is)) deallocate(bound%recv(nrecv)%is) !< Check if allocated
+           if (associated(bound%recv(nrecv)%ie)) deallocate(bound%recv(nrecv)%ie) !< Check if allocated
+           if (associated(bound%recv(nrecv)%js)) deallocate(bound%recv(nrecv)%js) !< Check if allocated
+           if (associated(bound%recv(nrecv)%je)) deallocate(bound%recv(nrecv)%je) !< Check if allocated
+           if (associated(bound%recv(nrecv)%dir)) deallocate(bound%recv(nrecv)%dir) !< Check if allocated
+           if (associated(bound%recv(nrecv)%index)) deallocate(bound%recv(nrecv)%index) !< Check if allocated
+           if (associated(bound%recv(nrecv)%tileMe)) deallocate(bound%recv(nrecv)%tileMe) !< Check if allocated
+           if (associated(bound%recv(nrecv)%rotation)) deallocate(bound%recv(nrecv)%rotation) !< Check if allocated
            allocate(bound%recv(nrecv)%is(count),     bound%recv(nrecv)%ie(count) )
            allocate(bound%recv(nrecv)%js(count),     bound%recv(nrecv)%je(count) )
            allocate(bound%recv(nrecv)%dir(count),    bound%recv(nrecv)%index(count)  )
@@ -6865,6 +6936,14 @@ subroutine set_bound_overlap( domain, position )
            nrecv = nrecv + 1
            bound%recv(nrecv)%count = count
            bound%recv(nrecv)%pe    = overlap%pe
+           if (associated(bound%recv(nrecv)%is)) deallocate(bound%recv(nrecv)%is) !< Check if allocated
+           if (associated(bound%recv(nrecv)%ie)) deallocate(bound%recv(nrecv)%ie) !< Check if allocated
+           if (associated(bound%recv(nrecv)%js)) deallocate(bound%recv(nrecv)%js) !< Check if allocated
+           if (associated(bound%recv(nrecv)%je)) deallocate(bound%recv(nrecv)%je) !< Check if allocated
+           if (associated(bound%recv(nrecv)%dir)) deallocate(bound%recv(nrecv)%dir) !< Check if allocated
+           if (associated(bound%recv(nrecv)%index)) deallocate(bound%recv(nrecv)%index) !< Check if allocated
+           if (associated(bound%recv(nrecv)%tileMe)) deallocate(bound%recv(nrecv)%tileMe) !< Check if allocated
+           if (associated(bound%recv(nrecv)%rotation)) deallocate(bound%recv(nrecv)%rotation) !< Check if allocated
            allocate(bound%recv(nrecv)%is(count),     bound%recv(nrecv)%ie(count) )
            allocate(bound%recv(nrecv)%js(count),     bound%recv(nrecv)%je(count) )
            allocate(bound%recv(nrecv)%dir(count),    bound%recv(nrecv)%index(count)  )
@@ -7531,6 +7610,7 @@ if(present(whalo) .or. present(ehalo) .or. present(shalo) .or. present(nhalo) ) 
 else
  call mpp_define_null_domain(domain_out)
  nlist = size(domain_in%list(:))
+ if (associated(domain_out%list)) deallocate(domain_out%list) !< Check if allocated
  allocate(domain_out%list(0:nlist-1) )
  do i = 0, nlist-1
     allocate(domain_out%list(i)%tile_id(1))

--- a/mpp/include/mpp_domains_util.inc
+++ b/mpp/include/mpp_domains_util.inc
@@ -1730,6 +1730,7 @@ end subroutine mpp_get_tile_compute_domains
      if (associated(domain_in%list)) then
          starting = lbound(domain_in%list, 1)
          ending = ubound(domain_in%list, 1)
+         if (associated(domain_out%list)) deallocate(domain_out%list) !< Check if allocated
          allocate(domain_out%list(starting:ending))
 
          do i = starting, ending
@@ -1835,6 +1836,7 @@ end subroutine mpp_get_tile_compute_domains
       starting = lbound(domain2D_spec_in%tile_id,1)
       ending = ubound(domain2D_spec_in%tile_id,1)
 
+      if (associated(domain2D_spec_out%tile_id)) deallocate(domain2D_spec_out%tile_id) !< Check if allocated
       allocate(domain2D_spec_out%tile_id(starting:ending))
       domain2D_spec_out%tile_id = domain2D_spec_in%tile_id
   endif
@@ -1843,6 +1845,7 @@ end subroutine mpp_get_tile_compute_domains
       starting = lbound(domain2D_spec_in%x,1)
       ending = ubound(domain2D_spec_in%x,1)
 
+      if (associated(domain2D_spec_out%x)) deallocate(domain2D_spec_out%x) !< Check if allocated
       allocate(domain2D_spec_out%x(starting:ending))
       do i = starting, ending
          call mpp_copy_domain1D_spec(domain2D_spec_in%x(i), domain2D_spec_out%x(i))
@@ -1853,6 +1856,7 @@ end subroutine mpp_get_tile_compute_domains
       starting = lbound(domain2D_spec_in%y,1)
       ending = ubound(domain2D_spec_in%y,1)
 
+      if (associated(domain2D_spec_out%y)) deallocate(domain2D_spec_out%y) !< Check if allocated
       allocate(domain2D_spec_out%y(starting:ending))
       do i = starting, ending
          call mpp_copy_domain1D_spec(domain2D_spec_in%y(i), domain2D_spec_out%y(i))

--- a/mpp/include/mpp_unstruct_domain.inc
+++ b/mpp/include/mpp_unstruct_domain.inc
@@ -137,6 +137,7 @@
         pe_end(n) = te
         ioff = ioff+ npts_tile(n)
      enddo
+     if (associated(UG_domain%list)) deallocate(UG_domain%list) !< Check if allocated
      allocate(UG_domain%list(0:ndivs-1))
      do p = 0, ndivs-1
         UG_domain%list(p)%compute%begin = ibegin(p)
@@ -185,12 +186,14 @@
      UG_domain%global%begin_index = grid_index(pos+1)
      UG_domain%global%end_index = grid_index(pos+npts_tile(n))
 
+     if (associated(UG_domain%grid_index)) deallocate(UG_domain%grid_index) !< Check if allocated
      allocate(UG_domain%grid_index(UG_domain%compute%size))
      do n = 1, UG_domain%compute%size
         UG_domain%grid_index(n) = grid_index(pos+UG_domain%compute%begin+n-1)
      enddo
 
      !--- define io_domain
+     if (associated(UG_domain%io_domain)) deallocate(UG_domain%io_domain) !< Check if allocated
      allocate(UG_domain%io_domain)
      tile_id = UG_domain%tile_id
      UG_domain%io_domain%pe = UG_domain%pe
@@ -230,6 +233,7 @@
      UG_domain%io_domain%global%size        = UG_domain%io_domain%global%end -  UG_domain%io_domain%global%begin + 1
 
      npes_in_group = iend(group_id) - ibegin(group_id) + 1
+     if (associated(UG_domain%io_domain%list)) deallocate(UG_domain%io_domain%list) !< Check if allocated
      allocate(UG_domain%io_domain%list(0:npes_in_group-1))
      do n = 0, npes_in_group-1
         pos = UG_domain%io_domain%tile_root_pe - mpp_root_pe() + n
@@ -307,6 +311,7 @@
 
      nrecv = count( recv_cnt > 0 )
      UG_domain%SG2UG%nrecv = nrecv
+     if (associated(UG_domain%SG2UG%recv)) deallocate(UG_domain%SG2UG%recv) !< Check if allocated
      allocate(UG_domain%SG2UG%recv(nrecv))
      nrecv = 0
      pos = 0
@@ -351,6 +356,7 @@
 
      nsend = count( recv_cnt(:) > 0 )
      UG_domain%SG2UG%nsend = nsend
+     if (associated(UG_domain%SG2UG%send)) deallocate(UG_domain%SG2UG%send) !< Check if allocated
      allocate(UG_domain%SG2UG%send(nsend))
      nsend = 0
      isc = SG_domain%x(1)%compute%begin
@@ -610,6 +616,7 @@ return
 
       if( .NOT.native )then
 !initialize domain%list and set null values in message
+         if (associated(domain%list)) deallocate(domain%list) !< Check if allocated
           allocate( domain%list(0:listsize-1) )
           domain%pe = NULL_PE
           domain%pos = -1


### PR DESCRIPTION
**Description**
Checks are inserted mostly for member pointers of DDTs, which are passed as arguments to functions and subroutines, before allocation.

Fixes #1099 

**How Has This Been Tested?**
The update was tested with 'make check' and 'make distcheck' without any issues on OS, 'CentOS Stream 8'. The following setup was used for compiler, MPI wrapper, and required packages:
oneapi v2022.2
hdf5 v1.12.0
tbb v2021.6.0
oclfpga v2022.1.0
netcdf v4.9.0
mpich v4.0.3
compiler-rt v2022.1.0
compiler v2022.1.0

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

