### PR TITLE
Update to fms_diag_yaml_mod

### DIFF
--- a/diag_manager/fms_diag_yaml.F90
+++ b/diag_manager/fms_diag_yaml.F90
@@ -51,6 +51,7 @@ public :: diag_yaml_object_init, diag_yaml_object_end
 public :: diagYamlObject_type, get_diag_yaml_obj, subRegion_type
 public :: diagYamlFiles_type, diagYamlFilesVar_type
 public :: get_num_unique_fields, find_diag_field, get_diag_fields_entries, get_diag_files_id
+public :: get_output_buffer_ids
 public :: dump_diag_yaml_obj
 !> @}
 

--- a/diag_manager/fms_diag_yaml.F90
+++ b/diag_manager/fms_diag_yaml.F90
@@ -1457,11 +1457,11 @@ function get_diag_fields_entries(indices) &
 
 end function get_diag_fields_entries
 
-!> @brief Gets the output buffer ids corresponding to the indicies in the sorted variable_list
-!! @return Array of indicies of the output buffers
+!> @brief Gets the output buffer ids corresponding to the indices in the sorted variable_list
+!! @return Array of indices of the output buffers
 function get_output_buffer_ids(indices) result(buffer_ids)
 
-  integer, intent(in) :: indices(:) !< Indicies of the fields in the sorted variable_list array
+  integer, intent(in) :: indices(:) !< Indices of the fields in the sorted variable_list array
   integer, allocatable :: buffer_ids(:)
   integer :: i !< For do loop
 

--- a/diag_manager/fms_diag_yaml.F90
+++ b/diag_manager/fms_diag_yaml.F90
@@ -1457,6 +1457,22 @@ function get_diag_fields_entries(indices) &
 
 end function get_diag_fields_entries
 
+!> @brief Gets the output buffer ids corresponding to the indicies in the sorted variable_list
+!! @return Array of indicies of the output buffers
+function get_output_buffer_ids(indices) result(buffer_ids)
+
+  integer, intent(in) :: indices(:) !< Indicies of the fields in the sorted variable_list array
+  integer, allocatable :: buffer_ids(:)
+  integer :: i !< For do loop
+
+  allocate(buffer_ids(size(indices)))
+
+  do i = 1, size(indices)
+    buffer_ids(i) = variable_list%diag_field_indices(indices(i))
+  end do
+
+end function get_output_buffer_ids
+
 !> @brief Finds the indices of the diag_yaml%diag_files(:) corresponding to fields in variable_list(indices)
 !! @return indices of the diag_yaml%diag_files(:)
 function get_diag_files_id(indices) &


### PR DESCRIPTION
**Description**
Adds routine _get_output_buffer_ids_ to _fms_diag_yaml_mod_ which gets indices of output buffers corresponding to indices in the sorted _variable_list_.

Fixes # (issue)
CI

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes. Please also note
any relevant details for your test configuration (e.g. compiler, OS).  Include
enough information so someone can reproduce your tests.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

