### PR TITLE
Adds a function, check_indices_order(), to diag_util_mod

### DIFF
--- a/diag_manager/diag_util.F90
+++ b/diag_manager/diag_util.F90
@@ -86,7 +86,7 @@ use,intrinsic :: iso_c_binding, only: c_double,c_float,c_int64_t, &
        & prepend_attribute, attribute_init, diag_util_init,&
        & fms_diag_check_out_of_bounds, &
        & fms_diag_check_bounds_are_exact_dynamic, fms_diag_check_bounds_are_exact_static,&
-       & get_time_string
+       & get_time_string, check_indices_order
 
 
   !> @brief Prepend a value to a string attribute in the output field or output file.
@@ -2498,6 +2498,55 @@ END SUBROUTINE check_bounds_are_exact_dynamic
        out_file%attributes(this_attribute)%len = length
     END IF
   END SUBROUTINE prepend_attribute_file
+
+  !> @brief Checks improper combinations of is, ie, js, and je.
+  !> @return Returns .false. if there is no error else .true.
+  !> @note send_data works in either one or another of two modes.
+  ! 1. Input field is a window (e.g. FMS physics)
+  ! 2. Input field includes halo data
+  ! It cannot handle a window of data that has halos.
+  ! (A field with no windows or halos can be thought of as a special case of either mode.)
+  ! The logic for indexing is quite different for these two modes, but is not clearly separated.
+  ! If both the beggining and ending indices are present, then field is assumed to have halos.
+  ! If only beggining indices are present, then field is assumed to be a window.
+  !> @par
+  ! There are a number of ways a user could mess up this logic, depending on the combination
+  ! of presence/absence of is,ie,js,je. The checks below should catch improper combinations.
+  function check_indices_order(is_in, ie_in, js_in, je_in, error_msg) result(rslt)
+    integer, intent(in), optional :: is_in, ie_in, js_in, je_in !< Indices passed to fms_diag_accept_data()
+    character(len=*), intent(inout), optional :: error_msg !< An error message used only for testing purpose!!!
+
+    character(len=128) :: err_module_name !< Stores the module name to be used in error calls
+    logical :: rslt !< Return value
+
+    rslt = .false. !< If no error occurs.
+
+    err_module_name = 'fms_diag_object_mod:fms_diag_check_indices_order'
+
+    IF ( PRESENT(ie_in) ) THEN
+      IF ( .NOT.PRESENT(is_in) ) THEN
+        rslt = fms_error_handler(trim(err_module_name), 'ie_in present without is_in', error_msg)
+        IF (rslt) return
+      END IF
+      IF ( PRESENT(js_in) .AND. .NOT.PRESENT(je_in) ) THEN
+        rslt = fms_error_handler(trim(err_module_name),&
+          & 'is_in and ie_in present, but js_in present without je_in', err_msg)
+        IF (rslt) return
+      END IF
+    END IF
+
+    IF ( PRESENT(je_in) ) THEN
+      IF ( .NOT.PRESENT(js_in) ) THEN
+        rslt = fms_error_handler(trim(err_module_name), 'je_in present without js_in', err_msg)
+        IF (rslt) return
+      END IF
+      IF ( PRESENT(is_in) .AND. .NOT.PRESENT(ie_in) ) THEN
+        rslt = fms_error_handler(trim(err_module_name),&
+          & 'js_in and je_in present, but is_in present without ie_in', err_msg)
+        IF (rslt) return
+      END IF
+    END IF
+  end function check_indices_order
 
 END MODULE diag_util_mod
 !> @}

--- a/diag_manager/diag_util.F90
+++ b/diag_manager/diag_util.F90
@@ -2521,7 +2521,7 @@ END SUBROUTINE check_bounds_are_exact_dynamic
 
     rslt = .false. !< If no error occurs.
 
