### PR TITLE
intel fix for allocatable type errors

### DIFF
--- a/horiz_interp/horiz_interp_bicubic.F90
+++ b/horiz_interp/horiz_interp_bicubic.F90
@@ -145,23 +145,25 @@ module horiz_interp_bicubic_mod
   subroutine horiz_interp_bicubic_del( Interp )
     type(horiz_interp_type), intent(inout) :: Interp
 
-    if(allocated(Interp%horizInterpReals8_type)) then
+    if(Interp%horizInterpReals8_type%is_allocated) then
       if(allocated(Interp%horizInterpReals8_type%rat_x))  deallocate ( Interp%horizInterpReals8_type%rat_x )
       if(allocated(Interp%horizInterpReals8_type%rat_y))  deallocate ( Interp%horizInterpReals8_type%rat_y )
       if(allocated(Interp%horizInterpReals8_type%lon_in)) deallocate ( Interp%horizInterpReals8_type%lon_in )
       if(allocated(Interp%horizInterpReals8_type%lat_in)) deallocate ( Interp%horizInterpReals8_type%lat_in )
       if(allocated(Interp%horizInterpReals8_type%wti))    deallocate ( Interp%horizInterpReals8_type%wti )
-      deallocate(Interp%horizInterpReals8_type)
-    else if(allocated(Interp%horizInterpReals4_type)) then
+    else if(Interp%horizInterpReals4_type%is_allocated) then
       if(allocated(Interp%horizInterpReals4_type%rat_x))  deallocate ( Interp%horizInterpReals4_type%rat_x )
       if(allocated(Interp%horizInterpReals4_type%rat_y))  deallocate ( Interp%horizInterpReals4_type%rat_y )
       if(allocated(Interp%horizInterpReals4_type%lon_in)) deallocate ( Interp%horizInterpReals4_type%lon_in )
       if(allocated(Interp%horizInterpReals4_type%lat_in)) deallocate ( Interp%horizInterpReals4_type%lat_in )
       if(allocated(Interp%horizInterpReals4_type%wti))    deallocate ( Interp%horizInterpReals4_type%wti )
-      deallocate(Interp%horizInterpReals4_type)
     endif
     if( allocated(Interp%i_lon) ) deallocate( Interp%i_lon )
     if( allocated(Interp%j_lat) ) deallocate( Interp%j_lat )
+
+    Interp%horizInterpReals8_type%is_allocated = .false.
+    Interp%horizInterpReals4_type%is_allocated = .false.
+
   end subroutine horiz_interp_bicubic_del
 
 #include "horiz_interp_bicubic_r4.fh"

--- a/horiz_interp/horiz_interp_bilinear.F90
+++ b/horiz_interp/horiz_interp_bilinear.F90
@@ -100,17 +100,18 @@ contains
                                    !! have allocated arrays. The returned variable will contain
                                    !! deallocated arrays
 
-    if( allocated(Interp%horizInterpReals4_type)) then
+    if( Interp%horizInterpReals4_type%is_allocated) then
       if(allocated(Interp%horizInterpReals4_type%wti))   deallocate(Interp%horizInterpReals4_type%wti)
       if(allocated(Interp%horizInterpReals4_type%wtj))   deallocate(Interp%horizInterpReals4_type%wtj)
-      deallocate(Interp%horizInterpReals4_type)
-    else if (allocated(Interp%horizInterpReals8_type)) then
+    else if (Interp%horizInterpReals8_type%is_allocated) then
       if(allocated(Interp%horizInterpReals8_type%wti))   deallocate(Interp%horizInterpReals8_type%wti)
       if(allocated(Interp%horizInterpReals8_type%wtj))   deallocate(Interp%horizInterpReals8_type%wtj)
-      deallocate(Interp%horizInterpReals8_type)
     endif
     if(allocated(Interp%i_lon)) deallocate(Interp%i_lon)
     if(allocated(Interp%j_lat)) deallocate(Interp%j_lat)
