### PR TITLE
mpp_scatter: add support for int64 integers

### DIFF
--- a/mpp/include/mpp_comm.inc
+++ b/mpp/include/mpp_comm.inc
@@ -434,6 +434,14 @@
 #undef  MPP_SCATTER_PELIST_2D_
 #undef  MPP_SCATTER_PELIST_3D_
 #undef MPP_TYPE_
+#define MPP_TYPE_ integer(i8_kind)
+#define MPP_SCATTER_PELIST_2D_ mpp_scatter_pelist_int8_2d
+#define MPP_SCATTER_PELIST_3D_ mpp_scatter_pelist_int8_3d
+#include <mpp_scatter.fh>
+
+#undef  MPP_SCATTER_PELIST_2D_
+#undef  MPP_SCATTER_PELIST_3D_
+#undef MPP_TYPE_
 #define MPP_TYPE_ real(r4_kind)
 #define MPP_SCATTER_PELIST_2D_ mpp_scatter_pelist_real4_2d
 #define MPP_SCATTER_PELIST_3D_ mpp_scatter_pelist_real4_3d

--- a/mpp/mpp.F90
+++ b/mpp/mpp.F90
@@ -734,6 +734,8 @@ private
   interface mpp_scatter
      module procedure mpp_scatter_pelist_int4_2d
      module procedure mpp_scatter_pelist_int4_3d
+     module procedure mpp_scatter_pelist_int8_2d
+     module procedure mpp_scatter_pelist_int8_3d
      module procedure mpp_scatter_pelist_real4_2d
      module procedure mpp_scatter_pelist_real4_3d
      module procedure mpp_scatter_pelist_real8_2d


### PR DESCRIPTION
**Description**
Add support for int64 integers in mpp_scatter

Fixes #1219 

**How Has This Been Tested?**
CI

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [x] `make distcheck` passes

