### PR TITLE
Updates function fms_diag_output_buffer_mod::remap_buffer

### DIFF
--- a/diag_manager/fms_diag_output_buffer.F90
+++ b/diag_manager/fms_diag_output_buffer.F90
@@ -221,17 +221,17 @@ function remap_buffer(buffobj, field_name)
     type is (outputBuffer2d_type)
       if (.not. allocated(buffobj%buffer)) call mpp_error(FATAL, "remap_buffer: buffer data not yet allocated" // &
                                                                  "for field:" // field_name)
-      remap_buffer(1:size(buffobj%buffer,1), 1:size(buffobj%buffer,2), 1:1, 1:1, 1:1) => buffobj%buffer(:,:)
+      remap_buffer(1:size(buffobj%buffer,1), 1:1, 1:1, 1:1, 1:size(buffobj%buffer,2)) => buffobj%buffer(:,:)
     type is (outputBuffer3d_type)
       if (.not. allocated(buffobj%buffer)) call mpp_error(FATAL, "remap_buffer: buffer data not yet allocated" // &
                                                                  "for field:" // field_name)
-      remap_buffer(1:size(buffobj%buffer,1), 1:size(buffobj%buffer,2), 1:size(buffobj%buffer,3), 1:1, 1:1) => &
+      remap_buffer(1:size(buffobj%buffer,1), 1:size(buffobj%buffer,2), 1:1, 1:1, 1:size(buffobj%buffer,3)) => &
                                                                                           & buffobj%buffer(:,:,:)
     type is (outputBuffer4d_type)
       if (.not. allocated(buffobj%buffer)) call mpp_error(FATAL, "remap_buffer: buffer data not yet allocated" // &
                                                                  "for field:" // field_name)
       remap_buffer(1:size(buffobj%buffer,1), 1:size(buffobj%buffer,2), 1:size(buffobj%buffer,3), &
-                   1:size(buffobj%buffer,4), 1:1) => buffobj%buffer(:,:,:,:)
+                  1:1, 1:size(buffobj%buffer,4)) => buffobj%buffer(:,:,:,:)
     type is (outputBuffer5d_type)
       if (.not. allocated(buffobj%buffer)) call mpp_error(FATAL, "remap_buffer: buffer data not yet allocated" // &
                                                                  "for field:" // field_name)

--- a/test_fms/diag_manager/test_diag_buffer.F90
+++ b/test_fms/diag_manager/test_diag_buffer.F90
@@ -49,7 +49,7 @@ program test_diag_buffer
         r8val = p_val
     end select
     ! get the 5d remapped buffer data
-    remap_buffer_out => buffobj0(5)%remap_buffer(fname)
+    remap_buffer_out => buffobj0(5)%remap_buffer(fname, .false.)
     ! check output from object and remapped buffer
     print *, r8val
     call print_5d(remap_buffer_out)
@@ -75,7 +75,7 @@ program test_diag_buffer
         arr1d = p_data1
     end select
     !! get the remapped buffer
-    remap_buffer_out => buffobj1%remap_buffer(fname)
+    remap_buffer_out => buffobj1%remap_buffer(fname, .false.)
     !! check output
     print *, arr1d
     call print_5d(remap_buffer_out)
@@ -94,7 +94,7 @@ program test_diag_buffer
     !!! get the buffer
     call buffobj2%get_buffer(arr2d, fname)
     !!! get the remapped buffer
-    remap_buffer_out => buffobj2%remap_buffer(fname)
+    remap_buffer_out => buffobj2%remap_buffer(fname, .false.)
     !!! check output
     select type(arr2d)
       type is(integer(i4_kind))
@@ -115,7 +115,7 @@ program test_diag_buffer
     !! get the buffer
     call buffobj3%get_buffer(arr3d, fname)
     !! get the remapped buffer
-    remap_buffer_out => buffobj3%remap_buffer(fname)
+    remap_buffer_out => buffobj3%remap_buffer(fname, .false.)
     !! check output
     select type (arr3d)
       type is(integer(i8_kind))
@@ -136,7 +136,7 @@ program test_diag_buffer
     !! get the buffer
     call buffobj4%get_buffer(arr4d, fname)
     !! get the remapped buffer
-    remap_buffer_out => buffobj4%remap_buffer(fname)
+    remap_buffer_out => buffobj4%remap_buffer(fname, .false.)
     !! check output
     select type (arr4d)
       type is(integer(i8_kind))
@@ -150,7 +150,7 @@ program test_diag_buffer
     !! init to given value
     call buffobj5%initialize_buffer( int(5, kind=i8_kind), fname )
     !! get the remapped buffer
-    remap_buffer_out => buffobj5%remap_buffer(fname)
+    remap_buffer_out => buffobj5%remap_buffer(fname, .false.)
     !! set some values in the buffer
     allocate(i8arr5d(2,2,2,2,2))
     i8arr5d = 10


### PR DESCRIPTION
**Description**
* Adds one more argument to function _remap_buffer_ which is related to diurnal axis because the diurnal axis should be the last dimension of the remapped buffer for looping purpose if the field has one.
* Updates 'test_diag_buffer.F90' for corresponding changes. 

Fixes # (issue)

**How Has This Been Tested?**

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

