### PR TITLE
Adds a routine allocate_diag_field_output_buffers to fmsDiagObject_type

### DIFF
--- a/diag_manager/Makefile.am
+++ b/diag_manager/Makefile.am
@@ -86,6 +86,7 @@ diag_manager_mod.$(FC_MODEXT): diag_axis_mod.$(FC_MODEXT) diag_data_mod.$(FC_MOD
                                fms_diag_object_container_mod.$(FC_MODEXT) fms_diag_axis_object_mod.$(FC_MODEXT) \
                                fms_diag_time_reduction_mod.$(FC_MODEXT) fms_diag_outfield_mod.$(FC_MODEXT) \
                                fms_diag_fieldbuff_update_mod.$(FC_MODEXT)
+fms_diag_output_buffer_mod.$(FC_MODEXT): diag_data_mod.$(FC_MODEXT)
 
 # Mod files are built and then installed as headers.
 MODFILES = \

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -866,7 +866,8 @@ subroutine allocate_diag_field_output_buffers(this, field_data, field_id)
   integer :: num_diurnal_samples !< Number of diurnal samples from diag_yaml
   integer, allocatable :: axes_length(:) !< Length of each axis
   integer :: i, j !< For looping
-  class(fmsDiagOutputBuffer_class), pointer :: ptr_diag_buffer_obj !< Pointer to the buffer class
+  !class(fmsDiagOutputBuffer_class), pointer :: ptr_diag_buffer_obj !< Pointer to the buffer class
+  class(*), pointer :: ptr_diag_buffer_obj !< Pointer to the buffer class
   class(DiagYamlFilesVar_type), pointer :: ptr_diag_field_yaml !< Pointer to a field from yaml fields
   integer, pointer :: axis_ids(:) !< Pointer to indices of axes of the field variable
 

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -34,7 +34,8 @@ use fms_diag_axis_object_mod, only: fms_diag_axis_object_init, fmsDiagAxis_type,
                                    &fmsDiagAxisContainer_type, fms_diag_axis_object_end, fmsDiagFullAxis_type, &
                                    &parse_compress_att, get_axis_id_from_name
 use fms_diag_output_buffer_mod, only: fmsDiagOutputBuffer_class, fmsDiagOutputBufferContainer_type, &
-                    fms_diag_output_buffer_create_container
+                    fms_diag_output_buffer_create_container, outputBuffer0d_type, outputBuffer1d_type, &
+                    outputBuffer2d_type, outputBuffer3d_type, outputBuffer4d_type, outputBuffer5d_type
 #endif
 #if defined(_OPENMP)
 use omp_lib

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -867,14 +867,14 @@ subroutine allocate_diag_field_output_buffers(this, field_data, field_id)
 
   ! Determine dimensions of the field
   ndims = 0
-  if (this%FMS_diag_fields(diag_field_id)%has_axis_ids()) then
-    axis_ids => this%FMS_diag_fields(diag_field_id)%get_axis_id() !< Get ids of axes of the variable
+  if (this%FMS_diag_fields(field_id)%has_axis_ids()) then
+    axis_ids => this%FMS_diag_fields(field_id)%get_axis_id() !< Get ids of axes of the variable
     ndims = size(axis_ids) !< Dimensions of the field
   endif
 
   ! Loop over a number of fields/buffers where this variable occurs
-  do i = 1, size(this%FMS_diag_fields(diag_field_id)%buffer_ids)
-    buffer_id = this%FMS_diag_fields(diag_field_id)%buffer_ids(i)
+  do i = 1, size(this%FMS_diag_fields(field_id)%buffer_ids)
+    buffer_id = this%FMS_diag_fields(field_id)%buffer_ids(i)
     num_diurnal_samples = diag_yaml%diag_fields(buffer_id)%get_n_diurnal() !< Get number of diurnal samples
     diag_buffer_obj => this%FMS_diag_output_buffers(buffer_id)%diag_buffer_obj
 
@@ -892,19 +892,19 @@ subroutine allocate_diag_field_output_buffers(this, field_data, field_id)
       if (allocated(diag_buffer_obj%buffer)) cycle !< If allocated, loop back
       if (ndims .eq. 0) then
         diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), & !< If scalar field variable
-          this%FMS_diag_fields(diag_field_id)%varname)
+          this%FMS_diag_fields(field_id)%varname)
       else
         diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), axes_length, &