+    
+    Interp%horizInterpReals4_type%is_allocated = .false.
+    Interp%horizInterpReals8_type%is_allocated = .false.
 
   end subroutine horiz_interp_bilinear_del
 

--- a/horiz_interp/horiz_interp_conserve.F90
+++ b/horiz_interp/horiz_interp_conserve.F90
@@ -165,42 +165,40 @@ contains
 
     select case(Interp%version)
     case (1)
-      if( allocated( Interp%horizInterpReals8_type)) then
+      if( Interp%horizInterpReals8_type%is_allocated) then
         if(allocated(Interp%horizInterpReals8_type%area_src)) deallocate(Interp%horizInterpReals8_type%area_src)
         if(allocated(Interp%horizInterpReals8_type%area_dst)) deallocate(Interp%horizInterpReals8_type%area_dst)
         if(allocated(Interp%horizInterpReals8_type%facj))     deallocate(Interp%horizInterpReals8_type%facj)
         if(allocated(Interp%jlat))                 deallocate(Interp%jlat)
         if(allocated(Interp%horizInterpReals8_type%faci))     deallocate(Interp%horizInterpReals8_type%faci)
         if(allocated(Interp%ilon))                 deallocate(Interp%ilon)
-        deallocate(Interp%horizInterpReals8_type)
-      else if( allocated( Interp%horizInterpReals4_type)) then
+      else if( Interp%horizInterpReals4_type%is_allocated) then
         if(allocated(Interp%horizInterpReals4_type%area_src)) deallocate(Interp%horizInterpReals4_type%area_src)
         if(allocated(Interp%horizInterpReals4_type%area_dst)) deallocate(Interp%horizInterpReals4_type%area_dst)
         if(allocated(Interp%horizInterpReals4_type%facj))     deallocate(Interp%horizInterpReals4_type%facj)
         if(allocated(Interp%jlat))                 deallocate(Interp%jlat)
         if(allocated(Interp%horizInterpReals4_type%faci))     deallocate(Interp%horizInterpReals4_type%faci)
         if(allocated(Interp%ilon))                 deallocate(Interp%ilon)
-        deallocate(Interp%horizInterpReals4_type)
       endif
     case (2)
-      if( allocated( Interp%horizInterpReals8_type)) then
+      if( Interp%horizInterpReals8_type%is_allocated) then
         if(allocated(Interp%i_src)) deallocate(Interp%i_src)
         if(allocated(Interp%j_src)) deallocate(Interp%j_src)
         if(allocated(Interp%i_dst)) deallocate(Interp%i_dst)
         if(allocated(Interp%j_dst)) deallocate(Interp%j_dst)
         if(allocated(Interp%horizInterpReals8_type%area_frac_dst)) &
             deallocate(Interp%horizInterpReals8_type%area_frac_dst)
-        deallocate(Interp%horizInterpReals8_type)
-      else if( allocated( Interp%horizInterpReals4_type)) then
+      else if( Interp%horizInterpReals4_type%is_allocated ) then
         if(allocated(Interp%i_src)) deallocate(Interp%i_src)
         if(allocated(Interp%j_src)) deallocate(Interp%j_src)
         if(allocated(Interp%i_dst)) deallocate(Interp%i_dst)
         if(allocated(Interp%j_dst)) deallocate(Interp%j_dst)
         if(allocated(Interp%horizInterpReals4_type%area_frac_dst)) &
             deallocate(Interp%horizInterpReals4_type%area_frac_dst)
-        deallocate(Interp%horizInterpReals4_type)
        endif
     end select
+    Interp%horizInterpReals4_type%is_allocated = .false.
+    Interp%horizInterpReals8_type%is_allocated = .false.
 
   end subroutine horiz_interp_conserve_del
 

--- a/horiz_interp/horiz_interp_spherical.F90
+++ b/horiz_interp/horiz_interp_spherical.F90
@@ -133,16 +133,17 @@ contains
                                            !! must have allocated arrays. The returned variable will
                                            !! contain deallocated arrays.
 
