### PR TITLE
fix bounds check in get_diag_buffer

### DIFF
--- a/diag_manager/fms_diag_buffer.F90
+++ b/diag_manager/fms_diag_buffer.F90
@@ -50,7 +50,8 @@ type, abstract :: fmsDiagBuffer_class
   procedure :: flush_buffer
   procedure :: remap_buffer
   procedure :: set_buffer_id
-  ! TODO deferred routines, will require some interfaces
+  ! TODO could make these 'defered' ie. declared here but defined in each child type
+  ! holding off cause the class(*) + polymorphism in here is probably already enough to upset the gods of compilation
   !procedure(allocate_buffer), deferred :: allocate_buffer
   !procedure, deferred :: get_buffer
   !procedure, deferred :: initialize_buffer
@@ -64,7 +65,7 @@ end type
 
 !> Scalar buffer type to extend fmsDiagBufferContainer_type
 type, extends(fmsDiagBuffer_class) :: buffer0d_type
-  class(*), allocatable :: buffer(:) !< "scalar" numberic buffer value
+  class(*), allocatable :: buffer(:) !< "scalar" numeric buffer value
                                      !! will only be allocated to hold 1 value
   class(*), allocatable :: counter(:) !< (x,y,z, time-of-day) used in the time averaging functions
   contains

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -712,9 +712,9 @@ result(rslt)
   class(fmsDiagObject_type), intent(in) :: this
   integer, intent(in)                   :: bufferid
   class(fmsDiagBuffer_class),allocatable:: rslt
-  if( (bufferid .gt. UBOUND(this%FMS_diag_buffers, 1)) .or. (bufferid .lt. UBOUND(this%FMS_diag_buffers, 1))) &
+  if( (bufferid .gt. UBOUND(this%FMS_diag_buffers, 1)) .or. (bufferid .lt. LBOUND(this%FMS_diag_buffers, 1))) &
     call mpp_error(FATAL, 'get_diag_bufer: invalid bufferid given')
-  rslt = fms_diag_object%FMS_diag_buffers(bufferid)%diag_buffer_obj
+  rslt = this%FMS_diag_buffers(bufferid)%diag_buffer_obj
 end function
 #endif
 


### PR DESCRIPTION
**Description**
fixes the bounds check and replaces the module level variable with `this`. 

Part of the reason I wrote it this way is because `fmsDiagObject_type` is public so there's nothing guaranteeing that this routine will only be called on `fms_diag_object` (the module's instance) and not any other new instances of the type.

I guess it's really just a scoping issue but we could potentially add checks that `this` matches up memory address-wise to `fms_diag_object` to avoid this or change some public/private declarations.

**How Has This Been Tested?**
oneapi 2023.0 on amd

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