-          this%FMS_diag_fields(diag_field_id)%varname, num_diurnal_samples)
+          this%FMS_diag_fields(field_id)%varname, num_diurnal_samples)
       endif
     else
-      diag_buffer_obj = fms_diag_buffer_create_container(ndims)
+      diag_buffer_obj = fms_diag_output_buffer_create_container(ndims)
       if (ndims .eq. 0) then
         diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), & !< If scalar field variable
-          this%FMS_diag_fields(diag_field_id)%varname)
+          this%FMS_diag_fields(field_id)%varname)
       else
         diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), axes_length, &
-          this%FMS_diag_fields(diag_field_id)%varname, num_diurnal_samples)
+          this%FMS_diag_fields(field_id)%varname, num_diurnal_samples)
       endif
     endif
   enddo

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -901,6 +901,8 @@ subroutine allocate_diag_field_output_buffers(this, field_data, field_id)
     ptr_diag_buffer_obj => this%FMS_diag_output_buffers(buffer_id)%diag_buffer_obj
 
     select type (ptr_diag_buffer_obj)
+      class is (fmsDiagOutputBuffer_class)
+        print *
       type is (outputBuffer0d_type) !< Scalar buffer
         if (allocated(ptr_diag_buffer_obj%buffer)) cycle !< If allocated, loop back
         ptr_diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), &

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -856,7 +856,7 @@ subroutine allocate_diag_field_output_buffers(this, field_data, field_id)
   class(fmsDiagObject_type), intent(inout) :: this !< diag object
   class(*), dimension(:,:,:,:), intent(in) :: field_data !< field data
   integer, intent(in) :: field_id !< Id of the field data
-
+#ifdef use_yaml
   integer :: ndims !< Number of dimensions in the input field data
   integer :: buffer_id !< Buffer index of FMS_diag_buffers
   integer :: num_diurnal_samples !< Number of diurnal samples from diag_yaml
@@ -910,6 +910,9 @@ subroutine allocate_diag_field_output_buffers(this, field_data, field_id)
       endif
     endif
   enddo
+#else
+  call mpp_error( FATAL, "You can not use the modern diag manager without compiling with -Duse_yaml")
+#endif
 end subroutine allocate_diag_field_output_buffers
 
 end module fms_diag_object_mod

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -896,7 +896,7 @@ subroutine allocate_diag_field_output_buffers(this, field_data, field_id)
     end if
 
     ptr_diag_buffer_obj => this%FMS_diag_output_buffers(buffer_id)%diag_buffer_obj
-    
+
     select type (ptr_diag_buffer_obj)
       type is (outputBuffer0d_type) !< Scalar buffer
         if (allocated(ptr_diag_buffer_obj%buffer)) cycle !< If allocated, loop back

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -867,7 +867,7 @@ subroutine allocate_diag_field_output_buffers(this, field_data, field_id)
   integer, allocatable :: axes_length(:) !< Length of each axis
   integer :: i, j !< For looping
   class(fmsDiagOutputBuffer_class), pointer :: ptr_diag_buffer_obj !< Pointer to the buffer class
-  type(DiagYamlFilesVar_type), pointer :: ptr_diag_field_yaml !< Pointer to a field from yaml fields
+  class(DiagYamlFilesVar_type), pointer :: ptr_diag_field_yaml !< Pointer to a field from yaml fields
   integer, pointer :: axis_ids(:) !< Pointer to indices of axes of the field variable
 
   ! Determine dimensions of the field
@@ -901,31 +901,29 @@ subroutine allocate_diag_field_output_buffers(this, field_data, field_id)
     ptr_diag_buffer_obj => this%FMS_diag_output_buffers(buffer_id)%diag_buffer_obj
 
     select type (ptr_diag_buffer_obj)
-      class is (fmsDiagOutputBuffer_class)
-        print *
       type is (outputBuffer0d_type) !< Scalar buffer
         if (allocated(ptr_diag_buffer_obj%buffer)) cycle !< If allocated, loop back
-        ptr_diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), &
+        call ptr_diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), &
           this%FMS_diag_fields(field_id)%get_varname())
       type is (outputBuffer1d_type) !< 1D buffer
         if (allocated(ptr_diag_buffer_obj%buffer)) cycle !< If allocated, loop back
