### PR TITLE
Fms2 io update:domain_reads

### DIFF
--- a/fms2_io/include/domain_read.inc
+++ b/fms2_io/include/domain_read.inc
@@ -86,21 +86,21 @@ end subroutine domain_read_1d
 !!        decomposed".
 subroutine domain_read_2d(fileobj, variable_name, vdata, unlim_dim_level, &
                           corner, edge_lengths)
-  type(FmsNetcdfDomainFile_t),intent(in)           :: fileobj         !< File object.
-  character(len=*),           intent(in)           :: variable_name   !< Variable name.
-  class(*), dimension(:,:),   intent(inout),target :: vdata           !< Data that will
-                                                                      !! be written out
-                                                                      !! to the netcdf file.
-  integer,                    intent(in), optional :: unlim_dim_level !< Level for the unlimited
-                                                                      !! dimension.
-  integer, dimension(2),      intent(in), optional :: corner          !< Array of starting
-                                                                      !! indices describing
-                                                                      !! where the data
-                                                                      !! will be written to.
-  integer, dimension(2),      intent(in), optional :: edge_lengths    !< The number of
-                                                                      !! elements that
-                                                                      !! will be written
-                                                                      !! in each dimension.
+  type(FmsNetcdfDomainFile_t),  intent(in)           :: fileobj         !< File object.
+  character(len=*),             intent(in)           :: variable_name   !< Variable name.
+  class(*), contiguous, target, intent(inout)        :: vdata(:,:)      !< Data that will
+                                                                        !! be written out
+                                                                        !! to the netcdf file.
+  integer,                      intent(in), optional :: unlim_dim_level !< Level for the unlimited
+                                                                        !! dimension.
+  integer, dimension(2),        intent(in), optional :: corner          !< Array of starting
+                                                                        !! indices describing
+                                                                        !! where the data
+                                                                        !! will be written to.
+  integer, dimension(2),        intent(in), optional :: edge_lengths    !< The number of
+                                                                        !! elements that
+                                                                        !! will be written
+                                                                        !! in each dimension.
 
   integer                 :: xdim_index            !< The index of the variable that is the x dimension
   integer                 :: ydim_index            !< The index of the variable that is the y dimension
@@ -268,21 +268,21 @@ end subroutine domain_read_2d
 !!        decomposed".
 subroutine domain_read_3d(fileobj, variable_name, vdata, unlim_dim_level, &
                           corner, edge_lengths)
-  type(FmsNetcdfDomainFile_t),intent(in)           :: fileobj         !< File object.
-  character(len=*),           intent(in)           :: variable_name   !< Variable name.
-  class(*), dimension(:,:,:), intent(inout),target :: vdata           !< Data that will
-                                                                      !! be written out
-                                                                      !! to the netcdf file.
-  integer,                    intent(in), optional :: unlim_dim_level !< Level for the unlimited
-                                                                      !! dimension.
-  integer, dimension(2),      intent(in), optional :: corner          !< Array of starting
-                                                                      !! indices describing
-                                                                      !! where the data
-                                                                      !! will be written to.
-  integer, dimension(2),      intent(in), optional :: edge_lengths    !< The number of
-                                                                      !! elements that
-                                                                      !! will be written
-                                                                      !! in each dimension.
+  type(FmsNetcdfDomainFile_t),  intent(in)           :: fileobj         !< File object.
+  character(len=*),             intent(in)           :: variable_name   !< Variable name.
+  class(*), contiguous, target, intent(inout)        :: vdata(:,:,:)    !< Data that will
+                                                                        !! be written out
+                                                                        !! to the netcdf file.
+  integer,                      intent(in), optional :: unlim_dim_level !< Level for the unlimited
+                                                                        !! dimension.
+  integer, dimension(3),        intent(in), optional :: corner          !< Array of starting
+                                                                        !! indices describing
+                                                                        !! where the data
+                                                                        !! will be written to.
+  integer, dimension(3),        intent(in), optional :: edge_lengths    !< The number of
+                                                                        !! elements that
+                                                                        !! will be written
+                                                                        !! in each dimension.
 
   integer                 :: xdim_index            !< The index of the variable that is the x dimension
   integer                 :: ydim_index            !< The index of the variable that is the y dimension

