### PR TITLE
Write global/variable attributes defined in the yaml + subregional files update

### DIFF
--- a/diag_manager/diag_data.F90
+++ b/diag_manager/diag_data.F90
@@ -128,6 +128,7 @@ use platform_mod
   INTEGER, PARAMETER :: begin_time  = 1 !< Use the begining of the time average bounds
   INTEGER, PARAMETER :: middle_time = 2 !< Use the middle of the time average bounds
   INTEGER, PARAMETER :: end_time    = 3 !< Use the end of the time average bounds
+  INTEGER, PARAMETER :: MAX_STR_LEN = 255 !< Max length for a string
   !> @}
 
   !> @brief Contains the coordinates of the local domain to output.

--- a/diag_manager/fms_diag_field_object.F90
+++ b/diag_manager/fms_diag_field_object.F90
@@ -8,7 +8,7 @@ module fms_diag_field_object_mod
 !! that contains all of the information of the variable.  It is extended by a type that holds the
 !! appropriate buffer for the data for manipulation.
 #ifdef use_yaml
-use diag_data_mod,  only: diag_null, CMOR_MISSING_VALUE, diag_null_string
+use diag_data_mod,  only: diag_null, CMOR_MISSING_VALUE, diag_null_string, MAX_STR_LEN
 use diag_data_mod,  only: r8, r4, i8, i4, string, null_type_int, NO_DOMAIN
 use diag_data_mod,  only: max_field_attributes, fmsDiagAttribute_type
 use diag_data_mod,  only: diag_null, diag_not_found, diag_not_registered, diag_registered_id, &