-        ptr_diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), axes_length, &
+        call ptr_diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), axes_length, &
           this%FMS_diag_fields(field_id)%get_varname(), num_diurnal_samples)
       type is (outputBuffer2d_type) !< 2D buffer
         if (allocated(ptr_diag_buffer_obj%buffer)) cycle !< If allocated, loop back
-        ptr_diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), axes_length, &
+        call ptr_diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), axes_length, &
           this%FMS_diag_fields(field_id)%get_varname(), num_diurnal_samples)
       type is (outputBuffer3d_type) !< 3D buffer
         if (allocated(ptr_diag_buffer_obj%buffer)) cycle !< If allocated, loop back
-        ptr_diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), axes_length, &
+        call ptr_diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), axes_length, &
           this%FMS_diag_fields(field_id)%get_varname(), num_diurnal_samples)
       type is (outputBuffer4d_type) !< 4D buffer
         if (allocated(ptr_diag_buffer_obj%buffer)) cycle !< If allocated, loop back
-        ptr_diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), axes_length, &
+        call ptr_diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), axes_length, &
           this%FMS_diag_fields(field_id)%get_varname(), num_diurnal_samples)
       type is (outputBuffer5d_type) !< 5D buffer
         if (allocated(ptr_diag_buffer_obj%buffer)) cycle !< If allocated, loop back
-        ptr_diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), axes_length, &
+        call ptr_diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), axes_length, &
           this%FMS_diag_fields(field_id)%get_varname(), num_diurnal_samples)
       class default
         call mpp_error( FATAL, 'allocate_diag_field_output_buffers: invalid buffer type')

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -862,7 +862,7 @@ subroutine allocate_diag_field_output_buffers(this, field_data, field_id)
   integer :: num_diurnal_samples !< Number of diurnal samples from diag_yaml
   integer, allocatable :: axes_length(:) !< Length of each axis
   integer :: i, j !< For looping
-  class(fmsDiagBuffer_class), pointer :: diag_buffer_obj !< Pointer to the buffer class
+  class(fmsDiagOutputBuffer_class), pointer :: diag_buffer_obj !< Pointer to the buffer class
   integer, pointer :: axis_ids(:) !< Pointer to indices of axes of the field variable
 
   ! Determine dimensions of the field

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -903,7 +903,7 @@ subroutine allocate_diag_field_output_buffers(this, field_data, field_id)
     select type (ptr_diag_buffer_obj)
       type is (outputBuffer0d_type) !< Scalar buffer
         if (allocated(ptr_diag_buffer_obj%buffer)) cycle !< If allocated, loop back
-        ptr_diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), & !< If scalar field variable
+        this%FMS_diag_output_buffers(buffer_id)%diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), & !< If scalar field variable
           this%FMS_diag_fields(field_id)%get_varname())
       type is (outputBuffer1d_type) !< 1D buffer
         if (allocated(ptr_diag_buffer_obj%buffer)) cycle !< If allocated, loop back

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -35,7 +35,8 @@ use fms_diag_axis_object_mod, only: fms_diag_axis_object_init, fmsDiagAxis_type,
                                    &parse_compress_att, get_axis_id_from_name
 use fms_diag_output_buffer_mod, only: fmsDiagOutputBuffer_class, fmsDiagOutputBufferContainer_type, &
                     fms_diag_output_buffer_create_container, outputBuffer0d_type, outputBuffer1d_type, &
-                    outputBuffer2d_type, outputBuffer3d_type, outputBuffer4d_type, outputBuffer5d_type
+                    outputBuffer2d_type, outputBuffer3d_type, outputBuffer4d_type, outputBuffer5d_type, &
+                    fms_diag_output_buffer_init
 #endif
 #if defined(_OPENMP)
 use omp_lib
@@ -854,8 +855,9 @@ subroutine dump_diag_obj( filename )
 end subroutine
 
 !> @brief Allocates the output buffers of the fields corresponding to the registered variable
+!! Input arguments are the field and its ID passed to routine fms_diag_accept_data()
 subroutine allocate_diag_field_output_buffers(this, field_data, field_id)
-  class(fmsDiagObject_type), intent(inout) :: this !< diag object
+  class(fmsDiagObject_type), target, intent(inout) :: this !< diag object
   class(*), dimension(:,:,:,:), intent(in) :: field_data !< field data
   integer, intent(in) :: field_id !< Id of the field data
 #ifdef use_yaml

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -907,23 +907,23 @@ subroutine allocate_diag_field_output_buffers(this, field_data, field_id)
           this%FMS_diag_fields(field_id)%get_varname())
       type is (outputBuffer1d_type) !< 1D buffer
         if (allocated(ptr_diag_buffer_obj%buffer)) cycle !< If allocated, loop back