--- a/fms2_io/include/domain_read.inc
+++ b/fms2_io/include/domain_read.inc
@@ -251,45 +251,48 @@ subroutine domain_read_3d(fileobj, variable_name, vdata, unlim_dim_level, &
   type(FmsNetcdfDomainFile_t), intent(in) :: fileobj !< File object.
   character(len=*), intent(in) :: variable_name !< Variable name.
   class(*), dimension(:,:,:), intent(inout) :: vdata !< Data that will
-                                                     !! be written out
-                                                     !! to the netcdf file.
+                                                   !! be written out
+                                                   !! to the netcdf file.
   integer, intent(in), optional :: unlim_dim_level !< Level for the unlimited
                                                    !! dimension.
-  integer, dimension(3), intent(in), optional :: corner !< Array of starting
+  integer, dimension(2), intent(in), optional :: corner !< Array of starting
                                                         !! indices describing
                                                         !! where the data
                                                         !! will be written to.
-  integer, dimension(3), intent(in), optional :: edge_lengths !< The number of
+  integer, dimension(2), intent(in), optional :: edge_lengths !< The number of
                                                               !! elements that
                                                               !! will be written
                                                               !! in each dimension.
 
-  integer :: xdim_index
-  integer :: ydim_index
-  type(domain2d), pointer :: io_domain
-  integer :: xpos
-  integer :: ypos
-  integer :: i
-  integer :: isd
-  integer :: isc
-  integer :: xc_size
-  integer :: jsd
-  integer :: jsc
-  integer :: yc_size
-  integer, dimension(:), allocatable :: pe_isc
-  integer, dimension(:), allocatable :: pe_icsize
-  integer, dimension(:), allocatable :: pe_jsc
-  integer, dimension(:), allocatable :: pe_jcsize
-  integer, dimension(3) :: c
-  integer, dimension(3) :: e
-  integer(kind=i4_kind), dimension(:,:,:), allocatable :: buf_i4_kind
-  integer(kind=i8_kind), dimension(:,:,:), allocatable :: buf_i8_kind
-  real(kind=r4_kind), dimension(:,:,:), allocatable :: buf_r4_kind
-  real(kind=r8_kind), dimension(:,:,:), allocatable :: buf_r8_kind
+  integer :: xdim_index !< The index of the variable that is the x dimension
+  integer :: ydim_index !< The index of the variable that is the y dimension
+  type(domain2d), pointer :: io_domain !< poitner to the io_domain
+  integer :: xpos !< The position of the x axis
+  integer :: ypos !< The position of the y axis
+  integer :: i !< For do loops
+  integer :: isd !< The starting x position of the data io_domain
+  integer :: isc !< The starting y position of the data io_domain
+  integer :: xc_size !< The size of the x compute io_domain
+  integer :: yc_size !< The size of the y compute io_domain
+  integer :: jsd !< The ending x position of the data io_domain
+  integer :: jsc !< The ending y position of the data io_domain
+  integer, dimension(3) :: c !< The corners of the data you want
+  integer, dimension(3) :: e !< The number of points (edges) you want
+  integer(kind=i4_kind), dimension(:,:,:), allocatable :: buf_i4_kind_pe
+  integer(kind=i8_kind), dimension(:,:,:), allocatable :: buf_i8_kind_pe
+  real(kind=r4_kind), dimension(:,:,:), allocatable :: buf_r4_kind_pe
+  real(kind=r8_kind), dimension(:,:,:), allocatable :: buf_r8_kind_pe
+  integer(kind=i4_kind), dimension(:,:,:), target, allocatable :: buf_i4_kind
+  integer(kind=i8_kind), dimension(:,:,:), target, allocatable :: buf_i8_kind
+  real(kind=r4_kind), dimension(:,:,:), target, allocatable :: buf_r4_kind
+  real(kind=r8_kind), dimension(:,:,:), target, allocatable :: buf_r8_kind
   logical :: buffer_includes_halos
-  integer :: xgmin !< Starting x index of global io domain
-  integer :: ygmin !< Starting y index of global io domain
+  integer :: xgbegin !< Starting x index of global io domain
+  integer :: xgsize  !< Ending x index of global io domain
+  integer :: ygbegin !< Starting y index of global io domain
+  integer :: ygszie   !< Ending y index of global io domain
 
+  write(mpp_pe()+100, *) "I am reading the data: ", trim(variable_name)
   if (.not. is_variable_domain_decomposed(fileobj, variable_name, .true., &
                                           xdim_index, ydim_index, xpos, ypos)) then
     call netcdf_read_data(fileobj, variable_name, vdata, &
@@ -304,160 +307,108 @@ subroutine domain_read_3d(fileobj, variable_name, vdata, unlim_dim_level, &
   c(:) = 1
   e(:) = shape(vdata)
 
+  call mpp_get_global_domain(io_domain, xbegin=xgbegin, xsize=xgsize, position=xpos)
+  call mpp_get_global_domain(io_domain, ybegin=ygbegin, ysize=ygszie, position=ypos)
+
   !I/O root reads in the data and scatters it.
   if (fileobj%is_root) then
-    allocate(pe_isc(size(fileobj%pelist)))
-    allocate(pe_icsize(size(fileobj%pelist)))
-    allocate(pe_jsc(size(fileobj%pelist)))
-    allocate(pe_jcsize(size(fileobj%pelist)))
-    call mpp_get_compute_domains(io_domain, xbegin=pe_isc, xsize=pe_icsize, position=xpos)
-    call mpp_get_compute_domains(io_domain, ybegin=pe_jsc, ysize=pe_jcsize, position=ypos)
-    call mpp_get_global_domain(io_domain, xbegin=xgmin, position=xpos)
-    call mpp_get_global_domain(io_domain, ybegin=ygmin, position=ypos)
-    do i = 1, size(fileobj%pelist)
-      c(xdim_index) = pe_isc(i)
-      c(ydim_index) = pe_jsc(i)
-      if (fileobj%adjust_indices) then
-        c(xdim_index) = c(xdim_index) - xgmin + 1
-        c(ydim_index) = c(ydim_index) - ygmin + 1
-      endif
-      e(xdim_index) = pe_icsize(i)
-      e(ydim_index) = pe_jcsize(i)
-      select type(vdata)
-        type is (integer(kind=i4_kind))
-          !Read in the data for fileobj%pelist(i)'s portion of the compute domain.
-          call allocate_array(buf_i4_kind, e)
-          call netcdf_read_data(fileobj, variable_name, buf_i4_kind, &
-                                unlim_dim_level=unlim_dim_level, &
-                                corner=c, edge_lengths=e, broadcast=.false.)
-          if (i .eq. 1) then
-            !Root rank stores data directly.
-            if (buffer_includes_halos) then
-              !Adjust if the input buffer has room for halos.
-              c(xdim_index) = isc - isd + 1
-              c(ydim_index) = jsc - jsd + 1
-            else
-              c(xdim_index) = 1
-              c(ydim_index) = 1
-            endif
-            call put_array_section(buf_i4_kind, vdata, c, e)
-          else
-            !Send data to non-root ranks.
-            call mpp_send(buf_i4_kind, size(buf_i4_kind), fileobj%pelist(i))
-            call mpp_sync_self(check=EVENT_SEND)
-          endif
-          deallocate(buf_i4_kind)
-        type is (integer(kind=i8_kind))
-          !Read in the data for fileobj%pelist(i)'s portion of the compute domain.
-          call allocate_array(buf_i8_kind, e)
-          call netcdf_read_data(fileobj, variable_name, buf_i8_kind, &
-                                unlim_dim_level=unlim_dim_level, &
-                                corner=c, edge_lengths=e, broadcast=.false.)
-          if (i .eq. 1) then
-            !Root rank stores data directly.
-            if (buffer_includes_halos) then
-              !Adjust if the input buffer has room for halos.
-              c(xdim_index) = isc - isd + 1
-              c(ydim_index) = jsc - jsd + 1
-            else
-              c(xdim_index) = 1
-              c(ydim_index) = 1
-            endif
-            call put_array_section(buf_i8_kind, vdata, c, e)
-          else
-            !Send data to non-root ranks.
-            call mpp_send(buf_i8_kind, size(buf_i8_kind), fileobj%pelist(i))
-            call mpp_sync_self(check=EVENT_SEND)
-          endif
-          deallocate(buf_i8_kind)
-        type is (real(kind=r4_kind))
-          !Read in the data for fileobj%pelist(i)'s portion of the compute domain.
-          call allocate_array(buf_r4_kind, e)
-          call netcdf_read_data(fileobj, variable_name, buf_r4_kind, &
-                                unlim_dim_level=unlim_dim_level, &
-                                corner=c, edge_lengths=e, broadcast=.false.)
-          if (i .eq. 1) then
-            !Root rank stores data directly.
-            if (buffer_includes_halos) then
-              !Adjust if the input buffer has room for halos.
-              c(xdim_index) = isc - isd + 1
-              c(ydim_index) = jsc - jsd + 1
-            else
-              c(xdim_index) = 1
-              c(ydim_index) = 1
-            endif
-            call put_array_section(buf_r4_kind, vdata, c, e)
-          else
-            !Send data to non-root ranks.
-            call mpp_send(buf_r4_kind, size(buf_r4_kind), fileobj%pelist(i))
-            call mpp_sync_self(check=EVENT_SEND)
-          endif
-          deallocate(buf_r4_kind)
-        type is (real(kind=r8_kind))
-          !Read in the data for fileobj%pelist(i)'s portion of the compute domain.
-          call allocate_array(buf_r8_kind, e)
-          call netcdf_read_data(fileobj, variable_name, buf_r8_kind, &
-                                unlim_dim_level=unlim_dim_level, &
-                                corner=c, edge_lengths=e, broadcast=.false.)
-          if (i .eq. 1) then
-            !Root rank stores data directly.
-            if (buffer_includes_halos) then
-              !Adjust if the input buffer has room for halos.
-              c(xdim_index) = isc - isd + 1
-              c(ydim_index) = jsc - jsd + 1
-            else
-              c(xdim_index) = 1
-              c(ydim_index) = 1
-            endif
-            call put_array_section(buf_r8_kind, vdata, c, e)
-          else
-            !Send data to non-root ranks.
-            call mpp_send(buf_r8_kind, size(buf_r8_kind), fileobj%pelist(i))
-            call mpp_sync_self(check=EVENT_SEND)
-          endif
-          deallocate(buf_r8_kind)
-        class default
-          call error("unsupported variable type: domain_read_3d: file: "//trim(fileobj%path)//" variable:"// &
-                   & trim(variable_name))
-      end select
-    enddo
-    deallocate(pe_isc)
-    deallocate(pe_icsize)
-    deallocate(pe_jsc)
-    deallocate(pe_jcsize)
-  else
-    if (buffer_includes_halos) then
-      c(xdim_index) = isc - isd + 1
-      c(ydim_index) = jsc - jsd + 1
+
+    if (fileobj%adjust_indices) then
+      !< If the file is distributed, the file only contains the io global domain
+      c(xdim_index) = 1
+      c(ydim_index) = 1
+    else
+      !< If the file is not distributed read, the file contains the global domain,
+      !! so you only need to read the global io domain
+      c(xdim_index) = xgbegin
+      c(ydim_index) = ygbegin
     endif
-    e(xdim_index) = xc_size
-    e(ydim_index) = yc_size
+
+    e(xdim_index) = xgsize
+    e(ydim_index) = ygszie
+
+    !Read in the global io domain
     select type(vdata)
       type is (integer(kind=i4_kind))
         call allocate_array(buf_i4_kind, e)
-        call mpp_recv(buf_i4_kind, size(buf_i4_kind), fileobj%io_root, block=.true.)
-        call put_array_section(buf_i4_kind, vdata, c, e)
-        deallocate(buf_i4_kind)
+        call netcdf_read_data(fileobj, variable_name, buf_i4_kind, &
+                              unlim_dim_level=unlim_dim_level, &
+                              corner=c, edge_lengths=e, broadcast=.false.)
       type is (integer(kind=i8_kind))
         call allocate_array(buf_i8_kind, e)
-        call mpp_recv(buf_i8_kind, size(buf_i8_kind), fileobj%io_root, block=.true.)
-        call put_array_section(buf_i8_kind, vdata, c, e)
-        deallocate(buf_i8_kind)
+        call netcdf_read_data(fileobj, variable_name, buf_i8_kind, &
+                              unlim_dim_level=unlim_dim_level, &
+                              corner=c, edge_lengths=e, broadcast=.false.)
       type is (real(kind=r4_kind))
         call allocate_array(buf_r4_kind, e)
-        call mpp_recv(buf_r4_kind, size(buf_r4_kind), fileobj%io_root, block=.true.)
-        call put_array_section(buf_r4_kind, vdata, c, e)
-        deallocate(buf_r4_kind)
+        call netcdf_read_data(fileobj, variable_name, buf_r4_kind, &
+                              unlim_dim_level=unlim_dim_level, &
+                              corner=c, edge_lengths=e, broadcast=.false.)
       type is (real(kind=r8_kind))
         call allocate_array(buf_r8_kind, e)
-        call mpp_recv(buf_r8_kind, size(buf_r8_kind), fileobj%io_root, block=.true.)
-        call put_array_section(buf_r8_kind, vdata, c, e)
-        deallocate(buf_r8_kind)
+        call netcdf_read_data(fileobj, variable_name, buf_r8_kind, &
+                              unlim_dim_level=unlim_dim_level, &
+                              corner=c, edge_lengths=e, broadcast=.false.)
       class default
-        call error("unsupported variable type: domain_read_3d: file: "//trim(fileobj%path)//" variable:"// &
-                 & trim(variable_name))
+        call error("unsupported variable type: domain_read_2d: file: "//trim(fileobj%path)//" variable:"// &
+                  & trim(variable_name))
     end select
+
+    write(mpp_pe()+100, *) "I am read the data: ", trim(variable_name)
   endif
+
+  c = 1
+  e = shape(vdata)
+
+  if (buffer_includes_halos) then
+    !Adjust if the input buffer has room for halos.
+    c(xdim_index) = isc - isd + 1
+    c(ydim_index) = jsc - jsd + 1
+  else
+    c(xdim_index) = 1
+    c(ydim_index) = 1
+  endif
+
+  e(xdim_index) = xc_size
+  e(ydim_index) = yc_size
+
+  write(mpp_pe()+100, *) "I am scattering the data: ", trim(variable_name)
+  select type(vdata)
+  type is (integer(kind=i4_kind))
+    call allocate_array(buf_i4_kind_pe, e)
+    call mpp_scatter(isc-xgbegin+1, isc+xc_size-xgbegin, jsc-ygbegin+1, jsc+yc_size-ygbegin, e(3), fileobj%pelist, &
+                     buf_i4_kind_pe, buf_i4_kind, fileobj%is_root)
+    call put_array_section(buf_i4_kind_pe, vdata, c, e)
+    deallocate(buf_i4_kind_pe)
+  type is (integer(kind=i8_kind))
+    call allocate_array(buf_i8_kind_pe, e)
+    call mpp_scatter(isc-xgbegin+1, isc+xc_size-xgbegin, jsc-ygbegin+1, jsc+yc_size-ygbegin, e(3), fileobj%pelist, &
+                     buf_i8_kind_pe, buf_i8_kind, fileobj%is_root)
+    call put_array_section(buf_i8_kind_pe, vdata, c, e)
+    deallocate(buf_i8_kind_pe)
+  type is (real(kind=r4_kind))
+    write(mpp_pe()+100, *) "I am allocating the data buffer: ", trim(variable_name)
+    call allocate_array(buf_r4_kind_pe, e)
+    write(mpp_pe()+100, *) "Indices:", isc-xgbegin+1, isc+xc_size-xgbegin, jsc-ygbegin+1, jsc+yc_size-ygbegin, e(3)
+
+    call mpp_scatter(isc-xgbegin+1, isc+xc_size-xgbegin, jsc-ygbegin+1, jsc+yc_size-ygbegin, e(3), fileobj%pelist, &
+                     buf_r4_kind_pe, buf_r4_kind, fileobj%is_root)
+    write(mpp_pe()+100, *) "I am scattered the data: ", trim(variable_name)
+    call put_array_section(buf_r4_kind_pe, vdata, c, e)
+    write(mpp_pe()+100, *) "I am putting the data back: ", trim(variable_name)
+    deallocate(buf_r4_kind_pe)
+  type is (real(kind=r8_kind))
+    call allocate_array(buf_r8_kind_pe, e)
+    write(mpp_pe()+100, *) "Indices:WUT", isc-xgbegin+1, isc+xc_size-xgbegin, jsc-ygbegin+1, jsc+yc_size-ygbegin, e(3)
+    if (fileobj%is_root) print *, "SHAPE of the thing:", shape(buf_r8_kind)
+    call mpp_scatter(isc-xgbegin+1, isc+xc_size-xgbegin, jsc-ygbegin+1, jsc+yc_size-ygbegin, e(3), fileobj%pelist, &
+                     buf_r8_kind_pe, buf_r8_kind, fileobj%is_root)
+    call put_array_section(buf_r8_kind_pe, vdata, c, e)
+    deallocate(buf_r8_kind_pe)
+  class default
+    call error("unsupported variable type: domain_read_2d: file: "//trim(fileobj%path)//" variable:"// &
+               & trim(variable_name))
+  end select
 end subroutine domain_read_3d
 
 

--- a/fms2_io/include/domain_read.inc
+++ b/fms2_io/include/domain_read.inc
@@ -108,26 +108,34 @@ subroutine domain_read_2d(fileobj, variable_name, vdata, unlim_dim_level, &
   type(domain2d), pointer :: io_domain
   integer :: xpos
   integer :: ypos
-  integer :: i
+  integer :: i, j ,k
   integer :: isd
   integer :: isc
   integer :: xc_size
   integer :: jsd
   integer :: jsc
   integer :: yc_size
-  integer, dimension(:), allocatable :: pe_isc
-  integer, dimension(:), allocatable :: pe_icsize
-  integer, dimension(:), allocatable :: pe_jsc
-  integer, dimension(:), allocatable :: pe_jcsize
+  integer, dimension(:), allocatable :: pe_isc !< Starting x index of compute domain for all PEs in the list
+  integer, dimension(:), allocatable :: pe_icsize !< Size of the x compute domain for all PEs in the list
+  integer, dimension(:), allocatable :: pe_jsc !< Size of the y compute domain for all PEs in the list
+  integer, dimension(:), allocatable :: pe_jcsize !< Ending y index of compute domain for all PEs in the list
   integer, dimension(2) :: c
   integer, dimension(2) :: e
-  integer(kind=i4_kind), dimension(:,:), allocatable :: buf_i4_kind
-  integer(kind=i8_kind), dimension(:,:), allocatable :: buf_i8_kind
-  real(kind=r4_kind), dimension(:,:), allocatable :: buf_r4_kind
-  real(kind=r8_kind), dimension(:,:), allocatable :: buf_r8_kind
+  integer, dimension(2) :: c_pe
+  integer, dimension(2) :: e_pe
+  integer(kind=i4_kind), dimension(:,:), pointer :: buf_i4_kind_pe
+  integer(kind=i8_kind), dimension(:,:), pointer :: buf_i8_kind_pe
+  real(kind=r4_kind), dimension(:,:), pointer :: buf_r4_kind_pe
+  real(kind=r8_kind), dimension(:,:), allocatable :: buf_r8_kind_pe
+  integer(kind=i4_kind), dimension(:,:), target, allocatable :: buf_i4_kind
+  integer(kind=i8_kind), dimension(:,:), target, allocatable :: buf_i8_kind
+  real(kind=r4_kind), dimension(:,:), target, allocatable :: buf_r4_kind
+  real(kind=r8_kind), dimension(:,:), target, allocatable :: buf_r8_kind
   logical :: buffer_includes_halos
-  integer :: xgmin !< Starting x index of global io domain
-  integer :: ygmin !< Starting y index of global io domain
+  integer :: xgbegin !< Starting x index of global io domain
+  integer :: xgend   !< Ending x index of global io domain
+  integer :: ygbegin !< Starting y index of global io domain
+  integer :: ygend   !< Ending y index of global io domain
 
   if (.not. is_variable_domain_decomposed(fileobj, variable_name, .true., &
                                           xdim_index, ydim_index, xpos, ypos)) then
@@ -151,150 +159,213 @@ subroutine domain_read_2d(fileobj, variable_name, vdata, unlim_dim_level, &
     allocate(pe_jcsize(size(fileobj%pelist)))
     call mpp_get_compute_domains(io_domain, xbegin=pe_isc, xsize=pe_icsize, position=xpos)
     call mpp_get_compute_domains(io_domain, ybegin=pe_jsc, ysize=pe_jcsize, position=ypos)
-    call mpp_get_global_domain(io_domain, xbegin=xgmin, position=xpos)
-    call mpp_get_global_domain(io_domain, ybegin=ygmin, position=ypos)
-    do i = 1, size(fileobj%pelist)
-      c(xdim_index) = pe_isc(i)
-      c(ydim_index) = pe_jsc(i)
-      if (fileobj%adjust_indices) then
-        c(xdim_index) = c(xdim_index) - xgmin + 1
-        c(ydim_index) = c(ydim_index) - ygmin + 1
-      endif
-      e(xdim_index) = pe_icsize(i)
-      e(ydim_index) = pe_jcsize(i)
-      select type(vdata)
-        type is (integer(kind=i4_kind))
-          !Read in the data for fileobj%pelist(i)'s portion of the compute domain.
-          call allocate_array(buf_i4_kind, e)
-          call netcdf_read_data(fileobj, variable_name, buf_i4_kind, &
-                                unlim_dim_level=unlim_dim_level, &
-                                corner=c, edge_lengths=e, broadcast=.false.)
-          if (i .eq. 1) then
-            !Root rank stores data directly.
+    call mpp_get_global_domain(io_domain, xbegin=xgbegin, xend=xgend, position=xpos)
+    call mpp_get_global_domain(io_domain, ybegin=ygend, yend=ygend, position=ypos)
+
+    if (fileobj%adjust_indices) then
+      !< If the file is distributed, the file only contains the io global domain
+      c(xdim_index) = 1
+      c(ydim_index) = 1
+    else
+      !< If the file is not distributed read, the file contains the global domain,
+      !! so you only need to read the global io domain
+      c(xdim_index) = xgbegin
+      c(ydim_index) = ygbegin
+    endif
+
+    e(xdim_index) = xgend
+    e(ydim_index) = ygend
+
+    !Read in the global io domain
+    select type(vdata)
+      type is (integer(kind=i4_kind))
+        call allocate_array(buf_i4_kind, e-c+1 )
+        call netcdf_read_data(fileobj, variable_name, buf_i4_kind, &
+                              unlim_dim_level=unlim_dim_level, &
+                              corner=c, edge_lengths=e, broadcast=.false.)
+        c_pe = 1
+        e_pe = size(vdata)
+        do i = 1, size(fileobj%pelist)
+          !< Adust the starting and ending indices based on the global io_domian
+          c_pe(xdim_index) = pe_isc(i) - xgbegin + 1
+          c_pe(ydim_index) = pe_jsc(i) - xgbegin + 1
+          e_pe(xdim_index) = pe_icsize(i) + pe_isc(i) + 1
+          e_pe(ydim_index) = pe_jcsize(i) + pe_jsc(i) + 1
+
+          !< Get the PE's portion of data
+          buf_i4_kind_pe(1:pe_icsize(i), 1:pe_jcsize(i)) => buf_i4_kind(c_pe(1):e_pe(1), c_pe(2):e_pe(2))
+
+          if (i .ne. 1) then
+            !< Send the data to each PE
+            write(fileobj%pelist(i) +100, *) "Sending Data:", buf_i4_kind_pe
+            call mpp_send(buf_i4_kind_pe, size(buf_i4_kind_pe), fileobj%pelist(i))
+            call mpp_sync_self(check=EVENT_SEND)
+          else
+            !< For the root pe, there is no need to send data because it already has it
+            c_pe = 1
+            e_pe = size(vdata)
+            e_pe(xdim_index) = pe_icsize(i)
+            e_pe(ydim_index) = pe_jcsize(i)
             if (buffer_includes_halos) then
-              !Adjust if the input buffer has room for halos.
               c(xdim_index) = isc - isd + 1
               c(ydim_index) = jsc - jsd + 1
-            else
-              c(xdim_index) = 1
-              c(ydim_index) = 1
             endif
-            call put_array_section(buf_i4_kind, vdata, c, e)
-          else
-            !Send data to non-root ranks.
-            call mpp_send(buf_i4_kind, size(buf_i4_kind), fileobj%pelist(i))
-            call mpp_sync_self(check=EVENT_SEND)
+            call put_array_section(buf_i4_kind_pe, vdata, c, e)
           endif
-          deallocate(buf_i4_kind)
-        type is (integer(kind=i8_kind))
-          !Read in the data for fileobj%pelist(i)'s portion of the compute domain.
-          call allocate_array(buf_i8_kind, e)
-          call netcdf_read_data(fileobj, variable_name, buf_i8_kind, &
-                                unlim_dim_level=unlim_dim_level, &
-                                corner=c, edge_lengths=e, broadcast=.false.)
-          if (i .eq. 1) then
-            !Root rank stores data directly.
+        enddo
+        deallocate(buf_i4_kind_pe)
+      type is (integer(kind=i8_kind))
+        call allocate_array(buf_i8_kind, e-c+1)
+        call netcdf_read_data(fileobj, variable_name, buf_i8_kind, &
+                              unlim_dim_level=unlim_dim_level, &
+                              corner=c, edge_lengths=e, broadcast=.false.)
+        c_pe = 1
+        e_pe = size(vdata)
+        do i = 1, size(fileobj%pelist)
+          !< Adust the starting and ending indices based on the global io_domian
+          c_pe(xdim_index) = pe_isc(i) - xgbegin + 1
+          c_pe(ydim_index) = pe_jsc(i) - xgbegin + 1
+          e_pe(xdim_index) = pe_icsize(i) + pe_isc(i) + 1
+          e_pe(ydim_index) = pe_jcsize(i) + pe_jsc(i) + 1
+
+          !< Get the PE's portion of data
+          buf_i8_kind_pe => buf_i8_kind(c_pe(1):e_pe(1), c_pe(2):e_pe(2))
+
+          if (i .ne. 1) then
+            !< Send the data to each PE
+            call mpp_send(buf_i8_kind_pe, size(buf_i8_kind_pe), fileobj%pelist(i))
+            call mpp_sync_self(check=EVENT_SEND)
+          else
+            !< For the root pe, there is no need to send data because it already has it
+            c_pe = 1
+            e_pe = size(vdata)
+            e_pe(xdim_index) = pe_icsize(i)
+            e_pe(ydim_index) = pe_jcsize(i)
             if (buffer_includes_halos) then
-              !Adjust if the input buffer has room for halos.
               c(xdim_index) = isc - isd + 1
               c(ydim_index) = jsc - jsd + 1
-            else
-              c(xdim_index) = 1
-              c(ydim_index) = 1
             endif
-            call put_array_section(buf_i8_kind, vdata, c, e)
-          else
-            !Send data to non-root ranks.
-            call mpp_send(buf_i8_kind, size(buf_i8_kind), fileobj%pelist(i))
-            call mpp_sync_self(check=EVENT_SEND)
+            call put_array_section(buf_i8_kind_pe, vdata, c, e)
           endif
-          deallocate(buf_i8_kind)
-        type is (real(kind=r4_kind))
-          !Read in the data for fileobj%pelist(i)'s portion of the compute domain.
-          call allocate_array(buf_r4_kind, e)
-          call netcdf_read_data(fileobj, variable_name, buf_r4_kind, &
-                                unlim_dim_level=unlim_dim_level, &
-                                corner=c, edge_lengths=e, broadcast=.false.)
-          if (i .eq. 1) then
-            !Root rank stores data directly.
+        enddo
+        deallocate(buf_i8_kind_pe)
+      type is (real(kind=r4_kind))
+        call allocate_array(buf_r4_kind, e-c+1)
+        call netcdf_read_data(fileobj, variable_name, buf_r4_kind, &
+                              unlim_dim_level=unlim_dim_level, &
+                              corner=c, edge_lengths=e, broadcast=.false.)
+        c_pe = 1
+        e_pe = size(vdata)
+        do i = 1, size(fileobj%pelist)
+          !< Adust the starting and ending indices based on the global io_domian
+          c_pe(xdim_index) = pe_isc(i) - xgbegin + 1
+          c_pe(ydim_index) = pe_jsc(i) - xgbegin + 1
+          e_pe(xdim_index) = pe_icsize(i) + pe_isc(i) + 1
+          e_pe(ydim_index) = pe_jcsize(i) + pe_jsc(i) + 1
+
+          !< Get the PE's portion of data
+          buf_r4_kind_pe => buf_r4_kind(c_pe(1):e_pe(1), c_pe(2):e_pe(2))
+
+          if (i .ne. 1) then
+            !< Send the data to each PE
+            write(fileobj%pelist(i) +100, *) "Sending Data:", buf_r4_kind_pe
+            call mpp_send(buf_r4_kind_pe, size(buf_r4_kind_pe), fileobj%pelist(i))
+            call mpp_sync_self(check=EVENT_SEND)
+          else
+            !< For the root pe, there is no need to send data because it already has it
+            c_pe = 1
+            e_pe = size(vdata)
+            e_pe(xdim_index) = pe_icsize(i)
+            e_pe(ydim_index) = pe_jcsize(i)
             if (buffer_includes_halos) then
-              !Adjust if the input buffer has room for halos.
               c(xdim_index) = isc - isd + 1
               c(ydim_index) = jsc - jsd + 1
-            else
-              c(xdim_index) = 1
-              c(ydim_index) = 1
             endif
-            call put_array_section(buf_r4_kind, vdata, c, e)
-          else
-            !Send data to non-root ranks.
-            call mpp_send(buf_r4_kind, size(buf_r4_kind), fileobj%pelist(i))
-            call mpp_sync_self(check=EVENT_SEND)
+            call put_array_section(buf_r4_kind_pe, vdata, c, e)
           endif
-          deallocate(buf_r4_kind)
-        type is (real(kind=r8_kind))
-          !Read in the data for fileobj%pelist(i)'s portion of the compute domain.
-          call allocate_array(buf_r8_kind, e)
-          call netcdf_read_data(fileobj, variable_name, buf_r8_kind, &
-                                unlim_dim_level=unlim_dim_level, &
-                                corner=c, edge_lengths=e, broadcast=.false.)
-          if (i .eq. 1) then
-            !Root rank stores data directly.
+        enddo
+        deallocate(buf_r4_kind_pe)
+      type is (real(kind=r8_kind))
+        call allocate_array(buf_r8_kind, e-c+1)
+        call netcdf_read_data(fileobj, variable_name, buf_r8_kind, &
+                              unlim_dim_level=unlim_dim_level, &
+                              corner=c, edge_lengths=e, broadcast=.false.)
+
+        c_pe = 1
+        e_pe = size(vdata)
+        do i = 1, size(fileobj%pelist)
+          !< Adust the starting and ending indices based on the global io_domian
+          c_pe(xdim_index) = pe_isc(i) - xgbegin + 1
+          c_pe(ydim_index) = pe_jsc(i) - xgbegin + 1
+          e_pe(xdim_index) = pe_icsize(i) + c_pe(xdim_index) - 1
+          e_pe(ydim_index) = pe_jcsize(i) + c_pe(ydim_index) - 1
+
+          !< Get the PE's portion of data
+          call allocate_array(buf_i4_kind, e_pe-c_pe+1)
+          buf_r8_kind_pe = buf_r8_kind(c_pe(1):e_pe(1), c_pe(2):e_pe(2))
+
+          if (i .ne. 1) then
+            !< Send the data to each PE
+            call mpp_send(buf_r8_kind_pe, size(buf_r8_kind_pe), fileobj%pelist(i))
+            call mpp_sync_self(check=EVENT_SEND)
+          else
+            !< For the root pe, there is no need to send data because it already has it
+            c_pe = 1
+            e_pe = size(vdata)
+            e_pe(xdim_index) = pe_icsize(i)
+            e_pe(ydim_index) = pe_jcsize(i)
             if (buffer_includes_halos) then
-              !Adjust if the input buffer has room for halos.
-              c(xdim_index) = isc - isd + 1
-              c(ydim_index) = jsc - jsd + 1
-            else
-              c(xdim_index) = 1
-              c(ydim_index) = 1
+              c_pe(xdim_index) = isc - isd + 1
+              c_pe(ydim_index) = jsc - jsd + 1
             endif
-            call put_array_section(buf_r8_kind, vdata, c, e)
-          else
-            !Send data to non-root ranks.
-            call mpp_send(buf_r8_kind, size(buf_r8_kind), fileobj%pelist(i))
-            call mpp_sync_self(check=EVENT_SEND)
+            call put_array_section(buf_r8_kind_pe, vdata, c_pe, e_pe)
           endif
-          deallocate(buf_r8_kind)
-        class default
-          call error("unsupported variable type: domain_read_2d: file: "//trim(fileobj%path)//" variable:"// &
-                   & trim(variable_name))
-      end select
-    enddo
+        enddo
+      class default
+        call error("unsupported variable type: domain_read_2d: file: "//trim(fileobj%path)//" variable:"// &
+                  & trim(variable_name))
+    end select
+    
     deallocate(pe_isc)
     deallocate(pe_icsize)
     deallocate(pe_jsc)
     deallocate(pe_jcsize)
   else
+    c_pe = 1
+    e_pe = size(vdata)
+
     if (buffer_includes_halos) then
-      c(xdim_index) = isc - isd + 1
-      c(ydim_index) = jsc - jsd + 1
+      c_pe(xdim_index) = isc - isd + 1
+      c_pe(ydim_index) = jsc - jsd + 1
     endif
-    e(xdim_index) = xc_size
-    e(ydim_index) = yc_size
+    e_pe(xdim_index) = xc_size
+    e_pe(ydim_index) = yc_size
+
     select type(vdata)
-      type is (integer(kind=i4_kind))
-        call allocate_array(buf_i4_kind, e)
-        call mpp_recv(buf_i4_kind, size(buf_i4_kind), fileobj%io_root, block=.true.)
-        call put_array_section(buf_i4_kind, vdata, c, e)
-        deallocate(buf_i4_kind)
-      type is (integer(kind=i8_kind))
-        call allocate_array(buf_i8_kind, e)
-        call mpp_recv(buf_i8_kind, size(buf_i8_kind), fileobj%io_root, block=.true.)
-        call put_array_section(buf_i8_kind, vdata, c, e)
-        deallocate(buf_i8_kind)
-      type is (real(kind=r4_kind))
-        call allocate_array(buf_r4_kind, e)
-        call mpp_recv(buf_r4_kind, size(buf_r4_kind), fileobj%io_root, block=.true.)
-        call put_array_section(buf_r4_kind, vdata, c, e)
-        deallocate(buf_r4_kind)
-      type is (real(kind=r8_kind))
-        call allocate_array(buf_r8_kind, e)
-        call mpp_recv(buf_r8_kind, size(buf_r8_kind), fileobj%io_root, block=.true.)
-        call put_array_section(buf_r8_kind, vdata, c, e)
-        deallocate(buf_r8_kind)
-      class default
-        call error("unsupported variable type: domain_read_2d: file: "//trim(fileobj%path)//" variable:"// &
-                 & trim(variable_name))
+    type is (integer(kind=i4_kind))
+      call allocate_array(buf_i4_kind, e_pe)
+      call mpp_recv(buf_i4_kind, size(buf_i4_kind), fileobj%io_root, block=.true.)
+      call put_array_section(buf_i4_kind, vdata, c_pe, e_pe)
+      deallocate(buf_i4_kind)
+    type is (integer(kind=i8_kind))
+      call allocate_array(buf_i8_kind, e_pe)
+      call mpp_recv(buf_i8_kind, size(buf_i8_kind), fileobj%io_root, block=.true.)
+      call put_array_section(buf_i8_kind, vdata, c_pe, e_pe)
+      deallocate(buf_i8_kind)
+    type is (real(kind=r4_kind))
+      call allocate_array(buf_r4_kind, e_pe)
+      call mpp_recv(buf_r4_kind, size(buf_r4_kind), fileobj%io_root, block=.true.)
+      write(mpp_pe() +100, *) "Receiving Data:", buf_r4_kind
+      call put_array_section(buf_r4_kind, vdata, c_pe, e_pe)
+      deallocate(buf_r4_kind)
+    type is (real(kind=r8_kind))
+      call allocate_array(buf_r8_kind, e_pe)
+      call mpp_recv(buf_r8_kind, size(buf_r8_kind), fileobj%io_root, block=.true.)
+      call put_array_section(buf_r8_kind, vdata, c_pe, e_pe)
+      deallocate(buf_r8_kind)
+    class default
+      call error("unsupported variable type: domain_read_2d: file: "//trim(fileobj%path)//" variable:"// &
+               & trim(variable_name))
     end select
   endif
 end subroutine domain_read_2d

--- a/fms2_io/include/domain_read.inc
+++ b/fms2_io/include/domain_read.inc
@@ -249,6 +249,13 @@ subroutine domain_read_2d(fileobj, variable_name, vdata, unlim_dim_level, &
     call error("unsupported variable type: domain_read_2d: file: "//trim(fileobj%path)//" variable:"// &
                & trim(variable_name))
   end select
+
+  if (fileobj%is_root) then
+    if (allocated(buf_i4_kind)) deallocate(buf_i4_kind)
+    if (allocated(buf_i8_kind)) deallocate(buf_i8_kind)
+    if (allocated(buf_r4_kind)) deallocate(buf_r4_kind)
+    if (allocated(buf_r8_kind)) deallocate(buf_r8_kind)
+  endif
 end subroutine domain_read_2d
 
 
@@ -422,6 +429,14 @@ subroutine domain_read_3d(fileobj, variable_name, vdata, unlim_dim_level, &
     call error("unsupported variable type: domain_read_2d: file: "//trim(fileobj%path)//" variable:"// &
                & trim(variable_name))
   end select
+
+  if (fileobj%is_root) then
+    if (allocated(buf_i4_kind)) deallocate(buf_i4_kind)
+    if (allocated(buf_i8_kind)) deallocate(buf_i8_kind)
+    if (allocated(buf_r4_kind)) deallocate(buf_r4_kind)
+    if (allocated(buf_r8_kind)) deallocate(buf_r8_kind)
+  endif
+
 end subroutine domain_read_3d
 
 

--- a/fms2_io/include/domain_read.inc
+++ b/fms2_io/include/domain_read.inc
@@ -292,7 +292,6 @@ subroutine domain_read_3d(fileobj, variable_name, vdata, unlim_dim_level, &
   integer :: ygbegin !< Starting y index of global io domain
   integer :: ygszie   !< Ending y index of global io domain
 
-  write(mpp_pe()+100, *) "I am reading the data: ", trim(variable_name)
   if (.not. is_variable_domain_decomposed(fileobj, variable_name, .true., &
                                           xdim_index, ydim_index, xpos, ypos)) then
     call netcdf_read_data(fileobj, variable_name, vdata, &
@@ -354,7 +353,6 @@ subroutine domain_read_3d(fileobj, variable_name, vdata, unlim_dim_level, &
                   & trim(variable_name))
     end select
 
-    write(mpp_pe()+100, *) "I am read the data: ", trim(variable_name)
   endif
 
   c = 1
@@ -372,7 +370,6 @@ subroutine domain_read_3d(fileobj, variable_name, vdata, unlim_dim_level, &
   e(xdim_index) = xc_size
   e(ydim_index) = yc_size
 
-  write(mpp_pe()+100, *) "I am scattering the data: ", trim(variable_name)
   select type(vdata)
   type is (integer(kind=i4_kind))
     call allocate_array(buf_i4_kind_pe, e)
@@ -387,20 +384,13 @@ subroutine domain_read_3d(fileobj, variable_name, vdata, unlim_dim_level, &
     call put_array_section(buf_i8_kind_pe, vdata, c, e)
     deallocate(buf_i8_kind_pe)
   type is (real(kind=r4_kind))
-    write(mpp_pe()+100, *) "I am allocating the data buffer: ", trim(variable_name)
     call allocate_array(buf_r4_kind_pe, e)
-    write(mpp_pe()+100, *) "Indices:", isc-xgbegin+1, isc+xc_size-xgbegin, jsc-ygbegin+1, jsc+yc_size-ygbegin, e(3)
-
     call mpp_scatter(isc-xgbegin+1, isc+xc_size-xgbegin, jsc-ygbegin+1, jsc+yc_size-ygbegin, e(3), fileobj%pelist, &
                      buf_r4_kind_pe, buf_r4_kind, fileobj%is_root)
-    write(mpp_pe()+100, *) "I am scattered the data: ", trim(variable_name)
     call put_array_section(buf_r4_kind_pe, vdata, c, e)
-    write(mpp_pe()+100, *) "I am putting the data back: ", trim(variable_name)
     deallocate(buf_r4_kind_pe)
   type is (real(kind=r8_kind))
     call allocate_array(buf_r8_kind_pe, e)
-    write(mpp_pe()+100, *) "Indices:WUT", isc-xgbegin+1, isc+xc_size-xgbegin, jsc-ygbegin+1, jsc+yc_size-ygbegin, e(3)
-    if (fileobj%is_root) print *, "SHAPE of the thing:", shape(buf_r8_kind)
     call mpp_scatter(isc-xgbegin+1, isc+xc_size-xgbegin, jsc-ygbegin+1, jsc+yc_size-ygbegin, e(3), fileobj%pelist, &
                      buf_r8_kind_pe, buf_r8_kind, fileobj%is_root)
     call put_array_section(buf_r8_kind_pe, vdata, c, e)

--- a/fms2_io/include/domain_read.inc
+++ b/fms2_io/include/domain_read.inc
@@ -32,14 +32,14 @@ subroutine domain_read_0d(fileobj, variable_name, vdata, unlim_dim_level, corner
   type(FmsNetcdfDomainFile_t), intent(in) :: fileobj !< File object.
   character(len=*), intent(in) :: variable_name !< Variable name.
   class(*), intent(inout) :: vdata !< Data that will
-                                   !! be written out
+                                   !! be read out
                                    !! to the netcdf file.
   integer, intent(in), optional :: unlim_dim_level !< Level for the unlimited
                                                    !! dimension.
   integer, intent(in), optional :: corner !< Array of starting
                                           !! indices describing
                                           !! where the data
-                                          !! will be written to.
+                                          !! will be read to.
 
   call netcdf_read_data(fileobj, variable_name, vdata, &
                           unlim_dim_level=unlim_dim_level, corner=corner, &
@@ -59,17 +59,17 @@ subroutine domain_read_1d(fileobj, variable_name, vdata, unlim_dim_level, &
   type(FmsNetcdfDomainFile_t), intent(in) :: fileobj !< File object.
   character(len=*), intent(in) :: variable_name !< Variable name.
   class(*), dimension(:), intent(inout) :: vdata !< Data that will
-                                                 !! be written out
+                                                 !! be read out
                                                  !! to the netcdf file.
   integer, intent(in), optional :: unlim_dim_level !< Level for the unlimited
                                                    !! dimension.
   integer, dimension(1), intent(in), optional :: corner !< Array of starting
                                                         !! indices describing
                                                         !! where the data
-                                                        !! will be written to.
+                                                        !! will be read to.
   integer, dimension(1), intent(in), optional :: edge_lengths !< The number of
                                                               !! elements that
-                                                              !! will be written
+                                                              !! will be read
                                                               !! in each dimension.
 
   call netcdf_read_data(fileobj, variable_name, vdata, &
@@ -89,17 +89,17 @@ subroutine domain_read_2d(fileobj, variable_name, vdata, unlim_dim_level, &
   type(FmsNetcdfDomainFile_t),  intent(in)           :: fileobj         !< File object.
   character(len=*),             intent(in)           :: variable_name   !< Variable name.
   class(*), contiguous, target, intent(inout)        :: vdata(:,:)      !< Data that will
-                                                                        !! be written out
+                                                                        !! be read out
                                                                         !! to the netcdf file.
   integer,                      intent(in), optional :: unlim_dim_level !< Level for the unlimited
                                                                         !! dimension.
   integer, dimension(2),        intent(in), optional :: corner          !< Array of starting
                                                                         !! indices describing
                                                                         !! where the data
-                                                                        !! will be written to.
+                                                                        !! will be read to.
   integer, dimension(2),        intent(in), optional :: edge_lengths    !< The number of
                                                                         !! elements that
-                                                                        !! will be written
+                                                                        !! will be read
                                                                         !! in each dimension.
 
   integer                 :: xdim_index            !< The index of the variable that is the x dimension
@@ -269,17 +269,17 @@ subroutine domain_read_3d(fileobj, variable_name, vdata, unlim_dim_level, &
   type(FmsNetcdfDomainFile_t),  intent(in)           :: fileobj         !< File object.
   character(len=*),             intent(in)           :: variable_name   !< Variable name.
   class(*), contiguous, target, intent(inout)        :: vdata(:,:,:)    !< Data that will
-                                                                        !! be written out
+                                                                        !! be read out
                                                                         !! to the netcdf file.
   integer,                      intent(in), optional :: unlim_dim_level !< Level for the unlimited
                                                                         !! dimension.
   integer, dimension(3),        intent(in), optional :: corner          !< Array of starting
                                                                         !! indices describing
                                                                         !! where the data
-                                                                        !! will be written to.
+                                                                        !! will be read to.
   integer, dimension(3),        intent(in), optional :: edge_lengths    !< The number of
                                                                         !! elements that
-                                                                        !! will be written
+                                                                        !! will be read
                                                                         !! in each dimension.
 
   integer                 :: xdim_index            !< The index of the variable that is the x dimension
@@ -451,17 +451,17 @@ subroutine domain_read_4d(fileobj, variable_name, vdata, unlim_dim_level, &
   type(FmsNetcdfDomainFile_t), intent(in) :: fileobj !< File object.
   character(len=*), intent(in) :: variable_name !< Variable name.
   class(*), dimension(:,:,:,:), intent(inout) :: vdata !< Data that will
-                                                       !! be written out
+                                                       !! be read out
                                                        !! to the netcdf file.
   integer, intent(in), optional :: unlim_dim_level !< Level for the unlimited
                                                    !! dimension.
   integer, dimension(4), intent(in), optional :: corner !< Array of starting
                                                         !! indices describing
                                                         !! where the data
-                                                        !! will be written to.
+                                                        !! will be read to.
   integer, dimension(4), intent(in), optional :: edge_lengths !< The number of
                                                               !! elements that
-                                                              !! will be written
+                                                              !! will be read
                                                               !! in each dimension.
 
   integer :: xdim_index
@@ -672,17 +672,17 @@ subroutine domain_read_5d(fileobj, variable_name, vdata, unlim_dim_level, &
   type(FmsNetcdfDomainFile_t), intent(in) :: fileobj !< File object.
   character(len=*), intent(in) :: variable_name !< Variable name.
   class(*), dimension(:,:,:,:,:), intent(inout) :: vdata !< Data that will
-                                                         !! be written out
+                                                         !! be read out
                                                          !! to the netcdf file.
   integer, intent(in), optional :: unlim_dim_level !< Level for the unlimited
                                                    !! dimension.
   integer, dimension(5), intent(in), optional :: corner !< Array of starting
                                                         !! indices describing
                                                         !! where the data
-                                                        !! will be written to.
+                                                        !! will be read to.
   integer, dimension(5), intent(in), optional :: edge_lengths !< The number of
                                                               !! elements that
-                                                              !! will be written
+                                                              !! will be read
                                                               !! in each dimension.
 
   integer :: xdim_index

--- a/fms2_io/include/domain_read.inc
+++ b/fms2_io/include/domain_read.inc
@@ -86,56 +86,76 @@ end subroutine domain_read_1d
 !!        decomposed".
 subroutine domain_read_2d(fileobj, variable_name, vdata, unlim_dim_level, &
                           corner, edge_lengths)
+  type(FmsNetcdfDomainFile_t),intent(in)           :: fileobj         !< File object.
+  character(len=*),           intent(in)           :: variable_name   !< Variable name.
+  class(*), dimension(:,:),   intent(inout),target :: vdata           !< Data that will
+                                                                      !! be written out
+                                                                      !! to the netcdf file.
+  integer,                    intent(in), optional :: unlim_dim_level !< Level for the unlimited
+                                                                      !! dimension.
+  integer, dimension(2),      intent(in), optional :: corner          !< Array of starting
+                                                                      !! indices describing
+                                                                      !! where the data
+                                                                      !! will be written to.
+  integer, dimension(2),      intent(in), optional :: edge_lengths    !< The number of
+                                                                      !! elements that
+                                                                      !! will be written
+                                                                      !! in each dimension.
 
-  type(FmsNetcdfDomainFile_t), intent(in) :: fileobj !< File object.
-  character(len=*), intent(in) :: variable_name !< Variable name.
-  class(*), dimension(:,:), intent(inout) :: vdata !< Data that will
-                                                   !! be written out
-                                                   !! to the netcdf file.
-  integer, intent(in), optional :: unlim_dim_level !< Level for the unlimited
-                                                   !! dimension.
-  integer, dimension(2), intent(in), optional :: corner !< Array of starting
-                                                        !! indices describing
-                                                        !! where the data
-                                                        !! will be written to.
-  integer, dimension(2), intent(in), optional :: edge_lengths !< The number of
-                                                              !! elements that
-                                                              !! will be written
-                                                              !! in each dimension.
+  integer                 :: xdim_index            !< The index of the variable that is the x dimension
+  integer                 :: ydim_index            !< The index of the variable that is the y dimension
+  integer                 :: xpos                  !< The position of the x axis
+  integer                 :: ypos                  !< The position of the y axis
+  integer                 :: i                     !< For do loops
+  integer                 :: isd                   !< The starting x position of the data io_domain
+  integer                 :: isc                   !< The starting y position of the data io_domain
+  integer                 :: xc_size               !< The size of the x compute io_domain
+  integer                 :: yc_size               !< The size of the y compute io_domain
+  integer                 :: jsd                   !< The ending x position of the data io_domain
+  integer                 :: jsc                   !< The ending y position of the data io_domain
+  integer                 :: c(2)                  !< The corners of the data
+  integer                 :: e(2)                  !< The number of points (edges)
+  logical                 :: buffer_includes_halos !< .True. if vdata includes halo points
+  integer                 :: xgbegin               !< Starting x index of global io domain
+  integer                 :: xgsize                !< Size of global io domain
+  integer                 :: ygbegin               !< Starting y index of global io domain
+  integer                 :: ygsize                !< Ending y index of global io domain
+  type(domain2d), pointer :: io_domain             !< pointer to the io_domain
 
-  integer :: xdim_index !< The index of the variable that is the x dimension
-  integer :: ydim_index !< The index of the variable that is the y dimension
-  type(domain2d), pointer :: io_domain !< poitner to the io_domain
-  integer :: xpos !< The position of the x axis
-  integer :: ypos !< The position of the y axis
-  integer :: i !< For do loops
-  integer :: isd !< The starting x position of the data io_domain
-  integer :: isc !< The starting y position of the data io_domain
-  integer :: xc_size !< The size of the x compute io_domain
-  integer :: yc_size !< The size of the y compute io_domain
-  integer :: jsd !< The ending x position of the data io_domain
-  integer :: jsc !< The ending y position of the data io_domain
-  integer, dimension(2) :: c !< The corners of the data you want
-  integer, dimension(2) :: e !< The number of points (edges) you want
-  integer(kind=i4_kind), dimension(:,:), allocatable :: buf_i4_kind_pe
-  integer(kind=i8_kind), dimension(:,:), allocatable :: buf_i8_kind_pe
-  real(kind=r4_kind), dimension(:,:), allocatable :: buf_r4_kind_pe
-  real(kind=r8_kind), dimension(:,:), allocatable :: buf_r8_kind_pe
-  integer(kind=i4_kind), dimension(:,:), target, allocatable :: buf_i4_kind
-  integer(kind=i8_kind), dimension(:,:), target, allocatable :: buf_i8_kind
-  real(kind=r4_kind), dimension(:,:), target, allocatable :: buf_r4_kind
-  real(kind=r8_kind), dimension(:,:), target, allocatable :: buf_r8_kind
-  logical :: buffer_includes_halos
-  integer :: xgbegin !< Starting x index of global io domain
-  integer :: xgsize  !< Ending x index of global io domain
-  integer :: ygbegin !< Starting y index of global io domain
-  integer :: ygszie   !< Ending y index of global io domain
+  !< The global data is only allocated by the io root PEs
+  integer(kind=i4_kind), dimension(:,:),     allocatable :: buf_i4_kind_pe !< PES section of the data
+  integer(kind=i8_kind), dimension(:,:),     allocatable :: buf_i8_kind_pe !< PES section of the data
+  real(kind=r4_kind),    dimension(:,:),     allocatable :: buf_r4_kind_pe !< PES section of the data
+  real(kind=r8_kind),    dimension(:,:),     allocatable :: buf_r8_kind_pe !< PES section of the data
+  integer(kind=i4_kind), dimension(:,:),     allocatable :: buf_i4_kind    !< Global section of the data
+  integer(kind=i8_kind), dimension(:,:),     allocatable :: buf_i8_kind    !< Global section of the data
+  real(kind=r4_kind),    dimension(:,:),     allocatable :: buf_r4_kind    !< Global section of the data
+  real(kind=r8_kind),    dimension(:,:),     allocatable :: buf_r8_kind    !< Global section of the data
+  class(*),              dimension(:,:,:,:), pointer     :: vdata_dummy    !< Vdata remapped as 4D
 
   if (.not. is_variable_domain_decomposed(fileobj, variable_name, .true., &
                                           xdim_index, ydim_index, xpos, ypos)) then
     call netcdf_read_data(fileobj, variable_name, vdata, &
                           unlim_dim_level=unlim_dim_level, corner=corner, &
                           edge_lengths=edge_lengths, broadcast=.true.)
+    return
+  endif
+
+  if (xdim_index .ne. 1 .or. ydim_index .ne. 2) then
+    ! This is a KLUDGE
+    ! mpp_scatter assumes that the variable is (x,y), if that is not the case it remaps the data
+    ! to a 4D array and calls domain_read_4d which does not use mpp_scatter yet
+    select type(vdata)
+    type is (real(kind=r8_kind))
+      vdata_dummy(1:size(vdata,1),1:size(vdata,2), 1:1, 1:1) => vdata(:,:)
+    type is (real(kind=r4_kind))
+      vdata_dummy(1:size(vdata,1),1:size(vdata,2), 1:1, 1:1) => vdata(:,:)
+    type is (integer(kind=i8_kind))
+      vdata_dummy(1:size(vdata,1),1:size(vdata,2), 1:1, 1:1) => vdata(:,:)
+    type is (integer(kind=i4_kind))
+      vdata_dummy(1:size(vdata,1),1:size(vdata,2), 1:1, 1:1) => vdata(:,:)
+    end select
+    call domain_read_4d(fileobj, variable_name, vdata_dummy, unlim_dim_level)
     return
   endif
   io_domain => mpp_get_io_domain(fileobj%domain)
@@ -146,7 +166,7 @@ subroutine domain_read_2d(fileobj, variable_name, vdata, unlim_dim_level, &
   e(:) = shape(vdata)
 
   call mpp_get_global_domain(io_domain, xbegin=xgbegin, xsize=xgsize, position=xpos)
-  call mpp_get_global_domain(io_domain, ybegin=ygbegin, ysize=ygszie, position=ypos)
+  call mpp_get_global_domain(io_domain, ybegin=ygbegin, ysize=ygsize, position=ypos)
 
   !I/O root reads in the data and scatters it.
   if (fileobj%is_root) then
@@ -163,7 +183,7 @@ subroutine domain_read_2d(fileobj, variable_name, vdata, unlim_dim_level, &
     endif
 
     e(xdim_index) = xgsize
-    e(ydim_index) = ygszie
+    e(ydim_index) = ygsize
 
     !Read in the global io domain
     select type(vdata)
@@ -191,10 +211,11 @@ subroutine domain_read_2d(fileobj, variable_name, vdata, unlim_dim_level, &
         call error("unsupported variable type: domain_read_2d: file: "//trim(fileobj%path)//" variable:"// &
                   & trim(variable_name))
     end select
+
   endif
 
   c = 1
-  e = size(vdata)
+  e = shape(vdata)
 
   if (buffer_includes_halos) then
     !Adjust if the input buffer has room for halos.
@@ -247,56 +268,76 @@ end subroutine domain_read_2d
 !!        decomposed".
 subroutine domain_read_3d(fileobj, variable_name, vdata, unlim_dim_level, &
                           corner, edge_lengths)
+  type(FmsNetcdfDomainFile_t),intent(in)           :: fileobj         !< File object.
+  character(len=*),           intent(in)           :: variable_name   !< Variable name.
+  class(*), dimension(:,:,:), intent(inout),target :: vdata           !< Data that will
+                                                                      !! be written out
+                                                                      !! to the netcdf file.
+  integer,                    intent(in), optional :: unlim_dim_level !< Level for the unlimited
+                                                                      !! dimension.
+  integer, dimension(2),      intent(in), optional :: corner          !< Array of starting
+                                                                      !! indices describing
+                                                                      !! where the data
+                                                                      !! will be written to.
+  integer, dimension(2),      intent(in), optional :: edge_lengths    !< The number of
+                                                                      !! elements that
+                                                                      !! will be written
+                                                                      !! in each dimension.
 
-  type(FmsNetcdfDomainFile_t), intent(in) :: fileobj !< File object.
-  character(len=*), intent(in) :: variable_name !< Variable name.
-  class(*), dimension(:,:,:), intent(inout) :: vdata !< Data that will
-                                                   !! be written out
-                                                   !! to the netcdf file.
-  integer, intent(in), optional :: unlim_dim_level !< Level for the unlimited
-                                                   !! dimension.
-  integer, dimension(2), intent(in), optional :: corner !< Array of starting
-                                                        !! indices describing
-                                                        !! where the data
-                                                        !! will be written to.
-  integer, dimension(2), intent(in), optional :: edge_lengths !< The number of
-                                                              !! elements that
-                                                              !! will be written
-                                                              !! in each dimension.
+  integer                 :: xdim_index            !< The index of the variable that is the x dimension
+  integer                 :: ydim_index            !< The index of the variable that is the y dimension
+  integer                 :: xpos                  !< The position of the x axis
+  integer                 :: ypos                  !< The position of the y axis
+  integer                 :: i                     !< For do loops
+  integer                 :: isd                   !< The starting x position of the data io_domain
+  integer                 :: isc                   !< The starting y position of the data io_domain
+  integer                 :: xc_size               !< The size of the x compute io_domain
+  integer                 :: yc_size               !< The size of the y compute io_domain
+  integer                 :: jsd                   !< The ending x position of the data io_domain
+  integer                 :: jsc                   !< The ending y position of the data io_domain
+  integer                 :: c(3)                  !< The corners of the data
+  integer                 :: e(3)                  !< The number of points (edges)
+  logical                 :: buffer_includes_halos !< .True. if vdata includes halo points
+  integer                 :: xgbegin               !< Starting x index of global io domain
+  integer                 :: xgsize                !< Size of global io domain
+  integer                 :: ygbegin               !< Starting y index of global io domain
+  integer                 :: ygsize                !< Ending y index of global io domain
+  type(domain2d), pointer :: io_domain             !< pointer to the io_domain
 
-  integer :: xdim_index !< The index of the variable that is the x dimension
-  integer :: ydim_index !< The index of the variable that is the y dimension
-  type(domain2d), pointer :: io_domain !< poitner to the io_domain
-  integer :: xpos !< The position of the x axis
-  integer :: ypos !< The position of the y axis
-  integer :: i !< For do loops
-  integer :: isd !< The starting x position of the data io_domain
-  integer :: isc !< The starting y position of the data io_domain
-  integer :: xc_size !< The size of the x compute io_domain
-  integer :: yc_size !< The size of the y compute io_domain
-  integer :: jsd !< The ending x position of the data io_domain
-  integer :: jsc !< The ending y position of the data io_domain
-  integer, dimension(3) :: c !< The corners of the data you want
-  integer, dimension(3) :: e !< The number of points (edges) you want
-  integer(kind=i4_kind), dimension(:,:,:), allocatable :: buf_i4_kind_pe
-  integer(kind=i8_kind), dimension(:,:,:), allocatable :: buf_i8_kind_pe
-  real(kind=r4_kind), dimension(:,:,:), allocatable :: buf_r4_kind_pe
-  real(kind=r8_kind), dimension(:,:,:), allocatable :: buf_r8_kind_pe
-  integer(kind=i4_kind), dimension(:,:,:), target, allocatable :: buf_i4_kind
-  integer(kind=i8_kind), dimension(:,:,:), target, allocatable :: buf_i8_kind
-  real(kind=r4_kind), dimension(:,:,:), target, allocatable :: buf_r4_kind
-  real(kind=r8_kind), dimension(:,:,:), target, allocatable :: buf_r8_kind
-  logical :: buffer_includes_halos
-  integer :: xgbegin !< Starting x index of global io domain
-  integer :: xgsize  !< Ending x index of global io domain
-  integer :: ygbegin !< Starting y index of global io domain
-  integer :: ygszie   !< Ending y index of global io domain
+  !< The global data is only allocated by the io root PEs
+  integer(kind=i4_kind), dimension(:,:,:),   allocatable :: buf_i4_kind_pe !< PES section of the data
+  integer(kind=i8_kind), dimension(:,:,:),   allocatable :: buf_i8_kind_pe !< PES section of the data
+  real(kind=r4_kind),    dimension(:,:,:),   allocatable :: buf_r4_kind_pe !< PES section of the data
+  real(kind=r8_kind),    dimension(:,:,:),   allocatable :: buf_r8_kind_pe !< PES section of the data
+  integer(kind=i4_kind), dimension(:,:,:),   allocatable :: buf_i4_kind    !< Global section of the data
+  integer(kind=i8_kind), dimension(:,:,:),   allocatable :: buf_i8_kind    !< Global section of the data
+  real(kind=r4_kind),    dimension(:,:,:),   allocatable :: buf_r4_kind    !< Global section of the data
+  real(kind=r8_kind),    dimension(:,:,:),   allocatable :: buf_r8_kind    !< Global section of the data
+  class(*),              dimension(:,:,:,:), pointer     :: vdata_dummy    !< Vdata remapped as 4D
 
   if (.not. is_variable_domain_decomposed(fileobj, variable_name, .true., &
                                           xdim_index, ydim_index, xpos, ypos)) then
     call netcdf_read_data(fileobj, variable_name, vdata, &
                           unlim_dim_level=unlim_dim_level, corner=corner, &
                           edge_lengths=edge_lengths, broadcast=.true.)
+    return
+  endif
+
+  if (xdim_index .ne. 1 .or. ydim_index .ne. 2) then
+    ! This is a KLUDGE
+    ! mpp_scatter assumes that the variable is (x,y), if that is not the case it remaps the data
+    ! to a 4D array and calls domain_read_4d which does not use mpp_scatter yet
+    select type(vdata)
+    type is (real(kind=r8_kind))
+      vdata_dummy(1:size(vdata,1),1:size(vdata,2), 1:size(vdata,3), 1:1) => vdata(:,:,:)
+    type is (real(kind=r4_kind))
+      vdata_dummy(1:size(vdata,1),1:size(vdata,2), 1:size(vdata,3), 1:1) => vdata(:,:,:)
+    type is (integer(kind=i8_kind))
+      vdata_dummy(1:size(vdata,1),1:size(vdata,2), 1:size(vdata,3), 1:1) => vdata(:,:,:)
+    type is (integer(kind=i4_kind))
+      vdata_dummy(1:size(vdata,1),1:size(vdata,2), 1:size(vdata,3), 1:1) => vdata(:,:,:)
+    end select
+    call domain_read_4d(fileobj, variable_name, vdata_dummy, unlim_dim_level)
     return
   endif
   io_domain => mpp_get_io_domain(fileobj%domain)
@@ -307,7 +348,7 @@ subroutine domain_read_3d(fileobj, variable_name, vdata, unlim_dim_level, &
   e(:) = shape(vdata)
 
   call mpp_get_global_domain(io_domain, xbegin=xgbegin, xsize=xgsize, position=xpos)
-  call mpp_get_global_domain(io_domain, ybegin=ygbegin, ysize=ygszie, position=ypos)
+  call mpp_get_global_domain(io_domain, ybegin=ygbegin, ysize=ygsize, position=ypos)
 
   !I/O root reads in the data and scatters it.
   if (fileobj%is_root) then
@@ -324,7 +365,7 @@ subroutine domain_read_3d(fileobj, variable_name, vdata, unlim_dim_level, &
     endif
 
     e(xdim_index) = xgsize
-    e(ydim_index) = ygszie
+    e(ydim_index) = ygsize
 
     !Read in the global io domain
     select type(vdata)

--- a/fms2_io/include/domain_read.inc
+++ b/fms2_io/include/domain_read.inc
@@ -103,29 +103,23 @@ subroutine domain_read_2d(fileobj, variable_name, vdata, unlim_dim_level, &
                                                               !! will be written
                                                               !! in each dimension.
 
-  integer :: xdim_index
-  integer :: ydim_index
-  type(domain2d), pointer :: io_domain
-  integer :: xpos
-  integer :: ypos
-  integer :: i, j ,k
-  integer :: isd
-  integer :: isc
-  integer :: xc_size
-  integer :: jsd
-  integer :: jsc
-  integer :: yc_size
-  integer, dimension(:), allocatable :: pe_isc !< Starting x index of compute domain for all PEs in the list
-  integer, dimension(:), allocatable :: pe_icsize !< Size of the x compute domain for all PEs in the list
-  integer, dimension(:), allocatable :: pe_jsc !< Size of the y compute domain for all PEs in the list
-  integer, dimension(:), allocatable :: pe_jcsize !< Ending y index of compute domain for all PEs in the list
-  integer, dimension(2) :: c
-  integer, dimension(2) :: e
-  integer, dimension(2) :: c_pe
-  integer, dimension(2) :: e_pe
-  integer(kind=i4_kind), dimension(:,:), pointer :: buf_i4_kind_pe
-  integer(kind=i8_kind), dimension(:,:), pointer :: buf_i8_kind_pe
-  real(kind=r4_kind), dimension(:,:), pointer :: buf_r4_kind_pe
+  integer :: xdim_index !< The index of the variable that is the x dimension
+  integer :: ydim_index !< The index of the variable that is the y dimension
+  type(domain2d), pointer :: io_domain !< poitner to the io_domain
+  integer :: xpos !< The position of the x axis
+  integer :: ypos !< The position of the y axis
+  integer :: i !< For do loops
+  integer :: isd !< The starting x position of the data io_domain
+  integer :: isc !< The starting y position of the data io_domain
+  integer :: xc_size !< The size of the x compute io_domain
+  integer :: yc_size !< The size of the y compute io_domain
+  integer :: jsd !< The ending x position of the data io_domain
+  integer :: jsc !< The ending y position of the data io_domain
+  integer, dimension(2) :: c !< The corners of the data you want
+  integer, dimension(2) :: e !< The number of points (edges) you want
+  integer(kind=i4_kind), dimension(:,:), allocatable :: buf_i4_kind_pe
+  integer(kind=i8_kind), dimension(:,:), allocatable :: buf_i8_kind_pe
+  real(kind=r4_kind), dimension(:,:), allocatable :: buf_r4_kind_pe
   real(kind=r8_kind), dimension(:,:), allocatable :: buf_r8_kind_pe
   integer(kind=i4_kind), dimension(:,:), target, allocatable :: buf_i4_kind
   integer(kind=i8_kind), dimension(:,:), target, allocatable :: buf_i8_kind
@@ -133,9 +127,9 @@ subroutine domain_read_2d(fileobj, variable_name, vdata, unlim_dim_level, &
   real(kind=r8_kind), dimension(:,:), target, allocatable :: buf_r8_kind
   logical :: buffer_includes_halos
   integer :: xgbegin !< Starting x index of global io domain
-  integer :: xgend   !< Ending x index of global io domain
+  integer :: xgsize  !< Ending x index of global io domain
   integer :: ygbegin !< Starting y index of global io domain
-  integer :: ygend   !< Ending y index of global io domain
+  integer :: ygszie   !< Ending y index of global io domain
 
   if (.not. is_variable_domain_decomposed(fileobj, variable_name, .true., &
                                           xdim_index, ydim_index, xpos, ypos)) then
@@ -151,16 +145,11 @@ subroutine domain_read_2d(fileobj, variable_name, vdata, unlim_dim_level, &
   c(:) = 1
   e(:) = shape(vdata)
 
+  call mpp_get_global_domain(io_domain, xbegin=xgbegin, xsize=xgsize, position=xpos)
+  call mpp_get_global_domain(io_domain, ybegin=ygbegin, ysize=ygszie, position=ypos)
+
   !I/O root reads in the data and scatters it.
   if (fileobj%is_root) then
-    allocate(pe_isc(size(fileobj%pelist)))
-    allocate(pe_icsize(size(fileobj%pelist)))
-    allocate(pe_jsc(size(fileobj%pelist)))
-    allocate(pe_jcsize(size(fileobj%pelist)))
-    call mpp_get_compute_domains(io_domain, xbegin=pe_isc, xsize=pe_icsize, position=xpos)
-    call mpp_get_compute_domains(io_domain, ybegin=pe_jsc, ysize=pe_jcsize, position=ypos)
-    call mpp_get_global_domain(io_domain, xbegin=xgbegin, xend=xgend, position=xpos)
-    call mpp_get_global_domain(io_domain, ybegin=ygend, yend=ygend, position=ypos)
 
     if (fileobj%adjust_indices) then
       !< If the file is distributed, the file only contains the io global domain
@@ -173,201 +162,81 @@ subroutine domain_read_2d(fileobj, variable_name, vdata, unlim_dim_level, &
       c(ydim_index) = ygbegin
     endif
 
-    e(xdim_index) = xgend
-    e(ydim_index) = ygend
+    e(xdim_index) = xgsize
+    e(ydim_index) = ygszie
 
     !Read in the global io domain
     select type(vdata)
       type is (integer(kind=i4_kind))
-        call allocate_array(buf_i4_kind, e-c+1 )
+        call allocate_array(buf_i4_kind, e)
         call netcdf_read_data(fileobj, variable_name, buf_i4_kind, &
                               unlim_dim_level=unlim_dim_level, &
                               corner=c, edge_lengths=e, broadcast=.false.)
-        c_pe = 1
-        e_pe = size(vdata)
-        do i = 1, size(fileobj%pelist)
-          !< Adust the starting and ending indices based on the global io_domian
-          c_pe(xdim_index) = pe_isc(i) - xgbegin + 1
-          c_pe(ydim_index) = pe_jsc(i) - xgbegin + 1
-          e_pe(xdim_index) = pe_icsize(i) + pe_isc(i) + 1
-          e_pe(ydim_index) = pe_jcsize(i) + pe_jsc(i) + 1
-
-          !< Get the PE's portion of data
-          buf_i4_kind_pe(1:pe_icsize(i), 1:pe_jcsize(i)) => buf_i4_kind(c_pe(1):e_pe(1), c_pe(2):e_pe(2))
-
-          if (i .ne. 1) then
-            !< Send the data to each PE
-            write(fileobj%pelist(i) +100, *) "Sending Data:", buf_i4_kind_pe
-            call mpp_send(buf_i4_kind_pe, size(buf_i4_kind_pe), fileobj%pelist(i))
-            call mpp_sync_self(check=EVENT_SEND)
-          else
-            !< For the root pe, there is no need to send data because it already has it
-            c_pe = 1
-            e_pe = size(vdata)
-            e_pe(xdim_index) = pe_icsize(i)
-            e_pe(ydim_index) = pe_jcsize(i)
-            if (buffer_includes_halos) then
-              c(xdim_index) = isc - isd + 1
-              c(ydim_index) = jsc - jsd + 1
-            endif
-            call put_array_section(buf_i4_kind_pe, vdata, c, e)
-          endif
-        enddo
-        deallocate(buf_i4_kind_pe)
       type is (integer(kind=i8_kind))
-        call allocate_array(buf_i8_kind, e-c+1)
+        call allocate_array(buf_i8_kind, e)
         call netcdf_read_data(fileobj, variable_name, buf_i8_kind, &
                               unlim_dim_level=unlim_dim_level, &
                               corner=c, edge_lengths=e, broadcast=.false.)
-        c_pe = 1
-        e_pe = size(vdata)
-        do i = 1, size(fileobj%pelist)
-          !< Adust the starting and ending indices based on the global io_domian
-          c_pe(xdim_index) = pe_isc(i) - xgbegin + 1
-          c_pe(ydim_index) = pe_jsc(i) - xgbegin + 1
-          e_pe(xdim_index) = pe_icsize(i) + pe_isc(i) + 1
-          e_pe(ydim_index) = pe_jcsize(i) + pe_jsc(i) + 1
-
-          !< Get the PE's portion of data
-          buf_i8_kind_pe => buf_i8_kind(c_pe(1):e_pe(1), c_pe(2):e_pe(2))
-
-          if (i .ne. 1) then
-            !< Send the data to each PE
-            call mpp_send(buf_i8_kind_pe, size(buf_i8_kind_pe), fileobj%pelist(i))
-            call mpp_sync_self(check=EVENT_SEND)
-          else
-            !< For the root pe, there is no need to send data because it already has it
-            c_pe = 1
-            e_pe = size(vdata)
-            e_pe(xdim_index) = pe_icsize(i)
-            e_pe(ydim_index) = pe_jcsize(i)
-            if (buffer_includes_halos) then
-              c(xdim_index) = isc - isd + 1
-              c(ydim_index) = jsc - jsd + 1
-            endif
-            call put_array_section(buf_i8_kind_pe, vdata, c, e)
-          endif
-        enddo
-        deallocate(buf_i8_kind_pe)
       type is (real(kind=r4_kind))
-        call allocate_array(buf_r4_kind, e-c+1)
+        call allocate_array(buf_r4_kind, e)
         call netcdf_read_data(fileobj, variable_name, buf_r4_kind, &
                               unlim_dim_level=unlim_dim_level, &
                               corner=c, edge_lengths=e, broadcast=.false.)
-        c_pe = 1
-        e_pe = size(vdata)
-        do i = 1, size(fileobj%pelist)
-          !< Adust the starting and ending indices based on the global io_domian
-          c_pe(xdim_index) = pe_isc(i) - xgbegin + 1
-          c_pe(ydim_index) = pe_jsc(i) - xgbegin + 1
-          e_pe(xdim_index) = pe_icsize(i) + pe_isc(i) + 1
-          e_pe(ydim_index) = pe_jcsize(i) + pe_jsc(i) + 1
-
-          !< Get the PE's portion of data
-          buf_r4_kind_pe => buf_r4_kind(c_pe(1):e_pe(1), c_pe(2):e_pe(2))
-
-          if (i .ne. 1) then
-            !< Send the data to each PE
-            write(fileobj%pelist(i) +100, *) "Sending Data:", buf_r4_kind_pe
-            call mpp_send(buf_r4_kind_pe, size(buf_r4_kind_pe), fileobj%pelist(i))
-            call mpp_sync_self(check=EVENT_SEND)
-          else
-            !< For the root pe, there is no need to send data because it already has it
-            c_pe = 1
-            e_pe = size(vdata)
-            e_pe(xdim_index) = pe_icsize(i)
-            e_pe(ydim_index) = pe_jcsize(i)
-            if (buffer_includes_halos) then
-              c(xdim_index) = isc - isd + 1
-              c(ydim_index) = jsc - jsd + 1
-            endif
-            call put_array_section(buf_r4_kind_pe, vdata, c, e)
-          endif
-        enddo
-        deallocate(buf_r4_kind_pe)
       type is (real(kind=r8_kind))
-        call allocate_array(buf_r8_kind, e-c+1)
+        call allocate_array(buf_r8_kind, e)
         call netcdf_read_data(fileobj, variable_name, buf_r8_kind, &
                               unlim_dim_level=unlim_dim_level, &
                               corner=c, edge_lengths=e, broadcast=.false.)
-
-        c_pe = 1
-        e_pe = size(vdata)
-        do i = 1, size(fileobj%pelist)
-          !< Adust the starting and ending indices based on the global io_domian
-          c_pe(xdim_index) = pe_isc(i) - xgbegin + 1
-          c_pe(ydim_index) = pe_jsc(i) - xgbegin + 1
-          e_pe(xdim_index) = pe_icsize(i) + c_pe(xdim_index) - 1
-          e_pe(ydim_index) = pe_jcsize(i) + c_pe(ydim_index) - 1
-
-          !< Get the PE's portion of data
-          call allocate_array(buf_i4_kind, e_pe-c_pe+1)
-          buf_r8_kind_pe = buf_r8_kind(c_pe(1):e_pe(1), c_pe(2):e_pe(2))
-
-          if (i .ne. 1) then
-            !< Send the data to each PE
-            call mpp_send(buf_r8_kind_pe, size(buf_r8_kind_pe), fileobj%pelist(i))
-            call mpp_sync_self(check=EVENT_SEND)
-          else
-            !< For the root pe, there is no need to send data because it already has it
-            c_pe = 1
-            e_pe = size(vdata)
-            e_pe(xdim_index) = pe_icsize(i)
-            e_pe(ydim_index) = pe_jcsize(i)
-            if (buffer_includes_halos) then
-              c_pe(xdim_index) = isc - isd + 1
-              c_pe(ydim_index) = jsc - jsd + 1
-            endif
-            call put_array_section(buf_r8_kind_pe, vdata, c_pe, e_pe)
-          endif
-        enddo
       class default
         call error("unsupported variable type: domain_read_2d: file: "//trim(fileobj%path)//" variable:"// &
                   & trim(variable_name))
     end select
-    
-    deallocate(pe_isc)
-    deallocate(pe_icsize)
-    deallocate(pe_jsc)
-    deallocate(pe_jcsize)
-  else
-    c_pe = 1
-    e_pe = size(vdata)
-
-    if (buffer_includes_halos) then
-      c_pe(xdim_index) = isc - isd + 1
-      c_pe(ydim_index) = jsc - jsd + 1
-    endif
-    e_pe(xdim_index) = xc_size
-    e_pe(ydim_index) = yc_size
-
-    select type(vdata)
-    type is (integer(kind=i4_kind))
-      call allocate_array(buf_i4_kind, e_pe)
-      call mpp_recv(buf_i4_kind, size(buf_i4_kind), fileobj%io_root, block=.true.)
-      call put_array_section(buf_i4_kind, vdata, c_pe, e_pe)
-      deallocate(buf_i4_kind)
-    type is (integer(kind=i8_kind))
-      call allocate_array(buf_i8_kind, e_pe)
-      call mpp_recv(buf_i8_kind, size(buf_i8_kind), fileobj%io_root, block=.true.)
-      call put_array_section(buf_i8_kind, vdata, c_pe, e_pe)
-      deallocate(buf_i8_kind)
-    type is (real(kind=r4_kind))
-      call allocate_array(buf_r4_kind, e_pe)
-      call mpp_recv(buf_r4_kind, size(buf_r4_kind), fileobj%io_root, block=.true.)
-      write(mpp_pe() +100, *) "Receiving Data:", buf_r4_kind
-      call put_array_section(buf_r4_kind, vdata, c_pe, e_pe)
-      deallocate(buf_r4_kind)
-    type is (real(kind=r8_kind))
-      call allocate_array(buf_r8_kind, e_pe)
-      call mpp_recv(buf_r8_kind, size(buf_r8_kind), fileobj%io_root, block=.true.)
-      call put_array_section(buf_r8_kind, vdata, c_pe, e_pe)
-      deallocate(buf_r8_kind)
-    class default
-      call error("unsupported variable type: domain_read_2d: file: "//trim(fileobj%path)//" variable:"// &
-               & trim(variable_name))
-    end select
   endif
+
+  c = 1
+  e = size(vdata)
+
+  if (buffer_includes_halos) then
+    !Adjust if the input buffer has room for halos.
+    c(xdim_index) = isc - isd + 1
+    c(ydim_index) = jsc - jsd + 1
+  else
+    c(xdim_index) = 1
+    c(ydim_index) = 1
+  endif
+
+  e(xdim_index) = xc_size
+  e(ydim_index) = yc_size
+
+  select type(vdata)
+  type is (integer(kind=i4_kind))
+    call allocate_array(buf_i4_kind_pe, e)
+    call mpp_scatter(isc-xgbegin+1, isc+xc_size-xgbegin, jsc-ygbegin+1, jsc+yc_size-ygbegin, fileobj%pelist, &
+                     buf_i4_kind_pe, buf_i4_kind, fileobj%is_root)
+    call put_array_section(buf_i4_kind_pe, vdata, c, e)
+    deallocate(buf_i4_kind_pe)
+  type is (integer(kind=i8_kind))
+    call allocate_array(buf_i8_kind_pe, e)
+    call mpp_scatter(isc-xgbegin+1, isc+xc_size-xgbegin, jsc-ygbegin+1, jsc+yc_size-ygbegin, fileobj%pelist, &
+                     buf_i8_kind_pe, buf_i8_kind, fileobj%is_root)
+    call put_array_section(buf_i8_kind_pe, vdata, c, e)
+    deallocate(buf_i8_kind_pe)
+  type is (real(kind=r4_kind))
+    call allocate_array(buf_r4_kind_pe, e)
+    call mpp_scatter(isc-xgbegin+1, isc+xc_size-xgbegin, jsc-ygbegin+1, jsc+yc_size-ygbegin, fileobj%pelist, &
+                     buf_r4_kind_pe, buf_r4_kind, fileobj%is_root)
+    call put_array_section(buf_r4_kind_pe, vdata, c, e)
+    deallocate(buf_r4_kind_pe)
+  type is (real(kind=r8_kind))
+    call allocate_array(buf_r8_kind_pe, e)
+    call mpp_scatter(isc-xgbegin+1, isc+xc_size-xgbegin, jsc-ygbegin+1, jsc+yc_size-ygbegin, fileobj%pelist, &
+                     buf_r8_kind_pe, buf_r8_kind, fileobj%is_root)
+    call put_array_section(buf_r8_kind_pe, vdata, c, e)
+    deallocate(buf_r8_kind_pe)
+  class default
+    call error("unsupported variable type: domain_read_2d: file: "//trim(fileobj%path)//" variable:"// &
+               & trim(variable_name))
+  end select
 end subroutine domain_read_2d
 
 

--- a/fms2_io/include/domain_read.inc
+++ b/fms2_io/include/domain_read.inc
@@ -108,18 +108,18 @@ subroutine domain_read_2d(fileobj, variable_name, vdata, unlim_dim_level, &
   integer                 :: ypos                  !< The position of the y axis
   integer                 :: i                     !< For do loops
   integer                 :: isd                   !< The starting x position of the data io_domain
-  integer                 :: isc                   !< The starting y position of the data io_domain
+  integer                 :: isc                   !< The starting x position of the compute io_domain
   integer                 :: xc_size               !< The size of the x compute io_domain
   integer                 :: yc_size               !< The size of the y compute io_domain
   integer                 :: jsd                   !< The ending x position of the data io_domain
-  integer                 :: jsc                   !< The ending y position of the data io_domain
+  integer                 :: jsc                   !< The ending y position of the compute io_domain
   integer                 :: c(2)                  !< The corners of the data
   integer                 :: e(2)                  !< The number of points (edges)
   logical                 :: buffer_includes_halos !< .True. if vdata includes halo points
   integer                 :: xgbegin               !< Starting x index of global io domain
-  integer                 :: xgsize                !< Size of global io domain
+  integer                 :: xgsize                !< Size of global x io domain
   integer                 :: ygbegin               !< Starting y index of global io domain
-  integer                 :: ygsize                !< Ending y index of global io domain
+  integer                 :: ygsize                !< Size of global y io domain
   type(domain2d), pointer :: io_domain             !< pointer to the io_domain
 
   !< The global data is only allocated by the io root PEs
@@ -288,18 +288,18 @@ subroutine domain_read_3d(fileobj, variable_name, vdata, unlim_dim_level, &
   integer                 :: ypos                  !< The position of the y axis
   integer                 :: i                     !< For do loops
   integer                 :: isd                   !< The starting x position of the data io_domain
-  integer                 :: isc                   !< The starting y position of the data io_domain
+  integer                 :: isc                   !< The starting x position of the compute io_domain
   integer                 :: xc_size               !< The size of the x compute io_domain
   integer                 :: yc_size               !< The size of the y compute io_domain
   integer                 :: jsd                   !< The ending x position of the data io_domain
-  integer                 :: jsc                   !< The ending y position of the data io_domain
+  integer                 :: jsc                   !< The ending y position of the compute io_domain
   integer                 :: c(3)                  !< The corners of the data
   integer                 :: e(3)                  !< The number of points (edges)
   logical                 :: buffer_includes_halos !< .True. if vdata includes halo points
   integer                 :: xgbegin               !< Starting x index of global io domain
-  integer                 :: xgsize                !< Size of global io domain
+  integer                 :: xgsize                !< Size of global x io domain
   integer                 :: ygbegin               !< Starting y index of global io domain
-  integer                 :: ygsize                !< Ending y index of global io domain
+  integer                 :: ygsize                !< Size of global y io domain
   type(domain2d), pointer :: io_domain             !< pointer to the io_domain
 
   !< The global data is only allocated by the io root PEs

--- a/fms2_io/include/domain_read.inc
+++ b/fms2_io/include/domain_read.inc
@@ -145,16 +145,7 @@ subroutine domain_read_2d(fileobj, variable_name, vdata, unlim_dim_level, &
     ! This is a KLUDGE
     ! mpp_scatter assumes that the variable is (x,y), if that is not the case it remaps the data
     ! to a 4D array and calls domain_read_4d which does not use mpp_scatter yet
-    select type(vdata)
-    type is (real(kind=r8_kind))
-      vdata_dummy(1:size(vdata,1),1:size(vdata,2), 1:1, 1:1) => vdata(:,:)
-    type is (real(kind=r4_kind))
-      vdata_dummy(1:size(vdata,1),1:size(vdata,2), 1:1, 1:1) => vdata(:,:)
-    type is (integer(kind=i8_kind))
-      vdata_dummy(1:size(vdata,1),1:size(vdata,2), 1:1, 1:1) => vdata(:,:)
-    type is (integer(kind=i4_kind))
-      vdata_dummy(1:size(vdata,1),1:size(vdata,2), 1:1, 1:1) => vdata(:,:)
-    end select
+    vdata_dummy(1:size(vdata,1),1:size(vdata,2), 1:1, 1:1) => vdata(:,:)
     call domain_read_4d(fileobj, variable_name, vdata_dummy, unlim_dim_level)
     return
   endif
@@ -327,16 +318,7 @@ subroutine domain_read_3d(fileobj, variable_name, vdata, unlim_dim_level, &
     ! This is a KLUDGE
     ! mpp_scatter assumes that the variable is (x,y), if that is not the case it remaps the data
     ! to a 4D array and calls domain_read_4d which does not use mpp_scatter yet
-    select type(vdata)
-    type is (real(kind=r8_kind))
-      vdata_dummy(1:size(vdata,1),1:size(vdata,2), 1:size(vdata,3), 1:1) => vdata(:,:,:)
-    type is (real(kind=r4_kind))
-      vdata_dummy(1:size(vdata,1),1:size(vdata,2), 1:size(vdata,3), 1:1) => vdata(:,:,:)
-    type is (integer(kind=i8_kind))
-      vdata_dummy(1:size(vdata,1),1:size(vdata,2), 1:size(vdata,3), 1:1) => vdata(:,:,:)
-    type is (integer(kind=i4_kind))
-      vdata_dummy(1:size(vdata,1),1:size(vdata,2), 1:size(vdata,3), 1:1) => vdata(:,:,:)
-    end select
+    vdata_dummy(1:size(vdata,1),1:size(vdata,2), 1:size(vdata,3), 1:1) => vdata(:,:,:)
     call domain_read_4d(fileobj, variable_name, vdata_dummy, unlim_dim_level)
     return
   endif

--- a/mpp/include/mpp_comm.inc
+++ b/mpp/include/mpp_comm.inc
@@ -434,6 +434,14 @@
 #undef  MPP_SCATTER_PELIST_2D_
 #undef  MPP_SCATTER_PELIST_3D_
 #undef MPP_TYPE_
+#define MPP_TYPE_ integer(i8_kind)
+#define MPP_SCATTER_PELIST_2D_ mpp_scatter_pelist_int8_2d
+#define MPP_SCATTER_PELIST_3D_ mpp_scatter_pelist_int8_3d
+#include <mpp_scatter.fh>
+
+#undef  MPP_SCATTER_PELIST_2D_
+#undef  MPP_SCATTER_PELIST_3D_
+#undef MPP_TYPE_
 #define MPP_TYPE_ real(r4_kind)
 #define MPP_SCATTER_PELIST_2D_ mpp_scatter_pelist_real4_2d
 #define MPP_SCATTER_PELIST_3D_ mpp_scatter_pelist_real4_3d

--- a/mpp/include/mpp_domains_util.inc
+++ b/mpp/include/mpp_domains_util.inc
@@ -324,6 +324,14 @@
         !call mpp_set_super_grid_indices(domain%list(i-1)%y(1)%data)
     enddo
 
+    do i=1, size(domain%x(1)%list)
+        call mpp_set_super_grid_indices(domain%x(1)%list(i-1)%compute)
+    enddo
+
+    do i=1, size(domain%y(1)%list)
+        call mpp_set_super_grid_indices(domain%y(1)%list(i-1)%compute)
+    enddo
+
   end subroutine mpp_create_super_grid_domain
 
   !#####################################################################

--- a/mpp/mpp.F90
+++ b/mpp/mpp.F90
@@ -734,6 +734,8 @@ private
   interface mpp_scatter
      module procedure mpp_scatter_pelist_int4_2d
      module procedure mpp_scatter_pelist_int4_3d
+     module procedure mpp_scatter_pelist_int8_2d
+     module procedure mpp_scatter_pelist_int8_3d
      module procedure mpp_scatter_pelist_real4_2d
      module procedure mpp_scatter_pelist_real4_3d
      module procedure mpp_scatter_pelist_real8_2d

--- a/test_fms/fms2_io/Makefile.am
+++ b/test_fms/fms2_io/Makefile.am
@@ -30,7 +30,7 @@ LDADD = $(top_builddir)/libFMS/libFMS.la
 
 # Build this test program.
 check_PROGRAMS = test_get_is_valid test_file_appendix test_fms2_io test_atmosphere_io test_io_simple test_io_with_mask test_global_att \
-                 test_bc_restart test_get_mosaic_tile_grid test_read_ascii_file test_unlimit_compressed test_chunksizes
+                 test_bc_restart test_get_mosaic_tile_grid test_read_ascii_file test_unlimit_compressed test_chunksizes test_domain_io
 
 # This is the source code for the test.
 test_get_is_valid_SOURCES = test_get_is_valid.F90
@@ -49,6 +49,7 @@ test_read_ascii_file_SOURCES=test_read_ascii_file.F90
 test_file_appendix_SOURCES=test_file_appendix.F90
 test_unlimit_compressed_SOURCES=test_unlimit_compressed.F90
 test_chunksizes_SOURCES = test_chunksizes.F90
+test_domain_io_SOURCES = test_domain_io.F90
 
 EXTRA_DIST = test_bc_restart.sh test_fms2_io.sh test_atmosphere_io.sh test_io_simple.sh test_global_att.sh test_io_with_mask.sh test_read_ascii_file.sh
 

--- a/test_fms/fms2_io/test_domain_io.F90
+++ b/test_fms/fms2_io/test_domain_io.F90
@@ -243,7 +243,7 @@ program test_domain_read
       call compare_var_data(mpp_chksum(var_data%var_i4(:,:,1,1,1)), mpp_chksum(ref_data%var_i4(:,:,1,1,1)), "var2_i4")
 
       call read_data(fileobj, trim(var_name)//"_i8", var_data%var_i8(:,:,1,1,1))
-      call compare_var_data(mpp_chksum(var_data%var_i4(:,:,1,1,1)), mpp_chksum(ref_data%var_i8(:,:,1,1,1)), "var2_i8")
+      call compare_var_data(mpp_chksum(var_data%var_i8(:,:,1,1,1)), mpp_chksum(ref_data%var_i8(:,:,1,1,1)), "var2_i8")
     case(3)
       call var_data_init(var_data)
       call read_data(fileobj, trim(var_name)//"_r4", var_data%var_r4(:,:,:,1,1))
@@ -256,7 +256,7 @@ program test_domain_read
       call compare_var_data(mpp_chksum(var_data%var_i4(:,:,:,1,1)), mpp_chksum(ref_data%var_i4(:,:,:,1,1)), "var3_i4")
 
       call read_data(fileobj, trim(var_name)//"_i8", var_data%var_i8(:,:,:,1,1))
-      call compare_var_data(mpp_chksum(var_data%var_i4(:,:,:,1,1)), mpp_chksum(ref_data%var_i8(:,:,:,1,1)), "var3_i8")
+      call compare_var_data(mpp_chksum(var_data%var_i8(:,:,:,1,1)), mpp_chksum(ref_data%var_i8(:,:,:,1,1)), "var3_i8")
     case(4)
       call var_data_init(var_data)
       call read_data(fileobj, trim(var_name)//"_r4", var_data%var_r4(:,:,:,:,1))
@@ -269,7 +269,7 @@ program test_domain_read
       call compare_var_data(mpp_chksum(var_data%var_i4(:,:,:,:,1)), mpp_chksum(ref_data%var_i4(:,:,:,:,1)), "var4_i4")
 
       call read_data(fileobj, trim(var_name)//"_i8", var_data%var_i8(:,:,:,:,1))
-      call compare_var_data(mpp_chksum(var_data%var_i4(:,:,:,:,1)), mpp_chksum(ref_data%var_i8(:,:,:,:,1)), "var4_i8")
+      call compare_var_data(mpp_chksum(var_data%var_i8(:,:,:,:,1)), mpp_chksum(ref_data%var_i8(:,:,:,:,1)), "var4_i8")
     case(5)
       call var_data_init(var_data)
       call read_data(fileobj, trim(var_name)//"_r4", var_data%var_r4(:,:,:,:,:))
@@ -282,7 +282,7 @@ program test_domain_read
       call compare_var_data(mpp_chksum(var_data%var_i4(:,:,:,:,:)), mpp_chksum(ref_data%var_i4(:,:,:,:,:)), "var5_i4")
 
       call read_data(fileobj, trim(var_name)//"_i8", var_data%var_i8(:,:,:,:,:))
-      call compare_var_data(mpp_chksum(var_data%var_i4(:,:,:,:,:)), mpp_chksum(ref_data%var_i8(:,:,:,:,:)), "var5_i8")
+      call compare_var_data(mpp_chksum(var_data%var_i8(:,:,:,:,:)), mpp_chksum(ref_data%var_i8(:,:,:,:,:)), "var5_i8")
     end select
 
   end subroutine read_data_wrapper

--- a/test_fms/fms2_io/test_domain_io.F90
+++ b/test_fms/fms2_io/test_domain_io.F90
@@ -29,7 +29,8 @@ program test_domain_read
 
   implicit none
 
-  type data_type
+  !> @brief Dummy type to hold variable data
+  type data_t
     real(kind=r4_kind),    allocatable   :: var_r4(:,:,:,:,:)
     real(kind=r8_kind),    allocatable   :: var_r8(:,:,:,:,:)
     integer(kind=i4_kind), allocatable   :: var_i4(:,:,:,:,:)
@@ -52,8 +53,8 @@ program test_domain_read
   type(domain2d)                        :: Domain              !< Domain with mask table
   type(FmsNetcdfDomainFile_t)           :: fileobj             !< fms2io fileobj for domain decomposed
   character(len=6), dimension(5)        :: names               !< Dimensions names
-  type(data_type)                       :: var_data_in         !< Variable data written in
-  type(data_type)                       :: var_data_out        !< Variable data read in
+  type(data_t)                          :: var_data_in         !< Variable data written in
+  type(data_t)                          :: var_data_out        !< Variable data read in
   logical, allocatable, dimension(:,:)  :: parsed_mask         !< Parsed masked
   integer                               :: io                  !< Error code when reading namelist
   integer                               :: ierr                !< Error code when reading namelist
@@ -128,23 +129,23 @@ program test_domain_read
 
   !> @brief registers all of the possible variable types for a given
   !! number of dimensions
-  subroutine register_field_wrapper(fileobj, var_name, dimension_names, ndim)
-    type(FmsNetcdfDomainFile_t), intent(inout) :: fileobj            !< fms2io fileobj for domain decomposed
+  subroutine register_field_wrapper(fileob, var_name, dimension_names, ndim)
+    type(FmsNetcdfDomainFile_t), intent(inout) :: fileob             !< fms2io fileobj for domain decomposed
     character(len=*),            intent(in)    :: var_name           !< Name of the variable
     character(len=*),            intent(in)    :: dimension_names(:) !< dimension names
     integer,                     intent(in)    :: ndim               !< Number of dimension
 
-    call register_field(fileobj, trim(var_name)//"_r8", "double", names(1:ndim))
-    call register_field(fileobj, trim(var_name)//"_r4", "float",  names(1:ndim))
-    call register_field(fileobj, trim(var_name)//"_i8", "int",    names(1:ndim))
-    call register_field(fileobj, trim(var_name)//"_i4", "int64",  names(1:ndim))
+    call register_field(fileob, trim(var_name)//"_r8", "double", names(1:ndim))
+    call register_field(fileob, trim(var_name)//"_r4", "float",  names(1:ndim))
+    call register_field(fileob, trim(var_name)//"_i8", "int",    names(1:ndim))
+    call register_field(fileob, trim(var_name)//"_i4", "int64",  names(1:ndim))
   end subroutine register_field_wrapper
 
   !> @brief Allocates the variable to be the size of data compute domain for x and y
   !! and for a given size for the 3rd 4th and 5th dimension
-  subroutine var_data_alloc(var_data, Domain, dim3, dim4, dim5)
-    type(data_type),             intent(inout)    :: var_data         !< Variable data
-    type(domain2d),              intent(in)       :: Domain           !< Domain with mask table
+  subroutine var_data_alloc(var_data, var_domain, dim3, dim4, dim5)
+    type(data_t),                intent(inout)    :: var_data         !< Variable data
+    type(domain2d),              intent(in)       :: var_domain       !< Domain with mask table
     integer,                     intent(in)       :: dim3             !< Size of dim3
     integer,                     intent(in)       :: dim4             !< Size of dim4
     integer,                     intent(in)       :: dim5             !< Size of dim5
@@ -154,7 +155,7 @@ program test_domain_read
     integer :: js !< Starting y index
     integer :: je !< Ending y index
 
-    call mpp_get_data_domain(Domain, is, ie, js, je) !< This includes halos (but halos will not be written!)
+    call mpp_get_data_domain(var_domain, is, ie, js, je) !< This includes halos (but halos will not be written!)
 
     allocate(var_data%var_r4(is:ie, js:je, dim3, dim4, dim5))
     allocate(var_data%var_r8(is:ie, js:je, dim3, dim4, dim5))
@@ -164,7 +165,7 @@ program test_domain_read
 
   !> @brief Initializes the data to -999.99 for reals and -999 for integers
   subroutine var_data_init(var_data)
-    type(data_type),             intent(inout)    :: var_data         !< Variable data
+    type(data_t),             intent(inout)    :: var_data         !< Variable data
 
     var_data%var_r4 = real(-999.99, kind=r4_kind)
     var_data%var_r8 = real(-999.99, kind=r8_kind)
@@ -173,22 +174,22 @@ program test_domain_read
   end subroutine var_data_init
 
   !> @brief Sets the dcompute domain part of the variable to the expected number
-  subroutine var_data_set(var_data, domain, dim3, dim4, dim5)
-    type(data_type),             intent(inout)    :: var_data         !< Variable data
-    type(domain2d),              intent(in)       :: Domain           !< Domain with mask table
+  subroutine var_data_set(var_data, var_domain, dim3, dim4, dim5)
+    type(data_t),                intent(inout)    :: var_data         !< Variable data
+    type(domain2d),              intent(in)       :: var_domain       !< Domain with mask table
     integer,                     intent(in)       :: dim3             !< Size of dim3
     integer,                     intent(in)       :: dim4             !< Size of dim4
     integer,                     intent(in)       :: dim5             !< Size of dim5
 
-    integer :: i, j, k, l, m
+    integer :: i, j, k, l, m !< For do loops
 
     integer :: is !< Starting x index
     integer :: ie !< Ending x index
     integer :: js !< Starting y index
     integer :: je !< Ending y index
-    integer :: var_count
+    integer :: var_count !< For keeping track of the varible's data
 
-    call mpp_get_compute_domain(Domain, is, ie, js, je) !< This does not include halos!
+    call mpp_get_compute_domain(var_domain, is, ie, js, je) !< This does not include halos!
 
     var_count = 0
     do i = is, ie
@@ -210,78 +211,78 @@ program test_domain_read
   end subroutine
 
   !> @brief Writes the data for a give variable type
-  subroutine write_data_wrapper(fileobj, var_kind, var_data)
-    type(FmsNetcdfDomainFile_t), intent(inout) :: fileobj             !< fms2io fileobj for domain decomposed
+  subroutine write_data_wrapper(fileob, var_kind, var_data)
+    type(FmsNetcdfDomainFile_t), intent(inout) :: fileob              !< fms2io fileobj for domain decomposed
     character(len=*),            intent(in)    :: var_kind            !< The kind of the variable
     class(*),                    intent(in)    :: var_data(:,:,:,:,:) !< Variable data
 
-    call write_data(fileobj, "var2_"//trim(var_kind), var_data(:,:,1,1,1))
-    call write_data(fileobj, "var3_"//trim(var_kind), var_data(:,:,:,1,1))
-    call write_data(fileobj, "var4_"//trim(var_kind), var_data(:,:,:,:,1))
-    call write_data(fileobj, "var5_"//trim(var_kind), var_data(:,:,:,:,:))
+    call write_data(fileob, "var2_"//trim(var_kind), var_data(:,:,1,1,1))
+    call write_data(fileob, "var3_"//trim(var_kind), var_data(:,:,:,1,1))
+    call write_data(fileob, "var4_"//trim(var_kind), var_data(:,:,:,:,1))
+    call write_data(fileob, "var5_"//trim(var_kind), var_data(:,:,:,:,:))
 
   end subroutine
 
   !> @brief Reads the data and compares the checksum from the expected result
-  subroutine read_data_wrapper(fileobj, var_name, dim, var_data, ref_data)
-    type(FmsNetcdfDomainFile_t), intent(inout) :: fileobj             !< fms2io fileobj for domain decomposed
+  subroutine read_data_wrapper(fileob, var_name, dim, var_data, ref_data)
+    type(FmsNetcdfDomainFile_t), intent(inout) :: fileob              !< fms2io fileobj for domain decomposed
     character(len=*),            intent(in)    :: var_name            !< The kind of the variable
-    integer,                     intent(in)    :: dim
-    type(data_type),             intent(inout) :: var_data
-    type(data_type),             intent(inout) :: ref_data
+    integer,                     intent(in)    :: dim                 !< The variable's dimension
+    type(data_t),                intent(inout) :: var_data            !< The variable's data
+    type(data_t),                intent(inout) :: ref_data            !< The variable's reference data
 
     select case(dim)
     case(2)
       call var_data_init(var_data)
-      call read_data(fileobj, trim(var_name)//"_r4", var_data%var_r4(:,:,1,1,1))
+      call read_data(fileob, trim(var_name)//"_r4", var_data%var_r4(:,:,1,1,1))
       call compare_var_data(mpp_chksum(var_data%var_r4(:,:,1,1,1)), mpp_chksum(ref_data%var_r4(:,:,1,1,1)), "var2_r4")
 
-      call read_data(fileobj, trim(var_name)//"_r8", var_data%var_r8(:,:,1,1,1))
+      call read_data(fileob, trim(var_name)//"_r8", var_data%var_r8(:,:,1,1,1))
       call compare_var_data(mpp_chksum(var_data%var_r8(:,:,1,1,1)), mpp_chksum(ref_data%var_r8(:,:,1,1,1)), "var2_r8")
 
-      call read_data(fileobj, trim(var_name)//"_i4", var_data%var_i4(:,:,1,1,1))
+      call read_data(fileob, trim(var_name)//"_i4", var_data%var_i4(:,:,1,1,1))
       call compare_var_data(mpp_chksum(var_data%var_i4(:,:,1,1,1)), mpp_chksum(ref_data%var_i4(:,:,1,1,1)), "var2_i4")
 
-      call read_data(fileobj, trim(var_name)//"_i8", var_data%var_i8(:,:,1,1,1))
+      call read_data(fileob, trim(var_name)//"_i8", var_data%var_i8(:,:,1,1,1))
       call compare_var_data(mpp_chksum(var_data%var_i8(:,:,1,1,1)), mpp_chksum(ref_data%var_i8(:,:,1,1,1)), "var2_i8")
     case(3)
       call var_data_init(var_data)
-      call read_data(fileobj, trim(var_name)//"_r4", var_data%var_r4(:,:,:,1,1))
+      call read_data(fileob, trim(var_name)//"_r4", var_data%var_r4(:,:,:,1,1))
       call compare_var_data(mpp_chksum(var_data%var_r4(:,:,:,1,1)), mpp_chksum(ref_data%var_r4(:,:,:,1,1)), "var3_r4")
 
-      call read_data(fileobj, trim(var_name)//"_r8", var_data%var_r8(:,:,:,1,1))
+      call read_data(fileob, trim(var_name)//"_r8", var_data%var_r8(:,:,:,1,1))
       call compare_var_data(mpp_chksum(var_data%var_r8(:,:,:,1,1)), mpp_chksum(ref_data%var_r8(:,:,:,1,1)), "var3_r8")
 
-      call read_data(fileobj, trim(var_name)//"_i4", var_data%var_i4(:,:,:,1,1))
+      call read_data(fileob, trim(var_name)//"_i4", var_data%var_i4(:,:,:,1,1))
       call compare_var_data(mpp_chksum(var_data%var_i4(:,:,:,1,1)), mpp_chksum(ref_data%var_i4(:,:,:,1,1)), "var3_i4")
 
-      call read_data(fileobj, trim(var_name)//"_i8", var_data%var_i8(:,:,:,1,1))
+      call read_data(fileob, trim(var_name)//"_i8", var_data%var_i8(:,:,:,1,1))
       call compare_var_data(mpp_chksum(var_data%var_i8(:,:,:,1,1)), mpp_chksum(ref_data%var_i8(:,:,:,1,1)), "var3_i8")
     case(4)
       call var_data_init(var_data)
-      call read_data(fileobj, trim(var_name)//"_r4", var_data%var_r4(:,:,:,:,1))
+      call read_data(fileob, trim(var_name)//"_r4", var_data%var_r4(:,:,:,:,1))
       call compare_var_data(mpp_chksum(var_data%var_r4(:,:,:,:,1)), mpp_chksum(ref_data%var_r4(:,:,:,:,1)), "var4_r4")
 
-      call read_data(fileobj, trim(var_name)//"_r8", var_data%var_r8(:,:,:,:,1))
+      call read_data(fileob, trim(var_name)//"_r8", var_data%var_r8(:,:,:,:,1))
       call compare_var_data(mpp_chksum(var_data%var_r8(:,:,:,:,1)), mpp_chksum(ref_data%var_r8(:,:,:,:,1)), "var4_r8")
 
-      call read_data(fileobj, trim(var_name)//"_i4", var_data%var_i4(:,:,:,:,1))
+      call read_data(fileob, trim(var_name)//"_i4", var_data%var_i4(:,:,:,:,1))
       call compare_var_data(mpp_chksum(var_data%var_i4(:,:,:,:,1)), mpp_chksum(ref_data%var_i4(:,:,:,:,1)), "var4_i4")
 
-      call read_data(fileobj, trim(var_name)//"_i8", var_data%var_i8(:,:,:,:,1))
+      call read_data(fileob, trim(var_name)//"_i8", var_data%var_i8(:,:,:,:,1))
       call compare_var_data(mpp_chksum(var_data%var_i8(:,:,:,:,1)), mpp_chksum(ref_data%var_i8(:,:,:,:,1)), "var4_i8")
     case(5)
       call var_data_init(var_data)
-      call read_data(fileobj, trim(var_name)//"_r4", var_data%var_r4(:,:,:,:,:))
+      call read_data(fileob, trim(var_name)//"_r4", var_data%var_r4(:,:,:,:,:))
       call compare_var_data(mpp_chksum(var_data%var_r4(:,:,:,:,:)), mpp_chksum(ref_data%var_r4(:,:,:,:,:)), "var5_r4")
 
-      call read_data(fileobj, trim(var_name)//"_r8", var_data%var_r8(:,:,:,:,:))
+      call read_data(fileob, trim(var_name)//"_r8", var_data%var_r8(:,:,:,:,:))
       call compare_var_data(mpp_chksum(var_data%var_r8(:,:,:,:,:)), mpp_chksum(ref_data%var_r8(:,:,:,:,:)), "var5_r8")
 
-      call read_data(fileobj, trim(var_name)//"_i4", var_data%var_i4(:,:,:,:,:))
+      call read_data(fileob, trim(var_name)//"_i4", var_data%var_i4(:,:,:,:,:))
       call compare_var_data(mpp_chksum(var_data%var_i4(:,:,:,:,:)), mpp_chksum(ref_data%var_i4(:,:,:,:,:)), "var5_i4")
 
-      call read_data(fileobj, trim(var_name)//"_i8", var_data%var_i8(:,:,:,:,:))
+      call read_data(fileob, trim(var_name)//"_i8", var_data%var_i8(:,:,:,:,:))
       call compare_var_data(mpp_chksum(var_data%var_i8(:,:,:,:,:)), mpp_chksum(ref_data%var_i8(:,:,:,:,:)), "var5_i8")
     end select
 
@@ -289,9 +290,9 @@ program test_domain_read
 
   !> @brief Compares two checksums and crashes if they are not the same
   subroutine compare_var_data(check_sum_in, check_sum_ref, varname)
-    integer(kind=i8_kind), intent(in) :: check_sum_in
-    integer(kind=i8_kind), intent(in) :: check_sum_ref
-    character(len=*), intent(in) :: varname
+    integer(kind=i8_kind), intent(in) :: check_sum_in   !< Checksum
+    integer(kind=i8_kind), intent(in) :: check_sum_ref  !< The reference checksum
+    character(len=*),      intent(in) :: varname        !< The variable's name (for error messages)
 
    if (check_sum_ref .ne. check_sum_in) call mpp_error(FATAL, &
      "Checksums do not match for variable: "//trim(varname))

--- a/test_fms/fms2_io/test_domain_io.F90
+++ b/test_fms/fms2_io/test_domain_io.F90
@@ -19,7 +19,7 @@
 
 program test_domain_read
   use   mpp_domains_mod, only: mpp_domains_set_stack_size, mpp_define_domains, mpp_define_io_domain, &
-                               mpp_get_compute_domain, mpp_get_data_domain, domain2d
+                               mpp_get_compute_domain, mpp_get_data_domain, domain2d, EAST, NORTH, CENTER
   use   mpp_mod,         only: mpp_chksum, mpp_pe, mpp_root_pe, mpp_error, FATAL, input_nml_file
   use   fms2_io_mod,     only: open_file, register_axis, register_variable_attribute, close_file, &
                                FmsNetcdfDomainFile_t, write_data, register_field, read_data, &
@@ -47,6 +47,7 @@ program test_domain_read
   integer                               :: yhalo = 2           !< Number of halo points in Y
   integer                               :: nz = 2              !< Number of points in the z dimension
   character(len=20)                     :: filename="test.nc"  !< Name of the file
+  logical                               :: use_edges=.false.   !< Use North and East domain positions
 
   integer                               :: ndim4               !< Number of points in dim4
   integer                               :: ndim5               !< Number of points in dim5
@@ -58,8 +59,10 @@ program test_domain_read
   logical, allocatable, dimension(:,:)  :: parsed_mask         !< Parsed masked
   integer                               :: io                  !< Error code when reading namelist
   integer                               :: ierr                !< Error code when reading namelist
+  integer                               :: xposition           !< position in the x dimension ("EAST" or "CENTER")
+  integer                               :: yposition           !< position in the y dimension ("NORTH" or "CENTER")
 
-  namelist /test_domain_io_nml/ layout, io_layout, nx, ny, nz, mask_table, xhalo, yhalo, nz, filename
+  namelist /test_domain_io_nml/ layout, io_layout, nx, ny, nz, mask_table, xhalo, yhalo, nz, filename, use_edges
 
   call fms_init
 
@@ -68,6 +71,14 @@ program test_domain_read
 
   ndim4 = 2
   ndim5 = 2
+
+  if (use_edges) then
+    xposition = EAST
+    yposition = NORTH
+  else
+    xposition = CENTER
+    yposition = CENTER
+  endif
 
   !< Parse the mask table
   allocate(parsed_mask(layout(1), layout(2)))
@@ -88,8 +99,8 @@ program test_domain_read
     names(4) = "dim4"
     names(5) = "dim5"
 
-    call register_axis(fileobj, "dim1", "x")
-    call register_axis(fileobj, "dim2", "y")
+    call register_axis(fileobj, "dim1", "x", domain_position=xposition )
+    call register_axis(fileobj, "dim2", "y", domain_position=yposition )
     call register_axis(fileobj, "dim3", nz)
     call register_axis(fileobj, "dim4", ndim4)
     call register_axis(fileobj, "dim5", ndim5)

--- a/test_fms/fms2_io/test_domain_io.F90
+++ b/test_fms/fms2_io/test_domain_io.F90
@@ -20,11 +20,11 @@
 program test_domain_read
   use   mpp_domains_mod, only: mpp_domains_set_stack_size, mpp_define_domains, mpp_define_io_domain, &
                                mpp_get_compute_domain, mpp_get_data_domain, domain2d
-  use   mpp_mod,         only: mpp_chksum, mpp_pe, mpp_root_pe, mpp_error, FATAL
+  use   mpp_mod,         only: mpp_chksum, mpp_pe, mpp_root_pe, mpp_error, FATAL, input_nml_file
   use   fms2_io_mod,     only: open_file, register_axis, register_variable_attribute, close_file, &
                                FmsNetcdfDomainFile_t, write_data, register_field, read_data, &
                                parse_mask_table
-  use   fms_mod,         only: fms_init, fms_end
+  use   fms_mod,         only: fms_init, fms_end, check_nml_error
   use   platform_mod,    only: r4_kind, r8_kind, i4_kind, i8_kind
 
   implicit none
@@ -36,31 +36,51 @@ program test_domain_read
     integer(kind=i8_kind), allocatable   :: var_i8(:,:,:,:,:)
   end type
 
-  integer, dimension(2)                 :: layout = (/2,3/) !< Domain layout
-  integer                               :: ndim1            !< Number of points in dim1
-  integer                               :: ndim2            !< Number of points in dim2
-  integer                               :: ndim3            !< Number of points in dim3
-  integer                               :: ndim4            !< Number of points in dim4
-  integer                               :: ndim5            !< Number of points in dim5
-  type(domain2d)                        :: Domain           !< Domain with mask table
-  type(FmsNetcdfDomainFile_t)           :: fileobj          !< fms2io fileobj for domain decomposed
-  character(len=6), dimension(5)        :: names            !< Dimensions names
-  type(data_type)                       :: var_data_in      !< Variable data written in
-  type(data_type)                       :: var_data_out     !< Variable data read in
+  ! Namelist variables
+  integer, dimension(2)                 :: layout    = (/2,3/) !< Domain layout
+  integer, dimension(2)                 :: io_layout = (/1,1/) !< Domain layout
+  integer                               :: nx = 96             !< Number of points in dim1
+  integer                               :: ny = 96             !< Number of points in dim2
+  character(len=20)                     :: mask_table = ""     !< Name of a masktable to use
+  integer                               :: xhalo = 3           !< Number of halo points in X
+  integer                               :: yhalo = 2           !< Number of halo points in Y
+  integer                               :: nz = 2              !< Number of points in the z dimension
+  character(len=20)                     :: filename="test.nc"  !< Name of the file
+
+  integer                               :: ndim4               !< Number of points in dim4
+  integer                               :: ndim5               !< Number of points in dim5
+  type(domain2d)                        :: Domain              !< Domain with mask table
+  type(FmsNetcdfDomainFile_t)           :: fileobj             !< fms2io fileobj for domain decomposed
+  character(len=6), dimension(5)        :: names               !< Dimensions names
+  type(data_type)                       :: var_data_in         !< Variable data written in
+  type(data_type)                       :: var_data_out        !< Variable data read in
+  logical, allocatable, dimension(:,:)  :: parsed_mask         !< Parsed masked
+  integer                               :: io                  !< Error code when reading namelist
+  integer                               :: ierr                !< Error code when reading namelist
+
+  namelist /test_domain_io_nml/ layout, io_layout, nx, ny, nz, mask_table, xhalo, yhalo, nz, filename
 
   call fms_init
 
-  ndim1 = 96
-  ndim2 = 96
-  ndim3 = 2
+  read(input_nml_file, nml=test_domain_io_nml, iostat=io)
+  ierr = check_nml_error(io, 'test_domain_io_nml')
+
   ndim4 = 2
   ndim5 = 2
 
-  call mpp_domains_set_stack_size(17280000)
-  call mpp_define_domains( (/1,ndim1,1,ndim2/), layout, Domain, xhalo=3, yhalo=2)
-  call mpp_define_io_domain(Domain, (/1,1/))
+  !< Parse the mask table
+  allocate(parsed_mask(layout(1), layout(2)))
+  parsed_mask = .True.
+  if (trim(mask_table) .ne. "") then
+    call parse_mask_table(trim(mask_table), parsed_mask, 'test_io_with_mask')
+  endif
 
-  if (open_file(fileobj, "test_domain_write.nc", "overwrite", domain, nc_format="netcdf4")) then
+  call mpp_domains_set_stack_size(17280000)
+  call mpp_define_domains( (/1,nx,1,ny/), layout, Domain, xhalo=xhalo, yhalo=yhalo, &
+    maskmap=parsed_mask)
+  call mpp_define_io_domain(Domain, io_layout)
+
+  if (open_file(fileobj, trim(filename), "overwrite", domain, nc_format="netcdf4")) then
     names(1) = "dim1"
     names(2) = "dim2"
     names(3) = "dim3"
@@ -69,7 +89,7 @@ program test_domain_read
 
     call register_axis(fileobj, "dim1", "x")
     call register_axis(fileobj, "dim2", "y")
-    call register_axis(fileobj, "dim3", ndim3)
+    call register_axis(fileobj, "dim3", nz)
     call register_axis(fileobj, "dim4", ndim4)
     call register_axis(fileobj, "dim5", ndim5)
 
@@ -78,9 +98,9 @@ program test_domain_read
     call register_field_wrapper(fileobj, "var4", names, 4)
     call register_field_wrapper(fileobj, "var5", names, 5)
 
-    call var_data_alloc(var_data_in, Domain, ndim3, ndim4, ndim5)
+    call var_data_alloc(var_data_in, Domain, nz, ndim4, ndim5)
     call var_data_init(var_data_in)
-    call var_data_set(var_data_in, Domain, ndim3, ndim4, ndim5)
+    call var_data_set(var_data_in, Domain, nz, ndim4, ndim5)
 
     call write_data_wrapper(fileobj, "r4", var_data_in%var_r4)
     call write_data_wrapper(fileobj, "r8", var_data_in%var_r8)
@@ -90,11 +110,11 @@ program test_domain_read
     call close_file(fileobj)
   endif
 
-  if (open_file(fileobj, "test_domain_write.nc", "read", domain, nc_format="netcdf4")) then
+  if (open_file(fileobj, trim(filename), "read", domain, nc_format="netcdf4")) then
     call register_axis(fileobj, "dim1", "x")
     call register_axis(fileobj, "dim2", "y")
 
-    call var_data_alloc(var_data_out, Domain, ndim3, ndim4, ndim5)
+    call var_data_alloc(var_data_out, Domain, nz, ndim4, ndim5)
     call read_data_wrapper(fileobj, "var2", 2, var_data_out, var_data_in)
     call read_data_wrapper(fileobj, "var3", 3, var_data_out, var_data_in)
     call read_data_wrapper(fileobj, "var4", 4, var_data_out, var_data_in)
@@ -106,6 +126,8 @@ program test_domain_read
 
   contains
 
+  !> @brief registers all of the possible variable types for a given
+  !! number of dimensions
   subroutine register_field_wrapper(fileobj, var_name, dimension_names, ndim)
     type(FmsNetcdfDomainFile_t), intent(inout) :: fileobj            !< fms2io fileobj for domain decomposed
     character(len=*),            intent(in)    :: var_name           !< Name of the variable
@@ -118,6 +140,8 @@ program test_domain_read
     call register_field(fileobj, trim(var_name)//"_i4", "int64",  names(1:ndim))
   end subroutine register_field_wrapper
 
+  !> @brief Allocates the variable to be the size of data compute domain for x and y
+  !! and for a given size for the 3rd 4th and 5th dimension
   subroutine var_data_alloc(var_data, Domain, dim3, dim4, dim5)
     type(data_type),             intent(inout)    :: var_data         !< Variable data
     type(domain2d),              intent(in)       :: Domain           !< Domain with mask table
@@ -138,6 +162,7 @@ program test_domain_read
     allocate(var_data%var_i8(is:ie, js:je, dim3, dim4, dim5))
   end subroutine var_data_alloc
 
+  !> @brief Initializes the data to -999.99 for reals and -999 for integers
   subroutine var_data_init(var_data)
     type(data_type),             intent(inout)    :: var_data         !< Variable data
 
@@ -147,6 +172,7 @@ program test_domain_read
     var_data%var_i8 = int(-999, kind=i8_kind)
   end subroutine var_data_init
 
+  !> @brief Sets the dcompute domain part of the variable to the expected number
   subroutine var_data_set(var_data, domain, dim3, dim4, dim5)
     type(data_type),             intent(inout)    :: var_data         !< Variable data
     type(domain2d),              intent(in)       :: Domain           !< Domain with mask table
@@ -183,6 +209,7 @@ program test_domain_read
 
   end subroutine
 
+  !> @brief Writes the data for a give variable type
   subroutine write_data_wrapper(fileobj, var_kind, var_data)
     type(FmsNetcdfDomainFile_t), intent(inout) :: fileobj             !< fms2io fileobj for domain decomposed
     character(len=*),            intent(in)    :: var_kind            !< The kind of the variable
@@ -195,6 +222,7 @@ program test_domain_read
 
   end subroutine
 
+  !> @brief Reads the data and compares the checksum from the expected result
   subroutine read_data_wrapper(fileobj, var_name, dim, var_data, ref_data)
     type(FmsNetcdfDomainFile_t), intent(inout) :: fileobj             !< fms2io fileobj for domain decomposed
     character(len=*),            intent(in)    :: var_name            !< The kind of the variable
@@ -259,6 +287,7 @@ program test_domain_read
 
   end subroutine read_data_wrapper
 
+  !> @brief Compares two checksums and crashes if they are not the same
   subroutine compare_var_data(check_sum_in, check_sum_ref, varname)
     integer(kind=i8_kind), intent(in) :: check_sum_in
     integer(kind=i8_kind), intent(in) :: check_sum_ref

--- a/test_fms/fms2_io/test_domain_io.F90
+++ b/test_fms/fms2_io/test_domain_io.F90
@@ -1,0 +1,271 @@
+!***********************************************************************
+!*                   GNU Lesser General Public License
+!*
+!* This file is part of the GFDL Flexible Modeling System (FMS).
+!*
+!* FMS is free software: you can redistribute it and/or modify it under
+!* the terms of the GNU Lesser General Public License as published by
+!* the Free Software Foundation, either version 3 of the License, or (at
+!* your option) any later version.
+!*
+!* FMS is distributed in the hope that it will be useful, but WITHOUT
+!* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+!* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+!* for more details.
+!*
+!* You should have received a copy of the GNU Lesser General Public
+!* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
+!***********************************************************************
+
+program test_domain_read
+  use   mpp_domains_mod, only: mpp_domains_set_stack_size, mpp_define_domains, mpp_define_io_domain, &
+                               mpp_get_compute_domain, mpp_get_data_domain, domain2d
+  use   mpp_mod,         only: mpp_chksum, mpp_pe, mpp_root_pe, mpp_error, FATAL
+  use   fms2_io_mod,     only: open_file, register_axis, register_variable_attribute, close_file, &
+                               FmsNetcdfDomainFile_t, write_data, register_field, read_data, &
+                               parse_mask_table
+  use   fms_mod,         only: fms_init, fms_end
+  use   platform_mod,    only: r4_kind, r8_kind, i4_kind, i8_kind
+
+  implicit none
+
+  type data_type
+    real(kind=r4_kind),    allocatable   :: var_r4(:,:,:,:,:)
+    real(kind=r8_kind),    allocatable   :: var_r8(:,:,:,:,:)
+    integer(kind=i4_kind), allocatable   :: var_i4(:,:,:,:,:)
+    integer(kind=i8_kind), allocatable   :: var_i8(:,:,:,:,:)
+  end type
+
+  integer, dimension(2)                 :: layout = (/2,3/) !< Domain layout
+  integer                               :: ndim1            !< Number of points in dim1
+  integer                               :: ndim2            !< Number of points in dim2
+  integer                               :: ndim3            !< Number of points in dim3
+  integer                               :: ndim4            !< Number of points in dim4
+  integer                               :: ndim5            !< Number of points in dim5
+  type(domain2d)                        :: Domain           !< Domain with mask table
+  type(FmsNetcdfDomainFile_t)           :: fileobj          !< fms2io fileobj for domain decomposed
+  character(len=6), dimension(5)        :: names            !< Dimensions names
+  type(data_type)                       :: var_data_in      !< Variable data written in
+  type(data_type)                       :: var_data_out     !< Variable data read in
+
+  call fms_init
+
+  ndim1 = 96
+  ndim2 = 96
+  ndim3 = 2
+  ndim4 = 2
+  ndim5 = 2
+
+  call mpp_domains_set_stack_size(17280000)
+  call mpp_define_domains( (/1,ndim1,1,ndim2/), layout, Domain, xhalo=3, yhalo=2)
+  call mpp_define_io_domain(Domain, (/1,1/))
+
+  if (open_file(fileobj, "test_domain_write.nc", "overwrite", domain, nc_format="netcdf4")) then
+    names(1) = "dim1"
+    names(2) = "dim2"
+    names(3) = "dim3"
+    names(4) = "dim4"
+    names(5) = "dim5"
+
+    call register_axis(fileobj, "dim1", "x")
+    call register_axis(fileobj, "dim2", "y")
+    call register_axis(fileobj, "dim3", ndim3)
+    call register_axis(fileobj, "dim4", ndim4)
+    call register_axis(fileobj, "dim5", ndim5)
+
+    call register_field_wrapper(fileobj, "var2", names, 2)
+    call register_field_wrapper(fileobj, "var3", names, 3)
+    call register_field_wrapper(fileobj, "var4", names, 4)
+    call register_field_wrapper(fileobj, "var5", names, 5)
+
+    call var_data_alloc(var_data_in, Domain, ndim3, ndim4, ndim5)
+    call var_data_init(var_data_in)
+    call var_data_set(var_data_in, Domain, ndim3, ndim4, ndim5)
+
+    call write_data_wrapper(fileobj, "r4", var_data_in%var_r4)
+    call write_data_wrapper(fileobj, "r8", var_data_in%var_r8)
+    call write_data_wrapper(fileobj, "i4", var_data_in%var_i4)
+    call write_data_wrapper(fileobj, "i8", var_data_in%var_i8)
+
+    call close_file(fileobj)
+  endif
+
+  if (open_file(fileobj, "test_domain_write.nc", "read", domain, nc_format="netcdf4")) then
+    call register_axis(fileobj, "dim1", "x")
+    call register_axis(fileobj, "dim2", "y")
+
+    call var_data_alloc(var_data_out, Domain, ndim3, ndim4, ndim5)
+    call read_data_wrapper(fileobj, "var2", 2, var_data_out, var_data_in)
+    call read_data_wrapper(fileobj, "var3", 3, var_data_out, var_data_in)
+    call read_data_wrapper(fileobj, "var4", 4, var_data_out, var_data_in)
+    call read_data_wrapper(fileobj, "var5", 5, var_data_out, var_data_in)
+
+    call close_file(fileobj)
+  endif
+  call fms_end
+
+  contains
+
+  subroutine register_field_wrapper(fileobj, var_name, dimension_names, ndim)
+    type(FmsNetcdfDomainFile_t), intent(inout) :: fileobj            !< fms2io fileobj for domain decomposed
+    character(len=*),            intent(in)    :: var_name           !< Name of the variable
+    character(len=*),            intent(in)    :: dimension_names(:) !< dimension names
+    integer,                     intent(in)    :: ndim               !< Number of dimension
+
+    call register_field(fileobj, trim(var_name)//"_r8", "double", names(1:ndim))
+    call register_field(fileobj, trim(var_name)//"_r4", "float",  names(1:ndim))
+    call register_field(fileobj, trim(var_name)//"_i8", "int",    names(1:ndim))
+    call register_field(fileobj, trim(var_name)//"_i4", "int64",  names(1:ndim))
+  end subroutine register_field_wrapper
+
+  subroutine var_data_alloc(var_data, Domain, dim3, dim4, dim5)
+    type(data_type),             intent(inout)    :: var_data         !< Variable data
+    type(domain2d),              intent(in)       :: Domain           !< Domain with mask table
+    integer,                     intent(in)       :: dim3             !< Size of dim3
+    integer,                     intent(in)       :: dim4             !< Size of dim4
+    integer,                     intent(in)       :: dim5             !< Size of dim5
+
+    integer :: is !< Starting x index
+    integer :: ie !< Ending x index
+    integer :: js !< Starting y index
+    integer :: je !< Ending y index
+
+    call mpp_get_data_domain(Domain, is, ie, js, je) !< This includes halos (but halos will not be written!)
+
+    allocate(var_data%var_r4(is:ie, js:je, dim3, dim4, dim5))
+    allocate(var_data%var_r8(is:ie, js:je, dim3, dim4, dim5))
+    allocate(var_data%var_i4(is:ie, js:je, dim3, dim4, dim5))
+    allocate(var_data%var_i8(is:ie, js:je, dim3, dim4, dim5))
+  end subroutine var_data_alloc
+
+  subroutine var_data_init(var_data)
+    type(data_type),             intent(inout)    :: var_data         !< Variable data
+
+    var_data%var_r4 = real(-999.99, kind=r4_kind)
+    var_data%var_r8 = real(-999.99, kind=r8_kind)
+    var_data%var_i4 = int(-999, kind=i4_kind)
+    var_data%var_i8 = int(-999, kind=i8_kind)
+  end subroutine var_data_init
+
+  subroutine var_data_set(var_data, domain, dim3, dim4, dim5)
+    type(data_type),             intent(inout)    :: var_data         !< Variable data
+    type(domain2d),              intent(in)       :: Domain           !< Domain with mask table
+    integer,                     intent(in)       :: dim3             !< Size of dim3
+    integer,                     intent(in)       :: dim4             !< Size of dim4
+    integer,                     intent(in)       :: dim5             !< Size of dim5
+
+    integer :: i, j, k, l, m
+
+    integer :: is !< Starting x index
+    integer :: ie !< Ending x index
+    integer :: js !< Starting y index
+    integer :: je !< Ending y index
+    integer :: var_count
+
+    call mpp_get_compute_domain(Domain, is, ie, js, je) !< This does not include halos!
+
+    var_count = 0
+    do i = is, ie
+      do j = js, je
+        do k = 1, dim3
+          do l = 1, dim4
+            do m = 1, dim5
+              var_count = var_count + 1
+              var_data%var_r4(i,j,k,l,m) = real(var_count, kind=r4_kind)
+              var_data%var_r8(i,j,k,l,m) = real(var_count, kind=r8_kind)
+              var_data%var_i4(i,j,k,l,m) = int(var_count, kind=i4_kind)
+              var_data%var_i8(i,j,k,l,m) = int(var_count, kind=i8_kind)
+            enddo
+          enddo
+        enddo
+      enddo
+    enddo
+
+  end subroutine
+
+  subroutine write_data_wrapper(fileobj, var_kind, var_data)
+    type(FmsNetcdfDomainFile_t), intent(inout) :: fileobj             !< fms2io fileobj for domain decomposed
+    character(len=*),            intent(in)    :: var_kind            !< The kind of the variable
+    class(*),                    intent(in)    :: var_data(:,:,:,:,:) !< Variable data
+
+    call write_data(fileobj, "var2_"//trim(var_kind), var_data(:,:,1,1,1))
+    call write_data(fileobj, "var3_"//trim(var_kind), var_data(:,:,:,1,1))
+    call write_data(fileobj, "var4_"//trim(var_kind), var_data(:,:,:,:,1))
+    call write_data(fileobj, "var5_"//trim(var_kind), var_data(:,:,:,:,:))
+
+  end subroutine
+
+  subroutine read_data_wrapper(fileobj, var_name, dim, var_data, ref_data)
+    type(FmsNetcdfDomainFile_t), intent(inout) :: fileobj             !< fms2io fileobj for domain decomposed
+    character(len=*),            intent(in)    :: var_name            !< The kind of the variable
+    integer,                     intent(in)    :: dim
+    type(data_type),             intent(inout) :: var_data
+    type(data_type),             intent(inout) :: ref_data
+
+    select case(dim)
+    case(2)
+      call var_data_init(var_data)
+      call read_data(fileobj, trim(var_name)//"_r4", var_data%var_r4(:,:,1,1,1))
+      call compare_var_data(mpp_chksum(var_data%var_r4(:,:,1,1,1)), mpp_chksum(ref_data%var_r4(:,:,1,1,1)), "var2_r4")
+
+      call read_data(fileobj, trim(var_name)//"_r8", var_data%var_r8(:,:,1,1,1))
+      call compare_var_data(mpp_chksum(var_data%var_r8(:,:,1,1,1)), mpp_chksum(ref_data%var_r8(:,:,1,1,1)), "var2_r8")
+
+      call read_data(fileobj, trim(var_name)//"_i4", var_data%var_i4(:,:,1,1,1))
+      call compare_var_data(mpp_chksum(var_data%var_i4(:,:,1,1,1)), mpp_chksum(ref_data%var_i4(:,:,1,1,1)), "var2_i4")
+
+      call read_data(fileobj, trim(var_name)//"_i8", var_data%var_i8(:,:,1,1,1))
+      call compare_var_data(mpp_chksum(var_data%var_i4(:,:,1,1,1)), mpp_chksum(ref_data%var_i8(:,:,1,1,1)), "var2_i8")
+    case(3)
+      call var_data_init(var_data)
+      call read_data(fileobj, trim(var_name)//"_r4", var_data%var_r4(:,:,:,1,1))
+      call compare_var_data(mpp_chksum(var_data%var_r4(:,:,:,1,1)), mpp_chksum(ref_data%var_r4(:,:,:,1,1)), "var3_r4")
+
+      call read_data(fileobj, trim(var_name)//"_r8", var_data%var_r8(:,:,:,1,1))
+      call compare_var_data(mpp_chksum(var_data%var_r8(:,:,:,1,1)), mpp_chksum(ref_data%var_r8(:,:,:,1,1)), "var3_r8")
+
+      call read_data(fileobj, trim(var_name)//"_i4", var_data%var_i4(:,:,:,1,1))
+      call compare_var_data(mpp_chksum(var_data%var_i4(:,:,:,1,1)), mpp_chksum(ref_data%var_i4(:,:,:,1,1)), "var3_i4")
+
+      call read_data(fileobj, trim(var_name)//"_i8", var_data%var_i8(:,:,:,1,1))
+      call compare_var_data(mpp_chksum(var_data%var_i4(:,:,:,1,1)), mpp_chksum(ref_data%var_i8(:,:,:,1,1)), "var3_i8")
+    case(4)
+      call var_data_init(var_data)
+      call read_data(fileobj, trim(var_name)//"_r4", var_data%var_r4(:,:,:,:,1))
+      call compare_var_data(mpp_chksum(var_data%var_r4(:,:,:,:,1)), mpp_chksum(ref_data%var_r4(:,:,:,:,1)), "var4_r4")
+
+      call read_data(fileobj, trim(var_name)//"_r8", var_data%var_r8(:,:,:,:,1))
+      call compare_var_data(mpp_chksum(var_data%var_r8(:,:,:,:,1)), mpp_chksum(ref_data%var_r8(:,:,:,:,1)), "var4_r8")
+
+      call read_data(fileobj, trim(var_name)//"_i4", var_data%var_i4(:,:,:,:,1))
+      call compare_var_data(mpp_chksum(var_data%var_i4(:,:,:,:,1)), mpp_chksum(ref_data%var_i4(:,:,:,:,1)), "var4_i4")
+
+      call read_data(fileobj, trim(var_name)//"_i8", var_data%var_i8(:,:,:,:,1))
+      call compare_var_data(mpp_chksum(var_data%var_i4(:,:,:,:,1)), mpp_chksum(ref_data%var_i8(:,:,:,:,1)), "var4_i8")
+    case(5)
+      call var_data_init(var_data)
+      call read_data(fileobj, trim(var_name)//"_r4", var_data%var_r4(:,:,:,:,:))
+      call compare_var_data(mpp_chksum(var_data%var_r4(:,:,:,:,:)), mpp_chksum(ref_data%var_r4(:,:,:,:,:)), "var5_r4")
+
+      call read_data(fileobj, trim(var_name)//"_r8", var_data%var_r8(:,:,:,:,:))
+      call compare_var_data(mpp_chksum(var_data%var_r8(:,:,:,:,:)), mpp_chksum(ref_data%var_r8(:,:,:,:,:)), "var5_r8")
+
+      call read_data(fileobj, trim(var_name)//"_i4", var_data%var_i4(:,:,:,:,:))
+      call compare_var_data(mpp_chksum(var_data%var_i4(:,:,:,:,:)), mpp_chksum(ref_data%var_i4(:,:,:,:,:)), "var5_i4")
+
+      call read_data(fileobj, trim(var_name)//"_i8", var_data%var_i8(:,:,:,:,:))
+      call compare_var_data(mpp_chksum(var_data%var_i4(:,:,:,:,:)), mpp_chksum(ref_data%var_i8(:,:,:,:,:)), "var5_i8")
+    end select
+
+  end subroutine read_data_wrapper
+
+  subroutine compare_var_data(check_sum_in, check_sum_ref, varname)
+    integer(kind=i8_kind), intent(in) :: check_sum_in
+    integer(kind=i8_kind), intent(in) :: check_sum_ref
+    character(len=*), intent(in) :: varname
+
+   if (check_sum_ref .ne. check_sum_in) call mpp_error(FATAL, &
+     "Checksums do not match for variable: "//trim(varname))
+  end subroutine compare_var_data
+
+end program test_domain_read

--- a/test_fms/fms2_io/test_fms2_io.sh
+++ b/test_fms/fms2_io/test_fms2_io.sh
@@ -72,6 +72,31 @@ test_expect_success "Domain Read Write Tests with 2 distributed files" '
 
 cat <<_EOF > input.nml
 &test_domain_io_nml
+  layout = 2, 8
+  io_layout = 1, 2
+  filename = "test_dist_layout.nc"
+  use_edges = .true.
+/
+_EOF
+test_expect_success "Domain Read Write Tests with 2 distributed files and EAST and NORTH axis" '
+  mpirun -n 16 ../test_domain_io
+'
+
+cat <<_EOF > input.nml
+&test_domain_io_nml
+  nx = 33
+  ny = 43
+  layout = 4, 6
+  io_layout = 2, 3
+  filename = "test_non_uniform.nc"
+/
+_EOF
+test_expect_success "Domain Read Write Tests with non uniform layouts" '
+  mpirun -n 24 ../test_domain_io
+'
+
+cat <<_EOF > input.nml
+&test_domain_io_nml
   layout = 3, 6
   io_layout = 1, 2
   mask_table = "mask_table"

--- a/test_fms/fms2_io/test_fms2_io.sh
+++ b/test_fms/fms2_io/test_fms2_io.sh
@@ -48,7 +48,44 @@ test_expect_success "FMS2 IO Test" '
   mpirun -n 6 ../test_fms2_io
 '
 
-test_expect_success "Domain Read Write Tests" '
+cat <<_EOF > input.nml
+&test_domain_io_nml
+  layout = 1, 6
+  io_layout = 1, 1
+  filename = "test_simple_layout.nc"
+/
+_EOF
+test_expect_success "Domain Read Write Tests with simple layout" '
   mpirun -n 6 ../test_domain_io
 '
+
+cat <<_EOF > input.nml
+&test_domain_io_nml
+  layout = 2, 8
+  io_layout = 1, 2
+  filename = "test_dist_layout.nc"
+/
+_EOF
+test_expect_success "Domain Read Write Tests with 2 distributed files" '
+  mpirun -n 16 ../test_domain_io
+'
+
+cat <<_EOF > input.nml
+&test_domain_io_nml
+  layout = 3, 6
+  io_layout = 1, 2
+  mask_table = "mask_table"
+  filename = "test_io_mask.nc"
+/
+_EOF
+
+cat <<_EOF > mask_table
+1
+3,6
+1,1
+_EOF
+test_expect_success "Domain Read Write Tests with a ocean mask" '
+  mpirun -n 17 ../test_domain_io
+'
+
 test_done

--- a/test_fms/fms2_io/test_fms2_io.sh
+++ b/test_fms/fms2_io/test_fms2_io.sh
@@ -48,4 +48,7 @@ test_expect_success "FMS2 IO Test" '
   mpirun -n 6 ../test_fms2_io
 '
 
+test_expect_success "Domain Read Write Tests" '
+  mpirun -n 6 ../test_domain_io
+'
 test_done


### PR DESCRIPTION
**Description**

1. Modified domain_reads_2d and domain_reads_3d:
    - Root pe reads the data
    - Uses mpp_scatter to send the data to the other pes
2. Extended mpp_scatter to work for int8
3.  Added unit tests to test all of the domain_read/domain_write interfaces
4. Domain_reads_4d and domains_reads_5d were unchanged
    - Mpp_scatter only support 2d and 3d arrays
5. Mpp_scatter assumes the data is (x,y,z), which may not always be the case, so I added a kludge for it … 

Fixes #1218 #1219

This should give some performance gain in initialization time for high resolutions.

**How Has This Been Tested?**
CI, SHiELD

The initialization timings for C3072 SHiELD run:
Original: 
Min: 206.756363 Max: 215.601578 Avg: 209.762848

New: 
Min: 153.169189 Max: 161.906982 Avg: 156.292923

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

