### PR TITLE
mixed precision fix libFMS.F90

### DIFF
--- a/libFMS.F90
+++ b/libFMS.F90
@@ -381,7 +381,7 @@ module fms
                                 lookup_es2, lookup_des2, lookup_es2_des2, &
                                 lookup_es3, lookup_des3, lookup_es3_des3, &
                                 lookup_es_des, compute_qs, compute_mrs, &
-                                escomp, descomp, check_1d, check_2d, temp_check, show_all_bad
+                                escomp, descomp
   !> string_utils
   use fms_string_utils_mod, only: string, fms_array_to_pointer, fms_pointer_to_array, fms_sort_this, &
                                   fms_find_my_string, fms_find_unique, fms_c2f_string, fms_cstring2cpointer, &

--- a/sat_vapor_pres/sat_vapor_pres.F90
+++ b/sat_vapor_pres/sat_vapor_pres.F90
@@ -202,7 +202,6 @@ private
 !public :: compute_es
  public :: escomp, descomp ! for backward compatibility
                            ! use lookup_es, lookup_des instead
- public :: check_1d, check_2d, temp_check, show_all_bad
 
 !-----------------------------------------------------------------------
 


### PR DESCRIPTION
Addition of private interfaces in sat_vapor_pres_mod to libFMS.F90 leads to compilation errors.  This PR removes the private interfaces in libFMS.F90 