-    if(allocated(Interp%horizInterpReals4_type)) then
+    if(Interp%horizInterpReals4_type%is_allocated) then
       if(allocated(Interp%horizInterpReals4_type%src_dist)) deallocate(Interp%horizInterpReals4_type%src_dist)
-      deallocate(Interp%horizInterpReals4_type)
-    else if (allocated(Interp%horizInterpReals8_type)) then
+    else if (Interp%horizInterpReals8_type%is_allocated) then
       if(allocated(Interp%horizInterpReals8_type%src_dist)) deallocate(Interp%horizInterpReals8_type%src_dist)
-      deallocate(Interp%horizInterpReals8_type)
     endif
     if(allocated(Interp%num_found)) deallocate(Interp%num_found)
     if(allocated(Interp%i_lon))     deallocate(Interp%i_lon)
     if(allocated(Interp%j_lat))     deallocate(Interp%j_lat)
+
+    Interp%horizInterpReals4_type%is_allocated = .false.
+    Interp%horizInterpReals8_type%is_allocated = .false.
 
   end subroutine horiz_interp_spherical_del
 

--- a/horiz_interp/horiz_interp_type.F90
+++ b/horiz_interp/horiz_interp_type.F90
@@ -80,7 +80,8 @@ type horizInterpReals8_type
    real(kind=r8_kind),    dimension(:), allocatable     :: lat_in   !< the coordinates of the source grid
    real(kind=r8_kind),    dimension(:), allocatable     :: area_frac_dst !< area fraction in destination grid.
    real(kind=r8_kind),    dimension(:,:), allocatable   :: mask_in
-   real(kind=r8_kind)                               :: max_src_dist
+   real(kind=r8_kind)                                   :: max_src_dist
+   logical                                              :: is_allocated !< set to true upon field allocation
 
 end type horizInterpReals8_type
 
@@ -106,7 +107,8 @@ type horizInterpReals4_type
    real(kind=r4_kind),    dimension(:), allocatable     :: lat_in   !< the coordinates of the source grid
    real(kind=r4_kind),    dimension(:), allocatable     :: area_frac_dst !< area fraction in destination grid.
    real(kind=r4_kind),    dimension(:,:), allocatable   :: mask_in
-   real(kind=r4_kind)                               :: max_src_dist
+   real(kind=r4_kind)                                   :: max_src_dist
+   logical                                              :: is_allocated !< set to true upon field allocation
 
 end type horizInterpReals4_type
 
@@ -142,11 +144,10 @@ end type horizInterpReals4_type
    integer, dimension(:), allocatable     :: j_src       !< indices in source grid.
    integer, dimension(:), allocatable     :: i_dst       !< indices in destination grid.
    integer, dimension(:), allocatable     :: j_dst       !< indices in destination grid.
-   type(horizInterpReals8_type), allocatable :: horizInterpReals8_type !< derived type holding kind 8 real data pointers
+   type(horizInterpReals8_type) :: horizInterpReals8_type !< derived type holding kind 8 real data pointers
                                                                     !! if compiled with r8_kind
-   type(horizInterpReals4_type), allocatable :: horizInterpReals4_type !< derived type holding kind 4 real data pointers
+   type(horizInterpReals4_type) :: horizInterpReals4_type !< derived type holding kind 4 real data pointers
                                                                     !! if compiled with r8_kind
-
  end type
 
 !> @addtogroup horiz_interp_type_mod
@@ -180,9 +181,7 @@ contains
     horiz_interp_out%i_dst           = horiz_interp_in%i_dst
     horiz_interp_out%j_dst           = horiz_interp_in%j_dst
 