-    err_module_name = 'fms_diag_object_mod:fms_diag_check_indices_order'
+    err_module_name = 'diag_util_mod:check_indices_order'
 
     IF ( PRESENT(ie_in) ) THEN
       IF ( .NOT.PRESENT(is_in) ) THEN
@@ -2530,19 +2530,19 @@ END SUBROUTINE check_bounds_are_exact_dynamic
       END IF
       IF ( PRESENT(js_in) .AND. .NOT.PRESENT(je_in) ) THEN
         rslt = fms_error_handler(trim(err_module_name),&
-          & 'is_in and ie_in present, but js_in present without je_in', err_msg)
+          & 'is_in and ie_in present, but js_in present without je_in', error_msg)
         IF (rslt) return
       END IF
     END IF
 
     IF ( PRESENT(je_in) ) THEN
       IF ( .NOT.PRESENT(js_in) ) THEN
-        rslt = fms_error_handler(trim(err_module_name), 'je_in present without js_in', err_msg)
+        rslt = fms_error_handler(trim(err_module_name), 'je_in present without js_in', error_msg)
         IF (rslt) return
       END IF
       IF ( PRESENT(is_in) .AND. .NOT.PRESENT(ie_in) ) THEN
         rslt = fms_error_handler(trim(err_module_name),&
-          & 'js_in and je_in present, but is_in present without ie_in', err_msg)
+          & 'js_in and je_in present, but is_in present without ie_in', error_msg)
         IF (rslt) return
       END IF
     END IF

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -34,6 +34,7 @@ use fms_diag_axis_object_mod, only: fms_diag_axis_object_init, fmsDiagAxis_type,
                                    &fmsDiagAxisContainer_type, fms_diag_axis_object_end, fmsDiagFullAxis_type, &
                                    &parse_compress_att, get_axis_id_from_name
 use fms_diag_output_buffer_mod
+use fms_mod, only: fms_error_handler
 #endif
 #if defined(_OPENMP)
 use omp_lib
@@ -97,6 +98,7 @@ public :: fms_diag_object
 public :: fmsDiagObject_type
 integer, private :: registered_variables !< Number of registered variables
 public :: dump_diag_obj
+public :: fms_diag_check_indices_order
 
 contains
 
@@ -465,9 +467,19 @@ logical function fms_diag_accept_data (this, diag_field_id, field_data, time, is
   integer :: omp_level !< The openmp active level
   logical :: buffer_the_data !< True if the user selects to buffer the data and run the calculations
                              !! later.  \note This is experimental
+  !TODO logical, allocatable, dimension(:,:,:) :: oor_mask !< Out of range mask
 #ifndef use_yaml
 CALL MPP_ERROR(FATAL,"You can not use the modern diag manager without compiling with -Duse_yaml")
 #else
+  !TODO: weight is for time averaging where each time level may have a different weight
+  ! call real_copy_set()
+
+  !TODO: oor_mask is only used for checking out of range values.
+  ! call init_mask_3d()
+
+  !TODO: Check improper combinations of is, ie, js, and je.
+  ! if (check_indices_order()) deallocate(oor_mask)
+
 !> Does the user want to push off calculations until send_diag_complete?
   buffer_the_data = .false.
 !> initialize the number of threads and level to be 0

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -98,7 +98,6 @@ public :: fms_diag_object
 public :: fmsDiagObject_type
 integer, private :: registered_variables !< Number of registered variables
 public :: dump_diag_obj
-public :: fms_diag_check_indices_order
 
 contains
 


### PR DESCRIPTION
**Description**
Adds a public function _check_indices_order()_ to the _diag_util_mod_ which checks improper combinations of indices _is_, _ie_, _js_, and _je_ passed by users in subroutines _send_data_nd()_ (n=0, 1, 2, 3), and _diag_send_data()_. This update also includes _TODO_ lists in _fms_diag_accept_data()_.

Fixes # (issue)
CI

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes. Please also note
any relevant details for your test configuration (e.g. compiler, OS).  Include
enough information so someone can reproduce your tests.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

