### PR TITLE
mixed mode intel 2022.2.1 allocation bug fix

### DIFF
--- a/horiz_interp/horiz_interp_bicubic.F90
+++ b/horiz_interp/horiz_interp_bicubic.F90
@@ -151,14 +151,16 @@ module horiz_interp_bicubic_mod
       if(allocated(Interp%horizInterpReals8_type%lon_in)) deallocate ( Interp%horizInterpReals8_type%lon_in )
       if(allocated(Interp%horizInterpReals8_type%lat_in)) deallocate ( Interp%horizInterpReals8_type%lat_in )
       if(allocated(Interp%horizInterpReals8_type%wti))    deallocate ( Interp%horizInterpReals8_type%wti )
-      deallocate(Interp%horizInterpReals8_type)
+      !! double check allocated for bug
+      if(allocated(Interp%horizInterpReals8_type))        deallocate (Interp%horizInterpReals8_type)
     else if(allocated(Interp%horizInterpReals4_type)) then
       if(allocated(Interp%horizInterpReals4_type%rat_x))  deallocate ( Interp%horizInterpReals4_type%rat_x )
       if(allocated(Interp%horizInterpReals4_type%rat_y))  deallocate ( Interp%horizInterpReals4_type%rat_y )
       if(allocated(Interp%horizInterpReals4_type%lon_in)) deallocate ( Interp%horizInterpReals4_type%lon_in )
       if(allocated(Interp%horizInterpReals4_type%lat_in)) deallocate ( Interp%horizInterpReals4_type%lat_in )
       if(allocated(Interp%horizInterpReals4_type%wti))    deallocate ( Interp%horizInterpReals4_type%wti )
-      deallocate(Interp%horizInterpReals4_type)
+      !! double check allocated for bug
+      if(allocated(Interp%horizInterpReals4_type))        deallocate (Interp%horizInterpReals4_type)
     endif
     if( allocated(Interp%i_lon) ) deallocate( Interp%i_lon )
     if( allocated(Interp%j_lat) ) deallocate( Interp%j_lat )

--- a/horiz_interp/horiz_interp_bilinear.F90
+++ b/horiz_interp/horiz_interp_bilinear.F90
@@ -103,11 +103,11 @@ contains
     if( allocated(Interp%horizInterpReals4_type)) then
       if(allocated(Interp%horizInterpReals4_type%wti))   deallocate(Interp%horizInterpReals4_type%wti)
       if(allocated(Interp%horizInterpReals4_type%wtj))   deallocate(Interp%horizInterpReals4_type%wtj)
-      deallocate(Interp%horizInterpReals4_type)
+      if(allocated(Interp%horizInterpReals4_type))       deallocate(Interp%horizInterpReals4_type)
     else if (allocated(Interp%horizInterpReals8_type)) then
       if(allocated(Interp%horizInterpReals8_type%wti))   deallocate(Interp%horizInterpReals8_type%wti)
       if(allocated(Interp%horizInterpReals8_type%wtj))   deallocate(Interp%horizInterpReals8_type%wtj)
-      deallocate(Interp%horizInterpReals8_type)
+      if(allocated(Interp%horizInterpReals8_type))       deallocate(Interp%horizInterpReals8_type)
     endif
     if(allocated(Interp%i_lon)) deallocate(Interp%i_lon)
     if(allocated(Interp%j_lat)) deallocate(Interp%j_lat)

--- a/horiz_interp/horiz_interp_conserve.F90
+++ b/horiz_interp/horiz_interp_conserve.F90
@@ -162,7 +162,7 @@ contains
     type (horiz_interp_type), intent(inout) :: Interp !< A derived-type variable returned by
                          !! previous call to horiz_interp_new. The input variable must have
                          !! allocated arrays. The returned variable will contain deallocated arrays.
-
+    !$OMP SINGLE
     select case(Interp%version)
     case (1)
       if( allocated( Interp%horizInterpReals8_type)) then
@@ -199,12 +199,13 @@ contains
         if(allocated(Interp%j_src))                           deallocate(Interp%j_src)
         if(allocated(Interp%i_dst))                           deallocate(Interp%i_dst)
         if(allocated(Interp%j_dst))                           deallocate(Interp%j_dst)
-        !! double checks still allocated for bug
-        if(allocated(Interp%horizInterpReals4_type))          deallocate(Interp%horizInterpReals8_type)
         if(allocated(Interp%horizInterpReals4_type%area_frac_dst)) &
             deallocate(Interp%horizInterpReals4_type%area_frac_dst)
+        !! double checks still allocated for bug
+        if(allocated(Interp%horizInterpReals4_type))          deallocate(Interp%horizInterpReals4_type)
        endif
     end select
+    !$OMP END SINGLE
 
   end subroutine horiz_interp_conserve_del
 

--- a/horiz_interp/horiz_interp_conserve.F90
+++ b/horiz_interp/horiz_interp_conserve.F90
@@ -169,36 +169,40 @@ contains
         if(allocated(Interp%horizInterpReals8_type%area_src)) deallocate(Interp%horizInterpReals8_type%area_src)
         if(allocated(Interp%horizInterpReals8_type%area_dst)) deallocate(Interp%horizInterpReals8_type%area_dst)
         if(allocated(Interp%horizInterpReals8_type%facj))     deallocate(Interp%horizInterpReals8_type%facj)
