### PR TITLE
Modern diag_manager: Add standard_name and coordinates attributes + minor bug fixes

### DIFF
--- a/diag_manager/fms_diag_axis_object.F90
+++ b/diag_manager/fms_diag_axis_object.F90
@@ -154,7 +154,7 @@ module fms_diag_axis_object_mod
      INTEGER                        , private :: direction       !< Direction of the axis 0, 1, -1
      CHARACTER(len=:),   ALLOCATABLE, private :: edges_name      !< Name for the previously defined "edges axis"
                                                                  !! This will be written as an attribute
-     CHARACTER(len=128)             , private :: aux             !< Auxiliary name, can only be <TT>geolon_t</TT>
+     CHARACTER(len=:), ALLOCATABLE,   private :: aux             !< Auxiliary name, can only be <TT>geolon_t</TT>
                                                                  !! or <TT>geolat_t</TT>
      CHARACTER(len=128)             , private :: req             !< Required field names.
      INTEGER                        , private :: tile_count      !< The number of tiles
@@ -174,6 +174,8 @@ module fms_diag_axis_object_mod
      PROCEDURE :: get_compute_domain
      PROCEDURE :: get_indices
      PROCEDURE :: get_global_io_domain
+     PROCEDURE :: get_aux
+     PROCEDURE :: has_aux
      ! TO DO:
      ! Get/has/is subroutines as needed
   END TYPE fmsDiagFullAxis_type
@@ -559,6 +561,28 @@ module fms_diag_axis_object_mod
     endif
 
   end function
+
+
+  !> @brief Determine if an axis object has an auxiliary name
+  !! @return .true. if an axis object has an auxiliary name
+  pure function has_aux(this) &
+  result(rslt)
+    class(fmsDiagFullAxis_type), intent(in)  :: this               !< diag_axis obj
+    logical :: rslt
+
+    rslt = .false.
+    if (allocated(this%aux)) rslt = trim(this%aux) .ne. ""
+  end function has_aux
+
+  !> @brief Get the auxiliary name of an axis object
+  !! @return the auxiliary name of an axis object
+  pure function get_aux(this) &
+  result(rslt)
+    class(fmsDiagFullAxis_type), intent(in)  :: this               !< diag_axis obj
+    character(len=:), allocatable :: rslt
+
+    rslt = this%aux
+  end function get_aux
 
   !> @brief Set the axis_id
   subroutine set_axis_id(this, axis_id)

--- a/diag_manager/fms_diag_field_object.F90
+++ b/diag_manager/fms_diag_field_object.F90
@@ -145,6 +145,7 @@ type fmsDiagField_type
      procedure :: get_var_skind
      procedure :: get_longname_to_write
      procedure :: write_field_metadata
