### PR TITLE
Fix a missing if statement in PR #1149

### DIFF
--- a/diag_manager/diag_manager.F90
+++ b/diag_manager/diag_manager.F90
@@ -1465,6 +1465,9 @@ CONTAINS
     elseif (present(rmask)) then
       send_data_3d = diag_send_data(diag_field_id, field, time=time, is_in=is_in, js_in=js_in, ks_in=ks_in, &
                                rmask=rmask, ie_in=ie_in, je_in=je_in, ke_in=ke_in, weight=weight, err_msg=err_msg)
+    elseif (present(mask)) then
+      send_data_3d = diag_send_data(diag_field_id, field, time=time, is_in=is_in, js_in=js_in, ks_in=ks_in, &
+                               mask=mask, ie_in=ie_in, je_in=je_in, ke_in=ke_in, weight=weight, err_msg=err_msg)
     else
       send_data_3d = diag_send_data(diag_field_id, field, time=time, is_in=is_in, js_in=js_in, ks_in=ks_in, &
                                ie_in=ie_in, je_in=je_in, ke_in=ke_in, weight=weight, err_msg=err_msg)


### PR DESCRIPTION
- send_data3d is not calling diag_send_data  correctly.
- it has to check for presence of  argument "mask" and call diag_send_data accordingly
is

**Description**
PR #1149 had a problem. It would not call diag_send_date subroutine if argument "mask" were present.
This causes some experiments to crash , particularly ESM4.2

Fixes # (issue)

**How Has This Been Tested?**
Tested ESM4.2 and MOM6_solo

**Checklist:**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] `make distcheck` passes

