### PR TITLE
Initializes buffer_ids and buffer_allocated

### DIFF
--- a/diag_manager/fms_diag_field_object.F90
+++ b/diag_manager/fms_diag_field_object.F90
@@ -75,6 +75,9 @@ type fmsDiagField_type
                                                                            !! been allocated
      logical, allocatable, private                    :: math_needs_to_be_done !< If true, do math
                                                                            !! functions. False when done.
+     logical, allocatable, dimension(:)               :: buffer_allocated  !< True if a buffer pointed by
+                                                                           !! the corresponding index in
+                                                                           !! buffer_ids(:) is allocated.
   contains
 !     procedure :: send_data => fms_send_data  !!TODO
 ! Get ID functions

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -28,7 +28,7 @@ use diag_data_mod,  only: diag_null, diag_not_found, diag_not_registered, diag_r
 use fms_diag_file_object_mod, only: fmsDiagFileContainer_type, fmsDiagFile_type, fms_diag_files_object_init
 use fms_diag_field_object_mod, only: fmsDiagField_type, fms_diag_fields_object_init
 use fms_diag_yaml_mod, only: diag_yaml_object_init, diag_yaml_object_end, find_diag_field, &
-                           & get_diag_files_id, diag_yaml
+                           & get_diag_files_id, diag_yaml, get_diag_field_ids
 use fms_diag_axis_object_mod, only: fms_diag_axis_object_init, fmsDiagAxis_type, fmsDiagSubAxis_type, &
                                    &diagDomain_t, get_domain_and_domain_type, diagDomain2d_t, &
                                    &fmsDiagAxisContainer_type, fms_diag_axis_object_end, fmsDiagFullAxis_type, &
@@ -214,6 +214,15 @@ CALL MPP_ERROR(FATAL,"You can not use the modern diag manager without compiling 
 
 !> Use pointers for convenience
   fieldptr => this%FMS_diag_fields(this%registered_variables)
+
+!> Initialize buffer_ids of this field with the diag_field_indices(diag_field_indices)
+!! of the sorted variable list
+  fieldptr%buffer_ids = get_diag_field_ids(diag_field_indices)
+
+!> Allocate and initialize member buffer_allocated of this field
+  allocate(fieldptr%buffer_allocated(size(diag_field_indices)))
+  fieldptr%buffer_allocated = .false.
+
 !> Register the data for the field
   call fieldptr%register(modname, varname, diag_field_indices, this%diag_axis, &
        axes=axes, longname=longname, units=units, missing_value=missing_value, varRange= varRange, &


### PR DESCRIPTION
**Description**
Adds a member _buffer_allocated_ to _fmsDiagField_type_. Each registered field initializes its members _buffer_ids_ and _buffer_allocated_ when unique field variables are registered within a call to _fms_register_diag_field_obj()_.

Fixes # (issue)
CI

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes. Please also note
any relevant details for your test configuration (e.g. compiler, OS).  Include
enough information so someone can reproduce your tests.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