-    if(allocated(horiz_interp_in%horizInterpReals8_type)) then
-      if(.not. allocated(horiz_interp_out%horizInterpReals8_type)) &
-        allocate(horiz_interp_out%horizInterpReals8_type)
+    if(horiz_interp_in%horizInterpReals8_type%is_allocated) then
       horiz_interp_out%horizInterpReals8_type%faci            = horiz_interp_in%horizInterpReals8_type%faci
       horiz_interp_out%horizInterpReals8_type%facj            = horiz_interp_in%horizInterpReals8_type%facj
       horiz_interp_out%horizInterpReals8_type%area_src        = horiz_interp_in%horizInterpReals8_type%area_src
@@ -196,12 +195,11 @@ contains
       horiz_interp_out%horizInterpReals8_type%lat_in          = horiz_interp_in%horizInterpReals8_type%lat_in
       horiz_interp_out%horizInterpReals8_type%area_frac_dst   = horiz_interp_in%horizInterpReals8_type%area_frac_dst
       horiz_interp_out%horizInterpReals8_type%max_src_dist    =  horiz_interp_in%horizInterpReals8_type%max_src_dist
+      horiz_interp_out%horizInterpReals8_type%is_allocated    = .true.
       ! this was left out previous to mixed mode
       horiz_interp_out%horizInterpReals8_type%mask_in         = horiz_interp_in%horizInterpReals8_type%mask_in
 
-    else if (allocated(horiz_interp_in%horizInterpReals4_type)) then
-      if(.not. allocated(horiz_interp_out%horizInterpReals4_type)) &
-        allocate(horiz_interp_out%horizInterpReals4_type)
+    else if (horiz_interp_in%horizInterpReals4_type%is_allocated) then
       horiz_interp_out%horizInterpReals4_type%faci            = horiz_interp_in%horizInterpReals4_type%faci
       horiz_interp_out%horizInterpReals4_type%facj            = horiz_interp_in%horizInterpReals4_type%facj
       horiz_interp_out%horizInterpReals4_type%area_src        = horiz_interp_in%horizInterpReals4_type%area_src
@@ -215,6 +213,7 @@ contains
       horiz_interp_out%horizInterpReals4_type%lat_in          = horiz_interp_in%horizInterpReals4_type%lat_in
       horiz_interp_out%horizInterpReals4_type%area_frac_dst   = horiz_interp_in%horizInterpReals4_type%area_frac_dst
       horiz_interp_out%horizInterpReals4_type%max_src_dist    =  horiz_interp_in%horizInterpReals4_type%max_src_dist
+      horiz_interp_out%horizInterpReals4_type%is_allocated    = .true.
       ! this was left out previous to mixed mode
       horiz_interp_out%horizInterpReals4_type%mask_in         = horiz_interp_in%horizInterpReals4_type%mask_in
 

--- a/horiz_interp/include/horiz_interp.inc
+++ b/horiz_interp/include/horiz_interp.inc
@@ -47,7 +47,6 @@
 
     method = 'conservative'
     if(present(interp_method)) method = interp_method
-    if(allocated(Interp%HI_KIND_TYPE_)) allocate(Interp%HI_KIND_TYPE_)
 
     select case (trim(method))
     case ("conservative")
@@ -146,6 +145,7 @@
     end select
 
     !-----------------------------------------------------------------------
+    Interp% HI_KIND_TYPE_ % is_allocated = .true.
     Interp%I_am_initialized = .true.
 
   end subroutine HORIZ_INTERP_NEW_1D_
@@ -181,8 +181,6 @@
 
    method = 'conservative'
    if(present(interp_method)) method = interp_method
-
-   if( .not. allocated(Interp % HI_KIND_TYPE_)) allocate (Interp % HI_KIND_TYPE_)
 
    select case (trim(method))
    case ("conservative")
@@ -265,6 +263,7 @@
    end select
 
    !-----------------------------------------------------------------------
+   Interp% HI_KIND_TYPE_ % is_allocated = .true.
    Interp%I_am_initialized = .true.
 
  end subroutine HORIZ_INTERP_NEW_1D_SRC_
@@ -293,8 +292,6 @@
 
    method = 'bilinear'
    if(present(interp_method)) method = interp_method
