### PR TITLE
Update to fmsDiagObject_type

### DIFF
--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -867,14 +867,14 @@ subroutine allocate_diag_field_output_buffers(this, field_data, field_id)
 
   ! Determine dimensions of the field
   ndims = 0
-  if (this%FMS_diag_fields(diag_field_id)%has_axis_ids()) then
-    axis_ids => this%FMS_diag_fields(diag_field_id)%get_axis_id() !< Get ids of axes of the variable
+  if (this%FMS_diag_fields(field_id)%has_axis_ids()) then
+    axis_ids => this%FMS_diag_fields(field_id)%get_axis_id() !< Get ids of axes of the variable
     ndims = size(axis_ids) !< Dimensions of the field
   endif
 
   ! Loop over a number of fields/buffers where this variable occurs
-  do i = 1, size(this%FMS_diag_fields(diag_field_id)%buffer_ids)
-    buffer_id = this%FMS_diag_fields(diag_field_id)%buffer_ids(i)
+  do i = 1, size(this%FMS_diag_fields(field_id)%buffer_ids)
+    buffer_id = this%FMS_diag_fields(field_id)%buffer_ids(i)
     num_diurnal_samples = diag_yaml%diag_fields(buffer_id)%get_n_diurnal() !< Get number of diurnal samples
     diag_buffer_obj => this%FMS_diag_output_buffers(buffer_id)%diag_buffer_obj
 
@@ -892,19 +892,19 @@ subroutine allocate_diag_field_output_buffers(this, field_data, field_id)
       if (allocated(diag_buffer_obj%buffer)) cycle !< If allocated, loop back
       if (ndims .eq. 0) then
         diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), & !< If scalar field variable
-          this%FMS_diag_fields(diag_field_id)%varname)
+          this%FMS_diag_fields(field_id)%varname)
       else
         diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), axes_length, &
-          this%FMS_diag_fields(diag_field_id)%varname, num_diurnal_samples)
+          this%FMS_diag_fields(field_id)%varname, num_diurnal_samples)
       endif
     else
-      diag_buffer_obj = fms_diag_buffer_create_container(ndims)
+      diag_buffer_obj = fms_diag_output_buffer_create_container(ndims)
       if (ndims .eq. 0) then
         diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), & !< If scalar field variable
-          this%FMS_diag_fields(diag_field_id)%varname)
+          this%FMS_diag_fields(field_id)%varname)
       else
         diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), axes_length, &
-          this%FMS_diag_fields(diag_field_id)%varname, num_diurnal_samples)
+          this%FMS_diag_fields(field_id)%varname, num_diurnal_samples)
       endif
     endif
   enddo

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -862,7 +862,7 @@ subroutine allocate_diag_field_output_buffers(this, field_data, field_id)
   integer :: num_diurnal_samples !< Number of diurnal samples from diag_yaml
   integer, allocatable :: axes_length(:) !< Length of each axis
   integer :: i, j !< For looping
-  class(fmsDiagBuffer_class), pointer :: diag_buffer_obj !< Pointer to the buffer class
+  class(fmsDiagOutputBuffer_class), pointer :: diag_buffer_obj !< Pointer to the buffer class
   integer, pointer :: axis_ids(:) !< Pointer to indices of axes of the field variable
 
   ! Determine dimensions of the field


### PR DESCRIPTION
**Description**
The update adds a member routine, _allocate_diag_field_output_buffers_, to _fmsDiagObject_type_ which allocates the output buffers of the fields corresponding to the registered field variable.

Fixes # (issue)
CI

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes. Please also note
any relevant details for your test configuration (e.g. compiler, OS).  Include
enough information so someone can reproduce your tests.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

