### PR TITLE
Adds a routine fms_diag_check_out_of_range_value to fmsDiagObject_type

### DIFF
--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -1044,8 +1044,6 @@ subroutine fms_diag_check_out_of_range_value(this, field_data, field_id, oor_mas
   integer, allocatable :: int_field(:,:,:,:)
   logical, allocatable :: oor_mask_4d(:,:,:,:) !< Copy of the input out of range mask to remove incompatibility
                                                !! in ranks when masking with the input field data (4d)
-  integer :: int_test(2)
-  real :: real_test(2)
 
   err_module_name = 'fms_diag_object_mod:fms_diag_check_out_of_range_value'
 

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -28,7 +28,7 @@ use diag_data_mod,  only: diag_null, diag_not_found, diag_not_registered, diag_r
        & get_ticks_per_second
 #ifdef use_yaml
 use fms_diag_file_object_mod, only: fmsDiagFileContainer_type, fmsDiagFile_type, fms_diag_files_object_init
-use fms_diag_field_object_mod, only: fmsDiagField_type, fms_diag_fields_object_init, get_default_missing_value &
+use fms_diag_field_object_mod, only: fmsDiagField_type, fms_diag_fields_object_init, get_default_missing_value, &
                                     & has_missing_value
 use fms_diag_yaml_mod, only: diag_yaml_object_init, diag_yaml_object_end, find_diag_field, &
                            & get_diag_files_id, diag_yaml, DiagYamlFilesVar_type
@@ -86,9 +86,9 @@ private
     procedure :: fms_diag_do_io
     procedure :: fms_diag_field_add_cell_measures
     procedure :: allocate_diag_field_output_buffers
+    procedure :: fms_diag_check_out_of_range_value
 #ifdef use_yaml
     procedure :: get_diag_buffer
-    procedure :: fms_diag_check_out_of_range_value
 #endif
 end type fmsDiagObject_type
 
@@ -1100,12 +1100,12 @@ subroutine fms_diag_check_out_of_range_value(this, field_data, field_id, oor_mas
   IF ( this%FMS_diag_fields(field_id)%has_data_RANGE() ) THEN
     IF ( ISSUE_OOR_WARNINGS .OR. OOR_WARNINGS_FATAL ) THEN
       select type (l_data_range)
-        type is (real*)
+        type is (real)
           WRITE (error_string, '("[",ES14.5E3,",",ES14.5E3,"]")') l_data_range
           WRITE (error_string2, '("(Min: ",ES14.5E3,", Max: ",ES14.5E3, ")")')&
             & MINVAL(field_data(fis:fie, fjs:fje, ks:ke, 1:1),MASK=oor_mask(fis:fie, fjs:fje, ks:ke)),&
             & MAXVAL(field_data(fis:fie, fjs:fje, ks:ke, 1:1),MASK=oor_mask(fis:fie, fjs:fje, ks:ke))
-        type is (integer*)
+        type is (integer)
           WRITE (error_string, '("[",ES14,",",ES14,"]")') l_data_range
           WRITE (error_string2, '("(Min: ",ES14,", Max: ",ES14, ")")')&
             & MINVAL(field_data(fis:fie, fjs:fje, ks:ke, 1:1),MASK=oor_mask(fis:fie, fjs:fje, ks:ke)),&

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -1094,12 +1094,12 @@ subroutine fms_diag_check_out_of_range_value(this, field_data, field_id, oor_mas
   IF ( this%FMS_diag_fields(field_id)%has_data_RANGE() ) THEN
     IF ( ISSUE_OOR_WARNINGS .OR. OOR_WARNINGS_FATAL ) THEN
       select type (l_data_range)
-        type is (real)
+        type is (real(kind=r4_kind) .or. real(kind=r8_kind))
           WRITE (error_string, '("[",ES14.5E3,",",ES14.5E3,"]")') l_data_range
           WRITE (error_string2, '("(Min: ",ES14.5E3,", Max: ",ES14.5E3, ")")')&
             & MINVAL(field_data(fis:fie, fjs:fje, ks:ke, 1:1),MASK=oor_mask(fis:fie, fjs:fje, ks:ke)),&
             & MAXVAL(field_data(fis:fie, fjs:fje, ks:ke, 1:1),MASK=oor_mask(fis:fie, fjs:fje, ks:ke))
-        type is (integer)
+        type is (integer(kind=i4_kind) .or. integer(kind=i8_kind))
           WRITE (error_string, '("[",I14,",",I14,"]")') l_data_range
           WRITE (error_string2, '("(Min: ",I14,", Max: ",I14, ")")')&
             & MINVAL(field_data(fis:fie, fjs:fje, ks:ke, 1:1),MASK=oor_mask(fis:fie, fjs:fje, ks:ke)),&

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -1033,8 +1033,8 @@ subroutine fms_diag_check_out_of_range_value(this, field_data, field_id, oor_mas
   integer, intent(in) :: fie, fje, ke !< End indices
 #ifdef use_yaml
   logical :: has_missvalue !< .true. if the field has missing value
-  real :: real_missing_value
-  integer :: int_missing_value
+  real, allocatable :: real_missing_value
+  integer, allocatable :: int_missing_value
   integer :: field_var_type !< Type of field data
   character(len=128) :: error_string, error_string2
   real, allocatable :: real_data_range(:)

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -1054,15 +1054,15 @@ subroutine fms_diag_check_out_of_range_value(this, field_data, field_id, oor_mas
   field_var_type = this%FMS_diag_fields(field_id)%get_vartype()
 
   ! Copy field data to proper type variables
-  select type (field_data(1,1,1,1))
+  select type (ftype => field_data(1,1,1,1))
   type is (real(kind=r4_kind))
-    real_field = real(field_data, kind=r4_kind)
+    real_field = real(ftype, kind=r4_kind)
   type is (real(kind=r8_kind))
-    real_field = real(field_data, kind=r8_kind)
+    real_field = real(ftype, kind=r8_kind)
   type is (integer(kind=i4_kind))
-    int_field = int(field_data, kind=i4_kind)
+    int_field = int(ftype, kind=i4_kind)
   type is (integer(kind=i8_kind))
-    int_field = int(field_data, kind=i8_kind)
+    int_field = int(ftype, kind=i8_kind)
   class default
     call mpp_error( FATAL, err_module_name//' Invalid type')
   end select

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -36,7 +36,7 @@ use fms_diag_axis_object_mod, only: fms_diag_axis_object_init, fmsDiagAxis_type,
                                    &fmsDiagAxisContainer_type, fms_diag_axis_object_end, fmsDiagFullAxis_type, &
                                    &parse_compress_att, get_axis_id_from_name
 use fms_diag_output_buffer_mod
-use fms_mod, only: fms_error_handler
+use fms_mod, only: fms_error_handler, error_mesg
 #endif
 #if defined(_OPENMP)
 use omp_lib

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -1116,7 +1116,7 @@ subroutine fms_diag_check_out_of_range_value(this, field_data, field_id, oor_mas
   ! Issue a warning if any value in field is outside the valid range
   IF ( this%FMS_diag_fields(field_id)%has_data_RANGE() ) THEN
     IF ( ISSUE_OOR_WARNINGS .OR. OOR_WARNINGS_FATAL ) THEN
-      if (field_var_type .eq. r4 .or. field_var_type .eq. r8) then
+      if ((field_var_type .eq. r4) .or. (field_var_type .eq. r8)) then
         WRITE (error_string, '("[",ES14.5E3,",",ES14.5E3,"]")') real_data_range
         WRITE (error_string2, '("(Min: ",ES14.5E3,", Max: ",ES14.5E3, ")")')&
           & MINVAL(real_field(fis:fie, fjs:fje, ks:ke, 1:1),MASK=oor_mask_4d(fis:fie, fjs:fje, ks:ke, 1:1)),&
@@ -1158,7 +1158,7 @@ subroutine fms_diag_check_out_of_range_value(this, field_data, field_id, oor_mas
           END IF
         END IF
       else
-        if (field_var_type .eq. i4 .or. field_var_type .eq. i8) then
+        if ((field_var_type .eq. i4) .or. (field_var_type .eq. i8)) then
           WRITE (error_string, '("[",I14,",",I14,"]")') int_data_range
           WRITE (error_string2, '("(Min: ",I14,", Max: ",I14, ")")')&
             & MINVAL(int_field(fis:fie, fjs:fje, ks:ke, 1:1),MASK=oor_mask_4d(fis:fie, fjs:fje, ks:ke, 1:1)),&

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -1044,6 +1044,8 @@ subroutine fms_diag_check_out_of_range_value(this, field_data, field_id, oor_mas
   integer, allocatable :: int_field(:,:,:,:)
   logical, allocatable :: oor_mask_4d(:,:,:,:) !< Copy of the input out of range mask to remove incompatibility
                                                !! in ranks when masking with the input field data (4d)
+  integer :: int_test(2)
+  real :: real_test(2)
 
   err_module_name = 'fms_diag_object_mod:fms_diag_check_out_of_range_value'
 
@@ -1117,7 +1119,7 @@ subroutine fms_diag_check_out_of_range_value(this, field_data, field_id, oor_mas
   IF ( this%FMS_diag_fields(field_id)%has_data_RANGE() ) THEN
     IF ( ISSUE_OOR_WARNINGS .OR. OOR_WARNINGS_FATAL ) THEN
       if ((field_var_type .eq. r4) .or. (field_var_type .eq. r8)) then
-        WRITE (error_string, '("[",ES14.5E3,",",ES14.5E3,"]")') real_data_range(1:2)
+        WRITE (error_string, '("[",ES14.5E3,",",ES14.5E3,"]")') real_test(1:2) !real_data_range(1:2)
         WRITE (error_string2, '("(Min: ",ES14.5E3,", Max: ",ES14.5E3, ")")')&
           & MINVAL(real_field(fis:fie, fjs:fje, ks:ke, 1:1),MASK=oor_mask_4d(fis:fie, fjs:fje, ks:ke, 1:1)),&
           & MAXVAL(real_field(fis:fie, fjs:fje, ks:ke, 1:1),MASK=oor_mask_4d(fis:fie, fjs:fje, ks:ke, 1:1))
@@ -1159,7 +1161,7 @@ subroutine fms_diag_check_out_of_range_value(this, field_data, field_id, oor_mas
         END IF
       else
         if ((field_var_type .eq. i4) .or. (field_var_type .eq. i8)) then
-          WRITE (error_string, '("[",I14,",",I14,"]")') int_data_range(1:2)
+          WRITE (error_string, '("[",I14,",",I14,"]")') int_test(1:2) !int_data_range(1:2)
           WRITE (error_string2, '("(Min: ",I14,", Max: ",I14, ")")')&
             & MINVAL(int_field(fis:fie, fjs:fje, ks:ke, 1:1),MASK=oor_mask_4d(fis:fie, fjs:fje, ks:ke, 1:1)),&
             & MAXVAL(int_field(fis:fie, fjs:fje, ks:ke, 1:1),MASK=oor_mask_4d(fis:fie, fjs:fje, ks:ke, 1:1))

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -1054,16 +1054,16 @@ subroutine fms_diag_check_out_of_range_value(this, field_data, field_id, oor_mas
   field_var_type = this%FMS_diag_fields(field_id)%get_vartype()
 
   ! Copy field data to proper type variables
-  select case (field_var_type)
-  case (r4)
+  select type (field_data(1,1,1,1))
+  type is (real(kind=r4_kind))
     real_field = real(field_data, kind=r4_kind)
-  case (r8)
+  type is (real(kind=r8_kind))
     real_field = real(field_data, kind=r8_kind)
-  case (i4)
+  type is (integer(kind=i4_kind))
     int_field = int(field_data, kind=i4_kind)
-  case (i8)
+  type is (integer(kind=i8_kind))
     int_field = int(field_data, kind=i8_kind)
-  case default
+  class default
     call mpp_error( FATAL, err_module_name//' Invalid type')
   end select
 

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -1159,7 +1159,7 @@ subroutine fms_diag_check_out_of_range_value(this, field_data, field_id, oor_mas
         END IF
       else
         if (field_var_type .eq. i4 .or. field_var_type .eq. i8) then
-          WRITE (error_string, '("[",I14,",",I14,"]")') real_data_range
+          WRITE (error_string, '("[",I14,",",I14,"]")') int_data_range
           WRITE (error_string2, '("(Min: ",I14,", Max: ",I14, ")")')&
             & MINVAL(int_field(fis:fie, fjs:fje, ks:ke, 1:1),MASK=oor_mask_4d(fis:fie, fjs:fje, ks:ke, 1:1)),&
             & MAXVAL(int_field(fis:fie, fjs:fje, ks:ke, 1:1),MASK=oor_mask_4d(fis:fie, fjs:fje, ks:ke, 1:1))

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -28,8 +28,7 @@ use diag_data_mod,  only: diag_null, diag_not_found, diag_not_registered, diag_r
        & get_ticks_per_second
 #ifdef use_yaml
 use fms_diag_file_object_mod, only: fmsDiagFileContainer_type, fmsDiagFile_type, fms_diag_files_object_init
-use fms_diag_field_object_mod, only: fmsDiagField_type, fms_diag_fields_object_init, get_default_missing_value, &
-                                    & has_missing_value
+use fms_diag_field_object_mod, only: fmsDiagField_type, fms_diag_fields_object_init, get_default_missing_value
 use fms_diag_yaml_mod, only: diag_yaml_object_init, diag_yaml_object_end, find_diag_field, &
                            & get_diag_files_id, diag_yaml, DiagYamlFilesVar_type
 use fms_diag_axis_object_mod, only: fms_diag_axis_object_init, fmsDiagAxis_type, fmsDiagSubAxis_type, &
@@ -1106,8 +1105,8 @@ subroutine fms_diag_check_out_of_range_value(this, field_data, field_id, oor_mas
             & MINVAL(field_data(fis:fie, fjs:fje, ks:ke, 1:1),MASK=oor_mask(fis:fie, fjs:fje, ks:ke)),&
             & MAXVAL(field_data(fis:fie, fjs:fje, ks:ke, 1:1),MASK=oor_mask(fis:fie, fjs:fje, ks:ke))
         type is (integer)
-          WRITE (error_string, '("[",ES14,",",ES14,"]")') l_data_range
-          WRITE (error_string2, '("(Min: ",ES14,", Max: ",ES14, ")")')&
+          WRITE (error_string, '("[",I14,",",I14,"]")') l_data_range
+          WRITE (error_string2, '("(Min: ",I14,", Max: ",I14, ")")')&
             & MINVAL(field_data(fis:fie, fjs:fje, ks:ke, 1:1),MASK=oor_mask(fis:fie, fjs:fje, ks:ke)),&
             & MAXVAL(field_data(fis:fie, fjs:fje, ks:ke, 1:1),MASK=oor_mask(fis:fie, fjs:fje, ks:ke))
         class default
@@ -1124,8 +1123,8 @@ subroutine fms_diag_check_out_of_range_value(this, field_data, field_id, oor_mas
             !   value.
             ! </ERROR>
             CALL error_mesg(err_module_name, 'A value for '//&
-                &TRIM(this%FMS_diag_fields(diag_field_id)%get_modname())//' in field '//&
-                &TRIM(this%FMS_diag_fields(diag_field_id)%get_varname())//' '&  !< Make sure the modern diag manager
+                &TRIM(this%FMS_diag_fields(field_id)%get_modname())//' in field '//&
+                &TRIM(this%FMS_diag_fields(field_id)%get_varname())//' '&  !< Make sure the modern diag manager
                                                                             ! 'varname' is same as
                                                                             ! the legacy 'field_name'
                 &//TRIM(error_string2)//&
@@ -1141,8 +1140,8 @@ subroutine fms_diag_check_out_of_range_value(this, field_data, field_id, oor_mas
               !   is outside the range [<lower_val>,<upper_val>].
               ! </ERROR>
               CALL error_mesg(err_module_name, 'A value for '//&
-                  &TRIM(this%FMS_diag_fields(diag_field_id)%get_modname())//' in field '//&
-                  &TRIM(this%FMS_diag_fields(diag_field_id)%get_varname())//' '& !< Make sure the modern diag manager
+                  &TRIM(this%FMS_diag_fields(field_id)%get_modname())//' in field '//&
+                  &TRIM(this%FMS_diag_fields(field_id)%get_varname())//' '& !< Make sure the modern diag manager
                                                                             ! 'varname' is same as
                                                                             ! the legacy 'field_name'
 

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -1094,21 +1094,17 @@ subroutine fms_diag_check_out_of_range_value(this, field_data, field_id, oor_mas
   IF ( this%FMS_diag_fields(field_id)%has_data_RANGE() ) THEN
     IF ( ISSUE_OOR_WARNINGS .OR. OOR_WARNINGS_FATAL ) THEN
       select type (l_data_range)
-        type is (real(kind=r4_kind) .or. real(kind=r8_kind))
+        type is (real(kind=r4_kind))
           WRITE (error_string, '("[",ES14.5E3,",",ES14.5E3,"]")') l_data_range
           WRITE (error_string2, '("(Min: ",ES14.5E3,", Max: ",ES14.5E3, ")")')&
             & MINVAL(field_data(fis:fie, fjs:fje, ks:ke, 1:1),MASK=oor_mask(fis:fie, fjs:fje, ks:ke)),&
-            & MAXVAL(field_data(fis:fie, fjs:fje, ks:ke, 1:1),MASK=oor_mask(fis:fie, fjs:fje, ks:ke))
-        type is (integer(kind=i4_kind) .or. integer(kind=i8_kind))
+            & MAXVAL(field_data(fis:fie, fjs:fje, ks:ke, 1:1),MASK=oor_mask(fis:fie, fjs:fje, ks:ke)
           WRITE (error_string, '("[",I14,",",I14,"]")') l_data_range
           WRITE (error_string2, '("(Min: ",I14,", Max: ",I14, ")")')&
             & MINVAL(field_data(fis:fie, fjs:fje, ks:ke, 1:1),MASK=oor_mask(fis:fie, fjs:fje, ks:ke)),&
             & MAXVAL(field_data(fis:fie, fjs:fje, ks:ke, 1:1),MASK=oor_mask(fis:fie, fjs:fje, ks:ke))
-        class default
-          call mpp_error( FATAL, err_module_name//' Invalid type')
-      end select
-        IF ( has_missvalue ) THEN
-          IF ( ANY(oor_mask(fis:fie, fjs:fje, ks:ke) .AND.&
+          IF ( has_missvalue ) THEN
+            IF ( ANY(oor_mask(fis:fie, fjs:fje, ks:ke) .AND.&
               & ((field_data(fis:fie, fjs:fje, ks:ke, 1:1) < l_data_range(1) .OR.&
               &   field_data(fis:fie, fjs:fje, ks:ke, 1:1) > l_data_range(2)).AND.&
               &   field_data(fis:fie, fjs:fje, ks:ke, 1:1) .NE. l_missing_value)) ) THEN
@@ -1144,6 +1140,9 @@ subroutine fms_diag_check_out_of_range_value(this, field_data, field_id, oor_mas
                   &' is outside the range '//TRIM(error_string)//'.', WARNING)
           END IF
         END IF
+        class default
+          call mpp_error( FATAL, err_module_name//' Invalid type')
+        end select
     END IF
   END IF
 #else

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -1098,7 +1098,7 @@ subroutine fms_diag_check_out_of_range_value(this, field_data, field_id, oor_mas
           WRITE (error_string, '("[",ES14.5E3,",",ES14.5E3,"]")') l_data_range
           WRITE (error_string2, '("(Min: ",ES14.5E3,", Max: ",ES14.5E3, ")")')&
             & MINVAL(field_data(fis:fie, fjs:fje, ks:ke, 1:1),MASK=oor_mask(fis:fie, fjs:fje, ks:ke)),&
-            & MAXVAL(field_data(fis:fie, fjs:fje, ks:ke, 1:1),MASK=oor_mask(fis:fie, fjs:fje, ks:ke)
+            & MAXVAL(field_data(fis:fie, fjs:fje, ks:ke, 1:1),MASK=oor_mask(fis:fie, fjs:fje, ks:ke))
           WRITE (error_string, '("[",I14,",",I14,"]")') l_data_range
           WRITE (error_string2, '("(Min: ",I14,", Max: ",I14, ")")')&
             & MINVAL(field_data(fis:fie, fjs:fje, ks:ke, 1:1),MASK=oor_mask(fis:fie, fjs:fje, ks:ke)),&

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -1107,7 +1107,7 @@ subroutine fms_diag_check_out_of_range_value(this, field_data, field_id, oor_mas
   logical, allocatable :: oor_mask_4d(:,:,:,:) !< Copy of the input out of range mask to remove incompatibility
                                                !! in ranks when masking with the input field data (4d)
 
-  err_module_name = 'fms_diag_object_mod:fms_diag_check_out_of_range_value'
+  err_module_name = 'fms_diag_object_mod::fms_diag_check_out_of_range_value'
 
   ! Remap the input out of range mask to 4d mask
   oor_mask_4d = reshape(oor_mask, (/shape(oor_mask), 1/))
@@ -1193,7 +1193,7 @@ subroutine fms_diag_check_out_of_range_value(this, field_data, field_id, oor_mas
             !   is outside the range [<lower_val>,<upper_val>] and not equal to the missing
             !   value.
             ! </ERROR>
-            CALL error_mesg(err_module_name, 'A value for '//&
+            CALL mpp_error(FATAL, TRIM(err_module_name)//' A value for '//&
                 &TRIM(this%FMS_diag_fields(field_id)%get_modname())//' in field '//&
                 &TRIM(this%FMS_diag_fields(field_id)%get_varname())//' '&  !< Make sure the modern diag manager
                                                                             ! 'varname' is same as
@@ -1210,7 +1210,7 @@ subroutine fms_diag_check_out_of_range_value(this, field_data, field_id, oor_mas
             !   A value for <module_name> in field <field_name> (Min: <min_val>, Max: <max_val>)
             !   is outside the range [<lower_val>,<upper_val>].
             ! </ERROR>
-            CALL error_mesg(err_module_name, 'A value for '//&
+            CALL mpp_error(FATAL, TRIM(err_module_name)//' A value for '//&
               &TRIM(this%FMS_diag_fields(field_id)%get_modname())//' in field '//&
               &TRIM(this%FMS_diag_fields(field_id)%get_varname())//' '& !< Make sure the modern diag manager
                                                                         ! 'varname' is same as
@@ -1235,7 +1235,7 @@ subroutine fms_diag_check_out_of_range_value(this, field_data, field_id, oor_mas
               !   is outside the range [<lower_val>,<upper_val>] and not equal to the missing
               !   value.
               ! </ERROR>
-              CALL error_mesg(err_module_name, 'A value for '//&
+              CALL mpp_error(FATAL, TRIM(err_module_name)//' A value for '//&
                 &TRIM(this%FMS_diag_fields(field_id)%get_modname())//' in field '//&
                 &TRIM(this%FMS_diag_fields(field_id)%get_varname())//' '&  !< Make sure the modern diag manager
                                                                            ! 'varname' is same as
@@ -1252,7 +1252,7 @@ subroutine fms_diag_check_out_of_range_value(this, field_data, field_id, oor_mas
               !   A value for <module_name> in field <field_name> (Min: <min_val>, Max: <max_val>)
               !   is outside the range [<lower_val>,<upper_val>].
               ! </ERROR>
-              CALL error_mesg(err_module_name, 'A value for '//&
+              CALL mpp_error(FATAL, TRIM(err_module_name)//' A value for '//&
                 &TRIM(this%FMS_diag_fields(field_id)%get_modname())//' in field '//&
                 &TRIM(this%FMS_diag_fields(field_id)%get_varname())//' '& !< Make sure the modern diag manager
                                                                           ! 'varname' is same as

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -1046,7 +1046,7 @@ subroutine fms_diag_check_out_of_range_value(this, field_data, field_id, oor_mas
                                                !! in ranks when masking with the input field data (4d)
 
   err_module_name = 'fms_diag_object_mod:fms_diag_check_out_of_range_value'
-  
+
   ! Remap the input out of range mask to 4d mask
   oor_mask_4d = reshape(oor_mask, (/shape(oor_mask), 1/))
 

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -21,7 +21,7 @@ use mpp_mod, only: fatal, note, warning, mpp_error, mpp_pe, mpp_root_pe, stdout
 use diag_data_mod,  only: diag_null, diag_not_found, diag_not_registered, diag_registered_id, &
                          &DIAG_FIELD_NOT_FOUND, diag_not_registered, max_axes, TWO_D_DOMAIN, &
                          &get_base_time, NULL_AXIS_ID, get_var_type, diag_not_registered, &
-                         &oor_warnings_fatal, issue_oor_warnings, i4, i4, r4, r8
+                         &oor_warnings_fatal, issue_oor_warnings, i4, i8, r4, r8
 
   USE time_manager_mod, ONLY: set_time, set_date, get_time, time_type, OPERATOR(>=), OPERATOR(>),&
        & OPERATOR(<), OPERATOR(==), OPERATOR(/=), OPERATOR(/), OPERATOR(+), ASSIGNMENT(=), get_date, &

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -486,11 +486,6 @@ logical function fms_diag_accept_data (this, diag_field_id, field_data, time, is
 #ifndef use_yaml
 CALL MPP_ERROR(FATAL,"You can not use the modern diag manager without compiling with -Duse_yaml")
 #else
-  ! Check if the field variable type is set
-  if (.not.this%FMS_diag_fields(diag_field_id)%has_vartype()) then
-    this%FMS_diag_fields(diag_field_id)%set_vartype(field_data(1, 1, 1, 1))
-  end if
-
   !TODO: weight is for time averaging where each time level may have a different weight
   ! call real_copy_set()
 

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -1117,7 +1117,7 @@ subroutine fms_diag_check_out_of_range_value(this, field_data, field_id, oor_mas
   IF ( this%FMS_diag_fields(field_id)%has_data_RANGE() ) THEN
     IF ( ISSUE_OOR_WARNINGS .OR. OOR_WARNINGS_FATAL ) THEN
       if ((field_var_type .eq. r4) .or. (field_var_type .eq. r8)) then
-        WRITE (error_string, '("[",ES14.5E3,",",ES14.5E3,"]")') real_data_range
+        WRITE (error_string, '("[",ES14.5E3,",",ES14.5E3,"]")') real_data_range(1:2)
         WRITE (error_string2, '("(Min: ",ES14.5E3,", Max: ",ES14.5E3, ")")')&
           & MINVAL(real_field(fis:fie, fjs:fje, ks:ke, 1:1),MASK=oor_mask_4d(fis:fie, fjs:fje, ks:ke, 1:1)),&
           & MAXVAL(real_field(fis:fie, fjs:fje, ks:ke, 1:1),MASK=oor_mask_4d(fis:fie, fjs:fje, ks:ke, 1:1))
@@ -1159,7 +1159,7 @@ subroutine fms_diag_check_out_of_range_value(this, field_data, field_id, oor_mas
         END IF
       else
         if ((field_var_type .eq. i4) .or. (field_var_type .eq. i8)) then
-          WRITE (error_string, '("[",I14,",",I14,"]")') int_data_range
+          WRITE (error_string, '("[",I14,",",I14,"]")') int_data_range(1:2)
           WRITE (error_string2, '("(Min: ",I14,", Max: ",I14, ")")')&
             & MINVAL(int_field(fis:fie, fjs:fje, ks:ke, 1:1),MASK=oor_mask_4d(fis:fie, fjs:fje, ks:ke, 1:1)),&
             & MAXVAL(int_field(fis:fie, fjs:fje, ks:ke, 1:1),MASK=oor_mask_4d(fis:fie, fjs:fje, ks:ke, 1:1))

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -1056,15 +1056,15 @@ subroutine fms_diag_check_out_of_range_value(this, field_data, field_id, oor_mas
   field_var_type = this%FMS_diag_fields(field_id)%get_vartype()
 
   ! Copy field data to proper type variables
-  select type (ftype => field_data(1,1,1,1))
+  select type (field_data)
   type is (real(kind=r4_kind))
-    real_field = real(ftype, kind=r4_kind)
+    real_field = real(field_data, kind=r4_kind)
   type is (real(kind=r8_kind))
-    real_field = real(ftype, kind=r8_kind)
+    real_field = real(field_data, kind=r8_kind)
   type is (integer(kind=i4_kind))
-    int_field = int(ftype, kind=i4_kind)
+    int_field = int(field_data, kind=i4_kind)
   type is (integer(kind=i8_kind))
-    int_field = int(ftype, kind=i8_kind)
+    int_field = int(field_data, kind=i8_kind)
   class default
     call mpp_error( FATAL, err_module_name//' Invalid type')
   end select
@@ -1119,7 +1119,7 @@ subroutine fms_diag_check_out_of_range_value(this, field_data, field_id, oor_mas
   IF ( this%FMS_diag_fields(field_id)%has_data_RANGE() ) THEN
     IF ( ISSUE_OOR_WARNINGS .OR. OOR_WARNINGS_FATAL ) THEN
       if ((field_var_type .eq. r4) .or. (field_var_type .eq. r8)) then
-        WRITE (error_string, '("[",ES14.5E3,",",ES14.5E3,"]")') real_test(1:2) !real_data_range(1:2)
+        WRITE (error_string, '("[",ES14.5E3,",",ES14.5E3,"]")') real_data_range(1:2)
         WRITE (error_string2, '("(Min: ",ES14.5E3,", Max: ",ES14.5E3, ")")')&
           & MINVAL(real_field(fis:fie, fjs:fje, ks:ke, 1:1),MASK=oor_mask_4d(fis:fie, fjs:fje, ks:ke, 1:1)),&
           & MAXVAL(real_field(fis:fie, fjs:fje, ks:ke, 1:1),MASK=oor_mask_4d(fis:fie, fjs:fje, ks:ke, 1:1))
@@ -1161,7 +1161,7 @@ subroutine fms_diag_check_out_of_range_value(this, field_data, field_id, oor_mas
         END IF
       else
         if ((field_var_type .eq. i4) .or. (field_var_type .eq. i8)) then
-          WRITE (error_string, '("[",I14,",",I14,"]")') int_test(1:2) !int_data_range(1:2)
+          WRITE (error_string, '("[",I14,",",I14,"]")') int_data_range(1:2)
           WRITE (error_string2, '("(Min: ",I14,", Max: ",I14, ")")')&
             & MINVAL(int_field(fis:fie, fjs:fje, ks:ke, 1:1),MASK=oor_mask_4d(fis:fie, fjs:fje, ks:ke, 1:1)),&
             & MAXVAL(int_field(fis:fie, fjs:fje, ks:ke, 1:1),MASK=oor_mask_4d(fis:fie, fjs:fje, ks:ke, 1:1))


### PR DESCRIPTION
**Description**
This update adds a member routine _fms_diag_check_out_of_range_value_ to type _fmsDiagObject_type_. The routine checks field data which are outside the valid data range.

Fixes # (issue)
CI

**How Has This Been Tested?**
* Tested locally with Intel oneAPI (v2023.1.0); intel ifort (v2021.9.0).
* Compiles on AMD box with gcc/13.1.0 and mpich/4.1.2 but some tests on mosaic, mpp, and fms2_io failed.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

