### PR TITLE
Fms2 io update: Compressed writes

### DIFF
--- a/fms2_io/include/compressed_write.inc
+++ b/fms2_io/include/compressed_write.inc
@@ -213,8 +213,8 @@ subroutine compressed_write_2d(fileobj, variable_name, cdata, unlim_dim_level, &
   integer :: index(1) !< index of the PE in the pelist
 
   integer :: is !< Starting index of the first dimension
-  integer :: js !< Ending index of the first dimension
-  integer :: ie !< Starting index of the second dimension
+  integer :: ie !< Ending index of the first dimension
+  integer :: js !< Starting index of the second dimension
   integer :: je !< Ending index of the second dimension
 
   append_error_msg = "compressed_write_2d: file:"//trim(fileobj%path)//" variable:"//trim(variable_name)
@@ -334,8 +334,8 @@ subroutine compressed_write_3d(fileobj, variable_name, cdata, unlim_dim_level, &
   integer :: index(1) !< index of the PE in the pelist
 
   integer :: is !< Starting index of the first dimension
-  integer :: js !< Ending index of the first dimension
-  integer :: ie !< Starting index of the second dimension
+  integer :: ie !< Ending index of the first dimension
+  integer :: js !< Starting index of the second dimension
   integer :: je !< Ending index of the second dimension
 
   append_error_msg = "compressed_write_3d: file:"//trim(fileobj%path)//" variable:"//trim(variable_name)

--- a/fms2_io/include/compressed_write.inc
+++ b/fms2_io/include/compressed_write.inc
@@ -283,6 +283,13 @@ subroutine compressed_write_2d(fileobj, variable_name, cdata, unlim_dim_level, &
     class default
       call error("unsupported variable type: "//trim(append_error_msg))
   end select
+
+  if (fileobj%is_root) then
+    if (allocated(buf_i4_kind)) deallocate(buf_i4_kind)
+    if (allocated(buf_i8_kind)) deallocate(buf_i8_kind)
+    if (allocated(buf_r4_kind)) deallocate(buf_r4_kind)
+    if (allocated(buf_r8_kind)) deallocate(buf_r8_kind)
+  endif
 end subroutine compressed_write_2d
 
 
@@ -405,6 +412,13 @@ subroutine compressed_write_3d(fileobj, variable_name, cdata, unlim_dim_level, &
     class default
       call error("unsupported variable type: "//trim(append_error_msg))
   end select
+
+  if (fileobj%is_root) then
+    if (allocated(buf_i4_kind)) deallocate(buf_i4_kind)
+    if (allocated(buf_i8_kind)) deallocate(buf_i8_kind)
+    if (allocated(buf_r4_kind)) deallocate(buf_r4_kind)
+    if (allocated(buf_r8_kind)) deallocate(buf_r8_kind)
+  endif
 end subroutine compressed_write_3d
 
 

--- a/fms2_io/include/compressed_write.inc
+++ b/fms2_io/include/compressed_write.inc
@@ -81,31 +81,32 @@ end subroutine compressed_write_0d_wrap
 subroutine compressed_write_1d(fileobj, variable_name, cdata, unlim_dim_level, &
                                corner, edge_lengths)
 
-  class(FmsNetcdfFile_t), intent(in) :: fileobj !< File object.
-  character(len=*), intent(in) :: variable_name !< Variable name.
-  class(*), dimension(:), intent(in) :: cdata !< Compressed data that
-                                              !! will be gathered and
-                                              !! written to the
-                                              !! netcdf file.
-  integer, intent(in), optional :: unlim_dim_level !< Level for the unlimited
-                                                   !! dimension.
-  integer, dimension(1), intent(in), optional :: corner !< Array of starting
-                                                        !! indices describing
-                                                        !! where the data
-                                                        !! will be written to.
-  integer, dimension(1), intent(in), optional :: edge_lengths !< The number of
-                                                              !! elements that
-                                                              !! will be written
-                                                              !! in each dimension.
+  class(FmsNetcdfFile_t), intent(in)           :: fileobj         !< File object.
+  character(len=*),       intent(in)           :: variable_name   !< Variable name.
+  class(*), dimension(:), intent(in)           :: cdata           !< Compressed data that
+                                                                  !! will be gathered and
+                                                                  !! written to the
+                                                                  !! netcdf file.
+  integer,                intent(in), optional :: unlim_dim_level !< Level for the unlimited
+                                                                  !! dimension.
+  integer,  dimension(1), intent(in), optional :: corner          !< Array of starting
+                                                                  !! indices describing
+                                                                  !! where the data
+                                                                  !! will be written to.
+  integer,  dimension(1), intent(in), optional :: edge_lengths    !< The number of
+                                                                  !! elements that
+                                                                  !! will be written
+                                                                  !! in each dimension.
 
-  integer, dimension(2) :: compressed_dim_index
-  integer, dimension(1) :: c
-  integer, dimension(1) :: e
-  integer :: i
-  integer(kind=i4_kind), dimension(:), allocatable :: buf_i4_kind
-  integer(kind=i8_kind), dimension(:), allocatable :: buf_i8_kind
-  real(kind=r4_kind), dimension(:), allocatable :: buf_r4_kind
-  real(kind=r8_kind), dimension(:), allocatable :: buf_r8_kind
+  integer, dimension(2) :: compressed_dim_index !< index of the compressed dimension
+                                                !! compressed_dim_index(1) relative to cdata
+                                                !! compressed_dim_index(2) relative to the fileobj
+  integer, dimension(1) :: e                    !< "edges" number of points to read
+
+  integer(kind=i4_kind), dimension(:), allocatable :: buf_i4_kind !< Global buffer of data
+  integer(kind=i8_kind), dimension(:), allocatable :: buf_i8_kind !< Global buffer of data
+  real   (kind=r4_kind), dimension(:), allocatable :: buf_r4_kind !< Global buffer of data
+  real   (kind=r8_kind), dimension(:), allocatable :: buf_r8_kind !< Global buffer of data
 
   character(len=200) :: append_error_msg !< Msg to be appended to FATAL error message
 
@@ -120,66 +121,54 @@ subroutine compressed_write_1d(fileobj, variable_name, cdata, unlim_dim_level, &
     return
   endif
 
-  !Gather the data onto the I/O root and write it out.
+  e(:) = shape(cdata)
+  !The root pe creates a buffer big enough to store the data:
   if (fileobj%is_root) then
-    c(:) = 1
-    e(:) = shape(cdata)
-    do i = 1, size(fileobj%pelist)
-      c(compressed_dim_index(1)) = fileobj%compressed_dims(compressed_dim_index(2))%npes_corner(i)
-      e(compressed_dim_index(1)) = fileobj%compressed_dims(compressed_dim_index(2))%npes_nelems(i)
-      if (i .eq. 1) then
-        call netcdf_write_data(fileobj, variable_name, cdata, &
-                               unlim_dim_level=unlim_dim_level, corner=c, &
-                               edge_lengths=e)
-      else
-        select type(cdata)
-          type is (integer(kind=i4_kind))
-            call allocate_array(buf_i4_kind, e)
-            call mpp_recv(buf_i4_kind, size(buf_i4_kind), fileobj%pelist(i), block=.true.)
-            call netcdf_write_data(fileobj, variable_name, buf_i4_kind, &
-                                   unlim_dim_level=unlim_dim_level, corner=c, &
-                                   edge_lengths=e)
-            deallocate(buf_i4_kind)
-          type is (integer(kind=i8_kind))
-            call allocate_array(buf_i8_kind, e)
-            call mpp_recv(buf_i8_kind, size(buf_i8_kind), fileobj%pelist(i), block=.true.)
-            call netcdf_write_data(fileobj, variable_name, buf_i8_kind, &
-                                   unlim_dim_level=unlim_dim_level, corner=c, &
-                                   edge_lengths=e)
-            deallocate(buf_i8_kind)
-          type is (real(kind=r4_kind))
-            call allocate_array(buf_r4_kind, e)
-            call mpp_recv(buf_r4_kind, size(buf_r4_kind), fileobj%pelist(i), block=.true.)
-            call netcdf_write_data(fileobj, variable_name, buf_r4_kind, &
-                                   unlim_dim_level=unlim_dim_level, corner=c, &
-                                   edge_lengths=e)
-            deallocate(buf_r4_kind)
-          type is (real(kind=r8_kind))
-            call allocate_array(buf_r8_kind, e)
-            call mpp_recv(buf_r8_kind, size(buf_r8_kind), fileobj%pelist(i), block=.true.)
-            call netcdf_write_data(fileobj, variable_name, buf_r8_kind, &
-                                   unlim_dim_level=unlim_dim_level, corner=c, &
-                                   edge_lengths=e)
-            deallocate(buf_r8_kind)
-          class default
-            call error("unsupported variable type: "//trim(append_error_msg))
-        end select
-      endif
-    enddo
-  else
+    e(compressed_dim_index(1)) = sum(fileobj%compressed_dims(compressed_dim_index(2))%npes_nelems)
     select type(cdata)
       type is (integer(kind=i4_kind))
-        call mpp_send(cdata, size(cdata), fileobj%io_root)
+        call allocate_array(buf_i4_kind, e)
       type is (integer(kind=i8_kind))
-        call mpp_send(cdata, size(cdata), fileobj%io_root)
+        call allocate_array(buf_i8_kind, e)
       type is (real(kind=r4_kind))
-        call mpp_send(cdata, size(cdata), fileobj%io_root)
+        call allocate_array(buf_r4_kind, e)
       type is (real(kind=r8_kind))
-        call mpp_send(cdata, size(cdata), fileobj%io_root)
+        call allocate_array(buf_r8_kind, e)
       class default
         call error("unsupported variable type: "//trim(append_error_msg))
-    end select
-    call mpp_sync_self(check=EVENT_SEND)
+     end select
+  endif
+
+  !Gather the data onto the I/O root and write it out.
+  select type(cdata)
+    type is (integer(kind=i4_kind))
+      call mpp_gather(cdata, size(cdata), buf_i4_kind, fileobj%compressed_dims(compressed_dim_index(2))%npes_nelems, &
+        fileobj%pelist)
+      call netcdf_write_data(fileobj, variable_name, buf_i4_kind, &
+        unlim_dim_level=unlim_dim_level)
+    type is (integer(kind=i8_kind))
+      call mpp_gather(cdata, size(cdata), buf_i8_kind, fileobj%compressed_dims(compressed_dim_index(2))%npes_nelems, &
+        fileobj%pelist)
+      call netcdf_write_data(fileobj, variable_name, buf_i8_kind, &
+        unlim_dim_level=unlim_dim_level)
+    type is (real(kind=r4_kind))
+      call mpp_gather(cdata, size(cdata), buf_r4_kind, fileobj%compressed_dims(compressed_dim_index(2))%npes_nelems, &
+        fileobj%pelist)
+      call netcdf_write_data(fileobj, variable_name, buf_r4_kind, &
+        unlim_dim_level=unlim_dim_level)
+    type is (real(kind=r8_kind))
+      call mpp_gather(cdata, size(cdata), buf_r8_kind, fileobj%compressed_dims(compressed_dim_index(2))%npes_nelems, &
+        fileobj%pelist)
+      call netcdf_write_data(fileobj, variable_name, buf_r8_kind, &
+        unlim_dim_level=unlim_dim_level)
+    class default
+      call error("unsupported variable type: "//trim(append_error_msg))
+  end select
+  if (fileobj%is_root) then
+    if (allocated(buf_i4_kind)) deallocate(buf_i4_kind)
+    if (allocated(buf_i8_kind)) deallocate(buf_i8_kind)
+    if (allocated(buf_r4_kind)) deallocate(buf_r4_kind)
+    if (allocated(buf_r8_kind)) deallocate(buf_r8_kind)
   endif
 end subroutine compressed_write_1d
 
@@ -191,32 +180,42 @@ end subroutine compressed_write_1d
 subroutine compressed_write_2d(fileobj, variable_name, cdata, unlim_dim_level, &
                                corner, edge_lengths)
 
-  class(FmsNetcdfFile_t), intent(in) :: fileobj !< File object.
-  character(len=*), intent(in) :: variable_name !< Variable name.
-  class(*), dimension(:,:), intent(in) :: cdata !< Compressed data that
-                                                !! will be gathered and
-                                                !! written to the
-                                                !! netcdf file.
-  integer, intent(in), optional :: unlim_dim_level !< Level for the unlimited
-                                                   !! dimension.
-  integer, dimension(2), intent(in), optional :: corner !< Array of starting
-                                                        !! indices describing
-                                                        !! where the data
-                                                        !! will be written to.
-  integer, dimension(2), intent(in), optional :: edge_lengths !< The number of
-                                                              !! elements that
-                                                              !! will be written
-                                                              !! in each dimension.
+  class(FmsNetcdfFile_t),   intent(in)           :: fileobj         !< File object.
+  character(len=*),         intent(in)           :: variable_name   !< Variable name.
+  class(*), dimension(:,:), intent(in)           :: cdata           !< Compressed data that
+                                                                    !! will be gathered and
+                                                                    !! written to the
+                                                                    !! netcdf file.
+  integer,                  intent(in), optional :: unlim_dim_level !< Level for the unlimited
+                                                                    !! dimension.
+  integer,  dimension(2),   intent(in), optional :: corner          !< Array of starting
+                                                                    !! indices describing
+                                                                    !! where the data
+                                                                    !! will be written to.
+  integer,  dimension(2),   intent(in), optional :: edge_lengths    !< The number of
+                                                                    !! elements that
+                                                                    !! will be written
+                                                                    !! in each dimension.
 
-  integer, dimension(2) :: compressed_dim_index
-  integer, dimension(2) :: c
-  integer, dimension(2) :: e
-  integer :: i
-  integer(kind=i4_kind), dimension(:,:), allocatable :: buf_i4_kind
-  integer(kind=i8_kind), dimension(:,:), allocatable :: buf_i8_kind
-  real(kind=r4_kind), dimension(:,:), allocatable :: buf_r4_kind
-  real(kind=r8_kind), dimension(:,:), allocatable :: buf_r8_kind
+  integer, dimension(2) :: compressed_dim_index !< index of the compressed dimension
+                                                !! compressed_dim_index(1) relative to cdata
+                                                !! compressed_dim_index(2) relative to the fileobj
+  integer, dimension(2) :: c                    !! corners of the data to read
+  integer, dimension(2) :: e                    !< "edges" number of points to read
+
+  integer(kind=i4_kind), dimension(:,:), allocatable :: buf_i4_kind !< Global buffer of data
+  integer(kind=i8_kind), dimension(:,:), allocatable :: buf_i8_kind !< Global buffer of data
+  real   (kind=r4_kind), dimension(:,:), allocatable :: buf_r4_kind !< Global buffer of data
+  real   (kind=r8_kind), dimension(:,:), allocatable :: buf_r8_kind !< Global buffer of data
+
   character(len=200) :: append_error_msg !< Msg to be appended to FATAL error message
+
+  integer :: index(1) !< index of the PE in the pelist
+  
+  integer :: is !< Starting index of the first dimension
+  integer :: js !< Ending index of the first dimension
+  integer :: ie !< Starting index of the second dimension
+  integer :: je !< Ending index of the second dimension
 
   append_error_msg = "compressed_write_2d: file:"//trim(fileobj%path)//" variable:"//trim(variable_name)
 
@@ -228,67 +227,62 @@ subroutine compressed_write_2d(fileobj, variable_name, cdata, unlim_dim_level, &
     return
   endif
 
-  !Gather the data onto the I/O root and write it out.
+  e(:) = shape(cdata)
+  !The root pe creates a buffer big enough to store the data:
   if (fileobj%is_root) then
-    c(:) = 1
-    e(:) = shape(cdata)
-    do i = 1, size(fileobj%pelist)
-      c(compressed_dim_index(1)) = fileobj%compressed_dims(compressed_dim_index(2))%npes_corner(i)
-      e(compressed_dim_index(1)) = fileobj%compressed_dims(compressed_dim_index(2))%npes_nelems(i)
-      if (i .eq. 1) then
-        call netcdf_write_data(fileobj, variable_name, cdata, &
-                               unlim_dim_level=unlim_dim_level, corner=c, &
-                               edge_lengths=e)
-      else
-        select type(cdata)
-          type is (integer(kind=i4_kind))
-            call allocate_array(buf_i4_kind, e)
-            call mpp_recv(buf_i4_kind, size(buf_i4_kind), fileobj%pelist(i), block=.true.)
-            call netcdf_write_data(fileobj, variable_name, buf_i4_kind, &
-                                   unlim_dim_level=unlim_dim_level, corner=c, &
-                                   edge_lengths=e)
-            deallocate(buf_i4_kind)
-          type is (integer(kind=i8_kind))
-            call allocate_array(buf_i8_kind, e)
-            call mpp_recv(buf_i8_kind, size(buf_i8_kind), fileobj%pelist(i), block=.true.)
-            call netcdf_write_data(fileobj, variable_name, buf_i8_kind, &
-                                   unlim_dim_level=unlim_dim_level, corner=c, &
-                                   edge_lengths=e)
-            deallocate(buf_i8_kind)
-          type is (real(kind=r4_kind))
-            call allocate_array(buf_r4_kind, e)
-            call mpp_recv(buf_r4_kind, size(buf_r4_kind), fileobj%pelist(i), block=.true.)
-            call netcdf_write_data(fileobj, variable_name, buf_r4_kind, &
-                                   unlim_dim_level=unlim_dim_level, corner=c, &
-                                   edge_lengths=e)
-            deallocate(buf_r4_kind)
-          type is (real(kind=r8_kind))
-            call allocate_array(buf_r8_kind, e)
-            call mpp_recv(buf_r8_kind, size(buf_r8_kind), fileobj%pelist(i), block=.true.)
-            call netcdf_write_data(fileobj, variable_name, buf_r8_kind, &
-                                   unlim_dim_level=unlim_dim_level, corner=c, &
-                                   edge_lengths=e)
-            deallocate(buf_r8_kind)
-          class default
-            call error("unsupported variable type: "//trim(append_error_msg))
-        end select
-      endif
-    enddo
-  else
+    e(compressed_dim_index(1)) = sum(fileobj%compressed_dims(compressed_dim_index(2))%npes_nelems)
     select type(cdata)
       type is (integer(kind=i4_kind))
-        call mpp_send(cdata, size(cdata), fileobj%io_root)
+        call allocate_array(buf_i4_kind, e)
       type is (integer(kind=i8_kind))
-        call mpp_send(cdata, size(cdata), fileobj%io_root)
+        call allocate_array(buf_i8_kind, e)
       type is (real(kind=r4_kind))
-        call mpp_send(cdata, size(cdata), fileobj%io_root)
+        call allocate_array(buf_r4_kind, e)
       type is (real(kind=r8_kind))
-        call mpp_send(cdata, size(cdata), fileobj%io_root)
+        call allocate_array(buf_r8_kind, e)
       class default
         call error("unsupported variable type: "//trim(append_error_msg))
-    end select
-    call mpp_sync_self(check=EVENT_SEND)
+     end select
   endif
+
+  c(:) = 1
+  index = FINDLOC(fileobj%pelist, mpp_pe())
+
+  c(compressed_dim_index(1)) = fileobj%compressed_dims(compressed_dim_index(2))%npes_corner(index(1))
+  e(compressed_dim_index(1)) = fileobj%compressed_dims(compressed_dim_index(2))%npes_nelems(index(1))
+
+  if (compressed_dim_index(1) .eq. 1) then
+    is = c(compressed_dim_index(1))
+    ie = c(compressed_dim_index(1)) + e(compressed_dim_index(1)) - 1
+    js = 1
+    je = size(cdata,2)
+  else
+    js = c(compressed_dim_index(1))
+    je = c(compressed_dim_index(1)) + e(compressed_dim_index(1)) - 1
+    is = 1
+    ie = size(cdata,2)
+  endif
+  
+  select type(cdata)
+    type is (integer(kind=i4_kind))
+      call mpp_gather(is, ie, js, je, fileobj%pelist, cdata, buf_i4_kind, fileobj%is_root)
+      call netcdf_write_data(fileobj, variable_name, buf_i4_kind, &
+        unlim_dim_level=unlim_dim_level)
+    type is (integer(kind=i8_kind))
+      call mpp_gather(is, ie, js, je, fileobj%pelist, cdata, buf_i8_kind, fileobj%is_root)
+      call netcdf_write_data(fileobj, variable_name, buf_i8_kind, &
+        unlim_dim_level=unlim_dim_level)
+    type is (real(kind=r4_kind))
+      call mpp_gather(is, ie, js, je, fileobj%pelist, cdata, buf_r4_kind, fileobj%is_root)
+      call netcdf_write_data(fileobj, variable_name, buf_r4_kind, &
+        unlim_dim_level=unlim_dim_level)
+    type is (real(kind=r8_kind))
+      call mpp_gather(is, ie, js, je, fileobj%pelist, cdata, buf_r8_kind, fileobj%is_root)
+      call netcdf_write_data(fileobj, variable_name, buf_r8_kind, &
+        unlim_dim_level=unlim_dim_level)
+    class default
+      call error("unsupported variable type: "//trim(append_error_msg))
+  end select
 end subroutine compressed_write_2d
 
 
@@ -299,32 +293,43 @@ end subroutine compressed_write_2d
 subroutine compressed_write_3d(fileobj, variable_name, cdata, unlim_dim_level, &
                                corner, edge_lengths)
 
-  class(FmsNetcdfFile_t), intent(in) :: fileobj !< File object.
-  character(len=*), intent(in) :: variable_name !< Variable name.
-  class(*), dimension(:,:,:), intent(in) :: cdata !< Compressed data that
-                                                  !! will be gathered and
-                                                  !! written to the
-                                                  !! netcdf file.
-  integer, intent(in), optional :: unlim_dim_level !< Level for the unlimited
-                                                   !! dimension.
-  integer, dimension(3), intent(in), optional :: corner !< Array of starting
-                                                        !! indices describing
-                                                        !! where the data
-                                                        !! will be written to.
-  integer, dimension(3), intent(in), optional :: edge_lengths !< The number of
-                                                              !! elements that
-                                                              !! will be written
-                                                              !! in each dimension.
+  class(FmsNetcdfFile_t),     intent(in)           :: fileobj         !< File object.
+  character(len=*),           intent(in)           :: variable_name   !< Variable name.
+  class(*), contiguous,       intent(in), target   :: cdata(:,:,:)    !< Compressed data that
+                                                                      !! will be gathered and
+                                                                      !! written to the
+                                                                      !! netcdf file.
+  integer,                    intent(in), optional :: unlim_dim_level !< Level for the unlimited
+                                                                      !! dimension.
+  integer,  dimension(3),     intent(in), optional :: corner          !< Array of starting
+                                                                      !! indices describing
+                                                                      !! where the data
+                                                                      !! will be written to.
+  integer,  dimension(3),     intent(in), optional :: edge_lengths    !< The number of
+                                                                      !! elements that
+                                                                      !! will be written
+                                                                      !! in each dimension.
 
-  integer, dimension(2) :: compressed_dim_index
-  integer, dimension(3) :: c
-  integer, dimension(3) :: e
-  integer :: i
-  integer(kind=i4_kind), dimension(:,:,:), allocatable :: buf_i4_kind
-  integer(kind=i8_kind), dimension(:,:,:), allocatable :: buf_i8_kind
-  real(kind=r4_kind), dimension(:,:,:), allocatable :: buf_r4_kind
-  real(kind=r8_kind), dimension(:,:,:), allocatable :: buf_r8_kind
+  integer, dimension(2) :: compressed_dim_index !< index of the compressed dimension
+                                                !! compressed_dim_index(1) relative to cdata
+                                                !! compressed_dim_index(2) relative to the fileobj
+  integer, dimension(3) :: c                    !! corners of the data to read
+  integer, dimension(3) :: e                    !< "edges" number of points to read
+
+  integer(kind=i4_kind), dimension(:,:,:), allocatable :: buf_i4_kind !< Global buffer of data
+  integer(kind=i8_kind), dimension(:,:,:), allocatable :: buf_i8_kind !< Global buffer of data
+  real   (kind=r4_kind), dimension(:,:,:), allocatable :: buf_r4_kind !< Global buffer of data
+  real   (kind=r8_kind), dimension(:,:,:), allocatable :: buf_r8_kind !< Global buffer of data
+
   character(len=200) :: append_error_msg !< Msg to be appended to FATAL error message
+  class(*), pointer :: cdata_dummy(:,:,:,:)
+
+  integer :: index(1) !< index of the PE in the pelist
+  
+  integer :: is !< Starting index of the first dimension
+  integer :: js !< Ending index of the first dimension
+  integer :: ie !< Starting index of the second dimension
+  integer :: je !< Ending index of the second dimension
 
   append_error_msg = "compressed_write_3d: file:"//trim(fileobj%path)//" variable:"//trim(variable_name)
 
@@ -334,69 +339,72 @@ subroutine compressed_write_3d(fileobj, variable_name, cdata, unlim_dim_level, &
                            unlim_dim_level=unlim_dim_level, corner=corner, &
                            edge_lengths=edge_lengths)
     return
+  else if (compressed_dim_index(1) .eq. 3) then
+    cdata_dummy(1:size(cdata,1), 1:size(cdata,2), 1:size(cdata,3), 1:1) => cdata(:,:,:)
+    call compressed_write_4d(fileobj, variable_name, cdata_dummy, unlim_dim_level, &
+      (/ corner, 1/), (/edge_lengths, 1/))
   endif
 
-  !Gather the data onto the I/O root and write it out.
+  e(:) = shape(cdata)
+  !The root pe creates a buffer big enough to store the data:
   if (fileobj%is_root) then
-    c(:) = 1
-    e(:) = shape(cdata)
-    do i = 1, size(fileobj%pelist)
-      c(compressed_dim_index(1)) = fileobj%compressed_dims(compressed_dim_index(2))%npes_corner(i)
-      e(compressed_dim_index(1)) = fileobj%compressed_dims(compressed_dim_index(2))%npes_nelems(i)
-      if (i .eq. 1) then
-        call netcdf_write_data(fileobj, variable_name, cdata, &
-                               unlim_dim_level=unlim_dim_level, corner=c, &
-                               edge_lengths=e)
-      else
-        select type(cdata)
-          type is (integer(kind=i4_kind))
-            call allocate_array(buf_i4_kind, e)
-            call mpp_recv(buf_i4_kind, size(buf_i4_kind), fileobj%pelist(i), block=.true.)
-            call netcdf_write_data(fileobj, variable_name, buf_i4_kind, &
-                                   unlim_dim_level=unlim_dim_level, corner=c, &
-                                   edge_lengths=e)
-            deallocate(buf_i4_kind)
-          type is (integer(kind=i8_kind))
-            call allocate_array(buf_i8_kind, e)
-            call mpp_recv(buf_i8_kind, size(buf_i8_kind), fileobj%pelist(i), block=.true.)
-            call netcdf_write_data(fileobj, variable_name, buf_i8_kind, &
-                                   unlim_dim_level=unlim_dim_level, corner=c, &
-                                   edge_lengths=e)
-            deallocate(buf_i8_kind)
-          type is (real(kind=r4_kind))
-            call allocate_array(buf_r4_kind, e)
-            call mpp_recv(buf_r4_kind, size(buf_r4_kind), fileobj%pelist(i), block=.true.)
-            call netcdf_write_data(fileobj, variable_name, buf_r4_kind, &
-                                   unlim_dim_level=unlim_dim_level, corner=c, &
-                                   edge_lengths=e)
-            deallocate(buf_r4_kind)
-          type is (real(kind=r8_kind))
-            call allocate_array(buf_r8_kind, e)
-            call mpp_recv(buf_r8_kind, size(buf_r8_kind), fileobj%pelist(i), block=.true.)
-            call netcdf_write_data(fileobj, variable_name, buf_r8_kind, &
-                                   unlim_dim_level=unlim_dim_level, corner=c, &
-                                   edge_lengths=e)
-            deallocate(buf_r8_kind)
-          class default
-            call error("unsupported variable type: "//trim(append_error_msg))
-        end select
-      endif
-    enddo
-  else
+    e(compressed_dim_index(1)) = sum(fileobj%compressed_dims(compressed_dim_index(2))%npes_nelems)
     select type(cdata)
       type is (integer(kind=i4_kind))
-        call mpp_send(cdata, size(cdata), fileobj%io_root)
+        call allocate_array(buf_i4_kind, e)
       type is (integer(kind=i8_kind))
-        call mpp_send(cdata, size(cdata), fileobj%io_root)
+        call allocate_array(buf_i8_kind, e)
       type is (real(kind=r4_kind))
-        call mpp_send(cdata, size(cdata), fileobj%io_root)
+        call allocate_array(buf_r4_kind, e)
       type is (real(kind=r8_kind))
-        call mpp_send(cdata, size(cdata), fileobj%io_root)
+        call allocate_array(buf_r8_kind, e)
       class default
         call error("unsupported variable type: "//trim(append_error_msg))
-    end select
-    call mpp_sync_self(check=EVENT_SEND)
+     end select
   endif
+
+  c(:) = 1
+  index = FINDLOC(fileobj%pelist, mpp_pe())
+
+  c(compressed_dim_index(1)) = fileobj%compressed_dims(compressed_dim_index(2))%npes_corner(index(1))
+  e(compressed_dim_index(1)) = fileobj%compressed_dims(compressed_dim_index(2))%npes_nelems(index(1))
+
+  if (compressed_dim_index(1) .eq. 1) then
+    is = c(compressed_dim_index(1))
+    ie = c(compressed_dim_index(1)) + e(compressed_dim_index(1)) - 1
+    js = 1
+    je = size(cdata,2)
+  else
+    js = c(compressed_dim_index(1))
+    je = c(compressed_dim_index(1)) + e(compressed_dim_index(1)) - 1
+    is = 1
+    ie = size(cdata,2)
+  endif
+
+  select type(cdata)
+    type is (integer(kind=i4_kind))
+      call mpp_gather(is, ie, js, je, size(cdata,3), &
+        fileobj%pelist, cdata, buf_i4_kind, fileobj%is_root)
+      call netcdf_write_data(fileobj, variable_name, buf_i4_kind, &
+        unlim_dim_level=unlim_dim_level)
+    type is (integer(kind=i8_kind))
+      call mpp_gather(is, ie, js, je, size(cdata,3), &
+        fileobj%pelist, cdata, buf_i8_kind, fileobj%is_root)
+      call netcdf_write_data(fileobj, variable_name, buf_i8_kind, &
+        unlim_dim_level=unlim_dim_level)
+    type is (real(kind=r4_kind))
+      call mpp_gather(is, ie, js, je, size(cdata,3), &
+        fileobj%pelist, cdata, buf_r4_kind, fileobj%is_root)
+      call netcdf_write_data(fileobj, variable_name, buf_r4_kind, &
+        unlim_dim_level=unlim_dim_level)
+    type is (real(kind=r8_kind))
+      call mpp_gather(is, ie, js, je, size(cdata,3), &
+        fileobj%pelist, cdata, buf_r8_kind, fileobj%is_root)
+      call netcdf_write_data(fileobj, variable_name, buf_r8_kind, &
+        unlim_dim_level=unlim_dim_level)
+    class default
+      call error("unsupported variable type: "//trim(append_error_msg))
+  end select
 end subroutine compressed_write_3d
 
 

--- a/fms2_io/include/compressed_write.inc
+++ b/fms2_io/include/compressed_write.inc
@@ -211,7 +211,7 @@ subroutine compressed_write_2d(fileobj, variable_name, cdata, unlim_dim_level, &
   character(len=200) :: append_error_msg !< Msg to be appended to FATAL error message
 
   integer :: index(1) !< index of the PE in the pelist
-  
+
   integer :: is !< Starting index of the first dimension
   integer :: js !< Ending index of the first dimension
   integer :: ie !< Starting index of the second dimension
@@ -262,7 +262,7 @@ subroutine compressed_write_2d(fileobj, variable_name, cdata, unlim_dim_level, &
     is = 1
     ie = size(cdata,2)
   endif
-  
+
   select type(cdata)
     type is (integer(kind=i4_kind))
       call mpp_gather(is, ie, js, je, fileobj%pelist, cdata, buf_i4_kind, fileobj%is_root)
@@ -332,7 +332,7 @@ subroutine compressed_write_3d(fileobj, variable_name, cdata, unlim_dim_level, &
   class(*), pointer :: cdata_dummy(:,:,:,:)
 
   integer :: index(1) !< index of the PE in the pelist
-  
+
   integer :: is !< Starting index of the first dimension
   integer :: js !< Ending index of the first dimension
   integer :: ie !< Starting index of the second dimension
@@ -348,8 +348,7 @@ subroutine compressed_write_3d(fileobj, variable_name, cdata, unlim_dim_level, &
     return
   else if (compressed_dim_index(1) .eq. 3) then
     cdata_dummy(1:size(cdata,1), 1:size(cdata,2), 1:size(cdata,3), 1:1) => cdata(:,:,:)
-    call compressed_write_4d(fileobj, variable_name, cdata_dummy, unlim_dim_level, &
-      (/ corner, 1/), (/edge_lengths, 1/))
+    call compressed_write_4d(fileobj, variable_name, cdata_dummy, unlim_dim_level)
   endif
 
   e(:) = shape(cdata)

--- a/fms2_io/netcdf_io.F90
+++ b/fms2_io/netcdf_io.F90
@@ -1015,6 +1015,7 @@ function get_variable_compressed_dimension_index(fileobj, variable_name, broadca
     endif
   endif
   call mpp_broadcast(compressed_dimension_index(1), fileobj%io_root, pelist=fileobj%pelist)
+  call mpp_broadcast(compressed_dimension_index(2), fileobj%io_root, pelist=fileobj%pelist)
 end function get_variable_compressed_dimension_index
 
 

--- a/mpp/include/mpp_comm.inc
+++ b/mpp/include/mpp_comm.inc
@@ -398,6 +398,20 @@
 #define MPP_GATHER_PELIST_3D_ mpp_gather_pelist_int4_3d
 #include <mpp_gather.fh>
 
+
+#undef MPP_GATHER_1D_
+#undef MPP_GATHER_1DV_
+#undef MPP_TYPE_
+#define MPP_TYPE_ integer(i8_kind)
+#define MPP_GATHER_1D_ mpp_gather_int8_1d
+#define MPP_GATHER_1DV_ mpp_gather_int8_1dv
+#undef  MPP_GATHER_PELIST_2D_
+#undef  MPP_GATHER_PELIST_3D_
+#define MPP_GATHER_PELIST_2D_ mpp_gather_pelist_int8_2d
+#define MPP_GATHER_PELIST_3D_ mpp_gather_pelist_int8_3d
+#include <mpp_gather.fh>
+
+
 #undef MPP_GATHER_1D_
 #undef MPP_GATHER_1DV_
 #undef MPP_TYPE_

--- a/mpp/mpp.F90
+++ b/mpp/mpp.F90
@@ -698,16 +698,20 @@ private
   interface mpp_gather
      module procedure mpp_gather_logical_1d
      module procedure mpp_gather_int4_1d
+     module procedure mpp_gather_int8_1d
      module procedure mpp_gather_real4_1d
      module procedure mpp_gather_real8_1d
      module procedure mpp_gather_logical_1dv
      module procedure mpp_gather_int4_1dv
+     module procedure mpp_gather_int8_1dv
      module procedure mpp_gather_real4_1dv
      module procedure mpp_gather_real8_1dv
      module procedure mpp_gather_pelist_logical_2d
      module procedure mpp_gather_pelist_logical_3d
      module procedure mpp_gather_pelist_int4_2d
      module procedure mpp_gather_pelist_int4_3d
+     module procedure mpp_gather_pelist_int8_2d
+     module procedure mpp_gather_pelist_int8_3d
      module procedure mpp_gather_pelist_real4_2d
      module procedure mpp_gather_pelist_real4_3d
      module procedure mpp_gather_pelist_real8_2d

--- a/test_fms/fms2_io/Makefile.am
+++ b/test_fms/fms2_io/Makefile.am
@@ -30,7 +30,7 @@ LDADD = $(top_builddir)/libFMS/libFMS.la
 
 # Build this test program.
 check_PROGRAMS = test_get_is_valid test_file_appendix test_fms2_io test_atmosphere_io test_io_simple test_io_with_mask test_global_att \
-                 test_bc_restart test_get_mosaic_tile_grid test_read_ascii_file test_unlimit_compressed test_chunksizes
+                 test_bc_restart test_get_mosaic_tile_grid test_read_ascii_file test_unlimit_compressed test_chunksizes test_compressed_writes
 
 # This is the source code for the test.
 test_get_is_valid_SOURCES = test_get_is_valid.F90
@@ -49,6 +49,7 @@ test_read_ascii_file_SOURCES=test_read_ascii_file.F90
 test_file_appendix_SOURCES=test_file_appendix.F90
 test_unlimit_compressed_SOURCES=test_unlimit_compressed.F90
 test_chunksizes_SOURCES = test_chunksizes.F90
+test_compressed_writes_SOURCES = test_compressed_writes.F90
 
 EXTRA_DIST = test_bc_restart.sh test_fms2_io.sh test_atmosphere_io.sh test_io_simple.sh test_global_att.sh test_io_with_mask.sh test_read_ascii_file.sh
 

--- a/test_fms/fms2_io/test_compressed_writes.F90
+++ b/test_fms/fms2_io/test_compressed_writes.F90
@@ -1,0 +1,244 @@
+program test_compressed_writes
+  use fms_mod, only: fms_init, fms_end
+  use fms2_io_mod
+  use mpp_mod
+  use   platform_mod,    only: r4_kind, r8_kind, i4_kind, i8_kind
+
+  implicit none
+
+  type data_type
+    real(kind=r4_kind),    allocatable   :: var_r4(:,:,:,:,:)
+    real(kind=r8_kind),    allocatable   :: var_r8(:,:,:,:,:)
+    integer(kind=i4_kind), allocatable   :: var_i4(:,:,:,:,:)
+    integer(kind=i8_kind), allocatable   :: var_i8(:,:,:,:,:)
+  end type
+
+  type(FmsNetcdfFile_t)                 :: fileobj             !< fms2io fileobj for domain decomposed
+  character(len=6), dimension(5)        :: names               !< Dimensions names
+  type(data_type)                       :: var_data_in         !< Variable data written in
+  type(data_type)                       :: var_data_out         !< Variable data read
+  type(data_type)                       :: var_data_ref         !< Variable data read
+  integer :: ndim2 = 2
+  integer :: ndim3 = 3
+  integer :: ndim4 = 4
+  integer :: ndim5 = 1
+  integer, allocatable :: pes(:)
+
+  call fms_init
+
+  allocate(pes(mpp_npes()))
+  call mpp_get_current_pelist(pes)
+
+  if (open_file(fileobj, "test_compressed_writes.nc", "overwrite", nc_format="netcdf4", pelist=pes)) then
+
+    names(1) = "c_xy"
+    names(2) = "dim2"
+    names(3) = "dim3"
+    names(4) = "dim4"
+    names(5) = "dim5"
+
+    call register_axis(fileobj, "c_xy", mpp_pe()+1, is_compressed=.true.)
+    call register_axis(fileobj, "dim2", ndim2)
+    call register_axis(fileobj, "dim3", ndim3)
+    call register_axis(fileobj, "dim4", ndim4)
+    call register_axis(fileobj, "dim5", ndim5)
+
+    call register_field_wrapper(fileobj, "var2", names, 2)
+    call register_field_wrapper(fileobj, "var3", names, 3)
+    call register_field_wrapper(fileobj, "var4", names, 4)
+    call register_field_wrapper(fileobj, "var5", names, 5)
+
+    call var_data_alloc(var_data_in, ndim2, ndim3, ndim4, ndim5, mpp_pe()+1)
+    call var_data_set(var_data_in, mpp_pe())
+
+    call write_data_wrapper(fileobj, "r4", var_data_in%var_r4)
+    call write_data_wrapper(fileobj, "r8", var_data_in%var_r8)
+    call write_data_wrapper(fileobj, "i4", var_data_in%var_i4)
+    call write_data_wrapper(fileobj, "i8", var_data_in%var_i8)
+
+    call close_file(fileobj)
+  endif
+
+  !< Now check answers
+  if (mpp_pe() .eq. mpp_root_pe()) then
+    !call mpp_set_current_pelist((/mpp_pe()/))
+    if (open_file(fileobj, "test_compressed_writes.nc", "read", nc_format="netcdf4")) then
+      call var_data_alloc(var_data_out, ndim2, ndim3, ndim4, ndim5, sum(pes)+mpp_npes())
+      call var_data_alloc(var_data_ref, ndim2, ndim3, ndim4, ndim5, sum(pes)+mpp_npes())
+      call var_data_set_ref(var_data_ref)
+
+      call read_data_wrapper(fileobj, "var2", 2, var_data_out, var_data_ref)
+      call read_data_wrapper(fileobj, "var3", 3, var_data_out, var_data_ref)
+      call read_data_wrapper(fileobj, "var4", 4, var_data_out, var_data_ref)
+      call read_data_wrapper(fileobj, "var5", 5, var_data_out, var_data_ref)
+  
+      call close_file(fileobj)
+    endif
+  endif
+  call fms_end
+
+  contains
+
+  !> @brief registers all of the possible variable types for a given
+  !! number of dimensions
+  subroutine register_field_wrapper(fileob, var_name, dimension_names, ndim)
+    type(FmsNetcdfFile_t),       intent(inout) :: fileob             !< fms2io fileobj for domain decomposed
+    character(len=*),            intent(in)    :: var_name           !< Name of the variable
+    character(len=*),            intent(in)    :: dimension_names(:) !< dimension names
+    integer,                     intent(in)    :: ndim               !< Number of dimension
+
+    call register_field(fileob, trim(var_name)//"_r8", "double", names(1:ndim))
+    call register_field(fileob, trim(var_name)//"_r4", "float",  names(1:ndim))
+    call register_field(fileob, trim(var_name)//"_i8", "int",    names(1:ndim))
+    call register_field(fileob, trim(var_name)//"_i4", "int64",  names(1:ndim))
+  end subroutine register_field_wrapper
+  
+!> @brief Allocates the variable to be the size of data compute domain for x and y
+  !! and for a given size for the 3rd 4th and 5th dimension
+  subroutine var_data_alloc(var_data, dim2, dim3, dim4, dim5, compressed_dim)
+    type(data_type),             intent(inout)    :: var_data         !< Variable data
+    integer,                     intent(in)       :: dim2             !< Size of dim3
+    integer,                     intent(in)       :: dim3             !< Size of dim3
+    integer,                     intent(in)       :: dim4             !< Size of dim4
+    integer,                     intent(in)       :: dim5             !< Size of dim5
+    integer,                     intent(in)       :: compressed_dim   !< Size of the compressed dimension
+
+    allocate(var_data%var_r4(compressed_dim, dim2, dim3, dim4, dim5))
+    allocate(var_data%var_r8(compressed_dim, dim2, dim3, dim4, dim5))
+    allocate(var_data%var_i4(compressed_dim, dim2, dim3, dim4, dim5))
+    allocate(var_data%var_i8(compressed_dim, dim2, dim3, dim4, dim5))
+  end subroutine var_data_alloc
+
+
+  !> @brief Sets the data to some value
+  subroutine var_data_set(var_data, var_value)
+    type(data_type),             intent(inout)    :: var_data         !< Variable data
+    integer,                     intent(in)       :: var_value        !< Value to set the data as
+
+    var_data%var_r4 = real(var_value, kind=r4_kind)
+    var_data%var_r8 = real(var_value, kind=r8_kind)
+    var_data%var_i4 = int(var_value, kind=i4_kind)
+    var_data%var_i8 = int(var_value, kind=i8_kind)
+  end subroutine var_data_set
+
+  !> @brief Writes the data for a give variable type
+  subroutine write_data_wrapper(fileob, var_kind, var_data)
+    type(FmsNetcdfFile_t),       intent(inout) :: fileob              !< fms2io fileobj for domain decomposed
+    character(len=*),            intent(in)    :: var_kind            !< The kind of the variable
+    class(*),                    intent(in)    :: var_data(:,:,:,:,:) !< Variable data
+
+    call write_data(fileob, "var2_"//trim(var_kind), var_data(:,:,1,1,1))
+    call write_data(fileob, "var3_"//trim(var_kind), var_data(:,:,:,1,1))
+    call write_data(fileob, "var4_"//trim(var_kind), var_data(:,:,:,:,1))
+    call write_data(fileob, "var5_"//trim(var_kind), var_data(:,:,:,:,:))
+
+  end subroutine
+
+  subroutine read_data_wrapper(fileob, var_name, dim, var_data, ref_data)
+    type(FmsNetcdfFile_t),        intent(inout):: fileob              !< fms2io fileobj for domain decomposed
+    character(len=*),            intent(in)    :: var_name            !< The kind of the variable
+    integer,                     intent(in)    :: dim
+    type(data_type),             intent(inout) :: var_data
+    type(data_type),             intent(in)    :: ref_data
+
+    integer :: i,j 
+    select case(dim)
+    case(2)
+      call var_data_set(var_data, -999)
+      call read_data(fileob, trim(var_name)//"_r4", var_data%var_r4(:,:,1,1,1))      
+      call compare_var_data(mpp_chksum(var_data%var_r4(:,:,1,1,1), (/mpp_pe()/)), &
+        mpp_chksum(ref_data%var_r4(:,:,1,1,1), (/mpp_pe()/)), "var2_r4")
+
+      call read_data(fileob, trim(var_name)//"_r8", var_data%var_r8(:,:,1,1,1))
+      call compare_var_data(mpp_chksum(var_data%var_r8(:,:,1,1,1), (/mpp_pe()/)), &
+        mpp_chksum(ref_data%var_r8(:,:,1,1,1), (/mpp_pe()/)), "var2_r8")
+
+      call read_data(fileob, trim(var_name)//"_i4", var_data%var_i4(:,:,1,1,1))
+      call compare_var_data(mpp_chksum(var_data%var_i4(:,:,1,1,1), (/mpp_pe()/)), &
+        mpp_chksum(ref_data%var_i4(:,:,1,1,1), (/mpp_pe()/)), "var2_i4")
+
+      call read_data(fileob, trim(var_name)//"_i8", var_data%var_i8(:,:,1,1,1))
+      call compare_var_data(mpp_chksum(var_data%var_i8(:,:,1,1,1), (/mpp_pe()/)), &
+        mpp_chksum(ref_data%var_i8(:,:,1,1,1), (/mpp_pe()/)), "var2_i8")
+    case(3)
+        call var_data_set(var_data, -999)
+        call read_data(fileob, trim(var_name)//"_r4", var_data%var_r4(:,:,:,1,1))      
+        call compare_var_data(mpp_chksum(var_data%var_r4(:,:,:,1,1), (/mpp_pe()/)), &
+          mpp_chksum(ref_data%var_r4(:,:,:,1,1), (/mpp_pe()/)), "var3_r4")
+  
+        call read_data(fileob, trim(var_name)//"_r8", var_data%var_r8(:,:,:,1,1))
+        call compare_var_data(mpp_chksum(var_data%var_r8(:,:,:,1,1), (/mpp_pe()/)), &
+          mpp_chksum(ref_data%var_r8(:,:,:,1,1), (/mpp_pe()/)), "var3_r8")
+  
+        call read_data(fileob, trim(var_name)//"_i4", var_data%var_i4(:,:,:,1,1))
+        call compare_var_data(mpp_chksum(var_data%var_i4(:,:,:,1,1), (/mpp_pe()/)), &
+          mpp_chksum(ref_data%var_i4(:,:,:,1,1), (/mpp_pe()/)), "var3_i4")
+  
+        call read_data(fileob, trim(var_name)//"_i8", var_data%var_i8(:,:,:,1,1))
+        call compare_var_data(mpp_chksum(var_data%var_i8(:,:,:,1,1), (/mpp_pe()/)), &
+          mpp_chksum(ref_data%var_i8(:,:,:,1,1), (/mpp_pe()/)), "var3_i8")
+    case(4)
+        call var_data_set(var_data, -999)
+        call read_data(fileob, trim(var_name)//"_r4", var_data%var_r4(:,:,:,:,1))      
+        call compare_var_data(mpp_chksum(var_data%var_r4(:,:,:,:,1), (/mpp_pe()/)), &
+          mpp_chksum(ref_data%var_r4(:,:,:,:,1), (/mpp_pe()/)), "var4_r4")
+  
+        call read_data(fileob, trim(var_name)//"_r8", var_data%var_r8(:,:,:,:,1))
+        call compare_var_data(mpp_chksum(var_data%var_r8(:,:,:,:,1), (/mpp_pe()/)), &
+          mpp_chksum(ref_data%var_r8(:,:,:,:,1), (/mpp_pe()/)), "var4_r8")
+  
+        call read_data(fileob, trim(var_name)//"_i4", var_data%var_i4(:,:,:,:,1))
+        call compare_var_data(mpp_chksum(var_data%var_i4(:,:,:,:,1), (/mpp_pe()/)), &
+          mpp_chksum(ref_data%var_i4(:,:,:,:,1), (/mpp_pe()/)), "var4_i4")
+  
+        call read_data(fileob, trim(var_name)//"_i8", var_data%var_i8(:,:,:,:,1))
+        call compare_var_data(mpp_chksum(var_data%var_i8(:,:,:,:,1), (/mpp_pe()/)), &
+          mpp_chksum(ref_data%var_i8(:,:,:,:,1), (/mpp_pe()/)), "var4_i8")
+    case(5)
+        call var_data_set(var_data, -999)
+        call read_data(fileob, trim(var_name)//"_r4", var_data%var_r4(:,:,:,:,:))      
+        call compare_var_data(mpp_chksum(var_data%var_r4(:,:,:,:,:), (/mpp_pe()/)), &
+          mpp_chksum(ref_data%var_r4(:,:,:,:,:), (/mpp_pe()/)), "var5_r4")
+  
+        call read_data(fileob, trim(var_name)//"_r8", var_data%var_r8(:,:,:,:,:))
+        call compare_var_data(mpp_chksum(var_data%var_r8(:,:,:,:,:), (/mpp_pe()/)), &
+          mpp_chksum(ref_data%var_r8(:,:,:,:,:), (/mpp_pe()/)), "var5_r8")
+  
+        call read_data(fileob, trim(var_name)//"_i4", var_data%var_i4(:,:,:,:,:))
+        call compare_var_data(mpp_chksum(var_data%var_i4(:,:,:,:,:), (/mpp_pe()/)), &
+          mpp_chksum(ref_data%var_i4(:,:,:,:,:), (/mpp_pe()/)), "var5_i4")
+  
+        call read_data(fileob, trim(var_name)//"_i8", var_data%var_i8(:,:,:,:,:))
+        call compare_var_data(mpp_chksum(var_data%var_i8(:,:,:,:,:), (/mpp_pe()/)), &
+          mpp_chksum(ref_data%var_i8(:,:,:,:,:), (/mpp_pe()/)), "var5_i8")
+    end select
+  end subroutine 
+
+  subroutine var_data_set_ref(var_data)
+    type(data_type),             intent(inout) :: var_data
+    integer :: starting_index, ending_index, i,j
+
+    ending_index = 0
+    do i = 1, size(pes)
+        starting_index = ending_index + 1
+        ending_index = starting_index + pes(i)
+
+        var_data%var_r4(starting_index:ending_index,:,:,:,:) = real(pes(i), kind=r4_kind)
+        var_data%var_r8(starting_index:ending_index,:,:,:,:) = real(pes(i), kind=r8_kind)
+        var_data%var_i4(starting_index:ending_index,:,:,:,:) = int(pes(i), kind=i4_kind)
+        var_data%var_i8(starting_index:ending_index,:,:,:,:) = int(pes(i), kind=i8_kind)
+
+    enddo
+  end subroutine
+
+  !> @brief Compares two checksums and crashes if they are not the same
+  subroutine compare_var_data(check_sum_in, check_sum_ref, varname)
+    integer(kind=i8_kind), intent(in) :: check_sum_in
+    integer(kind=i8_kind), intent(in) :: check_sum_ref
+    character(len=*), intent(in) :: varname
+
+   if (check_sum_ref .ne. check_sum_in) call mpp_error(FATAL, &
+     "Checksums do not match for variable: "//trim(varname))
+  end subroutine compare_var_data
+
+end program test_compressed_writes

--- a/test_fms/fms2_io/test_fms2_io.sh
+++ b/test_fms/fms2_io/test_fms2_io.sh
@@ -48,4 +48,8 @@ test_expect_success "FMS2 IO Test" '
   mpirun -n 6 ../test_fms2_io
 '
 
+test_expect_success "Compressed writes tests" '
+  mpirun -n 5 ../test_compressed_writes
+'
+
 test_done


### PR DESCRIPTION
**Description**

1. Modified compressed_writes_1d/2d/3d
2. Extended mpp_gather to work for int8
3. Added unit tests to test all of the compressed writes interfaces
4. Compressed_writes_4d/5d were unchanged
   - Mpp_gather only support 1d, 2d and 3d arrays

Fixes #1218 

**How Has This Been Tested?**
CI
AM5 c384L66 amip experiment

**Checklist:**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] `make distcheck` passes