-
-   if( .not. allocated(Interp % HI_KIND_TYPE_)) allocate (Interp % HI_KIND_TYPE_)
 
    select case (trim(method))
    case ("conservative")
@@ -343,7 +340,7 @@
       call mpp_error(FATAL,'when source grid are 2d, interp_method should be spherical or bilinear')
    end select
 
-!-----------------------------------------------------------------------
+   Interp% HI_KIND_TYPE_ % is_allocated = .true.
    Interp%I_am_initialized = .true.
 
  end subroutine HORIZ_INTERP_NEW_2D_
@@ -374,8 +371,6 @@
 
    method = 'bilinear'
    if(present(interp_method)) method = interp_method
-
-   if( .not. allocated(Interp % HI_KIND_TYPE_)) allocate (Interp % HI_KIND_TYPE_)
 
    nlon_out = size(lon_out(:)); nlat_out = size(lat_out(:))
    allocate(lon_dst(nlon_out,nlat_out), lat_dst(nlon_out,nlat_out))
@@ -423,7 +418,7 @@
 
    deallocate(lon_dst,lat_dst)
 
-   !-----------------------------------------------------------------------
+   Interp% HI_KIND_TYPE_ % is_allocated = .true.
    Interp%I_am_initialized = .true.
 
  end subroutine HORIZ_INTERP_NEW_1D_DST_

--- a/horiz_interp/include/horiz_interp_bicubic.inc
+++ b/horiz_interp/include/horiz_interp_bicubic.inc
@@ -62,7 +62,6 @@
     Interp%nlon_src = nlon_in;  Interp%nlat_src = nlat_in
     Interp%nlon_dst = nlon_out; Interp%nlat_dst = nlat_out
 !   use wti(:,:,1) for x-derivative, wti(:,:,2) for y-derivative, wti(:,:,3) for xy-derivative
-    if( .not. allocated(Interp%HI_KIND_TYPE_)) allocate(Interp%HI_KIND_TYPE_)
     allocate ( Interp%HI_KIND_TYPE_%wti    (nlon_in, nlat_in, 3) )
     allocate ( Interp%HI_KIND_TYPE_%lon_in (nlon_in) )
     allocate ( Interp%HI_KIND_TYPE_%lat_in (nlat_in) )
@@ -223,7 +222,6 @@
     nlon_out = size(lon_out); nlat_out = size(lat_out)
     Interp%nlon_src = nlon_in;  Interp%nlat_src = nlat_in
     Interp%nlon_dst = nlon_out; Interp%nlat_dst = nlat_out
-    if( .not. allocated(Interp%HI_KIND_TYPE_)) allocate(Interp%HI_KIND_TYPE_)
     allocate ( Interp%HI_KIND_TYPE_%wti     (nlon_in, nlat_in, 3) )
     allocate ( Interp%HI_KIND_TYPE_%lon_in  (nlon_in) )
     allocate ( Interp%HI_KIND_TYPE_%lat_in  (nlat_in) )

--- a/horiz_interp/include/horiz_interp_bilinear.inc
+++ b/horiz_interp/include/horiz_interp_bilinear.inc
@@ -52,7 +52,6 @@
     lt_err = 0
     !-----------------------------------------------------------------------
 