@@ -1126,6 +1126,7 @@ subroutine write_field_metadata(this, fileobj, file_id, yaml_id, diag_axis, unli
   character(len=120),          allocatable :: dimnames(:) !< Dimension names of the field
   character(len=120)                       :: cell_methods!< Cell methods attribute to write
   integer                                  :: i           !< For do loops
+  character (len=MAX_STR_LEN), allocatable :: yaml_field_attributes(:,:) !< Variable attributes defined in the yaml
 
   field_yaml => diag_yaml%get_diag_field_from_id(yaml_id)
   var_name = field_yaml%get_var_outname()
@@ -1208,6 +1209,15 @@ subroutine write_field_metadata(this, fileobj, file_id, yaml_id, diag_axis, unli
     trim(this%get_standname()), str_len=len_trim(this%get_standname()))
 
   call this%write_coordinate_attribute(fileobj, var_name, diag_axis)
+
+  if (field_yaml%has_var_attributes()) then
+    yaml_field_attributes = field_yaml%get_var_attributes()
+    do i = 1, size(yaml_field_attributes,1)
+      call register_variable_attribute(fileobj, var_name, trim(yaml_field_attributes(i,1)), &
+      trim(yaml_field_attributes(i,2)), str_len=len_trim(yaml_field_attributes(i,2)))
+    enddo
+    deallocate(yaml_field_attributes)
+  endif
 end subroutine write_field_metadata
 
 !> @brief Writes the coordinate attribute of a field if any of the field's axis has an

--- a/diag_manager/fms_diag_file_object.F90
+++ b/diag_manager/fms_diag_file_object.F90
@@ -538,7 +538,7 @@ end function get_file_varlist
 !! \return Copy of file_global_meta
 pure function get_file_global_meta (this) result(res)
  class(fmsDiagFile_type), intent(in) :: this !< The file object
- character (len=:), allocatable, dimension(:,:) :: res
+ character (len=MAX_STR_LEN), allocatable, dimension(:,:) :: res
   res = this%diag_yaml_file%get_file_global_meta()
 end function get_file_global_meta
 
@@ -995,16 +995,17 @@ end subroutine open_diag_file
 subroutine write_global_metadata(this)
   class(fmsDiagFileContainer_type), intent(inout), target :: this !< The file object
 
-  class(fmsDiagFile_type), pointer  :: diag_file      !< Diag_file object to open
   class(FmsNetcdfFile_t),  pointer  :: fileobj        !< The fileobj to write to
   integer                           :: i              !< For do loops
   character (len=MAX_STR_LEN), allocatable :: yaml_file_attributes(:,:) !< Global attributes defined in the yaml
 
-  diag_file => this%FMS_diag_file
-  fileobj => diag_file%fileobj
+  type(diagYamlFiles_type), pointer :: diag_file_yaml !< The diag_file yaml
 
-  if (diag_file%has_file_global_meta()) then
-    yaml_file_attributes = diag_file%get_file_global_meta()
+  diag_file_yaml => this%FMS_diag_file%diag_yaml_file
+  fileobj => this%FMS_diag_file%fileobj
+
+  if (diag_file_yaml%has_file_global_meta()) then
+    yaml_file_attributes = diag_file_yaml%get_file_global_meta()
     do i = 1, size(yaml_file_attributes,1)
       call register_global_attribute(fileobj, trim(yaml_file_attributes(i,1)), &
       trim(yaml_file_attributes(i,2)), str_len=len_trim(yaml_file_attributes(i,2)))

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -684,6 +684,7 @@ subroutine fms_diag_do_io(this, is_end_of_run)
 
     call diag_file%open_diag_file(model_time, file_is_opened_this_time_step)
     if (file_is_opened_this_time_step) then
+      call diag_file%write_global_metadata()
       call diag_file%write_axis_metadata(this%diag_axis)
       call diag_file%write_time_metadata()
       call diag_file%write_field_metadata(this%FMS_diag_fields, this%diag_axis)

--- a/diag_manager/fms_diag_yaml.F90
+++ b/diag_manager/fms_diag_yaml.F90
@@ -1056,7 +1056,7 @@ end function get_file_varlist
 pure function get_file_global_meta (this) &
 result (res)
  class (diagYamlFiles_type), intent(in) :: this !< The object being inquiried
- character (:), allocatable :: res(:,:) !< What is returned
+ character (len=MAX_STR_LEN), allocatable :: res(:,:) !< What is returned
   res = this%file_global_meta
 end function get_file_global_meta
 !> @brief Get the integer equivalent of the time to use to determine the filename,

--- a/diag_manager/fms_diag_yaml.F90
+++ b/diag_manager/fms_diag_yaml.F90
@@ -34,7 +34,7 @@ use diag_data_mod,   only: DIAG_NULL, DIAG_OCEAN, DIAG_ALL, DIAG_OTHER, set_base
                            index_gridtype, null_gridtype, DIAG_SECONDS, DIAG_MINUTES, DIAG_HOURS, DIAG_DAYS, &
                            DIAG_MONTHS, DIAG_YEARS, time_average, time_rms, time_max, time_min, time_sum, &
                            time_diurnal, time_power, time_none, r8, i8, r4, i4, DIAG_NOT_REGISTERED, &
-                           middle_time, begin_time, end_time
+                           middle_time, begin_time, end_time, MAX_STR_LEN
 use yaml_parser_mod, only: open_and_parse_file, get_value_from_key, get_num_blocks, get_nkeys, &
                            get_block_ids, get_key_value, get_key_ids, get_key_name
 use mpp_mod,         only: mpp_error, FATAL, mpp_pe, mpp_root_pe, stdout
@@ -58,7 +58,6 @@ public :: dump_diag_yaml_obj
 
 integer, parameter :: basedate_size = 6
 integer, parameter :: NUM_SUB_REGION_ARRAY = 8
-integer, parameter :: MAX_STR_LEN = 255
 integer, parameter :: MAX_FREQ = 12
 
 

--- a/test_fms/diag_manager/test_diag_manager2.sh
+++ b/test_fms/diag_manager/test_diag_manager2.sh
@@ -671,6 +671,9 @@ diag_files:
     var_name: var7
     reduction: none
     kind: r4
+  global_meta:
+  - is_important: False
+    has_important: True
 - file_name: file1
   freq: 6
   freq_units: hours
@@ -777,6 +780,8 @@ diag_files:
     var_name: var1
     reduction: none
     kind: r4
+    attributes:
+    - GFDL_name: var_var
 - file_name: file8%4yr%2mo%2dy%2hr%2min
   freq: 1 1 1
   freq_units: hours hours hours


### PR DESCRIPTION
**Description**
- Adds code to write out the global/variable attributes defined in the yaml
- Writes out `is_regional=.TRUE.` as a global attribute if the file is subregional. This attribute is only going to exist if the file is subregional. FYI @ceblanton 
- Updates tests to make sure this works

Fixes #1242 

**How Has This Been Tested?**
CI

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

