### PR TITLE
rename to add output to buffer names

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,7 +132,7 @@ list(APPEND fms_fortran_src_files
   diag_manager/fms_diag_axis_object.F90
   diag_manager/fms_diag_dlinked_list.F90
   diag_manager/fms_diag_object_container.F90
-  diag_manager/fms_diag_buffer.F90
+  diag_manager/fms_diag_output_buffer.F90
   diag_manager/fms_diag_time_reduction.F90
   diag_manager/fms_diag_outfield.F90
   diag_manager/fms_diag_elem_weight_procs.F90

--- a/diag_manager/Makefile.am
+++ b/diag_manager/Makefile.am
@@ -46,7 +46,7 @@ libdiag_manager_la_SOURCES = \
   fms_diag_axis_object.F90 \
   fms_diag_object_container.F90 \
   fms_diag_dlinked_list.F90 \
-  fms_diag_buffer.F90 \
+  fms_diag_output_buffer.F90 \
   fms_diag_time_reduction.F90 \
   fms_diag_outfield.F90 \
   fms_diag_elem_weight_procs.F90 \
@@ -66,7 +66,7 @@ diag_table_mod.$(FC_MODEXT): diag_data_mod.$(FC_MODEXT) diag_util_mod.$(FC_MODEX
 fms_diag_yaml_mod.$(FC_MODEXT): diag_data_mod.$(FC_MODEXT)
 fms_diag_object_mod.$(FC_MODEXT): diag_data_mod.$(FC_MODEXT) fms_diag_file_object_mod.$(FC_MODEXT) fms_diag_field_object_mod.$(FC_MODEXT) fms_diag_yaml_mod.$(FC_MODEXT) \
                                   fms_diag_time_utils_mod.$(FC_MODEXT) \
-                                  fms_diag_buffer_mod.$(FC_MODEXT)
+                                  fms_diag_output_buffer_mod.$(FC_MODEXT)
 fms_diag_field_object_mod.$(FC_MODEXT): diag_data_mod.$(FC_MODEXT) fms_diag_yaml_mod.$(FC_MODEXT) fms_diag_time_utils_mod.$(FC_MODEXT) \
                                         fms_diag_axis_object_mod.$(FC_MODEXT)
 fms_diag_file_object_mod.$(FC_MODEXT): diag_data_mod.$(FC_MODEXT) fms_diag_yaml_mod.$(FC_MODEXT) fms_diag_field_object_mod.$(FC_MODEXT) fms_diag_time_utils_mod.$(FC_MODEXT) \
@@ -103,7 +103,7 @@ MODFILES = \
   fms_diag_axis_object_mod.$(FC_MODEXT) \
   fms_diag_dlinked_list_mod.$(FC_MODEXT) \
   fms_diag_object_container_mod.$(FC_MODEXT) \
-  fms_diag_buffer_mod.$(FC_MODEXT) \
+  fms_diag_output_buffer_mod.$(FC_MODEXT) \
   diag_manager_mod.$(FC_MODEXT) \
   fms_diag_time_reduction_mod.$(FC_MODEXT) \
   fms_diag_outfield_mod.$(FC_MODEXT) \

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -113,7 +113,7 @@ subroutine fms_diag_object_init (this,diag_subset_output)
   this%axes_initialized = fms_diag_axis_object_init(this%diag_axis)
   this%files_initialized = fms_diag_files_object_init(this%FMS_diag_files)
   this%fields_initialized = fms_diag_fields_object_init(this%FMS_diag_fields)
-  this%buffers_initialized = fms_diag_output_buffer_init(this%FMS_diag_output_buffers, SIZE(diag_yaml%get_diag_fields()))
+  this%buffers_initialized = fms_diag_output_buffer_init(this%FMS_diag_output_buffers,SIZE(diag_yaml%get_diag_fields()))
   this%registered_variables = 0
   this%registered_axis = 0
   this%current_model_time = get_base_time()

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -50,6 +50,7 @@ private
   class(fmsDiagFileContainer_type), allocatable :: FMS_diag_files (:) !< array of diag files
   class(fmsDiagField_type), allocatable :: FMS_diag_fields(:) !< Array of diag fields
   type(fmsDiagOutputBufferContainer_type), allocatable :: FMS_diag_output_buffers(:) !< array of output buffer objects
+                                                                       !! one for each variable in the diag_table.yaml
   integer, private :: registered_buffers = 0 !< number of registered buffers, per dimension
   class(fmsDiagAxisContainer_type), allocatable :: diag_axis(:) !< Array of diag_axis
   type(time_type)  :: current_model_time !< The current model time

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -33,7 +33,7 @@ use fms_diag_axis_object_mod, only: fms_diag_axis_object_init, fmsDiagAxis_type,
                                    &diagDomain_t, get_domain_and_domain_type, diagDomain2d_t, &
                                    &fmsDiagAxisContainer_type, fms_diag_axis_object_end, fmsDiagFullAxis_type, &
                                    &parse_compress_att, get_axis_id_from_name
-use fms_diag_buffer_mod
+use fms_diag_output_buffer_mod
 #endif
 #if defined(_OPENMP)
 use omp_lib
@@ -49,7 +49,7 @@ private
 !TODO: Remove FMS prefix from variables in this type
   class(fmsDiagFileContainer_type), allocatable :: FMS_diag_files (:) !< array of diag files
   class(fmsDiagField_type), allocatable :: FMS_diag_fields(:) !< Array of diag fields
-  type(fmsDiagBufferContainer_type), allocatable :: FMS_diag_buffers(:) !< array of buffer objects
+  type(fmsDiagOutputBufferContainer_type), allocatable :: FMS_diag_output_buffers(:) !< array of output buffer objects
   integer, private :: registered_buffers = 0 !< number of registered buffers, per dimension
   class(fmsDiagAxisContainer_type), allocatable :: diag_axis(:) !< Array of diag_axis
   type(time_type)  :: current_model_time !< The current model time
@@ -113,7 +113,7 @@ subroutine fms_diag_object_init (this,diag_subset_output)
   this%axes_initialized = fms_diag_axis_object_init(this%diag_axis)
   this%files_initialized = fms_diag_files_object_init(this%FMS_diag_files)
   this%fields_initialized = fms_diag_fields_object_init(this%FMS_diag_fields)
-  this%buffers_initialized = fms_diag_buffer_init(this%FMS_diag_buffers, SIZE(diag_yaml%get_diag_fields()))
+  this%buffers_initialized = fms_diag_output_buffer_init(this%FMS_diag_output_buffers, SIZE(diag_yaml%get_diag_fields()))
   this%registered_variables = 0
   this%registered_axis = 0
   this%current_model_time = get_base_time()
@@ -139,12 +139,12 @@ subroutine fms_diag_object_end (this, time)
 
   call this%fms_diag_do_io(is_end_of_run=.true.)
   !TODO: Deallocate diag object arrays and clean up all memory
-  do i=1, size(this%FMS_diag_buffers)
-    if(allocated(this%FMS_diag_buffers(i)%diag_buffer_obj)) then
-      call this%FMS_diag_buffers(i)%diag_buffer_obj%flush_buffer()
+  do i=1, size(this%FMS_diag_output_buffers)
+    if(allocated(this%FMS_diag_output_buffers(i)%diag_buffer_obj)) then
+      call this%FMS_diag_output_buffers(i)%diag_buffer_obj%flush_buffer()
     endif
   enddo
-  deallocate(this%FMS_diag_buffers)
+  deallocate(this%FMS_diag_output_buffers)
   this%axes_initialized = fms_diag_axis_object_end(this%diag_axis)
   this%initialized = .false.
   call diag_yaml_object_end
@@ -721,10 +721,10 @@ function get_diag_buffer(this, bufferid) &
 result(rslt)
   class(fmsDiagObject_type), intent(in) :: this
   integer, intent(in)                   :: bufferid
-  class(fmsDiagBuffer_class),allocatable:: rslt
-  if( (bufferid .gt. UBOUND(this%FMS_diag_buffers, 1)) .or. (bufferid .lt. LBOUND(this%FMS_diag_buffers, 1))) &
+  class(fmsDiagOutputBuffer_class),allocatable:: rslt
+  if( (bufferid .gt. UBOUND(this%FMS_diag_output_buffers, 1)) .or. (bufferid .lt. LBOUND(this%FMS_diag_output_buffers, 1))) &
     call mpp_error(FATAL, 'get_diag_bufer: invalid bufferid given')
-  rslt = this%FMS_diag_buffers(bufferid)%diag_buffer_obj
+  rslt = this%FMS_diag_output_buffers(bufferid)%diag_buffer_obj
 end function
 #endif
 

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -113,7 +113,7 @@ subroutine fms_diag_object_init (this,diag_subset_output)
   this%axes_initialized = fms_diag_axis_object_init(this%diag_axis)
   this%files_initialized = fms_diag_files_object_init(this%FMS_diag_files)
   this%fields_initialized = fms_diag_fields_object_init(this%FMS_diag_fields)
-  this%buffers_initialized = fms_diag_output_buffer_init(this%FMS_diag_output_buffers,SIZE(diag_yaml%get_diag_fields()))
+  this%buffers_initialized =fms_diag_output_buffer_init(this%FMS_diag_output_buffers,SIZE(diag_yaml%get_diag_fields()))
   this%registered_variables = 0
   this%registered_axis = 0
   this%current_model_time = get_base_time()
@@ -722,7 +722,8 @@ result(rslt)
   class(fmsDiagObject_type), intent(in) :: this
   integer, intent(in)                   :: bufferid
   class(fmsDiagOutputBuffer_class),allocatable:: rslt
-  if( (bufferid .gt. UBOUND(this%FMS_diag_output_buffers, 1)) .or. (bufferid .lt. LBOUND(this%FMS_diag_output_buffers, 1))) &
+  if( (bufferid .gt. UBOUND(this%FMS_diag_output_buffers, 1)) .or. &
+      (bufferid .lt. LBOUND(this%FMS_diag_output_buffers, 1))) &
     call mpp_error(FATAL, 'get_diag_bufer: invalid bufferid given')
   rslt = this%FMS_diag_output_buffers(bufferid)%diag_buffer_obj
 end function

--- a/diag_manager/fms_diag_output_buffer.F90
+++ b/diag_manager/fms_diag_output_buffer.F90
@@ -156,7 +156,7 @@ logical function fms_diag_output_buffer_init(buffobjs, buff_list_size)
   integer, intent(in)                                          :: buff_list_size !< size of buffer array to allocate
   if (allocated(buffobjs)) call mpp_error(FATAL,'fms_diag_buffer_init: passed in buffobjs array is already allocated')
   allocate(buffobjs(buff_list_size))
-  fms_diag_buffer_init = allocated(buffobjs)
+  fms_diag_output_buffer_init = allocated(buffobjs)
 end function fms_diag_output_buffer_init
 
 !> Creates a container type encapsulating a new buffer object for the given dimensions.

--- a/diag_manager/fms_diag_output_buffer.F90
+++ b/diag_manager/fms_diag_output_buffer.F90
@@ -23,7 +23,7 @@
 !! @description Holds buffered data for fmsDiagVars_type objects
 !! buffer0-5d types extend fmsDiagBuffer_class, and upon allocation
 !! are added to the module's buffer_lists depending on it's dimension
-module fms_diag_buffer_mod
+module fms_diag_output_buffer_mod
 
 use platform_mod
 use iso_c_binding
@@ -38,7 +38,7 @@ private
 #ifdef use_yaml
 !> @brief Object that holds buffered data and other diagnostics
 !! Abstract to ensure use through its extensions(buffer0-5d types)
-type, abstract :: fmsDiagBuffer_class
+type, abstract :: fmsDiagOutputBuffer_class
   integer, allocatable, private               :: buffer_id !< index in buffer list
   integer, allocatable, public :: num_elements(:) !< used in time-averaging
   class(*), allocatable, public :: count_0d(:) !< used in time-averaging along with
@@ -56,15 +56,15 @@ type, abstract :: fmsDiagBuffer_class
   !procedure, deferred :: get_buffer
   !procedure, deferred :: initialize_buffer
 
-end type fmsDiagBuffer_class
+end type fmsDiagOutputBuffer_class
 
 !> holds an allocated buffer0-5d object
-type :: fmsDiagBufferContainer_type
-  class(fmsDiagBuffer_class), allocatable :: diag_buffer_obj !< any 0-5d buffer object
+type :: fmsDiagOutputBufferContainer_type
+  class(fmsDiagOutputBuffer_class), allocatable :: diag_buffer_obj !< any 0-5d buffer object
 end type
 
 !> Scalar buffer type to extend fmsDiagBufferContainer_type
-type, extends(fmsDiagBuffer_class) :: buffer0d_type
+type, extends(fmsDiagOutputBuffer_class) :: outputBuffer0d_type
   class(*), allocatable :: buffer(:) !< "scalar" numeric buffer value
                                      !! will only be allocated to hold 1 value
   class(*), allocatable :: counter(:) !< (x,y,z, time-of-day) used in the time averaging functions
@@ -74,10 +74,10 @@ type, extends(fmsDiagBuffer_class) :: buffer0d_type
   procedure :: add_to_buffer => add_to_buffer_0d
   procedure :: get_buffer => get_0d
 
-end type buffer0d_type
+end type outputBuffer0d_type
 
 !> 1D buffer type to extend fmsDiagBuffer_class
-type, extends(fmsDiagBuffer_class) :: buffer1d_type
+type, extends(fmsDiagOutputBuffer_class) :: outputBuffer1d_type
   class(*), allocatable :: buffer(:) !< 1D numeric data array
   class(*), allocatable :: counter(:) !< (x,y,z, time-of-day) used in the time averaging functions
   contains
@@ -85,10 +85,10 @@ type, extends(fmsDiagBuffer_class) :: buffer1d_type
   procedure :: initialize_buffer => initialize_buffer_1d
   procedure :: add_to_buffer => add_to_buffer_1d
   procedure :: get_buffer => get_1d
-end type buffer1d_type
+end type outputBuffer1d_type
 
 !> 2D buffer type to extend fmsDiagBuffer_class
-type, extends(fmsDiagBuffer_class) :: buffer2d_type
+type, extends(fmsDiagOutputBuffer_class) :: outputBuffer2d_type
   class(*), allocatable :: buffer(:,:) !< 2D numeric data array
   class(*), allocatable :: counter(:,:) !< (x,y,z, time-of-day) used in the time averaging functions
   contains
@@ -96,10 +96,10 @@ type, extends(fmsDiagBuffer_class) :: buffer2d_type
   procedure :: initialize_buffer => initialize_buffer_2d
   procedure :: add_to_buffer => add_to_buffer_2d
   procedure :: get_buffer => get_2d
-end type buffer2d_type
+end type outputBuffer2d_type
 
 !> 3D buffer type to extend fmsDiagBuffer_class
-type, extends(fmsDiagBuffer_class) :: buffer3d_type
+type, extends(fmsDiagOutputBuffer_class) :: outputBuffer3d_type
   class(*), allocatable :: buffer(:,:,:) !< 3D numeric data array
   class(*), allocatable :: counter(:,:,:) !< (x,y,z, time-of-day) used in the time averaging functions
   contains
@@ -107,10 +107,10 @@ type, extends(fmsDiagBuffer_class) :: buffer3d_type
   procedure :: initialize_buffer => initialize_buffer_3d
   procedure :: add_to_buffer => add_to_buffer_3d
   procedure :: get_buffer => get_3d
-end type buffer3d_type
+end type outputBuffer3d_type
 
 !> 4D buffer type to extend fmsDiagBuffer_class
-type, extends(fmsDiagBuffer_class) :: buffer4d_type
+type, extends(fmsDiagOutputBuffer_class) :: outputBuffer4d_type
   class(*), allocatable :: buffer(:,:,:,:) !< 4D numeric data array
   class(*), allocatable :: counter(:,:,:,:) !< (x,y,z, time-of-day) used in the time averaging functions
   contains
@@ -118,10 +118,10 @@ type, extends(fmsDiagBuffer_class) :: buffer4d_type
   procedure :: initialize_buffer => initialize_buffer_4d
   procedure :: add_to_buffer => add_to_buffer_4d
   procedure :: get_buffer => get_4d
-end type buffer4d_type
+end type outputBuffer4d_type
 
 !> 5D buffer type to extend fmsDiagBuffer_class
-type, extends(fmsDiagBuffer_class) :: buffer5d_type
+type, extends(fmsDiagOutputBuffer_class) :: outputBuffer5d_type
   class(*), allocatable :: buffer(:,:,:,:,:) !< 5D numeric data array
   class(*), allocatable :: counter(:,:,:,:,:) !< (x,y,z, time-of-day) used in the time averaging functions
   contains
@@ -129,20 +129,20 @@ type, extends(fmsDiagBuffer_class) :: buffer5d_type
   procedure :: initialize_buffer => initialize_buffer_5d
   procedure :: add_to_buffer => add_to_buffer_5d
   procedure :: get_buffer => get_5d
-end type buffer5d_type
+end type outputBuffer5d_type
 
 ! public types
-public :: buffer0d_type
-public :: buffer1d_type
-public :: buffer2d_type
-public :: buffer3d_type
-public :: buffer4d_type
-public :: buffer5d_type
-public :: fmsDiagBuffer_class
-public :: fmsDiagBufferContainer_type
+public :: outputBuffer0d_type
+public :: outputBuffer1d_type
+public :: outputBuffer2d_type
+public :: outputBuffer3d_type
+public :: outputBuffer4d_type
+public :: outputBuffer5d_type
+public :: fmsDiagOutputBuffer_class
+public :: fmsDiagOutputBufferContainer_type
 
 ! public routines
-public :: fms_diag_buffer_init
+public :: fms_diag_output_buffer_init
 
 contains
 
@@ -150,52 +150,51 @@ contains
 
 !> Initializes a list of diag buffers
 !> @returns true if allocation is successfull
-logical function fms_diag_buffer_init(buffobjs, buff_list_size)
-  type(fmsDiagBufferContainer_type), allocatable, intent(out) :: buffobjs(:) !< an array of buffer container types
+logical function fms_diag_output_buffer_init(buffobjs, buff_list_size)
+  type(fmsDiagOutputBufferContainer_type), allocatable, intent(out) :: buffobjs(:) !< an array of buffer container types
                                                                              !! to allocate
-  integer, intent(in)                                          :: buff_list_size !< number of dimensions needed for
-                                                                             !! the buffer data
+  integer, intent(in)                                          :: buff_list_size !< size of buffer array to allocate
   if (allocated(buffobjs)) call mpp_error(FATAL,'fms_diag_buffer_init: passed in buffobjs array is already allocated')
   allocate(buffobjs(buff_list_size))
   fms_diag_buffer_init = allocated(buffobjs)
-end function fms_diag_buffer_init
+end function fms_diag_output_buffer_init
 
 !> Creates a container type encapsulating a new buffer object for the given dimensions.
 !! The buffer object will still need to be allocated to a type via allocate_buffer() before use.
 !> @result A fmsDiagBufferContainer_type that holds a bufferNd_type, where N is buff_dims
-function fms_diag_buffer_create_container(buff_dims) &
+function fms_diag_output_buffer_create_container(buff_dims) &
 result(rslt)
   integer, intent(in)                            :: buff_dims !< dimensions
-  type(fmsDiagBufferContainer_type), allocatable :: rslt
+  type(fmsDiagOutputBufferContainer_type), allocatable :: rslt
   character(len=5) :: dim_output !< string to output buff_dims on error
 
   allocate(rslt)
   select case (buff_dims)
     case (0)
-      allocate(buffer0d_type :: rslt%diag_buffer_obj)
+      allocate(outputBuffer0d_type :: rslt%diag_buffer_obj)
     case (1)
-      allocate(buffer1d_type :: rslt%diag_buffer_obj)
+      allocate(outputBuffer1d_type :: rslt%diag_buffer_obj)
     case (2)
-      allocate(buffer2d_type :: rslt%diag_buffer_obj)
+      allocate(outputBuffer2d_type :: rslt%diag_buffer_obj)
     case (3)
-      allocate(buffer3d_type :: rslt%diag_buffer_obj)
+      allocate(outputBuffer3d_type :: rslt%diag_buffer_obj)
     case (4)
-      allocate(buffer4d_type :: rslt%diag_buffer_obj)
+      allocate(outputBuffer4d_type :: rslt%diag_buffer_obj)
     case (5)
-      allocate(buffer5d_type :: rslt%diag_buffer_obj)
+      allocate(outputBuffer5d_type :: rslt%diag_buffer_obj)
     case default
       write( dim_output, *) buff_dims
       dim_output = adjustl(dim_output)
       call mpp_error(FATAL, 'fms_diag_buffer_create_container: invalid number of dimensions given:' // dim_output //&
                             '. Must be 0-5')
   end select
-end function fms_diag_buffer_create_container
+end function fms_diag_output_buffer_create_container
 
 !!--------generic routines for any fmsDiagBuffer_class objects
 
 !> Setter for buffer_id for any buffer objects
 subroutine set_buffer_id(this, id)
-  class(fmsDiagBuffer_class), intent(inout) :: this !< buffer object to set id for
+  class(fmsDiagOutputBuffer_class), intent(inout) :: this !< buffer object to set id for
   integer, intent(in)                       :: id !< positive integer id to set
   if (.not.allocated(this%buffer_id) ) allocate(this%buffer_id)
   this%buffer_id = id
@@ -204,35 +203,35 @@ end subroutine set_buffer_id
 !> Remaps 0-5d data buffer from the given object onto a 5d array pointer.
 !> @returns a 5D remapped buffer, with 1:1 for any added dimensions.
 function remap_buffer(buffobj, field_name)
-  class(fmsDiagBuffer_class), target, intent(inout) :: buffobj !< any dimension buffer object
+  class(fmsDiagOutputBuffer_class), target, intent(inout) :: buffobj !< any dimension buffer object
   class(*), pointer                                 :: remap_buffer(:,:,:,:,:)
   character(len=*), intent(in)                      :: field_name !< name of field for error output
 
   ! get num dimensions from type extension
   select type (buffobj)
-    type is (buffer0d_type)
+    type is (outputBuffer0d_type)
       if (.not. allocated(buffobj%buffer)) call mpp_error(FATAL, "remap_buffer: buffer data not yet allocated" // &
                                                                  "for field:" // field_name)
       remap_buffer(1:size(buffobj%buffer,1), 1:1, 1:1, 1:1, 1:1) => buffobj%buffer
-    type is (buffer1d_type)
+    type is (outputBuffer1d_type)
       if (.not. allocated(buffobj%buffer)) call mpp_error(FATAL, "remap_buffer: buffer data not yet allocated" // &
                                                                  "for field:" // field_name)
       remap_buffer(1:size(buffobj%buffer,1), 1:1, 1:1, 1:1, 1:1) => buffobj%buffer(1:size(buffobj%buffer,1))
-    type is (buffer2d_type)
+    type is (outputBuffer2d_type)
       if (.not. allocated(buffobj%buffer)) call mpp_error(FATAL, "remap_buffer: buffer data not yet allocated" // &
                                                                  "for field:" // field_name)
       remap_buffer(1:size(buffobj%buffer,1), 1:size(buffobj%buffer,2), 1:1, 1:1, 1:1) => buffobj%buffer(:,:)
-    type is (buffer3d_type)
+    type is (outputBuffer3d_type)
       if (.not. allocated(buffobj%buffer)) call mpp_error(FATAL, "remap_buffer: buffer data not yet allocated" // &
                                                                  "for field:" // field_name)
       remap_buffer(1:size(buffobj%buffer,1), 1:size(buffobj%buffer,2), 1:size(buffobj%buffer,3), 1:1, 1:1) => &
                                                                                           & buffobj%buffer(:,:,:)
-    type is (buffer4d_type)
+    type is (outputBuffer4d_type)
       if (.not. allocated(buffobj%buffer)) call mpp_error(FATAL, "remap_buffer: buffer data not yet allocated" // &
                                                                  "for field:" // field_name)
       remap_buffer(1:size(buffobj%buffer,1), 1:size(buffobj%buffer,2), 1:size(buffobj%buffer,3), &
                    1:size(buffobj%buffer,4), 1:1) => buffobj%buffer(:,:,:,:)
-    type is (buffer5d_type)
+    type is (outputBuffer5d_type)
       if (.not. allocated(buffobj%buffer)) call mpp_error(FATAL, "remap_buffer: buffer data not yet allocated" // &
                                                                  "for field:" // field_name)
       remap_buffer(1:size(buffobj%buffer,1), 1:size(buffobj%buffer,2), 1:size(buffobj%buffer,3), &
@@ -245,24 +244,24 @@ end function remap_buffer
 
 !> Deallocates data fields from a buffer object.
 subroutine flush_buffer(this)
-  class(fmsDiagBuffer_class), intent(inout) :: this !< any buffer object
+  class(fmsDiagOutputBuffer_class), intent(inout) :: this !< any buffer object
   select type (this)
-    type is (buffer0d_type)
+    type is (outputBuffer0d_type)
       if (allocated(this%buffer)) deallocate(this%buffer)
       if (allocated(this%counter)) deallocate(this%counter)
-    type is (buffer1d_type)
+    type is (outputBuffer1d_type)
       if (allocated(this%buffer)) deallocate(this%buffer)
       if (allocated(this%counter)) deallocate(this%counter)
-    type is (buffer2d_type)
+    type is (outputBuffer2d_type)
       if (allocated(this%buffer)) deallocate(this%buffer)
       if (allocated(this%counter)) deallocate(this%counter)
-    type is (buffer3d_type)
+    type is (outputBuffer3d_type)
       if (allocated(this%buffer)) deallocate(this%buffer)
       if (allocated(this%counter)) deallocate(this%counter)
-    type is (buffer4d_type)
+    type is (outputBuffer4d_type)
       if (allocated(this%buffer)) deallocate(this%buffer)
       if (allocated(this%counter)) deallocate(this%counter)
-    type is (buffer5d_type)
+    type is (outputBuffer5d_type)
       if (allocated(this%buffer)) deallocate(this%buffer)
       if (allocated(this%counter)) deallocate(this%counter)
   end select
@@ -276,7 +275,7 @@ end subroutine flush_buffer
 
 !> Allocates scalar buffer data to the given buff_type.
 subroutine allocate_buffer_0d(this, buff_type, field_name, diurnal_samples)
-  class(buffer0d_type), intent(inout), target :: this !< scalar buffer object
+  class(outputBuffer0d_type), intent(inout), target :: this !< scalar buffer object
   class(*),intent(in) :: buff_type !< allocates to the given type, value does not matter
   character(len=*), intent(in) :: field_name !< field name for error output
   integer, intent(in),optional :: diurnal_samples !< number of diurnal samples, passed in from diag_yaml
@@ -335,7 +334,7 @@ end subroutine allocate_buffer_0d
 
 !> Allocates 1D buffer data to given buff_type.
 subroutine allocate_buffer_1d(this, buff_type, buff_size, field_name, diurnal_samples)
-  class(buffer1d_type), intent(inout), target :: this !< scalar buffer object
+  class(outputBuffer1d_type), intent(inout), target :: this !< scalar buffer object
   class(*),intent(in) :: buff_type !< allocates to the type of buff_type
   integer, intent(in) :: buff_size !< dimension bounds
   character(len=*), intent(in) :: field_name !< field name for error output
@@ -396,7 +395,7 @@ end subroutine allocate_buffer_1d
 
 !> Allocates a 2D buffer to given buff_type.
 subroutine allocate_buffer_2d(this, buff_type, buff_sizes, field_name, diurnal_samples)
-  class(buffer2d_type), intent(inout), target :: this !< 2D buffer object
+  class(outputBuffer2d_type), intent(inout), target :: this !< 2D buffer object
   class(*),intent(in) :: buff_type !< allocates to the type of buff_type
   integer, intent(in) :: buff_sizes(2) !< dimension sizes
   integer, intent(in),optional :: diurnal_samples !< number of diurnal samples, passed in from diag_yaml
@@ -456,7 +455,7 @@ end subroutine allocate_buffer_2d
 
 !> Allocates a 3D buffer to given buff_type.
 subroutine allocate_buffer_3d(this, buff_type, buff_sizes, field_name, diurnal_samples)
-  class(buffer3d_type), intent(inout), target :: this !< 3D buffer object
+  class(outputBuffer3d_type), intent(inout), target :: this !< 3D buffer object
   class(*),intent(in) :: buff_type !< allocates to the type of buff_type
   integer, intent(in) :: buff_sizes(3) !< dimension sizes
   integer, intent(in),optional :: diurnal_samples !< number of diurnal samples, passed in from diag_yaml
@@ -518,7 +517,7 @@ end subroutine allocate_buffer_3d
 
 !> Allocates a 4D buffer to given buff_type.
 subroutine allocate_buffer_4d(this, buff_type, buff_sizes, field_name, diurnal_samples)
-  class(buffer4d_type), intent(inout), target :: this !< 4D buffer object
+  class(outputBuffer4d_type), intent(inout), target :: this !< 4D buffer object
   class(*),intent(in) :: buff_type !< allocates to the type of buff_type
   integer, intent(in) :: buff_sizes(4) !< dimension buff_sizes
   character(len=*), intent(in) :: field_name !< field name for error output
@@ -582,7 +581,7 @@ end subroutine allocate_buffer_4d
 
 !> Allocates a 5D buffer to given buff_type.
 subroutine allocate_buffer_5d(this, buff_type, buff_sizes, field_name, diurnal_samples)
-  class(buffer5d_type), intent(inout), target :: this !< 5D buffer object
+  class(outputBuffer5d_type), intent(inout), target :: this !< 5D buffer object
   class(*),intent(in) :: buff_type !< allocates to the type of buff_type
   integer, intent(in) :: buff_sizes(5) !< dimension buff_sizes
   character(len=*), intent(in) :: field_name !< field name for error output
@@ -653,7 +652,7 @@ end subroutine allocate_buffer_5d
 !> Get routine for scalar buffers.
 !! Sets the buff_out argument to the integer or real value currently stored in the buffer.
 subroutine get_0d (this, buff_out, field_name)
-  class(buffer0d_type), intent(in) :: this !< 0d allocated buffer object
+  class(outputBuffer0d_type), intent(in) :: this !< 0d allocated buffer object
   class(*), allocatable, intent(out)  :: buff_out !< output of copied buffer data
   character(len=*), intent(in) :: field_name !< field name for error output
 
@@ -681,7 +680,7 @@ end subroutine
 !> Get routine for 1D buffers.
 !! Sets the buff_out argument to the integer or real array currently stored in the buffer.
 subroutine get_1d (this, buff_out, field_name)
-  class(buffer1d_type), intent(in) :: this !< 1d allocated buffer object
+  class(outputBuffer1d_type), intent(in) :: this !< 1d allocated buffer object
   class(*), allocatable, intent(out)  :: buff_out(:) !< output of copied buffer data
                                                 !! must be the same size as the allocated buffer
   integer(i4_kind) :: buff_size !< size for allocated buffer
@@ -713,7 +712,7 @@ end subroutine
 !> Get routine for 2D buffers.
 !! Sets the buff_out argument to the integer or real array currently stored in the buffer.
 subroutine get_2d (this, buff_out, field_name)
-  class(buffer2d_type), intent(in) :: this !< 2d allocated buffer object
+  class(outputBuffer2d_type), intent(in) :: this !< 2d allocated buffer object
   class(*), allocatable, intent(out)  :: buff_out(:,:) !< output of copied buffer data
                                                 !! must be the same size as the allocated buffer
   integer(i4_kind) :: buff_size(2) !< sizes for allocated buffer
@@ -747,7 +746,7 @@ end subroutine
 !> Get routine for 3D buffers.
 !! Sets the buff_out argument to the integer or real array currently stored in the buffer.
 subroutine get_3d (this, buff_out, field_name)
-  class(buffer3d_type), intent(in) :: this !< 3d allocated buffer object
+  class(outputBuffer3d_type), intent(in) :: this !< 3d allocated buffer object
   class(*), allocatable, intent(out)  :: buff_out(:,:,:) !< output of copied buffer data
                                                 !! must be the same size as the allocated buffer
   integer(i4_kind) :: buff_size(3)!< sizes for allocated buffer
@@ -781,7 +780,7 @@ end subroutine
 !> Get routine for 4D buffers.
 !! Sets the buff_out argument to the integer or real array currently stored in the buffer.
 subroutine get_4d (this, buff_out, field_name)
-  class(buffer4d_type), intent(in) :: this !< 4d allocated buffer object
+  class(outputBuffer4d_type), intent(in) :: this !< 4d allocated buffer object
   class(*), allocatable, intent(out)  :: buff_out(:,:,:,:) !< output of copied buffer data
                                                 !! must be the same size as the allocated buffer
   integer(i4_kind) :: buff_size(4)!< sizes for allocated buffer
@@ -816,7 +815,7 @@ end subroutine
 !> Get routine for 5D buffers.
 !! Sets the buff_out argument to the integer or real array currently stored in the buffer.
 subroutine get_5d (this, buff_out, field_name)
-  class(buffer5d_type), intent(in) :: this !< 5d allocated buffer object
+  class(outputBuffer5d_type), intent(in) :: this !< 5d allocated buffer object
   class(*), allocatable, intent(out)  :: buff_out(:,:,:,:,:) !< output of copied buffer data
                                                 !! must be the same size as the allocated buffer
   integer(i4_kind) :: buff_size(5)!< sizes for allocated buffer
@@ -851,7 +850,7 @@ end subroutine
 
 !> @brief Initializes a buffer to a given fill value.
 subroutine initialize_buffer_0d (this, fillval, field_name)
-  class(buffer0d_type), intent(inout) :: this !< scalar buffer object
+  class(outputBuffer0d_type), intent(inout) :: this !< scalar buffer object
   class(*), intent(in) :: fillval !< fill value, must be same type as the allocated buffer in this
   character(len=*), intent(in) :: field_name !< field name for error output
 
@@ -898,7 +897,7 @@ end subroutine initialize_buffer_0d
 
 !> @brief Initializes a buffer to a given fill value.
 subroutine initialize_buffer_1d (this, fillval, field_name)
-  class(buffer1d_type), intent(inout) :: this !< 1D buffer object
+  class(outputBuffer1d_type), intent(inout) :: this !< 1D buffer object
   class(*), intent(in) :: fillval !< fill value, must be same type as the allocated buffer in this
   character(len=*), intent(in) :: field_name !< field name for error output
 
@@ -946,7 +945,7 @@ end subroutine initialize_buffer_1d
 
 !> @brief Initializes a buffer to a given fill value.
 subroutine initialize_buffer_2d (this, fillval, field_name)
-  class(buffer2d_type), intent(inout) :: this !< 2D buffer object
+  class(outputBuffer2d_type), intent(inout) :: this !< 2D buffer object
   class(*), intent(in) :: fillval !< fill value, must be same type as the allocated buffer in this
   character(len=*), intent(in) :: field_name !< field name for error output
 
@@ -994,7 +993,7 @@ end subroutine initialize_buffer_2d
 
 !> @brief Initializes a buffer to a given fill value.
 subroutine initialize_buffer_3d (this, fillval, field_name)
-  class(buffer3d_type), intent(inout) :: this !< 3D buffer object
+  class(outputBuffer3d_type), intent(inout) :: this !< 3D buffer object
   class(*), intent(in) :: fillval!< fill value, must be same type as the allocated buffer in this
   character(len=*), intent(in) :: field_name !< field name for error output
 
@@ -1042,7 +1041,7 @@ end subroutine initialize_buffer_3d
 
 !> @brief Initializes a buffer to a given fill value.
 subroutine initialize_buffer_4d (this, fillval, field_name)
-  class(buffer4d_type), intent(inout) :: this !< allocated 4D buffer object
+  class(outputBuffer4d_type), intent(inout) :: this !< allocated 4D buffer object
   class(*), intent(in) :: fillval!< fill value, must be same type as the allocated buffer in this
   character(len=*), intent(in) :: field_name !< field name for error output
 
@@ -1090,7 +1089,7 @@ end subroutine initialize_buffer_4d
 
 !> @brief Initializes a buffer to a given fill value.
 subroutine initialize_buffer_5d (this, fillval, field_name)
-  class(buffer5d_type), intent(inout) :: this !< allocated 5D buffer object
+  class(outputBuffer5d_type), intent(inout) :: this !< allocated 5D buffer object
   class(*), intent(in) :: fillval!< fill value, must be same type as the allocated buffer in this
   character(len=*), intent(in) :: field_name !< field name for error output
 
@@ -1140,7 +1139,7 @@ end subroutine initialize_buffer_5d
 !! This will just call the init routine since there's only one value.
 !! @note input_data must match allocated type of buffer object.
 subroutine add_to_buffer_0d(this, input_data, field_name)
-  class(buffer0d_type), intent(inout) :: this !< allocated scalar buffer object
+  class(outputBuffer0d_type), intent(inout) :: this !< allocated scalar buffer object
   class(*), intent(in)      :: input_data !< data to copy into buffer
   character(len=*), intent(in) :: field_name !< field name for error output
   if( .not. allocated(this%buffer)) call mpp_error (FATAL, 'add_to_buffer_0d: buffer not yet allocated for field:'// &
@@ -1151,7 +1150,7 @@ end subroutine add_to_buffer_0d
 !> @brief Copy values ( from 1 to size(input_data)) into a 1d buffer object.
 !! @note input_data must match allocated type of buffer object.
 subroutine add_to_buffer_1d(this, input_data, field_name)
-  class(buffer1d_type), intent(inout) :: this !< allocated 1d buffer object
+  class(outputBuffer1d_type), intent(inout) :: this !< allocated 1d buffer object
   class(*), intent(in)            :: input_data(:) !< data to copy into the buffer
   integer            :: n !< number of elements in input data
   logical            :: type_error !< set to true if mismatch between input_data and allocated buffer
@@ -1200,7 +1199,7 @@ end subroutine add_to_buffer_1d
 !> @brief Copy values ( from 1 to size(input_data)) into a 2d buffer object.
 !! @note input_data must match allocated type of buffer object.
 subroutine add_to_buffer_2d(this, input_data, field_name)
-  class(buffer2d_type), intent(inout) :: this !< allocated 2d buffer object
+  class(outputBuffer2d_type), intent(inout) :: this !< allocated 2d buffer object
   class(*), intent(in)             :: input_data(:,:) !< 2d data array to copy into buffer
   integer            :: n1, n2 !< number of elements per dimension
   logical            :: type_error !< set to true if mismatch between input_data and allocated buffer
@@ -1251,7 +1250,7 @@ end subroutine add_to_buffer_2d
 !> @brief Copy values ( from 1 to size(input_data)) into a 3d buffer object.
 !! @note input_data must match allocated type of buffer object.
 subroutine add_to_buffer_3d(this, input_data, field_name)
-  class(buffer3d_type), intent(inout) :: this !< allocated 3d buffer object
+  class(outputBuffer3d_type), intent(inout) :: this !< allocated 3d buffer object
   class(*), intent(in)             :: input_data(:,:,:)!< 3d data array to copy into buffer
   integer            :: n1, n2, n3 !< number of elements per dimension
   logical            :: type_error !< set to true if mismatch between input_data and allocated buffer
@@ -1304,7 +1303,7 @@ end subroutine add_to_buffer_3d
 !> @brief Copy values ( from 1 to size(input_data)) into a 4d buffer object.
 !! @note input_data must match allocated type of buffer object.
 subroutine add_to_buffer_4d(this, input_data, field_name)
-  class(buffer4d_type), intent(inout) :: this !< allocated 4d buffer object
+  class(outputBuffer4d_type), intent(inout) :: this !< allocated 4d buffer object
   class(*), intent(in)             :: input_data(:,:,:,:) !< 4d data to copy into buffer
   integer            :: n1, n2, n3, n4!< number of elements per dimension
   logical            :: type_error !< set to true if mismatch between input_data and allocated buffer
@@ -1358,7 +1357,7 @@ end subroutine add_to_buffer_4d
 !> @brief Copy values (from 1 to size(input_data)) into a 5d buffer object.
 !! @note input_data must match allocated type of buffer object.
 subroutine add_to_buffer_5d(this, input_data, field_name)
-  class(buffer5d_type), intent(inout) :: this !< allocated 5d buffer object
+  class(outputBuffer5d_type), intent(inout) :: this !< allocated 5d buffer object
   class(*), intent(in)             :: input_data(:,:,:,:,:) !< 5d data to copy into buffer
   integer            :: n1, n2, n3, n4, n5 !< number of elements per dimension
   logical            :: type_error !< set to true if mismatch between input_data and allocated buffer
@@ -1411,4 +1410,4 @@ subroutine add_to_buffer_5d(this, input_data, field_name)
                                          'for field:'// field_name)
 end subroutine add_to_buffer_5d
 #endif
-end module fms_diag_buffer_mod
+end module fms_diag_output_buffer_mod

--- a/test_fms/diag_manager/test_diag_buffer.F90
+++ b/test_fms/diag_manager/test_diag_buffer.F90
@@ -1,18 +1,18 @@
 program test_diag_buffer
 #ifdef use_yaml
 
-    use fms_diag_buffer_mod
+    use fms_diag_output_buffer_mod
     use platform_mod
     use diag_data_mod, only: i4, i8, r4, r8
 
     implicit none
 
-    type(buffer0d_type) :: buffobj0(10)
-    type(buffer1d_type) :: buffobj1
-    type(buffer2d_type) :: buffobj2
-    type(buffer3d_type) :: buffobj3
-    type(buffer4d_type) :: buffobj4
-    type(buffer5d_type) :: buffobj5
+    type(outputBuffer0d_type) :: buffobj0(10)
+    type(outputBuffer1d_type) :: buffobj1
+    type(outputBuffer2d_type) :: buffobj2
+    type(outputBuffer3d_type) :: buffobj3
+    type(outputBuffer4d_type) :: buffobj4
+    type(outputBuffer5d_type) :: buffobj5
     class(*),allocatable       :: p_val, p_data1(:), p_data2(:,:)
     real(r8_kind)  :: r8_data
     real(r4_kind)  :: r4_data


### PR DESCRIPTION
**Description**
renames to make more sense

only did the first two subroutines in the buffer object, didn't think it needed it for everything

**How Has This Been Tested?**
amd oneapi

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