-        call ptr_diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), axes_length, &
+        call ptr_diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), axes_length(1), &
           this%FMS_diag_fields(field_id)%get_varname(), num_diurnal_samples)
       type is (outputBuffer2d_type) !< 2D buffer
         if (allocated(ptr_diag_buffer_obj%buffer)) cycle !< If allocated, loop back
-        call ptr_diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), axes_length, &
+        call ptr_diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), axes_length(2), &
           this%FMS_diag_fields(field_id)%get_varname(), num_diurnal_samples)
       type is (outputBuffer3d_type) !< 3D buffer
         if (allocated(ptr_diag_buffer_obj%buffer)) cycle !< If allocated, loop back
-        call ptr_diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), axes_length, &
+        call ptr_diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), axes_length(3), &
           this%FMS_diag_fields(field_id)%get_varname(), num_diurnal_samples)
       type is (outputBuffer4d_type) !< 4D buffer
         if (allocated(ptr_diag_buffer_obj%buffer)) cycle !< If allocated, loop back
-        call ptr_diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), axes_length, &
+        call ptr_diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), axes_length(4), &
           this%FMS_diag_fields(field_id)%get_varname(), num_diurnal_samples)
       type is (outputBuffer5d_type) !< 5D buffer
         if (allocated(ptr_diag_buffer_obj%buffer)) cycle !< If allocated, loop back
-        call ptr_diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), axes_length, &
+        call ptr_diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), axes_length(5), &
           this%FMS_diag_fields(field_id)%get_varname(), num_diurnal_samples)
       class default
         call mpp_error( FATAL, 'allocate_diag_field_output_buffers: invalid buffer type')

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -28,7 +28,7 @@ use diag_data_mod,  only: diag_null, diag_not_found, diag_not_registered, diag_r
 use fms_diag_file_object_mod, only: fmsDiagFileContainer_type, fmsDiagFile_type, fms_diag_files_object_init
 use fms_diag_field_object_mod, only: fmsDiagField_type, fms_diag_fields_object_init
 use fms_diag_yaml_mod, only: diag_yaml_object_init, diag_yaml_object_end, find_diag_field, &
-                            & get_diag_files_id, diag_yaml, fmsDiagYamlFilesVar_type
+                            & get_diag_files_id, diag_yaml, DiagYamlFilesVar_type
 use fms_diag_axis_object_mod, only: fms_diag_axis_object_init, fmsDiagAxis_type, fmsDiagSubAxis_type, &
                                    &diagDomain_t, get_domain_and_domain_type, diagDomain2d_t, &
                                    &fmsDiagAxisContainer_type, fms_diag_axis_object_end, fmsDiagFullAxis_type, &
@@ -863,7 +863,7 @@ subroutine allocate_diag_field_output_buffers(this, field_data, field_id)
   integer, allocatable :: axes_length(:) !< Length of each axis
   integer :: i, j !< For looping
   class(fmsDiagOutputBuffer_class), pointer :: ptr_diag_buffer_obj !< Pointer to the buffer class
-  class(fmsDiagYamlFilesVar_type), pointer :: ptr_diag_field_yaml !< Pointer to a field from yaml fields
+  class(DiagYamlFilesVar_type), pointer :: ptr_diag_field_yaml !< Pointer to a field from yaml fields
   integer, pointer :: axis_ids(:) !< Pointer to indices of axes of the field variable
 
   ! Determine dimensions of the field

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -866,8 +866,8 @@ subroutine allocate_diag_field_output_buffers(this, field_data, field_id)
   integer :: num_diurnal_samples !< Number of diurnal samples from diag_yaml
   integer, allocatable :: axes_length(:) !< Length of each axis
   integer :: i, j !< For looping
-  class(fmsDiagOutputBufferContainer_type), pointer :: ptr_diag_buffer_obj !< Pointer to the buffer class
-  class(DiagYamlFilesVar_type), pointer :: ptr_diag_field_yaml !< Pointer to a field from yaml fields
+  type(fmsDiagOutputBuffer_class), pointer :: ptr_diag_buffer_obj !< Pointer to the buffer class
+  type(DiagYamlFilesVar_type), pointer :: ptr_diag_field_yaml !< Pointer to a field from yaml fields
   integer, pointer :: axis_ids(:) !< Pointer to indices of axes of the field variable
 
   ! Determine dimensions of the field
