### PR TITLE
mpp test fixes for alltoall ifort compiler bug and input nml failures

### DIFF
--- a/test_fms/mpp/Makefile.am
+++ b/test_fms/mpp/Makefile.am
@@ -134,6 +134,12 @@ test_mpp_clock_begin_end_id_SOURCES=test_mpp_clock_begin_end_id.F90
 test_super_grid_SOURCES = test_super_grid.F90
 test_mpp_chksum_SOURCES = test_mpp_chksum.F90
 
+# ifort gets a internal error during compilation for this test, issue #1071
+# we'll just remove the openmp flag if present since it doesn't use openmp at all
+test_mpp_alltoall.$(OBJEXT): FCFLAGS:=  $(filter-out -fopenmp,$(FCFLAGS))
+test_mpp_alltoall.$(OBJEXT): CPPFLAGS:= $(filter-out -fopenmp,$(CPPFLAGS))
+
+
 # Run the test programs.
 TESTS = test_mpp_domains2.sh \
   test_redistribute_int.sh \

--- a/test_fms/mpp/test_clock_init.sh
+++ b/test_fms/mpp/test_clock_init.sh
@@ -28,6 +28,9 @@
 # Set common test settings.
 . ../test-lib.sh
 
+# ensure input.nml file present
+touch input.nml
+
 test_expect_success "clock initialization" '
     mpirun -n 1 ./test_clock_init
 '

--- a/test_fms/mpp/test_global_arrays.sh
+++ b/test_fms/mpp/test_global_arrays.sh
@@ -27,6 +27,9 @@
 # Set common test settings.
 . ../test-lib.sh
 
+# ensure input.nml file present
+touch input.nml
+
 test_expect_success "global array functions with mixed precision" '
     mpirun -n 8 ./test_global_arrays
 '

--- a/test_fms/mpp/test_mpp_alltoall.sh
+++ b/test_fms/mpp/test_mpp_alltoall.sh
@@ -26,6 +26,9 @@
 # Set common test settings.
 . ../test-lib.sh
 
+# ensure input.nml file present
+touch input.nml
+
 # Run the test for one processor
 test_expect_success "mpp all-to-all with mixed precision" '
     mpirun -n 4 ./test_mpp_alltoall

--- a/test_fms/mpp/test_mpp_global_sum_ad.sh
+++ b/test_fms/mpp/test_mpp_global_sum_ad.sh
@@ -27,6 +27,9 @@
 # Set common test settings.
 . ../test-lib.sh
 
+# ensure input.nml file present
+touch input.nml
+
 # Run the test
 test_expect_success "mpp global adjoint sum with mixed precision" '
     mpirun -n 4 ./test_mpp_global_sum_ad

--- a/test_fms/mpp/test_mpp_npes.sh
+++ b/test_fms/mpp/test_mpp_npes.sh
@@ -28,6 +28,9 @@
 # Set common test settings.
 . ../test-lib.sh
 
+# ensure input.nml file present
+touch input.nml
+
 export NUM_PES=1
 test_expect_success "get number of PEs single processor" '
     mpirun -n 1 ./test_mpp_npes

--- a/test_fms/mpp/test_mpp_pe.sh
+++ b/test_fms/mpp/test_mpp_pe.sh
@@ -27,6 +27,8 @@
 # Set common test settings.
 . ../test-lib.sh
 
+# ensure input.nml file present
+touch input.nml
 
 # Run the tests
 test_expect_success "get current PE single processor" '

--- a/test_fms/mpp/test_mpp_root_pe.sh
+++ b/test_fms/mpp/test_mpp_root_pe.sh
@@ -28,6 +28,9 @@
 # Set common test settings.
 . ../test-lib.sh
 
+# ensure input.nml file present
+touch input.nml
+
 # Run the test
 test_expect_success "get correct root PE single processor" '
     mpirun -n 1 ./test_mpp_root_pe

--- a/test_fms/mpp/test_mpp_sum.sh
+++ b/test_fms/mpp/test_mpp_sum.sh
@@ -28,6 +28,9 @@
 # Set common test settings.
 . ../test-lib.sh
 
+# ensure input.nml file present
+touch input.nml
+
 # Run the test for 5 processors
 test_expect_success "mpp_sum with mixed precision" '
     mpirun -n 5 ./test_mpp_sum

--- a/test_fms/mpp/test_mpp_transmit.sh
+++ b/test_fms/mpp/test_mpp_transmit.sh
@@ -28,6 +28,9 @@
 # Set common test settings.
 . ../test-lib.sh
 
+# ensure input.nml file present
+touch input.nml
+
 # Run the test for 5 processors
 test_expect_success "mpp transmit with mixed precision" '
     mpirun -n 6 ./test_mpp_transmit

--- a/test_fms/mpp/test_stderr.sh
+++ b/test_fms/mpp/test_stderr.sh
@@ -27,6 +27,9 @@
 # Set common test settings.
 . ../test-lib.sh
 
+# ensure input.nml file present
+touch input.nml
+
 test_expect_success "get stderr" '
     mpirun -n 1 ./test_stderr
 '

--- a/test_fms/mpp/test_stdin.sh
+++ b/test_fms/mpp/test_stdin.sh
@@ -26,6 +26,9 @@
 # Set common test settings.
 . ../test-lib.sh
 
+# ensure input.nml file present
+touch input.nml
+
 test_expect_success "correct STDIN writes" '
     mpirun -n 1 ./test_stdin
 '

--- a/test_fms/mpp/test_stdout.sh
+++ b/test_fms/mpp/test_stdout.sh
@@ -28,6 +28,9 @@
 # Set common test settings.
 . ../test-lib.sh
 
+# ensure input.nml file present
+touch input.nml
+
 # Run test with one processor
 test_expect_success "get stdout with 1 PE" '
     mpirun -n 2 ./test_stdout

--- a/test_fms/mpp/test_system_clock.sh
+++ b/test_fms/mpp/test_system_clock.sh
@@ -27,6 +27,9 @@
 # Set common test settings.
 . ../test-lib.sh
 
+# ensure input.nml file present
+touch input.nml
+
 # Run the test for one processor
 test_expect_success "system clock functionality" '
     mpirun -n 1 ./test_system_clock

--- a/test_fms/mpp/test_update_domains_performance.sh
+++ b/test_fms/mpp/test_update_domains_performance.sh
@@ -26,6 +26,10 @@
 
 # Set common test settings.
 . ../test-lib.sh
+
+# ensure input.nml file present
+touch input.nml
+
 # Run the test for one processor
 test_expect_success "domain update performance with 1 PE" '
     mpirun -n 1 ./test_update_domains_performance


### PR DESCRIPTION
**Description**
For the test_mpp_alltoall test, adds a rule to remove any openmp flags before compiling. You can see #1071 and the intel thread for more context but this will prevent an internal compiler error with ifort 2022.03.0 and later.

Since the intel ICE only comes up in this test program specifically i didn't do any explicit checks for compiler or version first, just removed the `-fopenmp` flag if its there for the test it fails with. Since the test and it's routine don't use openmp there shouldn't be any difference in the executable.

The rest of the updates add in `touch input.nml` commands missed in mpp scripts. These scripts would fail if run on their own since they wouldn't have a namelist, they just usually pass during a `make check` cause one was created already from a previous script.

Fixes #1071

**How Has This Been Tested?**
make check with intel 2023.01, 2022.02 (mpi) and gnu (mpich)

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