-    if( .not. allocated(Interp%HI_KIND_TYPE_)) allocate(Interp%HI_KIND_TYPE_)
     allocate ( Interp % HI_KIND_TYPE_ % wti (size(lon_out,1),size(lon_out,2),2),   &
                Interp % HI_KIND_TYPE_ % wtj (size(lon_out,1),size(lon_out,2),2),   &
                Interp % i_lon (size(lon_out,1),size(lon_out,2),2), &
@@ -234,7 +233,6 @@
     Interp%nlon_src = nlon_in;  Interp%nlat_src = nlat_in
     Interp%nlon_dst = nlon_out; Interp%nlat_dst = nlat_out
 
-    if( .not. allocated(Interp%HI_KIND_TYPE_)) allocate(Interp%HI_KIND_TYPE_)
     allocate ( Interp % HI_KIND_TYPE_ % wti (size(lon_out,1),size(lon_out,2),2),   &
                Interp % HI_KIND_TYPE_ % wtj (size(lon_out,1),size(lon_out,2),2),   &
                Interp % i_lon (size(lon_out,1),size(lon_out,2),2), &

--- a/horiz_interp/include/horiz_interp_conserve.inc
+++ b/horiz_interp/include/horiz_interp_conserve.inc
@@ -57,7 +57,6 @@ subroutine HORIZ_INTERP_CONSERVE_NEW_1DX1D_ ( Interp, lon_in, lat_in, lon_out, l
     nlon_in = size(lon_in(:))-1;  nlat_in = size(lat_in(:))-1
     nlon_out = size(lon_out(:))-1;  nlat_out = size(lat_out(:))-1
 
-    if( .not. allocated(Interp % HI_KIND_TYPE_)) allocate (Interp % HI_KIND_TYPE_)
     allocate ( Interp % HI_KIND_TYPE_ % facj (nlat_out,2), Interp % jlat (nlat_out,2),      &
                Interp % HI_KIND_TYPE_ % faci (nlon_out,2), Interp % ilon (nlon_out,2),      &
                Interp % HI_KIND_TYPE_ % area_src (nlon_in, nlat_in),   &
@@ -251,8 +250,6 @@ subroutine HORIZ_INTERP_CONSERVE_NEW_1DX1D_ ( Interp, lon_in, lat_in, lon_out, l
     if(.not. module_is_initialized) call mpp_error(FATAL, &
          'HORIZ_INTERP_CONSERVE_NEW_1DX2D_: horiz_interp_conserve_init is not called')
 
-    if( .not. allocated(Interp%HI_KIND_TYPE_)) allocate(Interp%HI_KIND_TYPE_)
-
     wordsz=size(transfer(lon_in(1), one_byte))
     if(wordsz .NE. 4 .AND. wordsz .NE. 8) call mpp_error(FATAL, &
          'HORIZ_INTERP_CONSERVE_NEW_1DX2D_: wordsz should be 4 or 8')
@@ -417,8 +414,6 @@ subroutine HORIZ_INTERP_CONSERVE_NEW_1DX1D_ ( Interp, lon_in, lat_in, lon_out, l
     if(.not. module_is_initialized) call mpp_error(FATAL, &
          'HORIZ_INTERP_CONSERVE_NEW_2DX1D_: horiz_interp_conserve_init is not called')
 
-    if( .not. allocated(Interp%HI_KIND_TYPE_)) allocate(Interp%HI_KIND_TYPE_)
-
     wordsz=size(transfer(lon_in(1,1), one_byte))
     if(wordsz .NE. 8) call mpp_error(FATAL, &
          'HORIZ_INTERP_CONSERVE_NEW_2DX1D_: currently only support 64-bit real(FMS_HI_KIND_), contact developer')
@@ -526,8 +521,6 @@ subroutine HORIZ_INTERP_CONSERVE_NEW_1DX1D_ ( Interp, lon_in, lat_in, lon_out, l
 
     if(.not. module_is_initialized) call mpp_error(FATAL, &
          'HORIZ_INTERP_CONSERVE_NEW_2DX2D_: horiz_interp_conserve_init is not called')
-
-    if( .not. allocated(Interp%HI_KIND_TYPE_)) allocate(Interp%HI_KIND_TYPE_)
 
     wordsz=size(transfer(lon_in(1,1), one_byte))
     if(wordsz .NE. 4 .AND. wordsz .NE. 8) call mpp_error(FATAL, &

--- a/horiz_interp/include/horiz_interp_spherical.inc
+++ b/horiz_interp/include/horiz_interp_spherical.inc
@@ -72,8 +72,6 @@
     if(present(num_nbrs)) num_neighbors = num_nbrs
     if (num_neighbors <= 0) call mpp_error(FATAL,'horiz_interp_spherical_mod: num_neighbors must be > 0')
 
-    if( .not. allocated(Interp%HI_KIND_TYPE_)) allocate(Interp%HI_KIND_TYPE_)
-
     max_src_dist = real(max_dist_default, FMS_HI_KIND_)
     if (PRESENT(max_dist)) max_src_dist = max_dist
     Interp%HI_KIND_TYPE_%max_src_dist = max_src_dist

--- a/test_fms/horiz_interp/test_horiz_interp.F90
+++ b/test_fms/horiz_interp/test_horiz_interp.F90
@@ -251,7 +251,7 @@ implicit none
     if( .not. test_solo) then
         do j=1, nj_src-1
             do i=1, ni_src-1
-                if(allocated(interp%horizInterpReals8_type)) then
+                if(interp%horizInterpReals8_type%is_allocated) then
                     if( interp%horizInterpReals8_type%wtj(i,j,1).ne.1.0_r8_kind ) then
                         write(*,*) 'expected ', 1.0_r8_kind, ' but computed ', interp%horizInterpReals8_type%wtj(i,j,1)
                         call mpp_error(FATAL, "failed at horiz_interp_bilinear_1d1d with wtj1")
@@ -325,7 +325,7 @@ implicit none
     if(.not. test_solo) then
         do j=1, nj_src-1
             do i=1, ni_src-1
-                if(allocated(interp%horizInterpReals8_type)) then
+                if(interp%horizInterpReals8_type%is_allocated) then
                     if( interp%horizInterpReals8_type%wtj(i,j,1).ne.1.0_r8_kind ) then
                         write(*,*) 'expected ', 1.0_r8_kind, ' but computed ', interp%horizInterpReals8_type%wtj(i,j,1)
                         call mpp_error(FATAL, "failed at horiz_interp_bilinear_1d2d with wtj1")
@@ -401,7 +401,7 @@ implicit none
     !j=1,i=1 is a special case; see subroutine find_neighbor
     if(.not. test_solo) then
         i=1 ; j=1
-        if(allocated(interp%horizInterpReals8_type)) then
+        if(interp%horizInterpReals8_type%is_allocated) then
             if( interp%horizInterpReals8_type%wtj(i,j,1).ne.1.0_r8_kind ) then
                 write(*,*) 'expected ', 1.0_r8_kind, ' but computed ', i,j,interp%horizInterpReals8_type%wtj(i,j,1)
                 call mpp_error(FATAL, "failed at horiz_interp_bilinear_2d1d with wtj(1,1,1)")
@@ -438,7 +438,7 @@ implicit none
         endif
         do j=2, nj_src
             do i=2, ni_src
-                if(allocated(interp%horizInterpReals8_type)) then
+                if(interp%horizInterpReals8_type%is_allocated) then
                     if( interp%horizInterpReals8_type%wtj(i,j,1).ne.0.0_r8_kind ) then
                         write(*,*) 'expected ', 1.0_r8_kind, ' but computed ', i,j, &
                                     interp%horizInterpReals8_type%wtj(i,j,1)
@@ -509,7 +509,7 @@ implicit none
     if(.not. test_solo) then
         !j=1,i=1 is a special case; see subroutine find_neighbor
         i=1 ; j=1
-        if(allocated(interp%horizInterpReals8_type)) then
+        if(interp%horizInterpReals8_type%is_allocated) then
             if( interp%horizInterpReals8_type%wtj(i,j,1).ne.1.0_r8_kind ) then
                 write(*,*) 'expected ', 1.0_r8_kind, ' but computed ', i,j,interp%horizInterpReals8_type%wtj(i,j,1)
                 call mpp_error(FATAL, "failed at horiz_interp_bilinear_2d2d wtj(1,1,1)")
@@ -546,7 +546,7 @@ implicit none
         endif
         do j=2, nj_src
             do i=2, ni_src
-                if(allocated(interp%horizInterpReals8_type)) then
+                if(interp%horizInterpReals8_type%is_allocated) then
                     if( interp%horizInterpReals8_type%wtj(i,j,1).ne.0.0_r8_kind ) then
                         write(*,*) 'expected ', 1.0_r8_kind, ' but computed ', i,j, &
                                     interp%horizInterpReals8_type%wtj(i,j,1)
@@ -688,7 +688,7 @@ implicit none
     if( .not. test_solo) then
         do i=1, ni_src-1
             do j=1, nj_src-1
-                if( allocated(interp_t%horizInterpReals4_type)) then
+                if( interp_t%horizInterpReals4_type%is_allocated) then
                     if( interp_t%horizInterpReals4_type%wti(i,j,1) * interp_t%horizInterpReals4_type%wti(i,j,2) &
                         - interp_t%horizInterpReals4_type%wti(i,j,3) .gt. SMALL .or.    &
                         interp_t%horizInterpReals4_type%wti(i,j,3) - (57.2958_lkind * 57.2958_lkind) .gt. SMALL) then
@@ -731,7 +731,7 @@ implicit none
     if( .not. test_solo) then
         do i=1, ni_src-1
             do j=1, nj_src-1
-                if( allocated(interp_t%horizInterpReals4_type)) then
+                if( interp_t%horizInterpReals4_type%is_allocated) then
                     if( interp_t%horizInterpReals4_type%wti(i,j,1) * interp_t%horizInterpReals4_type%wti(i,j,2) &
                         - interp_t%horizInterpReals4_type%wti(i,j,3) .gt. SMALL .or.    &
                         interp_t%horizInterpReals4_type%wti(i,j,3) - (57.2958_lkind * 57.2958_lkind) .gt. SMALL) then
@@ -1165,7 +1165,7 @@ implicit none
     subroutine check_type_eq(interp_1, interp_2)
         type(horiz_interp_type), intent(in) :: interp_1, interp_2
         integer :: k
-        if(allocated(interp_1%horizInterpReals4_type)) then
+        if(interp_1%horizInterpReals4_type%is_allocated) then
             if(allocated(interp_1%horizInterpReals4_type%faci)) then
                 if( ANY(interp_2%horizInterpReals4_type%faci .ne. interp_1%horizInterpReals4_type%faci)) &
                     call mpp_error(FATAL, "Invalid value for copied horiz_interp_type field: faci")
@@ -1225,7 +1225,7 @@ implicit none
                     call mpp_error(FATAL, "Invalid value for copied horiz_interp_type field: max_src_dist")
             endif
 
-        else if(allocated(interp_1%horizInterpReals8_type)) then
+        else if(interp_1%horizInterpReals8_type%is_allocated) then
             !!
             if(allocated(interp_1%horizInterpReals8_type%faci)) then
                 if( ANY(interp_2%horizInterpReals8_type%faci .ne. interp_1%horizInterpReals8_type%faci)) &
@@ -1355,10 +1355,10 @@ implicit none
     subroutine check_dealloc(hi_type)
         type(horiz_interp_type), intent(in) :: hi_type
         !! can only check the encapsulating real types, inner fields are inaccessible after deallocation
-        if(allocated(hi_type%horizInterpReals4_type)) then
+        if(hi_type%horizInterpReals4_type%is_allocated) then
             call mpp_error(FATAL, "horiz_interp_test: field left allocated after type deletion: horizInterpReals4_type")
         endif
-        if(allocated(hi_type%horizInterpReals8_type)) then
+        if(hi_type%horizInterpReals8_type%is_allocated) then
             call mpp_error(FATAL, "horiz_interp_test: field left allocated after type deletion: horizInterpReals8_type")
         endif
         !! non reals


### PR DESCRIPTION
**Description**
Removes the allocatable-ness from the sub-type that was added for the reals. I just replaced it with a logical to determine if the fields within the type have been allocated.

**How Has This Been Tested?**
am4 on c5 with intel-classic 2022.2.1

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