@@ -898,32 +898,32 @@ subroutine allocate_diag_field_output_buffers(this, field_data, field_id)
       this%FMS_diag_output_buffers(buffer_id) = fms_diag_output_buffer_create_container(ndims)
     end if
 
-    ptr_diag_buffer_obj => this%FMS_diag_output_buffers(buffer_id)
+    ptr_diag_buffer_obj => this%FMS_diag_output_buffers(buffer_id)%diag_buffer_obj
 
-    select type (ptr_diag_buffer_obj%diag_buffer_obj)
+    select type (ptr_diag_buffer_obj)
       type is (outputBuffer0d_type) !< Scalar buffer
-        if (allocated(ptr_diag_buffer_obj%diag_buffer_obj%buffer)) cycle !< If allocated, loop back
-        ptr_diag_buffer_obj%diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), &
+        if (allocated(ptr_diag_buffer_obj%buffer)) cycle !< If allocated, loop back
+        ptr_diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), &
           this%FMS_diag_fields(field_id)%get_varname())
       type is (outputBuffer1d_type) !< 1D buffer
-        if (allocated(ptr_diag_buffer_obj%diag_buffer_obj%buffer)) cycle !< If allocated, loop back
-        ptr_diag_buffer_obj%diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), axes_length, &
+        if (allocated(ptr_diag_buffer_obj%buffer)) cycle !< If allocated, loop back
+        ptr_diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), axes_length, &
           this%FMS_diag_fields(field_id)%get_varname(), num_diurnal_samples)
       type is (outputBuffer2d_type) !< 2D buffer
-        if (allocated(ptr_diag_buffer_obj%diag_buffer_obj%buffer)) cycle !< If allocated, loop back
-        ptr_diag_buffer_obj%diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), axes_length, &
+        if (allocated(ptr_diag_buffer_obj%buffer)) cycle !< If allocated, loop back
+        ptr_diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), axes_length, &
           this%FMS_diag_fields(field_id)%get_varname(), num_diurnal_samples)
       type is (outputBuffer3d_type) !< 3D buffer
-        if (allocated(ptr_diag_buffer_obj%diag_buffer_obj%buffer)) cycle !< If allocated, loop back
-        ptr_diag_buffer_obj%diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), axes_length, &
+        if (allocated(ptr_diag_buffer_obj%buffer)) cycle !< If allocated, loop back
+        ptr_diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), axes_length, &
           this%FMS_diag_fields(field_id)%get_varname(), num_diurnal_samples)
       type is (outputBuffer4d_type) !< 4D buffer
-        if (allocated(ptr_diag_buffer_obj%diag_buffer_obj%buffer)) cycle !< If allocated, loop back
-        ptr_diag_buffer_obj%diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), axes_length, &
+        if (allocated(ptr_diag_buffer_obj%buffer)) cycle !< If allocated, loop back
+        ptr_diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), axes_length, &
           this%FMS_diag_fields(field_id)%get_varname(), num_diurnal_samples)
       type is (outputBuffer5d_type) !< 5D buffer
-        if (allocated(ptr_diag_buffer_obj%diag_buffer_obj%buffer)) cycle !< If allocated, loop back
-        ptr_diag_buffer_obj%diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), axes_length, &
+        if (allocated(ptr_diag_buffer_obj%buffer)) cycle !< If allocated, loop back
+        ptr_diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), axes_length, &
           this%FMS_diag_fields(field_id)%get_varname(), num_diurnal_samples)
       class default
         call mpp_error( FATAL, 'allocate_diag_field_output_buffers: invalid buffer type')

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -903,7 +903,7 @@ subroutine allocate_diag_field_output_buffers(this, field_data, field_id)
     select type (ptr_diag_buffer_obj)
       type is (outputBuffer0d_type) !< Scalar buffer
         if (allocated(ptr_diag_buffer_obj%buffer)) cycle !< If allocated, loop back
