### PR TITLE
Modern diag_manager: Fixes related to static and scalar fields

### DIFF
--- a/diag_manager/fms_diag_field_object.F90
+++ b/diag_manager/fms_diag_field_object.F90
@@ -1109,7 +1109,13 @@ subroutine write_field_metadata(this, fileobj, file_id, yaml_id, diag_axis, unli
     call this%get_dimnames(diag_axis, field_yaml, unlim_dimname, dimnames, is_regional)
     call register_field_wrap(fileobj, var_name, this%get_var_skind(field_yaml), dimnames)
   else
-    call register_field_wrap(fileobj, var_name, this%get_var_skind(field_yaml))
+    if (this%is_static()) then
+      call register_field_wrap(fileobj, var_name, this%get_var_skind(field_yaml))
+    else
+      !< In this case, the scalar variable is a function of time, so we need to pass in the
+      !! unlimited dimension as a dimension
+      call register_field_wrap(fileobj, var_name, this%get_var_skind(field_yaml), (/unlim_dimname/))
+    endif
   endif
 
   !TODO Not sure what the old diag_manager did if long_name was never defined

--- a/diag_manager/fms_diag_file_object.F90
+++ b/diag_manager/fms_diag_file_object.F90
@@ -329,6 +329,9 @@ subroutine set_file_time_ops(this, VarYaml, is_static)
   type (diagYamlFilesVar_type), intent(in)    :: VarYaml   !< The variable's yaml file
   logical,                      intent(in)    :: is_static !< Flag indicating if variable is static
 
+  !< Go away if the file is static
+  if (this%is_static) return
+
   if (this%time_ops) then
     if (is_static) return
     if (VarYaml%get_var_reduction() .eq. time_none) then

--- a/diag_manager/fms_diag_file_object.F90
+++ b/diag_manager/fms_diag_file_object.F90
@@ -1212,7 +1212,7 @@ end subroutine increase_unlimited_dimension
 !! \return The unlimited dimension
 pure function get_unlimited_dimension(this) &
 result(res)
-  class(fmsDiagFileContainer_type), intent(inout), target   :: this            !< The file object
+  class(fmsDiagFileContainer_type), intent(in), target   :: this            !< The file object
   integer :: res
 
   res = this%FMS_diag_file%unlimited_dimension

--- a/diag_manager/fms_diag_file_object.F90
+++ b/diag_manager/fms_diag_file_object.F90
@@ -27,7 +27,8 @@ module fms_diag_file_object_mod
 #ifdef use_yaml
 use fms2_io_mod, only: FmsNetcdfFile_t, FmsNetcdfUnstructuredDomainFile_t, FmsNetcdfDomainFile_t, &
                        get_instance_filename, open_file, close_file, get_mosaic_tile_file, unlimited, &
-                       register_axis, register_field, register_variable_attribute, write_data
+                       register_axis, register_field, register_variable_attribute, write_data, &
+                       dimension_exists
 use diag_data_mod, only: DIAG_NULL, NO_DOMAIN, max_axes, SUB_REGIONAL, get_base_time, DIAG_NOT_REGISTERED, &
                          TWO_D_DOMAIN, UG_DOMAIN, prepend_date, DIAG_DAYS, VERY_LARGE_FILE_FREQ, &
                          get_base_year, get_base_month, get_base_day, get_base_hour, get_base_minute, &
@@ -1051,10 +1052,13 @@ subroutine write_time_metadata(this)
     call write_var_metadata(fileobj, avg_name//"_DT", dimensions(2:2), &
       "Length of average period", time_unit_list(diag_file%get_file_timeunit()))
 
-    !< Write out the *_bounds variable metadata
-    call register_axis(fileobj, "nv", 2) !< Time bounds need a vertex number
-    call write_var_metadata(fileobj, "nv", dimensions(1:1), &
-      "vertex number", no_units)
+    !< It is possible that the "nv" "axis" was registered via "diag_axis_init" call
+    !! so only adding it if it doesn't exist already
+    if ( .not. dimension_exists(fileobj, "nv")) then
+      call register_axis(fileobj, "nv", 2) !< Time bounds need a vertex number
+      call write_var_metadata(fileobj, "nv", dimensions(1:1), &
+        "vertex number", no_units)
+    endif
     call write_var_metadata(fileobj, time_var_name//"_bnds", dimensions, &
       trim(time_var_name)//" axis boundaries", time_units_str)
   endif

--- a/diag_manager/fms_diag_file_object.F90
+++ b/diag_manager/fms_diag_file_object.F90
@@ -167,6 +167,7 @@ type fmsDiagFileContainer_type
   procedure :: update_next_write
   procedure :: update_current_new_file_freq_index
   procedure :: increase_unlimited_dimension
+  procedure :: get_unlimited_dimension
   procedure :: close_diag_file
 end type fmsDiagFileContainer_type
 
@@ -1206,6 +1207,16 @@ subroutine increase_unlimited_dimension(this)
 
   this%FMS_diag_file%unlimited_dimension = this%FMS_diag_file%unlimited_dimension + 1
 end subroutine increase_unlimited_dimension
+
+!> \brief Get the unlimited dimension that is in the file
+!! \return The unlimited dimension
+pure function get_unlimited_dimension(this) &
+result(res)
+  class(fmsDiagFileContainer_type), intent(inout), target   :: this            !< The file object
+  integer :: res
+
+  res = this%FMS_diag_file%unlimited_dimension
+end function
 
 !< @brief Writes the axis metadata for the file
 subroutine write_axis_metadata(this, diag_axis)

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -607,9 +607,9 @@ subroutine fms_diag_do_io(this, is_end_of_run)
 
     call diag_file%open_diag_file(model_time, file_is_opened_this_time_step)
     if (file_is_opened_this_time_step) then
+      call diag_file%write_axis_metadata(this%diag_axis)
       call diag_file%write_time_metadata()
       call diag_file%write_field_metadata(this%FMS_diag_fields, this%diag_axis)
-      call diag_file%write_axis_metadata(this%diag_axis)
       call diag_file%write_axis_data(this%diag_axis)
     endif
 

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -615,15 +615,15 @@ subroutine fms_diag_do_io(this, is_end_of_run)
     endif
 
     if (diag_file%is_time_to_write(model_time)) then
-      call diag_file%increase_unlimited_dimension()
+      call diag_file%increase_unlim_dimension_level()
       call diag_file%write_time_data()
       !TODO call diag_file%add_variable_data()
       call diag_file%update_next_write(model_time)
       call diag_file%update_current_new_file_freq_index(model_time)
       if (diag_file%is_time_to_close_file(model_time)) call diag_file%close_diag_file()
     else if (force_write) then
-      if (diag_file%get_unlimited_dimension() .eq. 0) then
-        call diag_file%increase_unlimited_dimension()
+      if (diag_file%get_unlim_dimension_level() .eq. 0) then
+        call diag_file%increase_unlim_dimension_level()
         call diag_file%write_time_data()
       endif
       call diag_file%close_diag_file()

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -608,8 +608,8 @@ subroutine fms_diag_do_io(this, is_end_of_run)
     call diag_file%open_diag_file(model_time, file_is_opened_this_time_step)
     if (file_is_opened_this_time_step) then
       call diag_file%write_time_metadata()
-      call diag_file%write_axis_metadata(this%diag_axis)
       call diag_file%write_field_metadata(this%FMS_diag_fields, this%diag_axis)
+      call diag_file%write_axis_metadata(this%diag_axis)
       call diag_file%write_axis_data(this%diag_axis)
     endif
 
@@ -620,9 +620,11 @@ subroutine fms_diag_do_io(this, is_end_of_run)
       call diag_file%update_next_write(model_time)
       call diag_file%update_current_new_file_freq_index(model_time)
       if (diag_file%is_time_to_close_file(model_time)) call diag_file%close_diag_file()
-    else if (force_write .and. .not. diag_file%is_file_static()) then
-      call diag_file%increase_unlimited_dimension()
-      call diag_file%write_time_data()
+    else if (force_write) then
+      if (diag_file%get_unlimited_dimension() .eq. 0) then
+        call diag_file%increase_unlimited_dimension()
+        call diag_file%write_time_data()
+      endif
       call diag_file%close_diag_file()
     endif
   enddo


### PR DESCRIPTION
**Description**

- Fix so that scalar variables that depend on time can be a function of the unlimited dimension
- Fix to work around the issue that the old diag manager did not have the ability to register scalar static fields
- Fix to reproduce the `get_diag_field_id` behavior in the old diag manager
- Fix to prevent `nv` to be written twice, if it is defined as an axis in the model code
- Fix so that static files are only written once in the beginning of the run

Fixes # (issue)

**How Has This Been Tested?**
This + #1177 + #1176 run with the am4 cmip diag_table

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