-        if(allocated(Interp%jlat))                 deallocate(Interp%jlat)
         if(allocated(Interp%horizInterpReals8_type%faci))     deallocate(Interp%horizInterpReals8_type%faci)
-        if(allocated(Interp%ilon))                 deallocate(Interp%ilon)
-        deallocate(Interp%horizInterpReals8_type)
+        !! double checks still allocated for bug
+        if(allocated(Interp%horizInterpReals8_type))          deallocate(Interp%horizInterpReals8_type)
+        if(allocated(Interp%ilon))                            deallocate(Interp%ilon)
+        if(allocated(Interp%jlat))                            deallocate(Interp%jlat)
       else if( allocated( Interp%horizInterpReals4_type)) then
         if(allocated(Interp%horizInterpReals4_type%area_src)) deallocate(Interp%horizInterpReals4_type%area_src)
         if(allocated(Interp%horizInterpReals4_type%area_dst)) deallocate(Interp%horizInterpReals4_type%area_dst)
         if(allocated(Interp%horizInterpReals4_type%facj))     deallocate(Interp%horizInterpReals4_type%facj)
-        if(allocated(Interp%jlat))                 deallocate(Interp%jlat)
         if(allocated(Interp%horizInterpReals4_type%faci))     deallocate(Interp%horizInterpReals4_type%faci)
-        if(allocated(Interp%ilon))                 deallocate(Interp%ilon)
-        deallocate(Interp%horizInterpReals4_type)
+        !! double checks still allocated for bug
+        if(allocated(Interp%horizInterpReals4_type))          deallocate(Interp%horizInterpReals4_type)
+        if(allocated(Interp%jlat))                            deallocate(Interp%jlat)
+        if(allocated(Interp%ilon))                            deallocate(Interp%ilon)
       endif
     case (2)
       if( allocated( Interp%horizInterpReals8_type)) then
-        if(allocated(Interp%i_src)) deallocate(Interp%i_src)
-        if(allocated(Interp%j_src)) deallocate(Interp%j_src)
-        if(allocated(Interp%i_dst)) deallocate(Interp%i_dst)
-        if(allocated(Interp%j_dst)) deallocate(Interp%j_dst)
+        if(allocated(Interp%i_src))                           deallocate(Interp%i_src)
+        if(allocated(Interp%j_src))                           deallocate(Interp%j_src)
+        if(allocated(Interp%i_dst))                           deallocate(Interp%i_dst)
+        if(allocated(Interp%j_dst))                           deallocate(Interp%j_dst)
+        !! double checks still allocated for bug
+        if(allocated(Interp%horizInterpReals8_type))          deallocate(Interp%horizInterpReals8_type)
         if(allocated(Interp%horizInterpReals8_type%area_frac_dst)) &
             deallocate(Interp%horizInterpReals8_type%area_frac_dst)
-        deallocate(Interp%horizInterpReals8_type)
       else if( allocated( Interp%horizInterpReals4_type)) then
-        if(allocated(Interp%i_src)) deallocate(Interp%i_src)
-        if(allocated(Interp%j_src)) deallocate(Interp%j_src)
-        if(allocated(Interp%i_dst)) deallocate(Interp%i_dst)
-        if(allocated(Interp%j_dst)) deallocate(Interp%j_dst)
+        if(allocated(Interp%i_src))                           deallocate(Interp%i_src)
+        if(allocated(Interp%j_src))                           deallocate(Interp%j_src)
+        if(allocated(Interp%i_dst))                           deallocate(Interp%i_dst)
+        if(allocated(Interp%j_dst))                           deallocate(Interp%j_dst)
+        !! double checks still allocated for bug
+        if(allocated(Interp%horizInterpReals4_type))          deallocate(Interp%horizInterpReals8_type)
         if(allocated(Interp%horizInterpReals4_type%area_frac_dst)) &
             deallocate(Interp%horizInterpReals4_type%area_frac_dst)
-        deallocate(Interp%horizInterpReals4_type)
        endif
     end select
 

--- a/horiz_interp/horiz_interp_spherical.F90
+++ b/horiz_interp/horiz_interp_spherical.F90
@@ -135,10 +135,12 @@ contains
 
     if(allocated(Interp%horizInterpReals4_type)) then
       if(allocated(Interp%horizInterpReals4_type%src_dist)) deallocate(Interp%horizInterpReals4_type%src_dist)
-      deallocate(Interp%horizInterpReals4_type)
+      !! double check allocated for bug
+      if(allocated(Interp%horizInterpReals4_type))          deallocate(Interp%horizInterpReals4_type)
     else if (allocated(Interp%horizInterpReals8_type)) then
       if(allocated(Interp%horizInterpReals8_type%src_dist)) deallocate(Interp%horizInterpReals8_type%src_dist)
-      deallocate(Interp%horizInterpReals8_type)
+      !! double check allocated for bug
+      if(allocated(Interp%horizInterpReals8_type))          deallocate(Interp%horizInterpReals8_type)
     endif
     if(allocated(Interp%num_found)) deallocate(Interp%num_found)
     if(allocated(Interp%i_lon))     deallocate(Interp%i_lon)


### PR DESCRIPTION
**Description**
adds a second allocation checks for horiz_interp_Type's deletion routines. This is to fix a bug causing an error on the real types deallocation call, might be system related or just the compiler/mpi.

**How Has This Been Tested?**
CI

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