-        this%FMS_diag_output_buffers(buffer_id)%diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), & !< If scalar field variable
+        this%FMS_diag_output_buffers(buffer_id)%diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), &
           this%FMS_diag_fields(field_id)%get_varname())
       type is (outputBuffer1d_type) !< 1D buffer
         if (allocated(ptr_diag_buffer_obj%buffer)) cycle !< If allocated, loop back

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -866,7 +866,7 @@ subroutine allocate_diag_field_output_buffers(this, field_data, field_id)
   integer :: num_diurnal_samples !< Number of diurnal samples from diag_yaml
   integer, allocatable :: axes_length(:) !< Length of each axis
   integer :: i, j !< For looping
-  class(fmsDiagOutputBuffer_class), pointer :: ptr_diag_buffer_obj !< Pointer to the buffer class
+  class(fmsDiagOutputBufferContainer_type), pointer :: ptr_diag_buffer_obj !< Pointer to the buffer class
   class(DiagYamlFilesVar_type), pointer :: ptr_diag_field_yaml !< Pointer to a field from yaml fields
   integer, pointer :: axis_ids(:) !< Pointer to indices of axes of the field variable
 
@@ -898,32 +898,32 @@ subroutine allocate_diag_field_output_buffers(this, field_data, field_id)
       this%FMS_diag_output_buffers(buffer_id) = fms_diag_output_buffer_create_container(ndims)
     end if
 
-    ptr_diag_buffer_obj => this%FMS_diag_output_buffers(buffer_id)%diag_buffer_obj
+    ptr_diag_buffer_obj => this%FMS_diag_output_buffers(buffer_id)
 
-    select type (ptr_diag_buffer_obj)
+    select type (ptr_diag_buffer_obj%diag_buffer_obj)
       type is (outputBuffer0d_type) !< Scalar buffer
-        if (allocated(ptr_diag_buffer_obj%buffer)) cycle !< If allocated, loop back
+        if (allocated(ptr_diag_buffer_obj%diag_buffer_obj%buffer)) cycle !< If allocated, loop back
         ptr_diag_buffer_obj%diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), &
           this%FMS_diag_fields(field_id)%get_varname())
       type is (outputBuffer1d_type) !< 1D buffer
-        if (allocated(ptr_diag_buffer_obj%buffer)) cycle !< If allocated, loop back
-        ptr_diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), axes_length, &
+        if (allocated(ptr_diag_buffer_obj%diag_buffer_obj%buffer)) cycle !< If allocated, loop back
+        ptr_diag_buffer_obj%diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), axes_length, &
           this%FMS_diag_fields(field_id)%get_varname(), num_diurnal_samples)
       type is (outputBuffer2d_type) !< 2D buffer
-        if (allocated(ptr_diag_buffer_obj%buffer)) cycle !< If allocated, loop back
-        ptr_diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), axes_length, &
+        if (allocated(ptr_diag_buffer_obj%diag_buffer_obj%buffer)) cycle !< If allocated, loop back
+        ptr_diag_buffer_obj%diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), axes_length, &
           this%FMS_diag_fields(field_id)%get_varname(), num_diurnal_samples)
       type is (outputBuffer3d_type) !< 3D buffer
-        if (allocated(ptr_diag_buffer_obj%buffer)) cycle !< If allocated, loop back
-        ptr_diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), axes_length, &
+        if (allocated(ptr_diag_buffer_obj%diag_buffer_obj%buffer)) cycle !< If allocated, loop back
+        ptr_diag_buffer_obj%diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), axes_length, &
           this%FMS_diag_fields(field_id)%get_varname(), num_diurnal_samples)
       type is (outputBuffer4d_type) !< 4D buffer
-        if (allocated(ptr_diag_buffer_obj%buffer)) cycle !< If allocated, loop back
-        ptr_diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), axes_length, &
+        if (allocated(ptr_diag_buffer_obj%diag_buffer_obj%buffer)) cycle !< If allocated, loop back
+        ptr_diag_buffer_obj%diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), axes_length, &
           this%FMS_diag_fields(field_id)%get_varname(), num_diurnal_samples)
       type is (outputBuffer5d_type) !< 5D buffer
-        if (allocated(ptr_diag_buffer_obj%buffer)) cycle !< If allocated, loop back
-        ptr_diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), axes_length, &
+        if (allocated(ptr_diag_buffer_obj%diag_buffer_obj%buffer)) cycle !< If allocated, loop back
+        ptr_diag_buffer_obj%diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), axes_length, &
           this%FMS_diag_fields(field_id)%get_varname(), num_diurnal_samples)
       class default
         call mpp_error( FATAL, 'allocate_diag_field_output_buffers: invalid buffer type')

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -903,7 +903,7 @@ subroutine allocate_diag_field_output_buffers(this, field_data, field_id)
     select type (ptr_diag_buffer_obj)
       type is (outputBuffer0d_type) !< Scalar buffer
         if (allocated(ptr_diag_buffer_obj%buffer)) cycle !< If allocated, loop back
