### PR TITLE
Replace current_peset_num with 'n' which should be the active pelist.

### DIFF
--- a/mpp/include/mpp_transmit_mpi.fh
+++ b/mpp/include/mpp_transmit_mpi.fh
@@ -182,7 +182,7 @@
                'T=',tick, ' PE=',pe, ' MPP_BROADCAST begin: from_pe, length=', from_pe, length
       end if
 
-      if( .NOT.ANY(from_pe.EQ.peset(current_peset_num)%list) ) &
+      if( .NOT.ANY(from_pe.EQ.peset(n)%list) ) &
            call mpp_error( FATAL, 'MPP_BROADCAST: broadcasting from invalid PE.' )
 
       if( debug .and. (current_clock.NE.0) )call SYSTEM_CLOCK(start_tick)


### PR DESCRIPTION
While chasing down the cause of the following error message, I realized that the check to ensure the transmitting rank is part of the peset is not using the peset returned by the get_peset call.

"FATAL from PE 36: MPP_BROADCAST: broadcasting from invalid PE."

I converted part of the UFS/HAFS application to use mpp_broadcast() instead of numerous point-to-point messages.  Testing with a HAFS case revealed the above error message.  I was able to make the code work by surrounding the mpp_broadcast() call with appropriate mpp_set_current_pelist() calls.  A colleague said these mpp_set_current_pelist() calls should not be needed and provided a unit test to prove it.

Further investigation without the mpp_set_current_pelist() scoping calls revealed the issue addressed with the PR.

Fixes #1243

Testing was performance under Ubuntu-22.04 using the Intel 2023.1 suite of compilers and OpenMPI-4.1.5.
I have run the FMS internal check (make check) with and without the change in this PR.  No change in the results.
I have also run "make distcheck".  The logs config, make, check and distcheck logs are attached.

[checkOPT.log](https://github.com/NOAA-GFDL/FMS/files/11659060/checkOPT.log)
[config.log](https://github.com/NOAA-GFDL/FMS/files/11659061/config.log)
[distcheckOPT.log](https://github.com/NOAA-GFDL/FMS/files/11659062/distcheckOPT.log)
[makeOPT.log](https://github.com/NOAA-GFDL/FMS/files/11659063/makeOPT.log)


I also ran a HAFS case with a single nest on the NOAA 'acorn' system.  This is the original case that started this whole investigation.  That case ran fine using an FMS with the change contained in his PR.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

