### PR TITLE
Adds real_copy_set() to fms_diag_object_mod

### DIFF
--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -39,6 +39,7 @@ use fms_diag_output_buffer_mod
 use omp_lib
 #endif
 use mpp_domains_mod, only: domain1d, domain2d, domainUG, null_domain2d
+use platform_mod
 implicit none
 private
 

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -97,6 +97,7 @@ public :: fms_diag_object
 public :: fmsDiagObject_type
 integer, private :: registered_variables !< Number of registered variables
 public :: dump_diag_obj
+public :: real_copy_set
 
 contains
 
@@ -465,9 +466,15 @@ logical function fms_diag_accept_data (this, diag_field_id, field_data, time, is
   integer :: omp_level !< The openmp active level
   logical :: buffer_the_data !< True if the user selects to buffer the data and run the calculations
                              !! later.  \note This is experimental
+  real :: l_weight !< Local copy of input weight
+
 #ifndef use_yaml
 CALL MPP_ERROR(FATAL,"You can not use the modern diag manager without compiling with -Duse_yaml")
 #else
+
+  ! weight is for time averaging where each time level may have a different weight
+  call real_copy_set(l_weight, weight, 1.0)
+
 !> Does the user want to push off calculations until send_diag_complete?
   buffer_the_data = .false.
 !> initialize the number of threads and level to be 0
@@ -872,4 +879,27 @@ subroutine dump_diag_obj( filename )
   call mpp_error( FATAL, "You can not use the modern diag manager without compiling with -Duse_yaml")
 #endif
 end subroutine
+
+!> @brief Copies input data to output data with proper type if the input data is present
+!! else sets the output data to a given value val if it is present.
+!! If the value val and the input data are not present, the output data is untouched.
+subroutine real_copy_set(out_data, in_data, val)
+  real, intent(out) :: out_data !< Proper type copy of in_data
+  class(*), intent(in), optional :: in_data !< Data to copy to out_data
+  real, intent(in), optional :: val !< Default value to assign to out_data if in_data absent
+
+  IF ( PRESENT(in_data) ) THEN
+    SELECT TYPE (in_data)
+    TYPE IS (real(kind=r4_kind))
+      out_data = in_data
+    TYPE IS (real(kind=r8_kind))
+      out_data = real(in_data)
+    CLASS DEFAULT
+      CALL mpp_error('fms_diag_object_mod:real_copy_set',&
+        & 'The weight is not one of the supported types of real(kind=4) or real(kind=8)', FATAL)
+    END SELECT
+  ELSE
+    if (present(val)) out_data = val
+  END IF
+end subroutine real_copy_set
 end module fms_diag_object_mod


### PR DESCRIPTION
**Description**
This update adds a routine _real_copy_set()_ to the _fms_diag_object_mod_ which copies input data to output data or sets the output data to a given real value if the input data is not present. The routine is implemented in the _fms_diag_accept_data()_ to initialize local copy of weight to the user supplied weight (_r4_kind_ or _r8_kind_) if it is present else set to a given value _val_.

Fixes # (issue)

**How Has This Been Tested?**
CI
**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