-        this%FMS_diag_output_buffers(buffer_id)%diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), &
+        ptr_diag_buffer_obj%diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), &
           this%FMS_diag_fields(field_id)%get_varname())
       type is (outputBuffer1d_type) !< 1D buffer
         if (allocated(ptr_diag_buffer_obj%buffer)) cycle !< If allocated, loop back

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -866,7 +866,7 @@ subroutine allocate_diag_field_output_buffers(this, field_data, field_id)
   integer :: num_diurnal_samples !< Number of diurnal samples from diag_yaml
   integer, allocatable :: axes_length(:) !< Length of each axis
   integer :: i, j !< For looping
-  type(fmsDiagOutputBuffer_class), pointer :: ptr_diag_buffer_obj !< Pointer to the buffer class
+  class(fmsDiagOutputBuffer_class), pointer :: ptr_diag_buffer_obj !< Pointer to the buffer class
   type(DiagYamlFilesVar_type), pointer :: ptr_diag_field_yaml !< Pointer to a field from yaml fields
   integer, pointer :: axis_ids(:) !< Pointer to indices of axes of the field variable
 

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -867,7 +867,7 @@ subroutine allocate_diag_field_output_buffers(this, field_data, field_id)
   integer, allocatable :: axes_length(:) !< Length of each axis
   integer :: i, j !< For looping
   !class(fmsDiagOutputBuffer_class), pointer :: ptr_diag_buffer_obj !< Pointer to the buffer class
-  class(*), pointer :: ptr_diag_buffer_obj !< Pointer to the buffer class
+  !class(*), pointer :: ptr_diag_buffer_obj !< Pointer to the buffer class
   class(DiagYamlFilesVar_type), pointer :: ptr_diag_field_yaml !< Pointer to a field from yaml fields
   integer, pointer :: axis_ids(:) !< Pointer to indices of axes of the field variable
 
@@ -899,9 +899,9 @@ subroutine allocate_diag_field_output_buffers(this, field_data, field_id)
       this%FMS_diag_output_buffers(buffer_id) = fms_diag_output_buffer_create_container(ndims)
     end if
 
-    ptr_diag_buffer_obj => this%FMS_diag_output_buffers(buffer_id)%diag_buffer_obj
+    !ptr_diag_buffer_obj => this%FMS_diag_output_buffers(buffer_id)%diag_buffer_obj
 
-    select type (ptr_diag_buffer_obj)
+    select type (ptr_diag_buffer_obj => this%FMS_diag_output_buffers(buffer_id)%diag_buffer_obj)
       type is (outputBuffer0d_type) !< Scalar buffer
         if (allocated(ptr_diag_buffer_obj%buffer)) cycle !< If allocated, loop back
         ptr_diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), & !< If scalar field variable

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -893,7 +893,7 @@ subroutine allocate_diag_field_output_buffers(this, field_data, field_id)
 
     ! Allocate diag_buffer_obj, if it is not allocated.
     if (.not. allocated(this%FMS_diag_output_buffers(buffer_id)%diag_buffer_obj)) then
-      this%FMS_diag_output_buffers(buffer_id)%diag_buffer_obj = fms_diag_output_buffer_create_container(ndims)
+      this%FMS_diag_output_buffers(buffer_id) = fms_diag_output_buffer_create_container(ndims)
     end if
 
     ptr_diag_buffer_obj => this%FMS_diag_output_buffers(buffer_id)%diag_buffer_obj
@@ -902,27 +902,27 @@ subroutine allocate_diag_field_output_buffers(this, field_data, field_id)
       type is (outputBuffer0d_type) !< Scalar buffer
         if (allocated(ptr_diag_buffer_obj%buffer)) cycle !< If allocated, loop back
         ptr_diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), & !< If scalar field variable
-          this%FMS_diag_fields(field_id)%varname)
+          this%FMS_diag_fields(field_id)%get_varname())
       type is (outputBuffer1d_type) !< 1D buffer
         if (allocated(ptr_diag_buffer_obj%buffer)) cycle !< If allocated, loop back
         ptr_diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), axes_length, &