+     procedure :: write_coordinate_attribute
      procedure :: get_math_needs_to_be_done
 end type fmsDiagField_type
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! variables !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -1141,7 +1142,47 @@ subroutine write_field_metadata(this, fileobj, file_id, yaml_id, diag_axis, unli
     call register_variable_attribute(fileobj, var_name, "cell_methods", &
       trim(adjustl(cell_measures)), str_len=len_trim(adjustl(cell_measures)))
 
+  !< Write out the standard_name (this was defined in the register call)
+  if (this%has_standname()) &
+  call register_variable_attribute(fileobj, var_name, "standard_name", &
+    trim(this%get_standname()), str_len=len_trim(this%get_standname()))
+
+  call this%write_coordinate_attribute(fileobj, var_name, diag_axis)
 end subroutine write_field_metadata
+
+!> @brief Writes the coordinate attribute of a field if any of the field's axis has an
+!! auxiliary axis
+subroutine write_coordinate_attribute (this, fileobj, var_name, diag_axis)
+  CLASS(fmsDiagField_type),          intent(in)    :: this         !< The field object
+  class(FmsNetcdfFile_t),            INTENT(INOUT) :: fileobj      !< Fms2_io fileobj to write to
+  character(len=*),                  intent(in)    :: var_name     !< Variable name
+  class(fmsDiagAxisContainer_type),  intent(in)    :: diag_axis(:) !< Diag_axis object
+
+  integer              :: i         !< For do loops
+  character(len = 252) :: aux_coord !< Auxuliary axis name
+
+  !> If the variable is a scalar, go away
+  if (.not. allocated(this%axis_ids)) return
+
+  !> Determine if any of the field's axis has an auxiliary axis and the
+  !! axis_names as a variable attribute
+  aux_coord = ""
+  do i = 1, size(this%axis_ids)
+    select type (obj => diag_axis(this%axis_ids(i))%axis)
+    type is (fmsDiagFullAxis_type)
+      if (obj%has_aux()) then
+        aux_coord = trim(aux_coord)//" "//obj%get_aux()
+      endif
+    end select
+  enddo
+
+  if (trim(aux_coord) .eq. "") return
+
+  call register_variable_attribute(fileobj, var_name, "coordinates", &
+    trim(adjustl(aux_coord)), str_len=len_trim(adjustl(aux_coord)))
+
+end subroutine write_coordinate_attribute
+
 !> @brief Gets a fields data buffer
 !! @return a pointer to the data buffer
 function get_data_buffer (this) &

--- a/diag_manager/fms_diag_time_utils.F90
+++ b/diag_manager/fms_diag_time_utils.F90
@@ -195,7 +195,7 @@ contains
   !!     This string is used as suffix in output file name
   !! @return Character(len=128) get_time_string
   CHARACTER(len=128) FUNCTION get_time_string(filename, current_time)
-    CHARACTER(len=128), INTENT(in) :: filename     !< File name.
+    CHARACTER(len=*),   INTENT(in) :: filename     !< File name.
     TYPE(time_type),    INTENT(in) :: current_time !< Current model time.
 
     INTEGER :: yr1 !< get from current time

--- a/diag_manager/fms_diag_yaml.F90
+++ b/diag_manager/fms_diag_yaml.F90
@@ -41,6 +41,7 @@ use mpp_mod,         only: mpp_error, FATAL, mpp_pe, mpp_root_pe, stdout
 use, intrinsic :: iso_c_binding, only : c_ptr, c_null_char
 use fms_string_utils_mod, only: fms_array_to_pointer, fms_find_my_string, fms_sort_this, fms_find_unique
 use platform_mod, only: r4_kind, i4_kind
+use fms_mod, only: lowercase
 
 implicit none
 
@@ -413,7 +414,8 @@ subroutine diag_yaml_object_init(diag_subset_output)
     call fill_in_diag_files(diag_yaml_id, diag_file_ids(i), diag_yaml%diag_files(file_count))
 
     !> Save the file name in the file_list
-    file_list%file_name(file_count) = trim(diag_yaml%diag_files(file_count)%file_fname)//c_null_char
+    !! The diag_table is not case sensitive (so we are saving it as lowercase)
+    file_list%file_name(file_count) = lowercase(trim(diag_yaml%diag_files(file_count)%file_fname)//c_null_char)
     file_list%diag_file_indices(file_count) = file_count
 
     nvars = 0
@@ -441,6 +443,8 @@ subroutine diag_yaml_object_init(diag_subset_output)
       !> Save the variable name and the module name in the variable_list
       variable_list%var_name(var_count) = trim(diag_yaml%diag_fields(var_count)%var_varname)//&
                                         ":"//trim(diag_yaml%diag_fields(var_count)%var_module)//c_null_char
+      !! The diag_table is not case sensitive (so we are saving it as lowercase)
+      variable_list%var_name(var_count) = lowercase(variable_list%var_name(var_count))
       variable_list%diag_field_indices(var_count) = var_count
     enddo nvars_loop
     deallocate(var_ids)
@@ -1434,7 +1438,7 @@ result(indices)
   integer, allocatable :: indices(:)
 
   indices = fms_find_my_string(variable_list%var_pointer, size(variable_list%var_pointer), &
-                               & trim(diag_field_name)//":"//trim(module_name)//c_null_char)
+                               & lowercase(trim(diag_field_name))//":"//lowercase(trim(module_name)//c_null_char))
 end function find_diag_field
 
 !> @brief Gets the diag_field entries corresponding to the indices of the sorted variable_list


### PR DESCRIPTION
**Description**
- Adds code to write the `standard_name` and `coordinates` (this is used for field in the unstructured grid) attributes for field
- Makes the code that searches for a field in the diag_table.yaml case insensitive (to reproduce old behavior)
- Fixes a issue with gnu where the character length of a string argument was set to 128 so there was extra junk added to the string causing weird crashes

Fixes # (issue)

**How Has This Been Tested?**
CI

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