-          this%FMS_diag_fields(field_id)%varname, num_diurnal_samples)
+          this%FMS_diag_fields(field_id)%get_varname(), num_diurnal_samples)
       type is (outputBuffer2d_type) !< 2D buffer
         if (allocated(ptr_diag_buffer_obj%buffer)) cycle !< If allocated, loop back
         ptr_diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), axes_length, &
-          this%FMS_diag_fields(field_id)%varname, num_diurnal_samples)
+          this%FMS_diag_fields(field_id)%get_varname(), num_diurnal_samples)
       type is (outputBuffer3d_type) !< 3D buffer
         if (allocated(ptr_diag_buffer_obj%buffer)) cycle !< If allocated, loop back
         ptr_diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), axes_length, &
-          this%FMS_diag_fields(field_id)%varname, num_diurnal_samples)
+          this%FMS_diag_fields(field_id)%get_varname(), num_diurnal_samples)
       type is (outputBuffer4d_type) !< 4D buffer
         if (allocated(ptr_diag_buffer_obj%buffer)) cycle !< If allocated, loop back
         ptr_diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), axes_length, &
-          this%FMS_diag_fields(field_id)%varname, num_diurnal_samples)
+          this%FMS_diag_fields(field_id)%get_varname(), num_diurnal_samples)
       type is (outputBuffer5d_type) !< 5D buffer
         if (allocated(ptr_diag_buffer_obj%buffer)) cycle !< If allocated, loop back
         ptr_diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), axes_length, &
-          this%FMS_diag_fields(field_id)%varname, num_diurnal_samples)
+          this%FMS_diag_fields(field_id)%get_varname(), num_diurnal_samples)
       class default
         call mpp_error( FATAL, 'allocate_diag_field_output_buffers: invalid buffer type')
     end select

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -866,8 +866,7 @@ subroutine allocate_diag_field_output_buffers(this, field_data, field_id)
   integer :: num_diurnal_samples !< Number of diurnal samples from diag_yaml
   integer, allocatable :: axes_length(:) !< Length of each axis
   integer :: i, j !< For looping
-  !class(fmsDiagOutputBuffer_class), pointer :: ptr_diag_buffer_obj !< Pointer to the buffer class
-  !class(*), pointer :: ptr_diag_buffer_obj !< Pointer to the buffer class
+  class(fmsDiagOutputBuffer_class), pointer :: ptr_diag_buffer_obj !< Pointer to the buffer class
   class(DiagYamlFilesVar_type), pointer :: ptr_diag_field_yaml !< Pointer to a field from yaml fields
   integer, pointer :: axis_ids(:) !< Pointer to indices of axes of the field variable
 
@@ -899,9 +898,9 @@ subroutine allocate_diag_field_output_buffers(this, field_data, field_id)
       this%FMS_diag_output_buffers(buffer_id) = fms_diag_output_buffer_create_container(ndims)
     end if
 
-    !ptr_diag_buffer_obj => this%FMS_diag_output_buffers(buffer_id)%diag_buffer_obj
+    ptr_diag_buffer_obj => this%FMS_diag_output_buffers(buffer_id)%diag_buffer_obj
 
-    select type (ptr_diag_buffer_obj => this%FMS_diag_output_buffers(buffer_id)%diag_buffer_obj)
+    select type (ptr_diag_buffer_obj)
       type is (outputBuffer0d_type) !< Scalar buffer
         if (allocated(ptr_diag_buffer_obj%buffer)) cycle !< If allocated, loop back
         ptr_diag_buffer_obj%allocate_buffer(field_data(1, 1, 1, 1), & !< If scalar field variable

--- a/diag_manager/fms_diag_output_buffer.F90
+++ b/diag_manager/fms_diag_output_buffer.F90
@@ -143,6 +143,7 @@ public :: fmsDiagOutputBufferContainer_type
 
 ! public routines
 public :: fms_diag_output_buffer_init
+public :: fms_diag_output_buffer_create_container
 
 contains
 


### PR DESCRIPTION
**Description**
The Update adds member routine, _allocate_diag_field_output_buffers_, to _fmsDiagObject_type_ which allocates output buffers of fields corresponding to the registered variable.

Fixes # (issue)
CI

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes. Please also note
any relevant details for your test configuration (e.g. compiler, OS).  Include
enough information so someone can reproduce your tests.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

