### PR TITLE
add aliases for libfms routines

### DIFF
--- a/libFMS.F90
+++ b/libFMS.F90
@@ -23,13 +23,14 @@
 !!
 !! @date 2/2021
 !!
-!! Imports all supported FMS modules so that any public interfaces, &
+!! Imports all supported FMS modules so that any public interfaces,
 !! variables or routines can be used via this module. Excludes mpp_io modules
 !! and routines. Overloaded type operators/assignments cannot be imported individually
 !! (ie. `use fms, only: OPERATOR(*)` includes any defined '*' operators within FMS).
 !!
 !! Renaming scheme:
-!!   fms_<module_name>_routine_or_type_name
+!!   Routines and variables: fms_<module_name>_routine_name
+!!   Types:                  FmsModuleNameTypeName
 !!
 !! Exceptions (mainly for rep:
 !!   - Parameter values are kept their original names
@@ -76,7 +77,7 @@ module fms
                              fms_amip_interp_get_amip_ice             => get_amip_ice, &
                              fms_amip_interp_new          => amip_interp_new, &
                              fms_amip_interp_del          => amip_interp_del, &
-                             fms_amip_interp_type         => amip_interp_type, &
+                             FmsAmipInterp_type => amip_interp_type, &
                              assignment(=), &
                              fms_amip_interp_i_sst        => i_sst, &
                              fms_amip_interp_j_sst        => j_sst, &
@@ -111,7 +112,7 @@ module fms
                              fms_axis_utils2_axis_edges            => axis_edges
 
   !>block_control
-  use block_control_mod, only: fms_block_control_type                 => block_control_type, &
+  use block_control_mod, only: FmsBlockControl_type                   => block_control_type, &
                                fms_block_control_define_blocks        => define_blocks, &
                                fms_block_control_define_blocks_packed => define_blocks_packed
 
@@ -142,15 +143,15 @@ module fms
                                fms_coupler_type_set_data          => coupler_type_set_data, &
                                fms_coupler_type_copy_1d_2d        => coupler_type_copy_1d_2d, &
                                fms_coupler_type_copy_1d_3d        => coupler_type_copy_1d_3d, &
-                               fms_coupler_3d_values_type         => coupler_3d_values_type, &
-                               fms_coupler_3d_field_type          => coupler_3d_field_type, &
-                               fms_coupler_3d_bc_type             => coupler_3d_bc_type, &
-                               fms_coupler_2d_values_type         => coupler_2d_values_type, &
-                               fms_coupler_2d_field_type          => coupler_2d_field_type, &
-                               fms_coupler_2d_bc_type             => coupler_2d_bc_type, &
-                               fms_coupler_1d_values_type         => coupler_1d_values_type, &
-                               fms_coupler_1d_field_type          => coupler_1d_field_type, &
-                               fms_coupler_1d_bc_type             => coupler_1d_bc_type, &
+                               FmsCoupler3dValues_type         => coupler_3d_values_type, &
+                               FmsCoupler3dField_type          => coupler_3d_field_type, &
+                               FmsCoupler3dBC_type             => coupler_3d_bc_type, &
+                               FmsCoupler2dValues_type         => coupler_2d_values_type, &
+                               FmsCoupler2dField_type          => coupler_2d_field_type, &
+                               FmsCoupler2dBC_type             => coupler_2d_bc_type, &
+                               FmsCoupler1dValues_type         => coupler_1d_values_type, &
+                               FmsCoupler1dField_type          => coupler_1d_field_type, &
+                               FmsCoupler1dBC_type             => coupler_1d_bc_type, &
                                fms_coupler_ind_pcair                      => ind_pcair, &
                                fms_coupler_ind_u10                        => ind_u10, &
                                fms_coupler_ind_psurf                      => ind_psurf, &
@@ -224,7 +225,7 @@ module fms
                               null_axis_id
 
   !> exchange
-  use xgrid_mod, only: fms_xgrid_xmap_type => xmap_type, &
+  use xgrid_mod, only: FmsXgridXmap_type => xmap_type, &
                        fms_xgrid_setup_xmap => setup_xmap, &
                        fms_xgrid_set_frac_area => set_frac_area, &
                        fms_xgrid_put_to_xgrid => put_to_xgrid, &
@@ -235,7 +236,7 @@ module fms
                        fms_xgrid_init => xgrid_init, &
                        AREA_ATM_SPHERE, AREA_OCN_SPHERE, AREA_ATM_MODEL, AREA_OCN_MODEL, &
                        fms_xgrid_get_ocean_model_area_elements => get_ocean_model_area_elements, &
-                       fms_xgrid_grid_box_type => grid_box_type, &
+                       FmsXgridGridBox_type => grid_box_type, &
                        fms_xgrid_get_xmap_grid_area => get_xmap_grid_area, &
                        fms_xgrid_put_to_xgrid_ug => put_to_xgrid_ug, &
                        fms_xgrid_get_from_xgrid_ug => get_from_xgrid_ug, &
@@ -243,7 +244,7 @@ module fms
                        FIRST_ORDER, SECOND_ORDER, &
                        fms_xgrid_stock_move_ug => stock_move_ug, &
                        fms_xgrid_stock_move => stock_move, &
-                       fms_xgrid_stock_type => stock_type, &
+                       FmsXgridStock_type => stock_type, &
                        fms_xgrid_stock_print => stock_print, &
                        fms_xgrid_get_index_range => get_index_range, &
                        fms_xgrid_stock_integrate_2d => stock_integrate_2d
@@ -254,9 +255,9 @@ module fms
                        fms_stocks_report_init => stocks_report_init, &
                        fms_stocks_set_init_time => stocks_set_init_time, &
                        fms_stock_constants_atm_stock => atm_stock, &
-                       fms_ocn_stock => ocn_stock, &
-                       fms_lnd_stock => lnd_stock, &
-                       fms_ice_stock => ice_stock
+                       fms_stock_constants_ocn_stock => ocn_stock, &
+                       fms_stock_constants_lnd_stock => lnd_stock, &
+                       fms_stock_constants_ice_stock => ice_stock
 
   !> field manager
   use field_manager_mod, only: fms_field_manager_init => field_manager_init, &
@@ -290,10 +291,10 @@ module fms
                          fms_field_manager_fm_string_len => fm_string_len, &
                          fms_field_manager_fm_type_name_len => fm_type_name_len, &
                          NUM_MODELS, NO_FIELD, MODEL_ATMOS, MODEL_OCEAN, MODEL_LAND, MODEL_ICE, MODEL_COUPLER, &
-                         fms_field_manager_method_type => method_type, &
-                         fms_field_manager_method_type_short => method_type_short, &
-                         fms_field_manager_method_type_very_short => method_type_very_short, &
-                         fms_field_manager_fm_list_iter_type => fm_list_iter_type, &
+                         FmsFieldManagerMethod_type          => method_type, &
+                         FmsFieldManagerMethodShort_type     => method_type_short, &
+                         FmsFieldManagerMethodVeryShort_type => method_type_very_short, &
+                         FmsFieldManagerListIterator_type => fm_list_iter_type, &
                          fms_field_manager_default_method => default_method
   use fm_util_mod, only: fms_fm_util_start_namelist => fm_util_start_namelist, &
                          fms_fm_util_end_namelist => fm_util_end_namelist, &
@@ -333,63 +334,63 @@ module fms
   use fms2_io_mod, only: unlimited, FmsNetcdfFile_t, FmsNetcdfDomainFile_t, &
                          FmsNetcdfUnstructuredDomainFile_t, &
                          Valid_t, &
-                         fms_fms2_io_open_file => open_file, &
-                         fms_fms2_io_open_virtual_file => open_virtual_file, &
-                         fms_fms2_io_close_file => close_file, &
-                         fms_fms2_io_register_axis => register_axis, &
-                         fms_fms2_io_register_field => register_field, &
-                         fms_fms2_io_register_restart_field => register_restart_field, &
-                         fms_fms2_io_write_data => write_data, &
-                         fms_fms2_io_read_data => read_data, &
-                         fms_fms2_io_write_restart => write_restart, &
-                         fms_fms2_io_write_new_restart => write_new_restart, &
-                         fms_fms2_io_read_restart => read_restart, &
-                         fms_fms2_io_read_new_restart => read_new_restart, &
-                         fms_fms2_io_global_att_exists => global_att_exists, &
-                         fms_fms2_io_variable_att_exists => variable_att_exists, &
-                         fms_fms2_io_register_global_attribute => register_global_attribute, &
-                         fms_fms2_io_register_variable_attribute => register_variable_attribute, &
-                         fms_fms2_io_get_global_attribute => get_global_attribute, &
-                         fms_fms2_io_get_variable_attribute => get_variable_attribute, &
-                         fms_fms2_io_get_num_dimensions => get_num_dimensions, &
-                         fms_fms2_io_get_dimension_names => get_dimension_names, &
-                         fms_fms2_io_dimension_exists => dimension_exists, &
-                         fms_fms2_io_is_dimension_unlimited => is_dimension_unlimited, &
-                         fms_fms2_io_get_dimension_size => get_dimension_size, &
-                         fms_fms2_io_get_num_variables =>   get_num_variables, &
-                         fms_fms2_io_get_variable_names =>   get_variable_names, &
-                         fms_fms2_io_variable_exists => variable_exists, &
-                         fms_fms2_io_get_variable_num_dimensions => get_variable_num_dimensions, &
-                         fms_fms2_io_get_variable_dimension_names => get_variable_dimension_names, &
-                         fms_fms2_io_get_variable_size =>   get_variable_size, &
-                         fms_fms2_io_get_compute_domain_dimension_indices => get_compute_domain_dimension_indices, &
-                         fms_fms2_io_get_global_io_domain_indices => get_global_io_domain_indices, &
-                         fms_fms2_io_get_valid => get_valid, &
-                         fms_fms2_io_is_valid => is_valid, &
-                         fms_fms2_io_get_unlimited_dimension_name => get_unlimited_dimension_name, &
-                         fms_fms2_io_get_variable_unlimited_dimension_index => get_variable_unlimited_dimension_index, &
-                         fms_fms2_io_file_exists => file_exists, &
-                         fms_fms2_io_compressed_start_and_count => compressed_start_and_count, &
-                         fms_fms2_io_get_variable_sense =>   get_variable_sense, &
-                         fms_fms2_io_get_variable_missing =>   get_variable_missing, &
-                         fms_fms2_io_get_variable_units =>   get_variable_units, &
-                         fms_fms2_io_get_time_calendar =>   get_time_calendar, &
-                         fms_fms2_io_open_check =>   open_check, &
-                         fms_fms2_io_is_registered_to_restart =>  is_registered_to_restart, &
-                         fms_fms2_io_check_if_open =>   check_if_open, &
-                         fms_fms2_io_set_fileobj_time_name => set_fileobj_time_name, &
-                         fms_fms2_io_is_dimension_registered => is_dimension_registered, &
-                         fms_fms2_io_fms2_io_init =>   fms2_io_init, &
-                         fms_fms2_io_get_mosaic_tile_grid =>   get_mosaic_tile_grid, &
-                         fms_fms2_io_write_restart_bc =>   write_restart_bc, &
-                         fms_fms2_io_read_restart_bc =>   read_restart_bc, &
-                         fms_fms2_io_get_filename_appendix =>   get_filename_appendix, &
-                         fms_fms2_io_set_filename_appendix =>   set_filename_appendix, &
-                         fms_fms2_io_get_instance_filename =>   get_instance_filename, &
-                         fms_fms2_io_nullify_filename_appendix =>   nullify_filename_appendix, &
-                         fms_fms2_io_ascii_read =>   ascii_read, &
-                         fms_fms2_io_get_mosaic_tile_file =>   get_mosaic_tile_file, &
-                         fms_fms2_io_parse_mask_table => parse_mask_table
+                         fms2_io_open_file => open_file, &
+                         fms2_io_open_virtual_file => open_virtual_file, &
+                         fms2_io_close_file => close_file, &
+                         fms2_io_register_axis => register_axis, &
+                         fms2_io_register_field => register_field, &
+                         fms2_io_register_restart_field => register_restart_field, &
+                         fms2_io_write_data => write_data, &
+                         fms2_io_read_data => read_data, &
+                         fms2_io_write_restart => write_restart, &
+                         fms2_io_write_new_restart => write_new_restart, &
+                         fms2_io_read_restart => read_restart, &
+                         fms2_io_read_new_restart => read_new_restart, &
+                         fms2_io_global_att_exists => global_att_exists, &
+                         fms2_io_variable_att_exists => variable_att_exists, &
+                         fms2_io_register_global_attribute => register_global_attribute, &
+                         fms2_io_register_variable_attribute => register_variable_attribute, &
+                         fms2_io_get_global_attribute => get_global_attribute, &
+                         fms2_io_get_variable_attribute => get_variable_attribute, &
+                         fms2_io_get_num_dimensions => get_num_dimensions, &
+                         fms2_io_get_dimension_names => get_dimension_names, &
+                         fms2_io_dimension_exists => dimension_exists, &
+                         fms2_io_is_dimension_unlimited => is_dimension_unlimited, &
+                         fms2_io_get_dimension_size => get_dimension_size, &
+                         fms2_io_get_num_variables =>   get_num_variables, &
+                         fms2_io_get_variable_names =>   get_variable_names, &
+                         fms2_io_variable_exists => variable_exists, &
+                         fms2_io_get_variable_num_dimensions => get_variable_num_dimensions, &
+                         fms2_io_get_variable_dimension_names => get_variable_dimension_names, &
+                         fms2_io_get_variable_size =>   get_variable_size, &
+                         fms2_io_get_compute_domain_dimension_indices => get_compute_domain_dimension_indices, &
+                         fms2_io_get_global_io_domain_indices => get_global_io_domain_indices, &
+                         fms2_io_get_valid => get_valid, &
+                         fms2_io_is_valid => is_valid, &
+                         fms2_io_get_unlimited_dimension_name => get_unlimited_dimension_name, &
+                         fms2_io_get_variable_unlimited_dimension_index => get_variable_unlimited_dimension_index, &
+                         fms2_io_file_exists => file_exists, &
+                         fms2_io_compressed_start_and_count => compressed_start_and_count, &
+                         fms2_io_get_variable_sense =>   get_variable_sense, &
+                         fms2_io_get_variable_missing =>   get_variable_missing, &
+                         fms2_io_get_variable_units =>   get_variable_units, &
+                         fms2_io_get_time_calendar =>   get_time_calendar, &
+                         fms2_io_open_check =>   open_check, &
+                         fms2_io_is_registered_to_restart =>  is_registered_to_restart, &
+                         fms2_io_check_if_open =>   check_if_open, &
+                         fms2_io_set_fileobj_time_name => set_fileobj_time_name, &
+                         fms2_io_is_dimension_registered => is_dimension_registered, &
+                         fms2_io_fms2_io_init =>   fms2_io_init, &
+                         fms2_io_get_mosaic_tile_grid =>   get_mosaic_tile_grid, &
+                         fms2_io_write_restart_bc =>   write_restart_bc, &
+                         fms2_io_read_restart_bc =>   read_restart_bc, &
+                         fms2_io_get_filename_appendix =>   get_filename_appendix, &
+                         fms2_io_set_filename_appendix =>   set_filename_appendix, &
+                         fms2_io_get_instance_filename =>   get_instance_filename, &
+                         fms2_io_nullify_filename_appendix =>   nullify_filename_appendix, &
+                         fms2_io_ascii_read =>   ascii_read, &
+                         fms2_io_get_mosaic_tile_file =>   get_mosaic_tile_file, &
+                         fms2_io_parse_mask_table => parse_mask_table
   ! used via fms2_io
   ! fms_io_utils_mod, fms_netcdf_domain_io_mod, netcdf_io_mod, &
   ! fms_netcdf_unstructured_domain_io_mod, blackboxio
@@ -406,7 +407,7 @@ module fms
   use horiz_interp_mod, only: fms_horiz_interp => horiz_interp, fms_horiz_interp_new => horiz_interp_new, &
                               fms_horiz_interp_del => horiz_interp_del, fms_horiz_interp_init => horiz_interp_init, &
                               fms_horiz_interp_end => horiz_interp_end
-  use horiz_interp_type_mod, only: fms_horiz_interp_type => horiz_interp_type, &
+  use horiz_interp_type_mod, only: FmsHorizInterp_type => horiz_interp_type, &
                               assignment(=), CONSERVE, BILINEAR, SPHERICA, BICUBIC, &
                               fms_horiz_interp_type_stats => stats
   !! used via horiz_interp
@@ -422,7 +423,7 @@ module fms
                               fms_interpolator_end => interpolator_end, &
                               fms_interpolator_init_clim_diag => init_clim_diag, &
                               fms_interpolator_query_interpolator => query_interpolator, &
-                              fms_interpolate_type => interpolate_type, &
+                              FmsInterpolate_type => interpolate_type, &
                               CONSTANT, INTERP_WEIGHTED_P, INTERP_LINEAR_P, INTERP_LOG_P, &
                               FMS_INTERPOLATOR_ZERO=>ZERO, & !! conflicts with mpp_parameter's ZERO
                               fms_interpolator_read_data=>read_data
@@ -518,8 +519,8 @@ module fms
                      fms_mpp_gather => mpp_gather, &
                      fms_mpp_scatter => mpp_scatter, &
                      fms_mpp_alltoall => mpp_alltoall, &
-                     fms_mpp_type => mpp_type, &
-                     fms_mpp_byte => mpp_byte, &
+                     FmsMpp_type => mpp_type, &
+                     FmsMpp_byte => mpp_byte, &
                      fms_mpp_type_create => mpp_type_create, &
                      fms_mpp_type_free => mpp_type_free, &
                      fms_mpp_input_nml_file => input_nml_file
@@ -567,13 +568,13 @@ module fms
                          operator(+), operator(-), assignment(=), &
                          fms_mpp_efp_query_overflow_error => mpp_query_efp_overflow_error, &
                          fms_mpp_efp_reset_overflow_error => mpp_reset_efp_overflow_error, &
-                         fms_mpp_efp_type => mpp_efp_type
-  use mpp_domains_mod, only: fms_mpp_domains_domain_axis_spec => domain_axis_spec, &
-                             fms_mpp_domains_domain1D => domain1D, &
-                             fms_mpp_domains_domain2D => domain2D, &
-                             fms_mpp_domains_DomainCommunicator2D => DomainCommunicator2D, &
-                             fms_mpp_domains_nest_domain_type => nest_domain_type, &
-                             fms_mpp_domains_group_update_type => mpp_group_update_type, &
+                         FmsMppEfp_type => mpp_efp_type
+  use mpp_domains_mod, only: FmsMppDomains_axis_spec => domain_axis_spec, &
+                             FmsMppDomain1D => domain1D, &
+                             FmsMppDomain2D => domain2D, &
+                             FmsMppDomainCommunicator2D => DomainCommunicator2D, &
+                             FmsMppDomainsNestDomain_type => nest_domain_type, &
+                             FmsMppDomainsGroupUpdate_type => mpp_group_update_type, &
                              fms_mpp_domains_domains_set_stack_size => mpp_domains_set_stack_size, &
                              fms_mpp_domains_get_compute_domain => mpp_get_compute_domain, &
                              fms_mpp_domains_get_compute_domains => mpp_get_compute_domains, &
@@ -657,7 +658,7 @@ module fms
                              fms_mpp_domains_compute_extent => mpp_compute_extent, &
                              fms_mpp_domains_compute_block_extent => mpp_compute_block_extent, &
                              fms_mpp_domains_define_unstruct_domain => mpp_define_unstruct_domain, &
-                             fms_mpp_domains_domainUG => domainUG, &
+                             fmsMppDomainUG => domainUG, &
                              fms_mpp_domains_get_UG_io_domain => mpp_get_UG_io_domain, &
                              fms_mpp_domains_get_UG_domain_npes => mpp_get_UG_domain_npes, &
                              fms_mpp_domains_get_UG_compute_domain => mpp_get_UG_compute_domain, &
@@ -688,8 +689,8 @@ module fms
                              fms_mpp_domains_domain_UG_is_tile_root_pe => mpp_domain_UG_is_tile_root_pe, &
                              fms_mpp_domains_deallocate_domainUG => mpp_deallocate_domainUG, &
                              fms_mpp_domains_get_io_domain_UG_layout => mpp_get_io_domain_UG_layout, &
-                             fms_mpp_domains_NULL_DOMAIN1D => NULL_DOMAIN1D, &
-                             fms_mpp_domains_NULL_DOMAIN2D => NULL_DOMAIN2D, &
+                             NULL_DOMAIN1D, &
+                             NULL_DOMAIN2D, &
                              fms_mpp_domains_create_super_grid_domain => mpp_create_super_grid_domain, &
                              fms_mpp_domains_shift_nest_domains => mpp_shift_nest_domains
   !> parser
@@ -699,9 +700,9 @@ module fms
                              fms_yaml_parser_get_block_ids => get_block_ids, &
                              fms_yaml_parser_get_value_from_key => get_value_from_key, &
                              fms_yaml_parser_get_nkeys => get_nkeys, &
-                             fms_yaml_get_key_ids => get_key_ids, &
-                             fms_yaml_get_key_name => get_key_name, &
-                             fms_yaml_get_key_value => get_key_value
+                             fms_yaml_parser_get_key_ids => get_key_ids, &
+                             fms_yaml_parser_get_key_name => get_key_name, &
+                             fms_yaml_parser_get_key_value => get_key_value
 #endif
 
   !> platform
@@ -758,7 +759,7 @@ module fms
                              SUCCESS, ERR_FIELD_NOT_FOUND
 
   !> time_manager
-  use time_manager_mod, only: fms_time_type => time_type, &
+  use time_manager_mod, only: FmsTime_type => time_type, &
                               operator(+), operator(-), operator(*), assignment(=),&
                               operator(/), operator(>), operator(>=), operator(==), &
                               operator(/=), operator(<), operator(<=), operator(//), &

--- a/libFMS.F90
+++ b/libFMS.F90
@@ -23,14 +23,22 @@
 !!
 !! @date 2/2021
 !!
-!! Imports all supported FMS modules so that any public interfaces,
+!! Imports all supported FMS modules so that any public interfaces, &
 !! variables or routines can be used via this module. Excludes mpp_io modules
 !! and routines. Overloaded type operators/assignments cannot be imported individually
 !! (ie. `use fms, only: OPERATOR(*)` includes any defined '*' operators within FMS).
 !!
-!! Remappings due to conflicts:
+!! Renaming scheme:
+!!   fms_<module_name>_routine_or_type_name
 !!
-!!           get_mosaic_tile_grid from mosaic2(fms2_io) => mosaic2_get_mosaic_tile_grid
+!! Exceptions (mainly for rep:
+!!   - Parameter values are kept their original names
+!!   - If module name is already included (like in init routines) only fms prefix will be added.
+!!   - Similarly if theres a redundant module name included already included it will not be repeated (ie. mpp_update_domains => fms_mpp_domains_update_domains)
+!!
+!! Previous remappings due to conflicts:
+!!
+!!           fms_mosaic_get_mosaic_tile_grid (fms2_io) => mosaic2_get_mosaic_tile_grid
 !!
 !!           read_data from interpolator_mod(fms2_io)   => interpolator_read_data
 !!
@@ -41,7 +49,7 @@
 !! Not in this module:
 !!
 !!                     axis_utils_mod, fms_io_mod, time_interp_external_mod
-!!                     get_grid_version_mpp_mod, mpp_io_mod, mosaic_mod,
+!!                     get_grid_version_mpp_mod, mpp_io_mod, mosaic_mod, &
 !!                     fms_mod(partial, old io excluded), drifters modules
 !!                     constants_mod (FMSconstants should be used externally)
 !!                     grid_mod, mosaic_mod
@@ -81,7 +89,8 @@ module fms
   !> astronomy
   use astronomy_mod, only: fms_astronomy_init                   => astronomy_init, &
                            fms_astronomy_get_period             => get_period, &
-                           fms_astronomy_set_period             => set_period, fms_astronomy_set_orbital_parameters=>, &
+                           fms_astronomy_set_period             => set_period, &
+                           fms_astronomy_set_orbital_parameters => set_orbital_parameters, &
                            fms_astronomy_get_orbital_parameters => get_orbital_parameters, &
                            fms_astronomy_set_ref_date_of_ae     => set_ref_date_of_ae, &
                            fms_astronomy_get_ref_date_of_ae     => get_ref_date_of_ae, &
@@ -93,15 +102,15 @@ module fms
                            fms_astronomy_orbital_time           => orbital_time
 
   !> axis_utils
-  use axis_utils2_mod, only: fms_get_axis_cart         => get_axis_cart, &
-                             fms_get_axis_modulo       => get_axis_modulo, &
-                             fms_lon_in_range          => lon_in_range, &
-                             fms_tranlon               => tranlon, &
-                             fms_frac_index            => frac_index, &
-                             fms_nearest_index         => nearest_index, &
-                             fms_interp_1d             => interp_1d, &
-                             fms_get_axis_modulo_times => get_axis_modulo_times, &
-                             fms_axis_edges            => axis_edges
+  use axis_utils2_mod, only: fms_axis_utils2_get_axis_cart         => get_axis_cart, &
+                             fms_axis_utils2_get_axis_modulo       => get_axis_modulo, &
+                             fms_axis_utils2_lon_in_range          => lon_in_range, &
+                             fms_axis_utils2_tranlon               => tranlon, &
+                             fms_axis_utils2_frac_index            => frac_index, &
+                             fms_axis_utils2_nearest_index         => nearest_index, &
+                             fms_axis_utils2_interp_1d             => interp_1d, &
+                             fms_axis_utils2_get_axis_modulo_times => get_axis_modulo_times, &
+                             fms_axis_utils2_axis_edges            => axis_edges
 
   !>block_control
   use block_control_mod, only: fms_block_control_type                 => block_control_type, &
@@ -143,27 +152,27 @@ module fms
                                fms_coupler_1d_values_type         => coupler_1d_values_type, &
                                fms_coupler_1d_field_type          => coupler_1d_field_type, &
                                fms_coupler_1d_bc_type             => coupler_1d_bc_type, &
-                               fms_ind_pcair                      => ind_pcair, &
-                               fms_ind_u10                        => ind_u10, &
-                               fms_ind_psurf                      => ind_psurf, &
-                               fms_ind_alpha                      => ind_alpha, &
-                               fms_ind_csurf                      => ind_csurf, &
-                               fms_ind_sc_no                      => ind_sc_no, &
-                               fms_ind_flux                       => ind_flux, &
-                               fms_ind_deltap                     => ind_deltap, &
-                               fms_ind_kw                         => ind_kw, &
-                               fms_ind_flux0                      => ind_flux0, &
-                               fms_ind_deposition                 => ind_deposition,&
-                               fms_ind_runoff                     => ind_runoff
+                               fms_coupler_ind_pcair                      => ind_pcair, &
+                               fms_coupler_ind_u10                        => ind_u10, &
+                               fms_coupler_ind_psurf                      => ind_psurf, &
+                               fms_coupler_ind_alpha                      => ind_alpha, &
+                               fms_coupler_ind_csurf                      => ind_csurf, &
+                               fms_coupler_ind_sc_no                      => ind_sc_no, &
+                               fms_coupler_ind_flux                       => ind_flux, &
+                               fms_coupler_ind_deltap                     => ind_deltap, &
+                               fms_coupler_ind_kw                         => ind_kw, &
+                               fms_coupler_ind_flux0                      => ind_flux0, &
+                               fms_coupler_ind_deposition                 => ind_deposition,&
+                               fms_coupler_ind_runoff                     => ind_runoff
   use ensemble_manager_mod, only: fms_ensemble_manager_init     => ensemble_manager_init, &
-                               fms_get_ensemble_id              => get_ensemble_id,
-                               fms_get_ensemble_size            => get_ensemble_size, 
-                               fms_get_ensemble_pelist          => get_ensemble_pelist, &
-                               fms_ensemble_pelist_setup        => ensemble_pelist_setup, &
-                               fms_get_ensemble_filter_pelist   => get_ensemble_filter_pelist
-  use atmos_ocean_fluxes_mod, only: fms_atmos_ocean_fluxes_init => atmos_ocean_fluxes_init,
+                               fms_ensemble_manager_eget_ensemble_id              => get_ensemble_id, &
+                               fms_ensemble_manager_get_ensemble_size            => get_ensemble_size, & 
+                               fms_ensemble_manager_get_ensemble_pelist          => get_ensemble_pelist, &
+                               fms_ensemble_manager_ensemble_pelist_setup        => ensemble_pelist_setup, &
+                               fms_ensemble_manager_get_ensemble_filter_pelist   => get_ensemble_filter_pelist
+  use atmos_ocean_fluxes_mod, only: fms_atmos_ocean_fluxes_init => atmos_ocean_fluxes_init, &
                                fms_atmos_ocean_type_fluxes_init => atmos_ocean_type_fluxes_init, &
-                               fms_aof_set_coupler_flux         => aof_set_coupler_flux
+                               fms_atmos_ocean_fluxes_set_coupler_flux         => aof_set_coupler_flux
 
   !> data_override
   use data_override_mod, only: fms_data_override_init          => data_override_init, &
@@ -181,15 +190,15 @@ module fms
   !> diag_manager
   !! includes imports from submodules made public
   use diag_manager_mod, only: fms_diag_manager_init => diag_manager_init, &
-                              fms_send_data => send_data, &
-                              fms_send_tile_averaged_data => send_tile_averaged_data, &
-                              fms_diag_manager_end => diag_manager_end, &
-                              fms_register_diag_field => register_diag_field,
-                              fms_register_static_field => register_static_field, &
-                              fms_diag_axis_init => diag_axis_init, &
-                              fms_get_base_time => get_base_time,
-                              fms_get_base_date => get_base_date, &
-                              fms_need_data => need_data, &
+                              fms_diag_manager_send_data => send_data, &
+                              fms_diag_manager_send_tile_averaged_data => send_tile_averaged_data, &
+                              fms_diag_manager_diag_manager_end => diag_manager_end, &
+                              fms_diag_manager_register_diag_field => register_diag_field, &
+                              fms_diag_manager_register_static_field => register_static_field, &
+                              fms_diag_manager_diag_axis_init => diag_axis_init, &
+                              fms_diag_manager_get_base_time => get_base_time, &
+                              fms_diag_manager_get_base_date => get_base_date, &
+                              fms_diag_manager_need_data => need_data, &
                               DIAG_ALL, &
                               DIAG_OCEAN, &
                               DIAG_OTHER, &
@@ -200,82 +209,110 @@ module fms
                               DIAG_DAYS, &
                               DIAG_MONTHS, &
                               DIAG_YEARS, &
-                              fms_get_diag_global_att => get_diag_global_att, &
-                              fms_set_diag_global_att => set_diag_global_att, &
-                              fms_diag_field_add_attribute => diag_field_add_attribute, &
-                              fms_diag_field_add_cell_measures => diag_field_add_cell_measures, &
-                              fms_get_diag_field_id => get_diag_field_id, &
-                              fms_diag_axis_add_attribute => diag_axis_add_attribute, &
-                              fms_diag_grid_init => diag_grid_init, &
-                              fms_diag_grid_end => diag_grid_end, &
+                              fms_diag_manager_get_diag_global_att => get_diag_global_att, &
+                              fms_diag_manager_set_diag_global_att => set_diag_global_att, &
+                              fms_diag_manager_diag_field_add_attribute => diag_field_add_attribute, &
+                              fms_diag_manager_diag_field_add_cell_measures => diag_field_add_cell_measures, &
+                              fms_diag_manager_get_diag_field_id => get_diag_field_id, &
+                              fms_diag_manager_diag_axis_add_attribute => diag_axis_add_attribute, &
+                              fms_diag_manager_diag_grid_init => diag_grid_init, &
+                              fms_diag_manager_diag_grid_end => diag_grid_end, &
                               fms_diag_manager_set_time_end => diag_manager_set_time_end, &
-                              fms_diag_send_complete => diag_send_complete, &
-                              fms_diag_send_complete_instant => diag_send_complete_instant, &
+                              fms_diag_manager_diag_send_complete => diag_send_complete, &
+                              fms_diag_manager_diag_send_complete_instant => diag_send_complete_instant, &
                               DIAG_FIELD_NOT_FOUND, &
                               CMOR_MISSING_VALUE, &
                               null_axis_id
 
   !> exchange
-  use xgrid_mod, only: fms_xmap_type => xmap_type, &
-                       fms_setup_xmap => setup_xmap, &
-                       fms_set_frac_area => set_frac_area, &
-                       fms_put_to_xgrid => put_to_xgrid, &
-                       fms_get_from_xgrid => get_from_xgrid, &
-                       fms_xgrid_count => xgrid_count, &
-                       fms_some => some,
-                       fms_conservation_check => conservation_check, &
-                       fms_xgrid_init => xgrid_init, &
-                       fms_AREA_ATM_SPHERE => AREA_ATM_SPHERE, &
-                       fms_AREA_OCN_SPHERE => AREA_OCN_SPHERE, &
-                       fms_AREA_ATM_MODEL =>
-                       AREA_ATM_MODEL, fms_AREA_OCN_MODEL => AREA_OCN_MODEL, &
-                       fms_get_ocean_model_area_elements => get_ocean_model_area_elements, &
-                       fms_grid_box_type => grid_box_type, &
-                       fms_get_xmap_grid_area => get_xmap_grid_area, fms_put_to_xgrid_ug => put_to_xgrid_ug, &
-                       fms_get_from_xgrid_ug => get_from_xgrid_ug, fms_set_frac_area_ug => set_frac_area_ug, &
-                       FIRST_ORDER, SECOND_ORDER, fms_stock_move_ug => stock_move_ug, fms_stock_move => stock_move, fms_stock_type => stock_type, fms_stock_print => stock_print,
-                       fms_get_index_range => get_index_range, &
-                       fms_stock_integrate_2d => stock_integrate_2d
-  use stock_constants_mod, only: fms_NELEMS => NELEMS, fms_ISTOCK_WATER => ISTOCK_WATER, fms_ISTOCK_HEAT => ISTOCK_HEAT, &
-                       fms_ISTOCK_SALT => ISTOCK_SALT, &
-                       fms_ISTOCK_TOP => ISTOCK_TOP, fms_ISTOCK_BOTTOM => ISTOCK_BOTTOM, fms_ISTOCK_SIDE => ISTOCK_SIDE,
-                       fms_stocks_file => stocks_file, &
-                       fms_stocks_report => stocks_report, fms_stocks_report_init => stocks_report_init, fms_stocks_set_init_time => stocks_set_init_time, &
-                       fms_atm_stock => atm_stock, fms_ocn_stock => ocn_stock, fms_lnd_stock => lnd_stock, fms_ice_stock => ice_stock
+  use xgrid_mod, only: fms_xgrid_xmap_type => xmap_type, &
+                       fms_xgrid_setup_xmap => setup_xmap, &
+                       fms_xgrid_set_frac_area => set_frac_area, &
+                       fms_xgrid_put_to_xgrid => put_to_xgrid, &
+                       fms_xgrid_get_from_xgrid => get_from_xgrid, &
+                       fms_xgrid_xgrid_count => xgrid_count, &
+                       fms_xgrid_some => some, &
+                       fms_xgrid_conservation_check => conservation_check, &
+                       fms_xgrid_xgrid_init => xgrid_init, &
+                       AREA_ATM_SPHERE, AREA_OCN_SPHERE, AREA_ATM_MODEL, AREA_OCN_MODEL, &
+                       fms_xgrid_get_ocean_model_area_elements => get_ocean_model_area_elements, &
+                       fms_xgrid_grid_box_type => grid_box_type, &
+                       fms_xgrid_get_xmap_grid_area => get_xmap_grid_area, &
+                       fms_xgrid_put_to_xgrid_ug => put_to_xgrid_ug, &
+                       fms_xgrid_get_from_xgrid_ug => get_from_xgrid_ug, &
+                       fms_xgrid_set_frac_area_ug => set_frac_area_ug, &
+                       FIRST_ORDER, SECOND_ORDER, &
+                       fms_xgrid_stock_move_ug => stock_move_ug, &
+                       fms_xgrid_stock_move => stock_move, &
+                       fms_xgrid_stock_type => stock_type, &
+                       fms_xgrid_stock_print => stock_print, &
+                       fms_xgrid_get_index_range => get_index_range, &
+                       fms_xgrid_stock_integrate_2d => stock_integrate_2d
+  use stock_constants_mod, only: NELEMS, ISTOCK_WATER, ISTOCK_HEAT, ISTOCK_SALT, ISTOCK_TOP, ISTOCK_BOTTOM, ISTOCK_SIDE, &
+                       fms_stock_constants_stocks_file => stocks_file, &
+                       fms_stock_constants_stocks_report => stocks_report, &
+                       fms_stocks_report_init => stocks_report_init, &
+                       fms_stocks_set_init_time => stocks_set_init_time, &
+                       fms_stock_constants_atm_stock => atm_stock, &
+                       fms_ocn_stock => ocn_stock, &
+                       fms_lnd_stock => lnd_stock, &
+                       fms_ice_stock => ice_stock
 
   !> field manager
-  use field_manager_mod, only: fms_field_manager_init => field_manager_init, fms_field_manager_end => field_manager_end,
-                         fms_find_field_index => find_field_index, &
-                         fms_get_field_info => get_field_info, &
-                         fms_get_field_method => get_field_method, fms_get_field_methods => get_field_methods, fms_parse => parse,
-                         fms_fm_change_list => fm_change_list, &
-                         fms_fm_change_root => fm_change_root, fms_fm_dump_list => fm_dump_list, fms_fm_exists => fm_exists,
-                         fms_fm_get_index => fm_get_index, &
-                         fms_fm_get_current_list => fm_get_current_list, fms_fm_get_length => fm_get_length, fms_fm_get_type =>
-                         fm_get_type, fms_fm_get_value => fm_get_value, &
-                         fms_fm_init_loop => fm_init_loop, &
-                         fms_fm_loop_over_list => fm_loop_over_list, fms_fm_new_list => fm_new_list, fms_fm_new_value => fm_new_value, &
-                         fms_fm_reset_loop => fm_reset_loop, fms_fm_return_root => fm_return_root, &
-                         fms_fm_modify_name => fm_modify_name, fms_fm_query_method => fm_query_method, fms_fm_find_methods =>
-                         fm_find_methods, fms_fm_copy_list => fm_copy_list, &
-                         fms_fm_field_name_len => fm_field_name_len, fms_fm_path_name_len => fm_path_name_len, &
-                         fms_fm_string_len => fm_string_len, fms_fm_type_name_len => fm_type_name_len, fms_NUM_MODELS => NUM_MODELS,
-                         fms_NO_FIELD => NO_FIELD, &
-                         fms_MODEL_ATMOS => MODEL_ATMOS, fms_MODEL_OCEAN => MODEL_OCEAN, fms_MODEL_LAND => MODEL_LAND, fms_MODEL_ICE
-                         => MODEL_ICE, fms_MODEL_COUPLER => MODEL_COUPLER, &
-                         fms_method_type => method_type, fms_method_type_short => method_type_short, &
-                         fms_method_type_very_short => method_type_very_short, fms_fm_list_iter_type => fm_list_iter_type,
-                         fms_default_method => default_method
-  use fm_util_mod, only: fms_fm_util_start_namelist => fm_util_start_namelist, fms_fm_util_end_namelist => fm_util_end_namelist, &
-                         fms_fm_util_check_for_bad_fields => fm_util_check_for_bad_fields, fms_fm_util_set_caller => fm_util_set_caller, &
-                         fms_fm_util_reset_caller => fm_util_reset_caller, fms_fm_util_set_no_overwrite => fm_util_set_no_overwrite, &
-                         fms_fm_util_reset_no_overwrite => fm_util_reset_no_overwrite, fms_fm_util_set_good_name_list => fm_util_set_good_name_list, &
-                         fms_fm_util_reset_good_name_list => fm_util_reset_good_name_list, fms_fm_util_get_length => fm_util_get_length, &
-                         fms_fm_util_get_integer => fm_util_get_integer, fms_fm_util_get_logical => fm_util_get_logical,
+  use field_manager_mod, only: fms_field_manager_init => field_manager_init, fms_field_manager_end => field_manager_end, &
+                         fms_field_manager_find_field_index => find_field_index, &
+                         fms_field_manager_get_field_info => get_field_info, &
+                         fms_field_manager_get_field_method => get_field_method, &
+                         fms_field_manager_get_field_methods => get_field_methods, &
+                         fms_field_manager_parse => parse, &
+                         fms_field_manager_fm_change_list => fm_change_list, &
+                         fms_field_manager_fm_change_root => fm_change_root, &
+                         fms_field_manager_fm_dump_list => fm_dump_list, &
+                         fms_field_manager_fm_exists => fm_exists, &
+                         fms_field_manager_fm_get_index => fm_get_index, &
+                         fms_field_manager_fm_get_current_list => fm_get_current_list, &
+                         fms_field_manager_fm_get_length => fm_get_length, &
+                         fms_field_manager_fm_get_type => fm_get_type, &
+                         fms_field_manager_fm_get_value => fm_get_value, &
+                         fms_field_manager_fm_init_loop => fm_init_loop, &
+                         fms_field_manager_fm_loop_over_list => fm_loop_over_list, &
+                         fms_field_manager_fm_new_list => fm_new_list, &
+                         fms_field_manager_fm_new_value => fm_new_value, &
+                         fms_field_manager_fm_reset_loop => fm_reset_loop, &
+                         fms_field_manager_fm_return_root => fm_return_root, &
+                         fms_field_manager_fm_modify_name => fm_modify_name, &
+                         fms_field_manager_fm_query_method => fm_query_method, &
+                         fms_field_manager_fm_find_methods => fm_find_methods, &
+                         fms_field_manager_fm_copy_list => fm_copy_list, &
+                         fms_field_manager_fm_field_name_len => fm_field_name_len, &
+                         fms_field_manager_fm_path_name_len => fm_path_name_len, &
+                         fms_field_manager_fm_string_len => fm_string_len, &
+                         fms_field_manager_fm_type_name_len => fm_type_name_len, &
+                         NUM_MODELS, NO_FIELD, MODEL_ATMOS, MODEL_OCEAN, MODEL_LAND, MODEL_ICE, MODEL_COUPLER, &
+                         fms_field_manager_method_type => method_type, &
+                         fms_field_manager_method_type_short => method_type_short, &
+                         fms_field_manager_field_manager_method_type_very_short => method_type_very_short, &
+                         fms_field_manager_fm_list_iter_type => fm_list_iter_type, &
+                         fms_field_manager_default_method => default_method
+  use fm_util_mod, only: fms_fm_util_start_namelist => fm_util_start_namelist, &
+                         fms_fm_util_end_namelist => fm_util_end_namelist, &
+                         fms_fm_util_check_for_bad_fields => fm_util_check_for_bad_fields, &
+                         fms_fm_util_set_caller => fm_util_set_caller, &
+                         fms_fm_util_reset_caller => fm_util_reset_caller, &
+                         fms_fm_util_set_no_overwrite => fm_util_set_no_overwrite, &
+                         fms_fm_util_reset_no_overwrite => fm_util_reset_no_overwrite, &
+                         fms_fm_util_set_good_name_list => fm_util_set_good_name_list, &
+                         fms_fm_util_reset_good_name_list => fm_util_reset_good_name_list, &
+                         fms_fm_util_get_length => fm_util_get_length, &
+                         fms_fm_util_get_integer => fm_util_get_integer, &
+                         fms_fm_util_get_logical => fm_util_get_logical, &
                          fms_fm_util_get_real => fm_util_get_real, &
-                         fms_fm_util_get_string => fm_util_get_string, fms_fm_util_get_integer_array => fm_util_get_integer_array, &
-                         fms_fm_util_get_logical_array => fm_util_get_logical_array, fms_fm_util_get_real_array => fm_util_get_real_array,
-                         fms_fm_util_get_string_array => fm_util_get_string_array, fms_fm_util_set_value => fm_util_set_value, &
+                         fms_fm_util_get_string => fm_util_get_string, &
+                         fms_fm_util_get_integer_array => fm_util_get_integer_array, &
+                         fms_fm_util_get_logical_array => fm_util_get_logical_array, &
+                         fms_fm_util_get_real_array => fm_util_get_real_array, &
+                         fms_fm_util_get_string_array => fm_util_get_string_array, &
+                         fms_fm_util_set_value => fm_util_set_value, &
                          fms_fm_util_set_value_integer_array => fm_util_set_value_integer_array, &
                          fms_fm_util_set_value_logical_array => fm_util_set_value_logical_array, &
                          fms_fm_util_set_value_real_array => fm_util_set_value_real_array, &
@@ -290,36 +327,73 @@ module fms
 
   !> fms2_io
   use fms2_io_mod, only: unlimited, FmsNetcdfFile_t, FmsNetcdfDomainFile_t, &
-                         FmsNetcdfUnstructuredDomainFile_t, open_file, open_virtual_file, &
-                         close_file, register_axis, register_field, register_restart_field, &
-                         write_data, read_data, write_restart, write_new_restart, &
-                         read_restart, read_new_restart, global_att_exists, &
-                         variable_att_exists, register_global_attribute, &
-                         register_variable_attribute, get_global_attribute, &
-                         get_variable_attribute, get_num_dimensions, &
-                         get_dimension_names, dimension_exists, is_dimension_unlimited, &
-                         get_dimension_size, get_num_variables, get_variable_names, &
-                         variable_exists, get_variable_num_dimensions, &
-                         get_variable_dimension_names, get_variable_size, &
-                         get_compute_domain_dimension_indices, &
-                         get_global_io_domain_indices, Valid_t, get_valid, is_valid, &
-                         get_unlimited_dimension_name, get_variable_unlimited_dimension_index, &
-                         file_exists, compressed_start_and_count, get_variable_sense, &
-                         get_variable_missing, get_variable_units, get_time_calendar, &
-                         open_check, is_registered_to_restart, check_if_open, &
-                         set_fileobj_time_name, is_dimension_registered, &
-                         fms2_io_init, get_mosaic_tile_grid, &
-                         write_restart_bc, read_restart_bc, get_filename_appendix, & !> 2021.02-a1
-                         set_filename_appendix, get_instance_filename, &
-                         nullify_filename_appendix, ascii_read, get_mosaic_tile_file, &
-                         parse_mask_table
+                         FmsNetcdfUnstructuredDomainFile_t, &
+                         fms_fms2_io_open_file => open_file, &
+                         fms_fms2_io_open_virtual_file => open_virtual_file, &
+                         fms_fms2_io_close_file => close_file, &
+                         fms_fms2_io_register_axis => register_axis, &
+                         fms_fms2_io_register_field => register_field, &
+                         fms_fms2_io_register_restart_field => register_restart_field, &
+                         fms_fms2_io_write_data => write_data, &
+                         fms_fms2_io_read_data => read_data, &
+                         fms_fms2_io_write_restart => write_restart, &
+                         fms_fms2_io_write_new_restart => write_new_restart, &
+                         fms_fms2_io_read_restart => read_restart, &
+                         fms_fms2_io_read_new_restart => read_new_restart, &
+                         fms_fms2_io_global_att_exists => global_att_exists, &
+                         fms_fms2_io_variable_att_exists => variable_att_exists, &
+                         fms_fms2_io_register_global_attribute => register_global_attribute, &
+                         fms_fms2_io_register_variable_attribute => register_variable_attribute, &
+                         fms_fms2_io_get_global_attribute => get_global_attribute, &
+                         fms_fms2_io_get_variable_attribute => get_variable_attribute, &
+                         fms_fms2_io_get_num_dimensions => get_num_dimensions, &
+                         fms_fms2_io_get_dimension_names => get_dimension_names, &
+                         fms_fms2_io_dimension_exists => dimension_exists, &
+                         fms_fms2_io_is_dimension_unlimited => is_dimension_unlimited, &
+                         fms_fms2_io_get_dimension_size => get_dimension_size, &
+                         fms_fms2_io_get_num_variables =>   get_num_variables, &
+                         fms_fms2_io_get_variable_names =>   get_variable_names, &
+                         fms_fms2_io_variable_exists => variable_exists, &
+                         fms_fms2_io_get_variable_num_dimensions => get_variable_num_dimensions, &
+                         fms_fms2_io_get_variable_dimension_names => get_variable_dimension_names, &
+                         fms_fms2_io_get_variable_size =>   get_variable_size, &
+                         fms_fms2_io_get_compute_domain_dimension_indices => get_compute_domain_dimension_indices, &
+                         fms_fms2_io_get_global_io_domain_indices => get_global_io_domain_indices, &
+                         Valid_t, &
+                         fms_fms2_io_get_valid => get_valid, &
+                         fms_fms2_io_is_valid => is_valid, &
+                         fms_fms2_io_get_unlimited_dimension_name => get_unlimited_dimension_name, &
+                         fms_fms2_io_get_variable_unlimited_dimension_index =>   get_variable_unlimited_dimension_index, &
+                         fms_fms2_io_file_exists => file_exists, &
+                         fms_fms2_io_compressed_start_and_count => compressed_start_and_count, &
+                         fms_fms2_io_get_variable_sense =>   get_variable_sense, &
+                         fms_fms2_io_get_variable_missing =>   get_variable_missing, &
+                         fms_fms2_io_get_variable_units =>   get_variable_units, &
+                         fms_fms2_io_get_time_calendar =>   get_time_calendar, &
+                         fms_fms2_io_open_check =>   open_check, &
+                         fms_fms2_io_is_registered_to_restart =>  is_registered_to_restart, &
+                         fms_fms2_io_check_if_open =>   check_if_open, &
+                         fms_fms2_io_set_fileobj_time_name => set_fileobj_time_name, &
+                         fms_fms2_io_is_dimension_registered => is_dimension_registered, &
+                         fms_fms2_io_fms2_io_init =>   fms2_io_init, &
+                         fms_fms2_io_get_mosaic_tile_grid =>   get_mosaic_tile_grid, &
+                         fms_fms2_io_write_restart_bc =>   write_restart_bc, &
+                         fms_fms2_io_read_restart_bc =>   read_restart_bc, &
+                         fms_fms2_io_get_filename_appendix =>   get_filename_appendix, &
+                         fms_fms2_io_set_filename_appendix =>   set_filename_appendix, &
+                         fms_fms2_io_get_instance_filename =>   get_instance_filename, &
+                         fms_fms2_io_nullify_filename_appendix =>   nullify_filename_appendix, &
+                         fms_fms2_io_ascii_read =>   ascii_read, &
+                         fms_fms2_io_get_mosaic_tile_file =>   get_mosaic_tile_file, &
+                         fms_fms2_io_parse_mask_table => parse_mask_table
   ! used via fms2_io
-  ! fms_io_utils_mod, fms_netcdf_domain_io_mod, netcdf_io_mod,
+  ! fms_io_utils_mod, fms_netcdf_domain_io_mod, netcdf_io_mod, &
   ! fms_netcdf_unstructured_domain_io_mod, blackboxio
 
   !> fms
   !! routines that don't conflict with fms2_io
-  use fms_mod, only: fms_init, fms_end, error_mesg, fms_error_handler, check_nml_error, &
+  use fms_mod, only: fms_init, fms_end, error_mesg, fms_error_handler, &
+                     check_nml_error, &
                      fms_monotonic_array => monotonic_array, fms_string_array_index => string_array_index, &
                      fms_clock_flag_default => clock_flag_default, fms_print_memory_usage => print_memory_usage, &
                      fms_write_version_number => write_version_number
@@ -328,59 +402,123 @@ module fms
   use horiz_interp_mod, only: fms_horiz_interp => horiz_interp, fms_horiz_interp_new => horiz_interp_new, &
                               fms_horiz_interp_del => horiz_interp_del, fms_horiz_interp_init => horiz_interp_init, &
                               fms_horiz_interp_end => horiz_interp_end
-  use horiz_interp_type_mod, only: horiz_interp_type, assignment(=), CONSERVE, &
-                              BILINEAR, SPHERICA, BICUBIC, stats
+  use horiz_interp_type_mod, only: fms_horiz_interp_type => horiz_interp_type, &
+                              assignment(=), CONSERVE, BILINEAR, SPHERICA, BICUBIC, &
+                              fms_horiz_interp_type_stats => stats
   !! used via horiz_interp
   ! horiz_interp_bicubic_mod, horiz_interp_bilinear_mod
   ! horiz_interp_conserve_mod, horiz_interp_spherical_mod
 
   !> interpolator
-  use interpolator_mod, only: interpolator_init, interpolator, interpolate_type_eq, &
-                              obtain_interpolator_time_slices, unset_interpolator_time_flag, &
-                              interpolator_end, init_clim_diag, query_interpolator, &
-                              interpolate_type, CONSTANT, &
-                              INTERP_WEIGHTED_P, INTERP_LINEAR_P, INTERP_LOG_P, &
-                              INTERPOLATOR_ZERO=>ZERO, & !! conflicts with mpp_parameter's ZERO
-                              interpolator_read_data=>read_data !! conflicts with fms2_io interface
+  use interpolator_mod, only: fms_interpolator_init => interpolator_init, &
+                              fms_interpolator_interpolator => interpolator, &
+                              fms_interpolate_type_eq => interpolate_type_eq, &
+                              fms_interpolator_obtain_interpolator_time_slices => obtain_interpolator_time_slices, &
+                              fms_interpolator_unset_interpolator_time_flag => unset_interpolator_time_flag, &
+                              fms_interpolator_interpolator_end => interpolator_end, &
+                              fms_interpolator_init_clim_diag => init_clim_diag, &
+                              fms_interpolator_query_interpolator => query_interpolator, &
+                              fms_interpolate_type => interpolate_type, &
+                              CONSTANT, INTERP_WEIGHTED_P, INTERP_LINEAR_P, INTERP_LOG_P, &
+                              FMS_INTERPOLATOR_ZERO=>ZERO, & !! conflicts with mpp_parameter's ZERO
+                              fms_interpolator_read_data=>read_data 
 
   !> memutils
-  use memutils_mod, only: memutils_init, print_memuse_stats
+  use memutils_mod, only: fms_memutils_init => memutils_init, &
+                          fms_memutils_print_memuse_stats => print_memuse_stats
 
   !> monin_obukhov
-  use monin_obukhov_mod, only: monin_obukhov_init, monin_obukhov_end, &
-                               mo_drag, mo_profile, mo_diff, stable_mix
-  use monin_obukhov_inter, only: monin_obukhov_diff, monin_obukhov_drag_1d, &
-                               monin_obukhov_solve_zeta, monin_obukhov_derivative_t, &
-                               monin_obukhov_derivative_m, monin_obukhov_profile_1d, &
-                               monin_obukhov_integral_m, monin_obukhov_integral_tq, &
-                               monin_obukhov_stable_mix
+  use monin_obukhov_mod, only: fms_monin_obukhov_init => monin_obukhov_init, &
+                               fms_monin_obukhov_end => monin_obukhov_end, &
+                               fms_monin_obukhov_mo_drag => mo_drag, &
+                               fms_monin_obukhov_mo_profile => mo_profile, &
+                               fms_monin_obukhov_mo_diff => mo_diff, &
+                               fms_monin_obukhov_stable_mix => stable_mix
+  use monin_obukhov_inter, only: fms_monin_obukhov_inter_diff => monin_obukhov_diff, &
+                                 fms_monin_obukhov_inter_drag_1d => monin_obukhov_drag_1d, &
+                                 fms_monin_obukhov_inter_solve_zeta => monin_obukhov_solve_zeta, &
+                                 fms_monin_obukhov_inter_derivative_t => monin_obukhov_derivative_t, &
+                                 fms_monin_obukhov_inter_derivative_m => monin_obukhov_derivative_m, &
+                                 fms_monin_obukhov_inter_profile_1d => monin_obukhov_profile_1d, &
+                                 fms_monin_obukhov_inter_integral_m => monin_obukhov_integral_m, &
+                                 fms_monin_obukhov_inter_integral_tq => monin_obukhov_integral_tq, &
+                                 fms_monin_obukhov_inter_stable_mix => monin_obukhov_stable_mix
 
   !> mosaic
-  use mosaic2_mod, only: get_mosaic_ntiles, get_mosaic_ncontacts, &
-                      get_mosaic_grid_sizes, get_mosaic_contact, &
-                      get_mosaic_xgrid_size, get_mosaic_xgrid, &
-                      calc_mosaic_grid_area, calc_mosaic_grid_great_circle_area, &
-                      is_inside_polygon, &
-                      mosaic2_get_mosaic_tile_grid => get_mosaic_tile_grid !overloaded in fms2_io
-  use grid2_mod, only: get_grid_ntiles, get_grid_size, get_grid_cell_centers, &
-                      get_grid_cell_vertices, get_grid_cell_Area, get_grid_comp_area, &
-                      define_cube_mosaic, get_great_circle_algorithm, grid_init, grid_end
-  use gradient_mod, only: gradient_cubic, calc_cubic_grid_info
+  use mosaic2_mod, only: fms_mosaic2_get_mosaic_ntiles => get_mosaic_ntiles, &
+                      fms_mosaic2_get_mosaic_ncontacts => get_mosaic_ncontacts, &
+                      fms_mosaic2_get_mosaic_grid_sizes => get_mosaic_grid_sizes, &
+                      fms_mosaic2_get_mosaic_contact => get_mosaic_contact, &
+                      fms_mosaic2_get_mosaic_xgrid_size => get_mosaic_xgrid_size, &
+                      fms_mosaic2_get_mosaic_xgrid => get_mosaic_xgrid, &
+                      fms_mosaic2_calc_mosaic_grid_area => calc_mosaic_grid_area, &
+                      fms_mosaic2_calc_mosaic_grid_great_circle_area => calc_mosaic_grid_great_circle_area, &
+                      fms_mosaic2_is_inside_polygon => is_inside_polygon, &
+                      fms_mosaic2_get_mosaic_tile_grid => get_mosaic_tile_grid !overloaded in fms2_io
+  use grid2_mod, only: fms_grid2_get_grid_ntiles => get_grid_ntiles, &
+                       fms_grid2_get_grid_size => get_grid_size, &
+                       fms_grid2_get_grid_cell_centers => get_grid_cell_centers, &
+                       fms_grid2_get_grid_cell_vertices => get_grid_cell_vertices, &
+                       fms_grid2_get_grid_cell_Area => get_grid_cell_Area, &
+                       fms_grid2_get_grid_comp_area => get_grid_comp_area, &
+                       fms_grid2_define_cube_mosaic => define_cube_mosaic, &
+                       fms_grid2_get_great_circle_algorithm => get_great_circle_algorithm, &
+                       fms_grid2_grid_init => grid_init, &
+                       fms_grid2_end => grid_end
+  use gradient_mod, only: fms_gradient_cubic => gradient_cubic, &
+                          fms_gradient_calc_cubic_grid_info => calc_cubic_grid_info
 
   !> mpp
-  use mpp_mod, only: stdin, stdout, stderr, &
-                     stdlog, lowercase, uppercase, mpp_error, mpp_error_state, &
-                     mpp_set_warn_level, mpp_sync, mpp_sync_self, mpp_set_stack_size, &
-                     mpp_pe, mpp_npes, mpp_root_pe, mpp_set_root_pe, mpp_declare_pelist, &
-                     mpp_get_current_pelist, mpp_set_current_pelist, &
-                     mpp_get_current_pelist_name, mpp_clock_id, mpp_clock_set_grain, &
-                     mpp_record_timing_data, get_unit, read_ascii_file, read_input_nml, &
-                     mpp_clock_begin, mpp_clock_end, get_ascii_file_num_lines, &
-                     mpp_record_time_start, mpp_record_time_end, mpp_chksum, &
-                     mpp_max, mpp_min, mpp_sum, mpp_transmit, mpp_send, mpp_recv, &
-                     mpp_sum_ad, mpp_broadcast, mpp_init, mpp_exit, mpp_gather, &
-                     mpp_scatter, mpp_alltoall, mpp_type, mpp_byte, mpp_type_create, &
-                     mpp_type_free, input_nml_file
+  use mpp_mod, only: fms_mpp_stdin => stdin, &
+                     fms_mpp_stdout => stdout, &
+                     fms_mpp_stderr => stderr, &
+                     fms_mpp_stdlog => stdlog, &
+                     fms_mpp_lowercase => lowercase, &
+                     fms_mpp_uppercase => uppercase, &
+                     fms_mpp_error => mpp_error, &
+                     fms_mpp_error_state => mpp_error_state, &
+                     fms_mpp_set_warn_level => mpp_set_warn_level, &
+                     fms_mpp_sync => mpp_sync, &
+                     fms_mpp_sync_self => mpp_sync_self, &
+                     fms_mpp_set_stack_size => mpp_set_stack_size, &
+                     fms_mpp_pe => mpp_pe, &
+                     fms_mpp_npes => mpp_npes, &
+                     fms_mpp_root_pe => mpp_root_pe, &
+                     fms_mpp_set_root_pe => mpp_set_root_pe, &
+                     fms_mpp_declare_pelist => mpp_declare_pelist, &
+                     fms_mpp_get_current_pelist => mpp_get_current_pelist, &
+                     fms_mpp_set_current_pelist => mpp_set_current_pelist, &
+                     fms_mpp_get_current_pelist_name => mpp_get_current_pelist_name, &
+                     fms_mpp_clock_id => mpp_clock_id, &
+                     fms_mpp_clock_set_grain => mpp_clock_set_grain, &
+                     fms_mpp_record_timing_data => mpp_record_timing_data, &
+                     fms_mpp_get_unit => get_unit, &
+                     fms_mpp_read_ascii_file => read_ascii_file, &
+                     fms_mpp_read_input_nml => read_input_nml, &
+                     fms_mpp_clock_begin => mpp_clock_begin, &
+                     fms_mpp_clock_end => mpp_clock_end, &
+                     fms_mpp_get_ascii_file_num_lines => get_ascii_file_num_lines, &
+                     fms_mpp_record_time_start => mpp_record_time_start, &
+                     fms_mpp_record_time_end => mpp_record_time_end, &
+                     fms_mpp_chksum => mpp_chksum, &
+                     fms_mpp_max => mpp_max, &
+                     fms_mpp_min => mpp_min, &
+                     fms_mpp_sum => mpp_sum, &
+                     fms_mpp_transmit => mpp_transmit, &
+                     fms_mpp_send => mpp_send, &
+                     fms_mpp_recv => mpp_recv, &
+                     fms_mpp_sum_ad => mpp_sum_ad, &
+                     fms_mpp_broadcast => mpp_broadcast, &
+                     fms_mpp_init => mpp_init, &
+                     fms_mpp_exit => mpp_exit, &
+                     fms_mpp_gather => mpp_gather, &
+                     fms_mpp_scatter => mpp_scatter, &
+                     fms_mpp_alltoall => mpp_alltoall, &
+                     fms_mpp_type => mpp_type, &
+                     fms_mpp_byte => mpp_byte, &
+                     fms_mpp_type_create => mpp_type_create, &
+                     fms_mpp_type_free => mpp_type_free, &
+                     fms_mpp_input_nml_file => input_nml_file
   use mpp_parameter_mod,only:MAXPES, MPP_VERBOSE, MPP_DEBUG, ALL_PES, ANY_PE, NULL_PE, &
                      NOTE, WARNING, FATAL, MPP_WAIT, MPP_READY, MAX_CLOCKS, &
                      MAX_EVENT_TYPES, MAX_EVENTS, MPP_CLOCK_SYNC, MPP_CLOCK_DETAILED, &
@@ -405,74 +543,161 @@ module fms
                      MAX_DOMAIN_FIELDS, MAX_TILES, ZERO, NINETY, MINUS_NINETY, &
                      ONE_HUNDRED_EIGHTY, NONBLOCK_UPDATE_TAG, EDGEUPDATE, EDGEONLY, &
                      NONSYMEDGEUPDATE, NONSYMEDGE
-  use mpp_data_mod, only: stat, mpp_stack, ptr_stack, status, ptr_status, sync, &
-                     ptr_sync, mpp_from_pe, ptr_from, remote_Data_loc, &
-                     ptr_remote, mpp_domains_stack, ptr_domains_stack, &
-                     mpp_domains_stack_nonblock, ptr_domains_stack_nonblock
-  use mpp_utilities_mod, only: mpp_array_global_min_max
-  use mpp_memutils_mod, only: mpp_print_memuse_stats, mpp_mem_dump, &
-                     mpp_memuse_begin, mpp_memuse_end
-  use mpp_efp_mod, only: mpp_reproducing_sum, mpp_efp_list_sum_across_PEs, &
-                     mpp_efp_plus, mpp_efp_minus, mpp_efp_to_real, &
-                     mpp_real_to_efp, mpp_efp_real_diff, operator(+), &
-                     operator(-), assignment(=), mpp_query_efp_overflow_error, &
-                     mpp_reset_efp_overflow_error, mpp_efp_type
-  use mpp_domains_mod, only: domain_axis_spec, domain1D, domain2D, DomainCommunicator2D, &
-                     nest_domain_type, mpp_group_update_type, &
-                     mpp_domains_set_stack_size, mpp_get_compute_domain, &
-                     mpp_get_compute_domains, mpp_get_data_domain, &
-                     mpp_get_global_domain, mpp_get_domain_components, &
-                     mpp_get_layout, mpp_get_pelist, operator(.EQ.), operator(.NE.), &
-                     mpp_domain_is_symmetry, mpp_domain_is_initialized, &
-                     mpp_get_neighbor_pe, mpp_nullify_domain_list, &
-                     mpp_set_compute_domain, mpp_set_data_domain, mpp_set_global_domain, &
-                     mpp_get_memory_domain, mpp_get_domain_shift, &
-                     mpp_domain_is_tile_root_pe, mpp_get_tile_id, &
-                     mpp_get_domain_extents, mpp_get_current_ntile, &
-                     mpp_get_ntile_count, mpp_get_tile_list, mpp_get_tile_npes, &
-                     mpp_get_domain_root_pe, mpp_get_tile_pelist, &
-                     mpp_get_tile_compute_domains, mpp_get_num_overlap, &
-                     mpp_get_overlap, mpp_get_io_domain, mpp_get_domain_pe, &
-                     mpp_get_domain_tile_root_pe, mpp_get_domain_name, &
-                     mpp_get_io_domain_layout, mpp_copy_domain, mpp_set_domain_symmetry, &
-                     mpp_get_update_pelist, mpp_get_update_size, &
-                     mpp_get_domain_npes, mpp_get_domain_pelist, &
-                     mpp_clear_group_update, mpp_group_update_initialized, &
-                     mpp_group_update_is_set, mpp_get_global_domains, &
-                     mpp_global_field, mpp_global_max, mpp_global_min, mpp_global_sum, &
-                     mpp_global_sum_tl, mpp_global_sum_ad, mpp_broadcast_domain, &
-                     mpp_domains_init, mpp_domains_exit, mpp_redistribute, &
-                     mpp_update_domains, mpp_check_field, mpp_start_update_domains, &
-                     mpp_complete_update_domains, mpp_create_group_update, &
-                     mpp_do_group_update, mpp_start_group_update, &
-                     mpp_complete_group_update, mpp_reset_group_update_field, &
-                     mpp_update_nest_fine, mpp_update_nest_coarse, mpp_get_boundary, &
-                     mpp_update_domains_ad, mpp_get_boundary_ad, mpp_pass_SG_to_UG, &
-                     mpp_pass_UG_to_SG, mpp_define_layout, mpp_define_domains, &
-                     mpp_modify_domain, mpp_define_mosaic, mpp_define_mosaic_pelist, &
-                     mpp_define_null_domain, mpp_mosaic_defined, &
-                     mpp_define_io_domain, mpp_deallocate_domain, &
-                     mpp_compute_extent, mpp_compute_block_extent, &
-                     mpp_define_unstruct_domain, domainUG, mpp_get_UG_io_domain, &
-                     mpp_get_UG_domain_npes, mpp_get_UG_compute_domain, &
-                     mpp_get_UG_domain_tile_id, mpp_get_UG_domain_pelist, &
-                     mpp_get_ug_domain_grid_index, mpp_get_UG_domain_ntiles, &
-                     mpp_get_UG_global_domain, mpp_global_field_ug, &
-                     mpp_get_ug_domain_tile_list, mpp_get_UG_compute_domains, &
-                     mpp_define_null_UG_domain, NULL_DOMAINUG, mpp_get_UG_domains_index, &
-                     mpp_get_UG_SG_domain, mpp_get_UG_domain_tile_pe_inf, &
-                     mpp_define_nest_domains, mpp_get_C2F_index, mpp_get_F2C_index, &
-                     mpp_get_nest_coarse_domain, mpp_get_nest_fine_domain, &
-                     mpp_is_nest_coarse, mpp_is_nest_fine, &
-                     mpp_get_nest_pelist, mpp_get_nest_npes, &
-                     mpp_get_nest_fine_pelist, mpp_get_nest_fine_npes, &
-                     mpp_domain_UG_is_tile_root_pe, mpp_deallocate_domainUG, &
-                     mpp_get_io_domain_UG_layout, NULL_DOMAIN1D, NULL_DOMAIN2D, &
-                     mpp_create_super_grid_domain, mpp_shift_nest_domains
+  ! this should really only be used internally
+  !use mpp_data_mod, only: stat, mpp_stack, ptr_stack, status, ptr_status, sync, &
+  !                   ptr_sync, mpp_from_pe, ptr_from, remote_Data_loc, &
+  !                   ptr_remote, mpp_domains_stack, ptr_domains_stack, &
+  !                   mpp_domains_stack_nonblock, ptr_domains_stack_nonblock
+  use mpp_utilities_mod, only: fms_mpp_utilities_array_global_min_max => mpp_array_global_min_max
+  use mpp_memutils_mod, only: fms_mpp_memutils_print_memuse_stats => mpp_print_memuse_stats, &
+                              fms_mpp_memutils_mem_dump => mpp_mem_dump, &
+                              fms_mpp_memutils_memuse_begin => mpp_memuse_begin, &
+                              fms_mpp_memutils_memuse_end => mpp_memuse_end
+  use mpp_efp_mod, only: fms_mpp_efp_reproducing_sum => mpp_reproducing_sum, &
+                         fms_mpp_efp_list_sum_across_PEs => mpp_efp_list_sum_across_PEs, &
+                         fms_mpp_efp_plus => mpp_efp_plus, &
+                         fms_mpp_efp_minus => mpp_efp_minus, &
+                         fms_mpp_efp_to_real => mpp_efp_to_real, &
+                         fms_mpp_efp_real_to_efp => mpp_real_to_efp, &
+                         fms_mpp_efp_real_diff => mpp_efp_real_diff, &
+                         operator(+), operator(-), assignment(=), &
+                         fms_mpp_efp_query_efp_overflow_error => mpp_query_efp_overflow_error, &
+                         fms_mpp_efp_reset_efp_overflow_error => mpp_reset_efp_overflow_error, &
+                         fms_mpp_efp_type => mpp_efp_type
+  use mpp_domains_mod, only: fms_mpp_domains_domain_axis_spec => domain_axis_spec, &
+                             fms_mpp_domains_domain1D => domain1D, &
+                             fms_mpp_domains_domain2D => domain2D, &
+                             fms_mpp_domains_DomainCommunicator2D => DomainCommunicator2D, &
+                             fms_mpp_domains_nest_domain_type => nest_domain_type, &
+                             fms_mpp_domains_group_update_type => mpp_group_update_type, &
+                             fms_mpp_domains_domains_set_stack_size => mpp_domains_set_stack_size, &
+                             fms_mpp_domains_get_compute_domain => mpp_get_compute_domain, &
+                             fms_mpp_domains_get_compute_domains => mpp_get_compute_domains, &
+                             fms_mpp_domains_get_data_domain => mpp_get_data_domain, &
+                             fms_mpp_domains_get_global_domain => mpp_get_global_domain, &
+                             fms_mpp_domains_get_domain_components => mpp_get_domain_components, &
+                             fms_mpp_domains_get_layout => mpp_get_layout, &
+                             fms_mpp_domains_get_pelist => mpp_get_pelist, &
+                             operator(.EQ.), operator(.NE.), &
+                             fms_mpp_domains_domain_is_symmetry => mpp_domain_is_symmetry, &
+                             fms_mpp_domains_domain_is_initialized => mpp_domain_is_initialized, &
+                             fms_mpp_domains_get_neighbor_pe => mpp_get_neighbor_pe, &
+                             fms_mpp_domains_nullify_domain_list => mpp_nullify_domain_list, &
+                             fms_mpp_domains_set_compute_domain => mpp_set_compute_domain, &
+                             fms_mpp_domains_set_data_domain => mpp_set_data_domain, &
+                             fms_mpp_domains_set_global_domain => mpp_set_global_domain, &
+                             fms_mpp_domains_get_memory_domain => mpp_get_memory_domain, &
+                             fms_mpp_domains_get_domain_shift => mpp_get_domain_shift, &
+                             fms_mpp_domains_domain_is_tile_root_pe => mpp_domain_is_tile_root_pe, &
+                             fms_mpp_domains_get_tile_id => mpp_get_tile_id, &
+                             fms_mpp_domains_get_domain_extents => mpp_get_domain_extents, &
+                             fms_mpp_domains_get_current_ntile => mpp_get_current_ntile, &
+                             fms_mpp_domains_get_ntile_count => mpp_get_ntile_count, &
+                             fms_mpp_domains_get_tile_list => mpp_get_tile_list, &
+                             fms_mpp_domains_get_tile_npes => mpp_get_tile_npes, &
+                             fms_mpp_domains_get_domain_root_pe => mpp_get_domain_root_pe, &
+                             fms_mpp_domains_get_tile_pelist => mpp_get_tile_pelist, &
+                             fms_mpp_domains_get_tile_compute_domains => mpp_get_tile_compute_domains, &
+                             fms_mpp_domains_get_num_overlap => mpp_get_num_overlap, &
+                             fms_mpp_domains_get_overlap => mpp_get_overlap, &
+                             fms_mpp_domains_get_io_domain => mpp_get_io_domain, &
+                             fms_mpp_domains_get_domain_pe => mpp_get_domain_pe, &
+                             fms_mpp_domains_get_domain_tile_root_pe => mpp_get_domain_tile_root_pe, &
+                             fms_mpp_domains_get_domain_name => mpp_get_domain_name, &
+                             fms_mpp_domains_get_io_domain_layout => mpp_get_io_domain_layout, &
+                             fms_mpp_domains_copy_domain => mpp_copy_domain, &
+                             fms_mpp_domains_set_domain_symmetry => mpp_set_domain_symmetry, &
+                             fms_mpp_domains_get_update_pelist => mpp_get_update_pelist, &
+                             fms_mpp_domains_get_update_size => mpp_get_update_size, &
+                             fms_mpp_domains_get_domain_npes => mpp_get_domain_npes, &
+                             fms_mpp_domains_get_domain_pelist => mpp_get_domain_pelist, &
+                             fms_mpp_domains_clear_group_update => mpp_clear_group_update, &
+                             fms_mpp_domains_group_update_initialized => mpp_group_update_initialized, &
+                             fms_mpp_domains_group_update_is_set => mpp_group_update_is_set, &
+                             fms_mpp_domains_get_global_domains => mpp_get_global_domains, &
+                             fms_mpp_domains_global_field => mpp_global_field, &
+                             fms_mpp_domains_global_max => mpp_global_max, &
+                             fms_mpp_domains_global_min => mpp_global_min, &
+                             fms_mpp_domains_global_sum => mpp_global_sum, &
+                             fms_mpp_domains_global_sum_tl => mpp_global_sum_tl, &
+                             fms_mpp_domains_global_sum_ad => mpp_global_sum_ad, &
+                             fms_mpp_domains_broadcast_domain => mpp_broadcast_domain, &
+                             fms_mpp_domains_domains_init => mpp_domains_init, &
+                             fms_mpp_domains_domains_exit => mpp_domains_exit, &
+                             fms_mpp_domains_redistribute => mpp_redistribute, &
+                             fms_mpp_domains_update_domains => mpp_update_domains, &
+                             fms_mpp_domains_check_field => mpp_check_field, &
+                             fms_mpp_domains_start_update_domains => mpp_start_update_domains, &
+                             fms_mpp_domains_complete_update_domains => mpp_complete_update_domains, &
+                             fms_mpp_domains_create_group_update => mpp_create_group_update, &
+                             fms_mpp_domains_do_group_update => mpp_do_group_update, &
+                             fms_mpp_domains_start_group_update => mpp_start_group_update, &
+                             fms_mpp_domains_complete_group_update => mpp_complete_group_update, &
+                             fms_mpp_domains_reset_group_update_field => mpp_reset_group_update_field, &
+                             fms_mpp_domains_update_nest_fine => mpp_update_nest_fine, &
+                             fms_mpp_domains_update_nest_coarse => mpp_update_nest_coarse, &
+                             fms_mpp_domains_get_boundary => mpp_get_boundary, &
+                             fms_mpp_domains_update_domains_ad => mpp_update_domains_ad, &
+                             fms_mpp_domains_get_boundary_ad => mpp_get_boundary_ad, &
+                             fms_mpp_domains_pass_SG_to_UG => mpp_pass_SG_to_UG, &
+                             fms_mpp_domains_pass_UG_to_SG => mpp_pass_UG_to_SG, &
+                             fms_mpp_domains_define_layout => mpp_define_layout, &
+                             fms_mpp_domains_define_domains => mpp_define_domains, &
+                             fms_mpp_domains_modify_domain => mpp_modify_domain, &
+                             fms_mpp_domains_define_mosaic => mpp_define_mosaic, &
+                             fms_mpp_domains_define_mosaic_pelist => mpp_define_mosaic_pelist, &
+                             fms_mpp_domains_define_null_domain => mpp_define_null_domain, &
+                             fms_mpp_domains_mosaic_defined => mpp_mosaic_defined, &
+                             fms_mpp_domains_define_io_domain => mpp_define_io_domain, &
+                             fms_mpp_domains_deallocate_domain => mpp_deallocate_domain, &
+                             fms_mpp_domains_compute_extent => mpp_compute_extent, &
+                             fms_mpp_domains_compute_block_extent => mpp_compute_block_extent, &
+                             fms_mpp_domains_define_unstruct_domain => mpp_define_unstruct_domain, &
+                             fms_mpp_domains_domainUG => domainUG, &
+                             fms_mpp_domains_get_UG_io_domain => mpp_get_UG_io_domain, &
+                             fms_mpp_domains_get_UG_domain_npes => mpp_get_UG_domain_npes, &
+                             fms_mpp_domains_get_UG_compute_domain => mpp_get_UG_compute_domain, &
+                             fms_mpp_domains_get_UG_domain_tile_id => mpp_get_UG_domain_tile_id, &
+                             fms_mpp_domains_get_UG_domain_pelist => mpp_get_UG_domain_pelist, &
+                             fms_mpp_domains_get_ug_domain_grid_index => mpp_get_ug_domain_grid_index, &
+                             fms_mpp_domains_get_UG_domain_ntiles => mpp_get_UG_domain_ntiles, &
+                             fms_mpp_domains_get_UG_global_domain => mpp_get_UG_global_domain, &
+                             fms_mpp_domains_global_field_ug => mpp_global_field_ug, &
+                             fms_mpp_domains_get_ug_domain_tile_list => mpp_get_ug_domain_tile_list, &
+                             fms_mpp_domains_get_UG_compute_domains => mpp_get_UG_compute_domains, &
+                             fms_mpp_domains_define_null_UG_domain => mpp_define_null_UG_domain, &
+                             fms_mpp_domains_NULL_DOMAINUG => NULL_DOMAINUG, &
+                             fms_mpp_domains_get_UG_domains_index => mpp_get_UG_domains_index, &
+                             fms_mpp_domains_get_UG_SG_domain => mpp_get_UG_SG_domain, &
+                             fms_mpp_domains_get_UG_domain_tile_pe_inf => mpp_get_UG_domain_tile_pe_inf, &
+                             fms_mpp_domains_define_nest_domains => mpp_define_nest_domains, &
+                             fms_mpp_domains_get_C2F_index => mpp_get_C2F_index, &
+                             fms_mpp_domains_get_F2C_index => mpp_get_F2C_index, &
+                             fms_mpp_domains_get_nest_coarse_domain => mpp_get_nest_coarse_domain, &
+                             fms_mpp_domains_get_nest_fine_domain => mpp_get_nest_fine_domain, &
+                             fms_mpp_domains_is_nest_coarse => mpp_is_nest_coarse, &
+                             fms_mpp_domains_is_nest_fine => mpp_is_nest_fine, &
+                             fms_mpp_domains_get_nest_pelist => mpp_get_nest_pelist, &
+                             fms_mpp_domains_get_nest_npes => mpp_get_nest_npes, &
+                             fms_mpp_domains_get_nest_fine_pelist => mpp_get_nest_fine_pelist, &
+                             fms_mpp_domains_get_nest_fine_npes => mpp_get_nest_fine_npes, &
+                             fms_mpp_domains_domain_UG_is_tile_root_pe => mpp_domain_UG_is_tile_root_pe, &
+                             fms_mpp_domains_deallocate_domainUG => mpp_deallocate_domainUG, &
+                             fms_mpp_domains_get_io_domain_UG_layout => mpp_get_io_domain_UG_layout, &
+                             fms_mpp_domains_NULL_DOMAIN1D => NULL_DOMAIN1D, &
+                             fms_mpp_domains_NULL_DOMAIN2D => NULL_DOMAIN2D, &
+                             fms_mpp_domains_create_super_grid_domain => mpp_create_super_grid_domain, &
+                             fms_mpp_domains_shift_nest_domains => mpp_shift_nest_domains
   !> parser
 #ifdef use_yaml
-  use yaml_parser_mod, only: open_and_parse_file, get_num_blocks, get_block_ids, get_value_from_key, &
-                        get_nkeys, get_key_ids, get_key_name, get_key_value
+  use yaml_parser_mod, only: fms_yaml_parser_open_and_parse_file => open_and_parse_file, &
+                             fms_yaml_parser_get_num_blocks => get_num_blocks, &
+                             fms_yaml_parser_get_block_ids => get_block_ids, &
+                             fms_yaml_parser_get_value_from_key => get_value_from_key, &
+                             fms_yaml_parser_get_nkeys => get_nkeys, &
+                             fms_yaml_get_key_ids => get_key_ids, &
+                             fms_yaml_get_key_name => get_key_name, &
+                             fms_yaml_get_key_value => get_key_value
 #endif
 
   !> platform
@@ -480,64 +705,121 @@ module fms
                           l8_kind, l4_kind, i2_kind, ptr_kind
 
   !> random_numbers
-  use random_numbers_mod, only: randomNumberStream, initializeRandomNumberStream, &
-                                getRandomNumbers, constructSeed
+  use random_numbers_mod, only: fms_random_numbers_randomNumberStream => randomNumberStream, &
+                                fms_random_numbers_initializeRandomNumbersStream => initializeRandomNumberStream, &
+                                fms_random_numbers_getRandomNumbers => getRandomNumbers, &
+                                fms_random_numbers_constructSeed => constructSeed
 
   !> sat_vapor_pres
-  use sat_vapor_pres_mod, only: lookup_es, lookup_des, sat_vapor_pres_init, &
-                                lookup_es2, lookup_des2, lookup_es2_des2, &
-                                lookup_es3, lookup_des3, lookup_es3_des3, &
-                                lookup_es_des, compute_qs, compute_mrs, &
-                                escomp, descomp
+  use sat_vapor_pres_mod, only: fms_sat_vapor_pres_lookup_es => lookup_es, &
+                                fms_sat_vapor_pres_lookup_des => lookup_des, &
+                                fms_sat_vapor_pres_sat_vapor_pres_init => sat_vapor_pres_init, &
+                                fms_sat_vapor_pres_lookup_es2 => lookup_es2, &
+                                fms_sat_vapor_pres_lookup_des2 => lookup_des2, &
+                                fms_sat_vapor_pres_lookup_es2_des2 => lookup_es2_des2, &
+                                fms_sat_vapor_pres_lookup_es3 => lookup_es3, &
+                                fms_sat_vapor_pres_lookup_des3 => lookup_des3, &
+                                fms_sat_vapor_pres_lookup_es3_des3 => lookup_es3_des3, &
+                                fms_sat_vapor_pres_lookup_es_des => lookup_es_des, &
+                                fms_sat_vapor_pres_compute_qs => compute_qs, &
+                                fms_sat_vapor_pres_compute_mrs => compute_mrs, &
+                                fms_sat_vapor_pres_escomp => escomp, &
+                                fms_sat_vapor_pres_descomp => descomp
   !> string_utils
-  use fms_string_utils_mod, only: string, fms_array_to_pointer, fms_pointer_to_array, fms_sort_this, &
+  use fms_string_utils_mod, only: fms_string_utils_string => string, &
+                                  fms_string_utils_array_to_pointer => fms_array_to_pointer, &
+                                  fms_string_utils_fms_pointer_to_array => fms_pointer_to_array, &
+                                  fms_sort_this, &
                                   fms_find_my_string, fms_find_unique, fms_c2f_string, fms_cstring2cpointer, &
                                   string_copy
 
   !> time_interp
-  use time_interp_mod, only: time_interp_init, time_interp, fraction_of_year, &
+  use time_interp_mod, only: fms_time_interp_init => time_interp_init, &
+                             fms_time_interp => time_interp, fms_fraction_of_year=> fraction_of_year, &
                              NONE, YEAR, MONTH, DAY
-  use time_interp_external2_mod, only: init_external_field, time_interp_external, &
-                             time_interp_external_init, time_interp_external_exit, &
-                             get_external_field_size, get_time_axis, &
-                             get_external_field_missing, set_override_region, &
-                             reset_src_data_region, get_external_fileobj, &
+  use time_interp_external2_mod, only: fms_time_interp_external_init_external_field => init_external_field, &
+                             fms_time_interp_external => time_interp_external, &
+                             fms_time_interp_external_init => time_interp_external_init, &
+                             fms_time_interp_external_exit => time_interp_external_exit, &
+                             fms_time_interp_external_get_external_field_size => get_external_field_size, &
+                             fms_time_interp_external_get_time_axis => get_time_axis, &
+                             fms_time_interp_external_get_external_field_missing => get_external_field_missing, &
+                             fms_time_interp_external_set_override_region => set_override_region, &
+                             fms_time_interp_external_reset_src_data_region => reset_src_data_region, &
+                             fms_time_interp_external_get_external_fileobj => get_external_fileobj, &
                              NO_REGION, INSIDE_REGION, OUTSIDE_REGION, &
                              SUCCESS, ERR_FIELD_NOT_FOUND
 
   !> time_manager
-  use time_manager_mod, only: time_type, operator(+), operator(-), operator(*), &
+  use time_manager_mod, only: fms_time_type => time_type, &
+                              operator(+), operator(-), operator(*), assignment(=),&
                               operator(/), operator(>), operator(>=), operator(==), &
                               operator(/=), operator(<), operator(<=), operator(//), &
-                              assignment(=), set_time, increment_time, decrement_time, &
-                              get_time, interval_alarm, repeat_alarm, time_type_to_real, &
-                              real_to_time_type, time_list_error, THIRTY_DAY_MONTHS, &
-                              JULIAN, GREGORIAN, NOLEAP, NO_CALENDAR, INVALID_CALENDAR, &
-                              set_calendar_type, get_calendar_type, set_ticks_per_second, &
-                              get_ticks_per_second, set_date, get_date, increment_date, &
-                              decrement_date, days_in_month, leap_year, length_of_year, &
-                              days_in_year, day_of_year, month_name, valid_calendar_types, &
-                              time_manager_init, print_time, print_date, set_date_julian, &
-                              get_date_julian, get_date_no_leap, date_to_string
-  use get_cal_time_mod, only: get_cal_time
+                              fms_time_manager_set_time => set_time, &
+                              fms_time_manager_increment_time => increment_time, &
+                              fms_time_manager_decrement_time => decrement_time, &
+                              fms_time_manager_get_time => get_time, &
+                              fms_time_manager_interval_alarm => interval_alarm, &
+                              fms_time_manager_repeat_alarm => repeat_alarm, &
+                              fms_time_manager_time_type_to_real => time_type_to_real, &
+                              fms_time_manager_real_to_time_type => real_to_time_type, &
+                              fms_time_manager_time_list_error => time_list_error, &
+                              THIRTY_DAY_MONTHS, JULIAN, GREGORIAN, NOLEAP, NO_CALENDAR, INVALID_CALENDAR, &
+                              fms_time_manager_set_calendar_type => set_calendar_type, &
+                              fms_time_manager_get_calendar_type => get_calendar_type, &
+                              fms_time_manager_set_ticks_per_second => set_ticks_per_second, &
+                              fms_time_manager_get_ticks_per_second => get_ticks_per_second, &
+                              fms_time_manager_set_date => set_date, &
+                              fms_time_manager_get_date => get_date, &
+                              fms_time_manager_increment_date => increment_date, &
+                              fms_time_manager_decrement_date => decrement_date, &
+                              fms_time_manager_days_in_month => days_in_month, &
+                              fms_time_manager_leap_year => leap_year, &
+                              fms_time_manager_length_of_year => length_of_year, &
+                              fms_time_manager_days_in_year => days_in_year, &
+                              fms_time_manager_day_of_year => day_of_year, &
+                              fms_time_manager_month_name => month_name, &
+                              fms_time_manager_valid_calendar_types => valid_calendar_types, &
+                              fms_time_manager_init => time_manager_init, &
+                              fms_time_manager_print_time => print_time, &
+                              fms_time_manager_print_date => print_date, &
+                              fms_time_manager_set_date_julian => set_date_julian, &
+                              fms_time_manager_get_date_julian => get_date_julian, &
+                              fms_time_manager_get_date_no_leap => get_date_no_leap, &
+                              fms_time_manager_date_to_string => date_to_string
+  use get_cal_time_mod, only: fms_get_cal_time => get_cal_time
 
   !> topography
-  use gaussian_topog_mod, only: gaussian_topog_init, get_gaussian_topog
-  use topography_mod, only: topography_init, get_topog_mean, get_topog_stdev, &
-                            get_ocean_frac, get_ocean_mask, get_water_frac, &
-                            get_water_mask
+  use gaussian_topog_mod, only: fms_gaussian_topog_init => gaussian_topog_init, &
+                                fms_get_gaussian_topog => get_gaussian_topog
+  use topography_mod, only: fms_topography_init => topography_init, &
+                            fms_topography_get_topog_mean => get_topog_mean, &
+                            fms_topography_get_topog_stdev => get_topog_stdev, &
+                            fms_topography_get_ocean_frac => get_ocean_frac, &
+                            fms_topography_get_ocean_mask => get_ocean_mask, &
+                            fms_topography_get_water_frac => get_water_frac, &
+                            fms_topography_get_water_mask => get_water_mask
 
   !> tracer_manager
-  use tracer_manager_mod, only: tracer_manager_init, tracer_manager_end, &
-                                check_if_prognostic, get_tracer_indices,  &
-                                get_tracer_index, get_tracer_names, &
-                                get_tracer_name, query_method, &
-                                set_tracer_atts, set_tracer_profile, &
-                                register_tracers, get_number_tracers,  &
-                                adjust_mass, adjust_positive_def, NO_TRACER, MAX_TRACER_FIELDS
+  use tracer_manager_mod, only: fms_tracer_manager_init => tracer_manager_init, &
+                                fms_tracer_manager_end => tracer_manager_end, &
+                                fms_tracer_manager_check_if_prognostic => check_if_prognostic, &
+                                fms_tracer_manager_get_tracer_indices => get_tracer_indices, &
+                                fms_tracer_manager_get_tracer_index => get_tracer_index, &
+                                fms_tracer_manager_get_tracer_names => get_tracer_names, &
+                                fms_tracer_manager_get_tracer_name => get_tracer_name, &
+                                fms_tracer_manager_query_method => query_method, &
+                                fms_tracer_manager_set_tracer_atts => set_tracer_atts, &
+                                fms_tracer_manager_set_tracer_profile => set_tracer_profile, &
+                                fms_tracer_manager_register_tracers => register_tracers, &
+                                fms_tracer_manager_get_number_tracers => get_number_tracers, &
+                                fms_tracer_manager_adjust_mass => adjust_mass, &
+                                fms_tracer_manager_adjust_positive_def => adjust_positive_def, &
+                                NO_TRACER, MAX_TRACER_FIELDS
 
   !> tridiagonal
-  use tridiagonal_mod, only: tri_invert, close_tridiagonal
+  use tridiagonal_mod, only: fms_tridiagonal_tri_invert => tri_invert, &
+                             fms_tridiagonal_close_tridiagonal => close_tridiagonal
 
   implicit none
 

--- a/libFMS.F90
+++ b/libFMS.F90
@@ -189,16 +189,16 @@ module fms
 
   !> diag_manager
   !! includes imports from submodules made public
-  use diag_manager_mod, only: fms_diag_manager_init => diag_manager_init, &
-                              fms_diag_manager_send_data => send_data, &
-                              fms_diag_manager_send_tile_averaged_data => send_tile_averaged_data, &
-                              fms_diag_manager_end => diag_manager_end, &
-                              fms_diag_manager_register_diag_field => register_diag_field, &
-                              fms_diag_manager_register_static_field => register_static_field, &
-                              fms_diag_manager_diag_axis_init => diag_axis_init, &
-                              fms_diag_manager_get_base_time => get_base_time, &
-                              fms_diag_manager_get_base_date => get_base_date, &
-                              fms_diag_manager_need_data => need_data, &
+  use diag_manager_mod, only: fms_diag_init => diag_manager_init, &
+                              fms_diag_send_data => send_data, &
+                              fms_diag_send_tile_averaged_data => send_tile_averaged_data, &
+                              fms_diag_end => diag_manager_end, &
+                              fms_diag_register_diag_field => register_diag_field, &
+                              fms_diag_register_static_field => register_static_field, &
+                              fms_diag_axis_init => diag_axis_init, &
+                              fms_diag_get_base_time => get_base_time, &
+                              fms_diag_get_base_date => get_base_date, &
+                              fms_diag_need_data => need_data, &
                               DIAG_ALL, &
                               DIAG_OCEAN, &
                               DIAG_OTHER, &
@@ -209,17 +209,17 @@ module fms
                               DIAG_DAYS, &
                               DIAG_MONTHS, &
                               DIAG_YEARS, &
-                              fms_diag_manager_get_diag_global_att => get_diag_global_att, &
-                              fms_diag_manager_set_diag_global_att => set_diag_global_att, &
-                              fms_diag_manager_diag_field_add_attribute => diag_field_add_attribute, &
-                              fms_diag_manager_diag_field_add_cell_measures => diag_field_add_cell_measures, &
-                              fms_diag_manager_get_diag_field_id => get_diag_field_id, &
-                              fms_diag_manager_diag_axis_add_attribute => diag_axis_add_attribute, &
-                              fms_diag_manager_diag_grid_init => diag_grid_init, &
-                              fms_diag_manager_diag_grid_end => diag_grid_end, &
-                              fms_diag_manager_set_time_end => diag_manager_set_time_end, &
-                              fms_diag_manager_diag_send_complete => diag_send_complete, &
-                              fms_diag_manager_diag_send_complete_instant => diag_send_complete_instant, &
+                              fms_diag_get_global_att => get_diag_global_att, &
+                              fms_diag_set_global_att => set_diag_global_att, &
+                              fms_diag_field_add_attribute => diag_field_add_attribute, &
+                              fms_diag_field_add_cell_measures => diag_field_add_cell_measures, &
+                              fms_diag_get_field_id => get_diag_field_id, &
+                              fms_diag_axis_add_attribute => diag_axis_add_attribute, &
+                              fms_diag_grid_init => diag_grid_init, &
+                              fms_diag_grid_end => diag_grid_end, &
+                              fms_diag_set_time_end => diag_manager_set_time_end, &
+                              fms_diag_send_complete => diag_send_complete, &
+                              fms_diag_send_complete_instant => diag_send_complete_instant, &
                               DIAG_FIELD_NOT_FOUND, &
                               CMOR_MISSING_VALUE, &
                               null_axis_id

--- a/libFMS.F90
+++ b/libFMS.F90
@@ -1,4 +1,4 @@
-***********************************************************************
+!***********************************************************************
 !*                   GNU Lesser General Public License
 !*
 !* This file is part of the GFDL Flexible Modeling System (FMS).
@@ -332,6 +332,7 @@ module fms
   !! types do not follow our typical naming convention(no _type and uses camel case instead of _ spacing)
   use fms2_io_mod, only: unlimited, FmsNetcdfFile_t, FmsNetcdfDomainFile_t, &
                          FmsNetcdfUnstructuredDomainFile_t, &
+                         Valid_t, &
                          fms_fms2_io_open_file => open_file, &
                          fms_fms2_io_open_virtual_file => open_virtual_file, &
                          fms_fms2_io_close_file => close_file, &
@@ -363,7 +364,6 @@ module fms
                          fms_fms2_io_get_variable_size =>   get_variable_size, &
                          fms_fms2_io_get_compute_domain_dimension_indices => get_compute_domain_dimension_indices, &
                          fms_fms2_io_get_global_io_domain_indices => get_global_io_domain_indices, &
-                         d_t, &
                          fms_fms2_io_get_valid => get_valid, &
                          fms_fms2_io_is_valid => is_valid, &
                          fms_fms2_io_get_unlimited_dimension_name => get_unlimited_dimension_name, &

--- a/libFMS.F90
+++ b/libFMS.F90
@@ -34,13 +34,10 @@
 !! Exceptions (mainly for rep:
 !!   - Parameter values are kept their original names
 !!   - If module name is already included (like in init routines) only fms prefix will be added.
-!!   - Similarly if theres a redundant module name included already included it will not be repeated (ie. mpp_update_domains => fms_mpp_domains_update_domains)
+!!   - Similarly if theres a redundant module name included already included it will not be repeated 
+!!     (ie. mpp_update_domains => fms_mpp_domains_update_domains)
 !!
-!! Previous remappings due to conflicts:
-!!
-!!           fms_mosaic_get_mosaic_tile_grid (fms2_io) => mosaic2_get_mosaic_tile_grid
-!!
-!!           read_data from interpolator_mod(fms2_io)   => interpolator_read_data
+!! Remappings due to name conflicts:
 !!
 !!           ZERO from interpolator_mod(mpp_parameter)  => INTERPOLATOR_ZERO
 !!
@@ -74,8 +71,8 @@ module fms
 
   !> amip_interp
   use amip_interp_mod, only: fms_amip_interp_init         => amip_interp_init, &
-                             fms_get_amip_sst             => get_amip_sst, &
-                             fms_get_amip_ice             => get_amip_ice, &
+                             fms_amip_interp_get_amip_sst             => get_amip_sst, &
+                             fms_amio_interp_get_amip_ice             => get_amip_ice, &
                              fms_amip_interp_new          => amip_interp_new, &
                              fms_amip_interp_del          => amip_interp_del, &
                              fms_amip_interp_type         => amip_interp_type, &
@@ -119,9 +116,10 @@ module fms
 
   !> column_diagnostics
   use column_diagnostics_mod, only: fms_column_diagnostics_init        => column_diagnostics_init, &
-                                    fms_initialize_diagnostic_columns  => initialize_diagnostic_columns, &
+                                    fms_column_diagnostics_initialize_diagnostic_columns => &
+                                                                          initialize_diagnostic_columns, &
                                     fms_column_diagnostics_header      => column_diagnostics_header, &
-                                    fms_close_column_diagnostics_units => close_column_diagnostics_units
+                                    fms_column_diagnostics_close_units => close_column_diagnostics_units
 
   !> coupler
   use coupler_types_mod, only: fms_coupler_types_init             => coupler_types_init, &
@@ -166,7 +164,7 @@ module fms
                                fms_coupler_ind_runoff                     => ind_runoff
   use ensemble_manager_mod, only: fms_ensemble_manager_init     => ensemble_manager_init, &
                                fms_ensemble_manager_eget_ensemble_id              => get_ensemble_id, &
-                               fms_ensemble_manager_get_ensemble_size            => get_ensemble_size, & 
+                               fms_ensemble_manager_get_ensemble_size            => get_ensemble_size, &
                                fms_ensemble_manager_get_ensemble_pelist          => get_ensemble_pelist, &
                                fms_ensemble_manager_ensemble_pelist_setup        => ensemble_pelist_setup, &
                                fms_ensemble_manager_get_ensemble_filter_pelist   => get_ensemble_filter_pelist
@@ -248,7 +246,8 @@ module fms
                        fms_xgrid_stock_print => stock_print, &
                        fms_xgrid_get_index_range => get_index_range, &
                        fms_xgrid_stock_integrate_2d => stock_integrate_2d
-  use stock_constants_mod, only: NELEMS, ISTOCK_WATER, ISTOCK_HEAT, ISTOCK_SALT, ISTOCK_TOP, ISTOCK_BOTTOM, ISTOCK_SIDE, &
+  use stock_constants_mod, only: NELEMS, ISTOCK_WATER, ISTOCK_HEAT, ISTOCK_SALT, &
+                       ISTOCK_TOP, ISTOCK_BOTTOM, ISTOCK_SIDE, &
                        fms_stock_constants_stocks_file => stocks_file, &
                        fms_stock_constants_stocks_report => stocks_report, &
                        fms_stocks_report_init => stocks_report_init, &
@@ -259,7 +258,8 @@ module fms
                        fms_ice_stock => ice_stock
 
   !> field manager
-  use field_manager_mod, only: fms_field_manager_init => field_manager_init, fms_field_manager_end => field_manager_end, &
+  use field_manager_mod, only: fms_field_manager_init => field_manager_init, &
+                         fms_field_manager_end => field_manager_end, &
                          fms_field_manager_find_field_index => find_field_index, &
                          fms_field_manager_get_field_info => get_field_info, &
                          fms_field_manager_get_field_method => get_field_method, &
@@ -291,7 +291,7 @@ module fms
                          NUM_MODELS, NO_FIELD, MODEL_ATMOS, MODEL_OCEAN, MODEL_LAND, MODEL_ICE, MODEL_COUPLER, &
                          fms_field_manager_method_type => method_type, &
                          fms_field_manager_method_type_short => method_type_short, &
-                         fms_field_manager_field_manager_method_type_very_short => method_type_very_short, &
+                         fms_field_manager_method_type_very_short => method_type_very_short, &
                          fms_field_manager_fm_list_iter_type => fm_list_iter_type, &
                          fms_field_manager_default_method => default_method
   use fm_util_mod, only: fms_fm_util_start_namelist => fm_util_start_namelist, &
@@ -363,7 +363,7 @@ module fms
                          fms_fms2_io_get_valid => get_valid, &
                          fms_fms2_io_is_valid => is_valid, &
                          fms_fms2_io_get_unlimited_dimension_name => get_unlimited_dimension_name, &
-                         fms_fms2_io_get_variable_unlimited_dimension_index =>   get_variable_unlimited_dimension_index, &
+                         fms_fms2_io_get_variable_unlimited_dimension_index => get_variable_unlimited_dimension_index, &
                          fms_fms2_io_file_exists => file_exists, &
                          fms_fms2_io_compressed_start_and_count => compressed_start_and_count, &
                          fms_fms2_io_get_variable_sense =>   get_variable_sense, &
@@ -421,7 +421,7 @@ module fms
                               fms_interpolate_type => interpolate_type, &
                               CONSTANT, INTERP_WEIGHTED_P, INTERP_LINEAR_P, INTERP_LOG_P, &
                               FMS_INTERPOLATOR_ZERO=>ZERO, & !! conflicts with mpp_parameter's ZERO
-                              fms_interpolator_read_data=>read_data 
+                              fms_interpolator_read_data=>read_data
 
   !> memutils
   use memutils_mod, only: fms_memutils_init => memutils_init, &
@@ -561,8 +561,8 @@ module fms
                          fms_mpp_efp_real_to_efp => mpp_real_to_efp, &
                          fms_mpp_efp_real_diff => mpp_efp_real_diff, &
                          operator(+), operator(-), assignment(=), &
-                         fms_mpp_efp_query_efp_overflow_error => mpp_query_efp_overflow_error, &
-                         fms_mpp_efp_reset_efp_overflow_error => mpp_reset_efp_overflow_error, &
+                         fms_mpp_efp_query_overflow_error => mpp_query_efp_overflow_error, &
+                         fms_mpp_efp_reset_overflow_error => mpp_reset_efp_overflow_error, &
                          fms_mpp_efp_type => mpp_efp_type
   use mpp_domains_mod, only: fms_mpp_domains_domain_axis_spec => domain_axis_spec, &
                              fms_mpp_domains_domain1D => domain1D, &

--- a/libFMS.F90
+++ b/libFMS.F90
@@ -65,123 +65,228 @@ module fms
                               fms_affinity_set
 
   !> amip_interp
-  use amip_interp_mod, only: amip_interp_init, get_amip_sst, get_amip_ice, &
-                             amip_interp_new,amip_interp_del, amip_interp_type, &
-                             assignment(=), i_sst, j_sst, sst_ncep, sst_anom, &
-                             forecast_mode, use_ncep_sst
+  use amip_interp_mod, only: fms_amip_interp_init         => amip_interp_init, &
+                             fms_get_amip_sst             => get_amip_sst, &
+                             fms_get_amip_ice             => get_amip_ice, &
+                             fms_amip_interp_new          => amip_interp_new, &
+                             fms_amip_interp_del          => amip_interp_del, &
+                             fms_amip_interp_type         => amip_interp_type, &
+                             assignment(=), &
+                             fms_amip_interp_i_sst        => i_sst, &
+                             fms_amip_interp_j_sst        => j_sst, &
+                             fms_amip_interp_sst_ncep     => sst_ncep, &
+                             fms_amip_interp_sst_anom     => sst_anom, &
+                             fms_amip_interp_forecast_mode=> forecast_mode, &
+                             fms_amip_interp_use_ncep_sst => use_ncep_sst
   !> astronomy
-  use astronomy_mod, only: astronomy_init, get_period, set_period, &
-                           set_orbital_parameters, get_orbital_parameters, &
-                           set_ref_date_of_ae, get_ref_date_of_ae,  &
-                           diurnal_solar, daily_mean_solar, annual_mean_solar,  &
-                           astronomy_end, universal_time, orbital_time
+  use astronomy_mod, only: fms_astronomy_init                   => astronomy_init, &
+                           fms_astronomy_get_period             => get_period, &
+                           fms_astronomy_set_period             => set_period, fms_astronomy_set_orbital_parameters=>, &
+                           fms_astronomy_get_orbital_parameters => get_orbital_parameters, &
+                           fms_astronomy_set_ref_date_of_ae     => set_ref_date_of_ae, &
+                           fms_astronomy_get_ref_date_of_ae     => get_ref_date_of_ae, &
+                           fms_astronomy_diurnal_solar          => diurnal_solar, &
+                           fms_astronomy_daily_mean_solar       => daily_mean_solar, &
+                           fms_astronomy_annual_mean_solar      => annual_mean_solar,  &
+                           fms_astronomy_end                    => astronomy_end, &
+                           fms_astronomy_universal_time         => universal_time, &
+                           fms_astronomy_orbital_time           => orbital_time
 
   !> axis_utils
-  use axis_utils2_mod, only: get_axis_cart, get_axis_modulo, lon_in_range, &
-                             tranlon, frac_index, nearest_index, interp_1d, &
-                             get_axis_modulo_times, axis_edges
+  use axis_utils2_mod, only: fms_get_axis_cart         => get_axis_cart, &
+                             fms_get_axis_modulo       => get_axis_modulo, &
+                             fms_lon_in_range          => lon_in_range, &
+                             fms_tranlon               => tranlon, &
+                             fms_frac_index            => frac_index, &
+                             fms_nearest_index         => nearest_index, &
+                             fms_interp_1d             => interp_1d, &
+                             fms_get_axis_modulo_times => get_axis_modulo_times, &
+                             fms_axis_edges            => axis_edges
 
   !>block_control
-  use block_control_mod, only: block_control_type, define_blocks, &
-                               define_blocks_packed
+  use block_control_mod, only: fms_block_control_type                 => block_control_type, &
+                               fms_block_control_define_blocks        => define_blocks, &
+                               fms_block_control_define_blocks_packed => define_blocks_packed
 
   !> column_diagnostics
-  use column_diagnostics_mod, only: column_diagnostics_init, &
-                                    initialize_diagnostic_columns, &
-                                    column_diagnostics_header, &
-                                    close_column_diagnostics_units
+  use column_diagnostics_mod, only: fms_column_diagnostics_init        => column_diagnostics_init, &
+                                    fms_initialize_diagnostic_columns  => initialize_diagnostic_columns, &
+                                    fms_column_diagnostics_header      => column_diagnostics_header, &
+                                    fms_close_column_diagnostics_units => close_column_diagnostics_units
 
   !> coupler
-  use coupler_types_mod, only: coupler_types_init, coupler_type_copy, &
-                               coupler_type_spawn, coupler_type_set_diags, &
-                               coupler_type_write_chksums, coupler_type_send_data, &
-                               coupler_type_data_override, coupler_type_register_restarts, &
-                               coupler_type_restore_state, coupler_type_increment_data, &
-                               coupler_type_rescale_data, coupler_type_copy_data, &
-                               coupler_type_redistribute_data, coupler_type_destructor, &
-                               coupler_type_initialized, coupler_type_extract_data, &
-                               coupler_type_set_data,coupler_type_copy_1d_2d, &
-                               coupler_type_copy_1d_3d, coupler_3d_values_type, &
-                               coupler_3d_field_type, coupler_3d_bc_type, &
-                               coupler_2d_values_type, coupler_2d_field_type, &
-                               coupler_2d_bc_type, coupler_1d_values_type, &
-                               coupler_1d_field_type, coupler_1d_bc_type, &
-                               ind_pcair, ind_u10, ind_psurf, ind_alpha, ind_csurf, &
-                               ind_sc_no, ind_flux, ind_deltap, ind_kw, ind_flux0, &
-                               ind_deposition, ind_runoff
-  use ensemble_manager_mod, only: ensemble_manager_init, get_ensemble_id, get_ensemble_size, &
-                               get_ensemble_pelist, ensemble_pelist_setup, &
-                               get_ensemble_filter_pelist
-  use atmos_ocean_fluxes_mod, only: atmos_ocean_fluxes_init, atmos_ocean_type_fluxes_init, &
-                               aof_set_coupler_flux
+  use coupler_types_mod, only: fms_coupler_types_init             => coupler_types_init, &
+                               fms_coupler_type_copy              => coupler_type_copy, &
+                               fms_coupler_type_spawn             => coupler_type_spawn, &
+                               fms_coupler_type_set_diags         => coupler_type_set_diags, &
+                               fms_coupler_type_write_chksums     => coupler_type_write_chksums, &
+                               fms_coupler_type_send_data         => coupler_type_send_data, &
+                               fms_coupler_type_data_override     => coupler_type_data_override, &
+                               fms_coupler_type_register_restarts => coupler_type_register_restarts, &
+                               fms_coupler_type_restore_state     => coupler_type_restore_state, &
+                               fms_coupler_type_increment_data    => coupler_type_increment_data, &
+                               fms_coupler_type_rescale_data      => coupler_type_rescale_data, &
+                               fms_coupler_type_copy_data         => coupler_type_copy_data, &
+                               fms_coupler_type_redistribute_data => coupler_type_redistribute_data, &
+                               fms_coupler_type_destructor        => coupler_type_destructor, &
+                               fms_coupler_type_initialized       => coupler_type_initialized, &
+                               fms_coupler_type_extract_data      => coupler_type_extract_data, &
+                               fms_coupler_type_set_data          => coupler_type_set_data, &
+                               fms_coupler_type_copy_1d_2d        => coupler_type_copy_1d_2d, &
+                               fms_coupler_type_copy_1d_3d        => coupler_type_copy_1d_3d, &
+                               fms_coupler_3d_values_type         => coupler_3d_values_type, &
+                               fms_coupler_3d_field_type          => coupler_3d_field_type, &
+                               fms_coupler_3d_bc_type             => coupler_3d_bc_type, &
+                               fms_coupler_2d_values_type         => coupler_2d_values_type, &
+                               fms_coupler_2d_field_type          => coupler_2d_field_type, &
+                               fms_coupler_2d_bc_type             => coupler_2d_bc_type, &
+                               fms_coupler_1d_values_type         => coupler_1d_values_type, &
+                               fms_coupler_1d_field_type          => coupler_1d_field_type, &
+                               fms_coupler_1d_bc_type             => coupler_1d_bc_type, &
+                               fms_ind_pcair                      => ind_pcair, &
+                               fms_ind_u10                        => ind_u10, &
+                               fms_ind_psurf                      => ind_psurf, &
+                               fms_ind_alpha                      => ind_alpha, &
+                               fms_ind_csurf                      => ind_csurf, &
+                               fms_ind_sc_no                      => ind_sc_no, &
+                               fms_ind_flux                       => ind_flux, &
+                               fms_ind_deltap                     => ind_deltap, &
+                               fms_ind_kw                         => ind_kw, &
+                               fms_ind_flux0                      => ind_flux0, &
+                               fms_ind_deposition                 => ind_deposition,&
+                               fms_ind_runoff                     => ind_runoff
+  use ensemble_manager_mod, only: fms_ensemble_manager_init     => ensemble_manager_init, &
+                               fms_get_ensemble_id              => get_ensemble_id,
+                               fms_get_ensemble_size            => get_ensemble_size, 
+                               fms_get_ensemble_pelist          => get_ensemble_pelist, &
+                               fms_ensemble_pelist_setup        => ensemble_pelist_setup, &
+                               fms_get_ensemble_filter_pelist   => get_ensemble_filter_pelist
+  use atmos_ocean_fluxes_mod, only: fms_atmos_ocean_fluxes_init => atmos_ocean_fluxes_init,
+                               fms_atmos_ocean_type_fluxes_init => atmos_ocean_type_fluxes_init, &
+                               fms_aof_set_coupler_flux         => aof_set_coupler_flux
 
   !> data_override
-  use data_override_mod, only: data_override_init, data_override, &
-                               data_override_unset_domains, data_override_UG
+  use data_override_mod, only: fms_data_override_init          => data_override_init, &
+                               fms_data_override               => data_override, &
+                               fms_data_override_unset_domains => data_override_unset_domains, &
+                               fms_data_override_UG            => data_override_UG
 
   !> diag_integral
-  use diag_integral_mod, only: diag_integral_init, diag_integral_field_init, &
-                               sum_diag_integral_field, diag_integral_output, &
-                               diag_integral_end
+  use diag_integral_mod, only: fms_diag_integral_init       => diag_integral_init, &
+                               fms_diag_integral_field_init => diag_integral_field_init, &
+                               fms_sum_diag_integral_field  => sum_diag_integral_field, &
+                               fms_diag_integral_output     => diag_integral_output, &
+                               fms_diag_integral_end        => diag_integral_end
 
   !> diag_manager
   !! includes imports from submodules made public
-  use diag_manager_mod, only: diag_manager_init, send_data, send_tile_averaged_data, &
-                           diag_manager_end, register_diag_field, register_static_field, &
-                           diag_axis_init, get_base_time, get_base_date, need_data, &
-                           DIAG_ALL, DIAG_OCEAN, DIAG_OTHER, get_date_dif, DIAG_SECONDS,&
-                           DIAG_MINUTES, DIAG_HOURS, DIAG_DAYS, DIAG_MONTHS, DIAG_YEARS, &
-                           get_diag_global_att, set_diag_global_att, diag_field_add_attribute, &
-                           diag_field_add_cell_measures, get_diag_field_id, &
-                           diag_axis_add_attribute, diag_grid_init, diag_grid_end, &
-                           diag_manager_set_time_end, diag_send_complete, &
-                           diag_send_complete_instant, DIAG_FIELD_NOT_FOUND, &
-                           CMOR_MISSING_VALUE, null_axis_id
+  use diag_manager_mod, only: fms_diag_manager_init => diag_manager_init, &
+                              fms_send_data => send_data, &
+                              fms_send_tile_averaged_data => send_tile_averaged_data, &
+                              fms_diag_manager_end => diag_manager_end, &
+                              fms_register_diag_field => register_diag_field,
+                              fms_register_static_field => register_static_field, &
+                              fms_diag_axis_init => diag_axis_init, &
+                              fms_get_base_time => get_base_time,
+                              fms_get_base_date => get_base_date, &
+                              fms_need_data => need_data, &
+                              DIAG_ALL, &
+                              DIAG_OCEAN, &
+                              DIAG_OTHER, &
+                              fms_get_date_dif => get_date_dif, &
+                              DIAG_SECONDS,&
+                              DIAG_MINUTES, &
+                              DIAG_HOURS, &
+                              DIAG_DAYS, &
+                              DIAG_MONTHS, &
+                              DIAG_YEARS, &
+                              fms_get_diag_global_att => get_diag_global_att, &
+                              fms_set_diag_global_att => set_diag_global_att, &
+                              fms_diag_field_add_attribute => diag_field_add_attribute, &
+                              fms_diag_field_add_cell_measures => diag_field_add_cell_measures, &
+                              fms_get_diag_field_id => get_diag_field_id, &
+                              fms_diag_axis_add_attribute => diag_axis_add_attribute, &
+                              fms_diag_grid_init => diag_grid_init, &
+                              fms_diag_grid_end => diag_grid_end, &
+                              fms_diag_manager_set_time_end => diag_manager_set_time_end, &
+                              fms_diag_send_complete => diag_send_complete, &
+                              fms_diag_send_complete_instant => diag_send_complete_instant, &
+                              DIAG_FIELD_NOT_FOUND, &
+                              CMOR_MISSING_VALUE, &
+                              null_axis_id
 
   !> exchange
-  use xgrid_mod, only: xmap_type, setup_xmap, set_frac_area, put_to_xgrid, &
-                       get_from_xgrid, xgrid_count, some, conservation_check, &
-                       xgrid_init, AREA_ATM_SPHERE, AREA_OCN_SPHERE, AREA_ATM_MODEL, &
-                       AREA_OCN_MODEL, get_ocean_model_area_elements, grid_box_type, &
-                       get_xmap_grid_area, put_to_xgrid_ug, get_from_xgrid_ug, &
-                       set_frac_area_ug, FIRST_ORDER, SECOND_ORDER, stock_move_ug, &
-                       stock_move, stock_type, stock_print, get_index_range, &
-                       stock_integrate_2d
-  use stock_constants_mod, only: NELEMS, ISTOCK_WATER, ISTOCK_HEAT, ISTOCK_SALT, &
-                       ISTOCK_TOP, ISTOCK_BOTTOM, ISTOCK_SIDE, stocks_file, &
-                       stocks_report, stocks_report_init, stocks_set_init_time, &
-                       atm_stock, ocn_stock, lnd_stock, ice_stock
+  use xgrid_mod, only: fms_xmap_type => xmap_type, &
+                       fms_setup_xmap => setup_xmap, &
+                       fms_set_frac_area => set_frac_area, &
+                       fms_put_to_xgrid => put_to_xgrid, &
+                       fms_get_from_xgrid => get_from_xgrid, &
+                       fms_xgrid_count => xgrid_count, &
+                       fms_some => some,
+                       fms_conservation_check => conservation_check, &
+                       fms_xgrid_init => xgrid_init, &
+                       fms_AREA_ATM_SPHERE => AREA_ATM_SPHERE, &
+                       fms_AREA_OCN_SPHERE => AREA_OCN_SPHERE, &
+                       fms_AREA_ATM_MODEL =>
+                       AREA_ATM_MODEL, fms_AREA_OCN_MODEL => AREA_OCN_MODEL, &
+                       fms_get_ocean_model_area_elements => get_ocean_model_area_elements, &
+                       fms_grid_box_type => grid_box_type, &
+                       fms_get_xmap_grid_area => get_xmap_grid_area, fms_put_to_xgrid_ug => put_to_xgrid_ug, &
+                       fms_get_from_xgrid_ug => get_from_xgrid_ug, fms_set_frac_area_ug => set_frac_area_ug, &
+                       FIRST_ORDER, SECOND_ORDER, fms_stock_move_ug => stock_move_ug, fms_stock_move => stock_move, fms_stock_type => stock_type, fms_stock_print => stock_print,
+                       fms_get_index_range => get_index_range, &
+                       fms_stock_integrate_2d => stock_integrate_2d
+  use stock_constants_mod, only: fms_NELEMS => NELEMS, fms_ISTOCK_WATER => ISTOCK_WATER, fms_ISTOCK_HEAT => ISTOCK_HEAT, &
+                       fms_ISTOCK_SALT => ISTOCK_SALT, &
+                       fms_ISTOCK_TOP => ISTOCK_TOP, fms_ISTOCK_BOTTOM => ISTOCK_BOTTOM, fms_ISTOCK_SIDE => ISTOCK_SIDE,
+                       fms_stocks_file => stocks_file, &
+                       fms_stocks_report => stocks_report, fms_stocks_report_init => stocks_report_init, fms_stocks_set_init_time => stocks_set_init_time, &
+                       fms_atm_stock => atm_stock, fms_ocn_stock => ocn_stock, fms_lnd_stock => lnd_stock, fms_ice_stock => ice_stock
 
   !> field manager
-  use field_manager_mod, only: field_manager_init, field_manager_end, find_field_index, &
-                         get_field_info, &
-                         get_field_method, get_field_methods, parse, fm_change_list, &
-                         fm_change_root, fm_dump_list, fm_exists, fm_get_index, &
-                         fm_get_current_list, fm_get_length, fm_get_type, fm_get_value, &
-                         fm_init_loop, &
-                         fm_loop_over_list, fm_new_list, fm_new_value, &
-                         fm_reset_loop, fm_return_root, &
-                         fm_modify_name, fm_query_method, fm_find_methods, fm_copy_list, &
-                         fm_field_name_len, fm_path_name_len, &
-                         fm_string_len, fm_type_name_len, NUM_MODELS, NO_FIELD, &
-                         MODEL_ATMOS, MODEL_OCEAN, MODEL_LAND, MODEL_ICE, MODEL_COUPLER, &
-                         method_type, method_type_short, &
-                         method_type_very_short, fm_list_iter_type, default_method
-  use fm_util_mod, only: fm_util_start_namelist, fm_util_end_namelist, &
-                         fm_util_check_for_bad_fields, fm_util_set_caller, &
-                         fm_util_reset_caller, fm_util_set_no_overwrite, &
-                         fm_util_reset_no_overwrite, fm_util_set_good_name_list, &
-                         fm_util_reset_good_name_list, fm_util_get_length, &
-                         fm_util_get_integer, fm_util_get_logical, fm_util_get_real, &
-                         fm_util_get_string, fm_util_get_integer_array, &
-                         fm_util_get_logical_array, fm_util_get_real_array, &
-                         fm_util_get_string_array, fm_util_set_value, &
-                         fm_util_set_value_integer_array, fm_util_set_value_logical_array, &
-                         fm_util_set_value_real_array, fm_util_set_value_string_array, &
-                         fm_util_set_value_integer, fm_util_set_value_logical, &
-                         fm_util_set_value_real, fm_util_set_value_string, &
-                         fm_util_get_index_list, fm_util_get_index_string, &
-                         fm_util_default_caller
+  use field_manager_mod, only: fms_field_manager_init => field_manager_init, fms_field_manager_end => field_manager_end,
+                         fms_find_field_index => find_field_index, &
+                         fms_get_field_info => get_field_info, &
+                         fms_get_field_method => get_field_method, fms_get_field_methods => get_field_methods, fms_parse => parse,
+                         fms_fm_change_list => fm_change_list, &
+                         fms_fm_change_root => fm_change_root, fms_fm_dump_list => fm_dump_list, fms_fm_exists => fm_exists,
+                         fms_fm_get_index => fm_get_index, &
+                         fms_fm_get_current_list => fm_get_current_list, fms_fm_get_length => fm_get_length, fms_fm_get_type =>
+                         fm_get_type, fms_fm_get_value => fm_get_value, &
+                         fms_fm_init_loop => fm_init_loop, &
+                         fms_fm_loop_over_list => fm_loop_over_list, fms_fm_new_list => fm_new_list, fms_fm_new_value => fm_new_value, &
+                         fms_fm_reset_loop => fm_reset_loop, fms_fm_return_root => fm_return_root, &
+                         fms_fm_modify_name => fm_modify_name, fms_fm_query_method => fm_query_method, fms_fm_find_methods =>
+                         fm_find_methods, fms_fm_copy_list => fm_copy_list, &
+                         fms_fm_field_name_len => fm_field_name_len, fms_fm_path_name_len => fm_path_name_len, &
+                         fms_fm_string_len => fm_string_len, fms_fm_type_name_len => fm_type_name_len, fms_NUM_MODELS => NUM_MODELS,
+                         fms_NO_FIELD => NO_FIELD, &
+                         fms_MODEL_ATMOS => MODEL_ATMOS, fms_MODEL_OCEAN => MODEL_OCEAN, fms_MODEL_LAND => MODEL_LAND, fms_MODEL_ICE
+                         => MODEL_ICE, fms_MODEL_COUPLER => MODEL_COUPLER, &
+                         fms_method_type => method_type, fms_method_type_short => method_type_short, &
+                         fms_method_type_very_short => method_type_very_short, fms_fm_list_iter_type => fm_list_iter_type,
+                         fms_default_method => default_method
+  use fm_util_mod, only: fms_fm_util_start_namelist => fm_util_start_namelist, fms_fm_util_end_namelist => fm_util_end_namelist, &
+                         fms_fm_util_check_for_bad_fields => fm_util_check_for_bad_fields, fms_fm_util_set_caller => fm_util_set_caller, &
+                         fms_fm_util_reset_caller => fm_util_reset_caller, fms_fm_util_set_no_overwrite => fm_util_set_no_overwrite, &
+                         fms_fm_util_reset_no_overwrite => fm_util_reset_no_overwrite, fms_fm_util_set_good_name_list => fm_util_set_good_name_list, &
+                         fms_fm_util_reset_good_name_list => fm_util_reset_good_name_list, fms_fm_util_get_length => fm_util_get_length, &
+                         fms_fm_util_get_integer => fm_util_get_integer, fms_fm_util_get_logical => fm_util_get_logical,
+                         fms_fm_util_get_real => fm_util_get_real, &
+                         fms_fm_util_get_string => fm_util_get_string, fms_fm_util_get_integer_array => fm_util_get_integer_array, &
+                         fms_fm_util_get_logical_array => fm_util_get_logical_array, fms_fm_util_get_real_array => fm_util_get_real_array,
+                         fms_fm_util_get_string_array => fm_util_get_string_array, fms_fm_util_set_value => fm_util_set_value, &
+                         fms_fm_util_set_value_integer_array => fm_util_set_value_integer_array, &
+                         fms_fm_util_set_value_logical_array => fm_util_set_value_logical_array, &
+                         fms_fm_util_set_value_real_array => fm_util_set_value_real_array, &
+                         fms_fm_util_set_value_string_array => fm_util_set_value_string_array, &
+                         fms_fm_util_set_value_integer => fm_util_set_value_integer, &
+                         fms_fm_util_set_value_logical => fm_util_set_value_logical, &
+                         fms_fm_util_set_value_real => fm_util_set_value_real, &
+                         fms_fm_util_set_value_string => fm_util_set_value_string, &
+                         fms_fm_util_get_index_list => fm_util_get_index_list, &
+                         fms_fm_util_get_index_string => fm_util_get_index_string, &
+                         fms_fm_util_default_caller => fm_util_default_caller
 
   !> fms2_io
   use fms2_io_mod, only: unlimited, FmsNetcdfFile_t, FmsNetcdfDomainFile_t, &
@@ -215,12 +320,14 @@ module fms
   !> fms
   !! routines that don't conflict with fms2_io
   use fms_mod, only: fms_init, fms_end, error_mesg, fms_error_handler, check_nml_error, &
-                     monotonic_array, string_array_index, clock_flag_default, &
-                     print_memory_usage, write_version_number
+                     fms_monotonic_array => monotonic_array, fms_string_array_index => string_array_index, &
+                     fms_clock_flag_default => clock_flag_default, fms_print_memory_usage => print_memory_usage, &
+                     fms_write_version_number => write_version_number
 
   !> horiz_interp
-  use horiz_interp_mod, only: horiz_interp, horiz_interp_new, horiz_interp_del, &
-                              horiz_interp_init, horiz_interp_end
+  use horiz_interp_mod, only: fms_horiz_interp => horiz_interp, fms_horiz_interp_new => horiz_interp_new, &
+                              fms_horiz_interp_del => horiz_interp_del, fms_horiz_interp_init => horiz_interp_init, &
+                              fms_horiz_interp_end => horiz_interp_end
   use horiz_interp_type_mod, only: horiz_interp_type, assignment(=), CONSERVE, &
                               BILINEAR, SPHERICA, BICUBIC, stats
   !! used via horiz_interp

--- a/libFMS.F90
+++ b/libFMS.F90
@@ -1,4 +1,4 @@
-!***********************************************************************
+***********************************************************************
 !*                   GNU Lesser General Public License
 !*
 !* This file is part of the GFDL Flexible Modeling System (FMS).
@@ -34,8 +34,9 @@
 !! Exceptions (mainly for rep:
 !!   - Parameter values are kept their original names
 !!   - If module name is already included (like in init routines) only fms prefix will be added.
-!!   - Similarly if theres a redundant module name included already included it will not be repeated 
+!!   - Similarly if theres a redundant module name included already included it will not be repeated
 !!     (ie. mpp_update_domains => fms_mpp_domains_update_domains)
+!!   - Override interfaces for operators and assignment are provided
 !!
 !! Remappings due to name conflicts:
 !!
@@ -72,7 +73,7 @@ module fms
   !> amip_interp
   use amip_interp_mod, only: fms_amip_interp_init         => amip_interp_init, &
                              fms_amip_interp_get_amip_sst             => get_amip_sst, &
-                             fms_amio_interp_get_amip_ice             => get_amip_ice, &
+                             fms_amip_interp_get_amip_ice             => get_amip_ice, &
                              fms_amip_interp_new          => amip_interp_new, &
                              fms_amip_interp_del          => amip_interp_del, &
                              fms_amip_interp_type         => amip_interp_type, &
@@ -163,7 +164,7 @@ module fms
                                fms_coupler_ind_deposition                 => ind_deposition,&
                                fms_coupler_ind_runoff                     => ind_runoff
   use ensemble_manager_mod, only: fms_ensemble_manager_init     => ensemble_manager_init, &
-                               fms_ensemble_manager_eget_ensemble_id              => get_ensemble_id, &
+                               fms_ensemble_manager_get_ensemble_id              => get_ensemble_id, &
                                fms_ensemble_manager_get_ensemble_size            => get_ensemble_size, &
                                fms_ensemble_manager_get_ensemble_pelist          => get_ensemble_pelist, &
                                fms_ensemble_manager_ensemble_pelist_setup        => ensemble_pelist_setup, &
@@ -190,7 +191,7 @@ module fms
   use diag_manager_mod, only: fms_diag_manager_init => diag_manager_init, &
                               fms_diag_manager_send_data => send_data, &
                               fms_diag_manager_send_tile_averaged_data => send_tile_averaged_data, &
-                              fms_diag_manager_diag_manager_end => diag_manager_end, &
+                              fms_diag_manager_end => diag_manager_end, &
                               fms_diag_manager_register_diag_field => register_diag_field, &
                               fms_diag_manager_register_static_field => register_static_field, &
                               fms_diag_manager_diag_axis_init => diag_axis_init, &
@@ -228,10 +229,10 @@ module fms
                        fms_xgrid_set_frac_area => set_frac_area, &
                        fms_xgrid_put_to_xgrid => put_to_xgrid, &
                        fms_xgrid_get_from_xgrid => get_from_xgrid, &
-                       fms_xgrid_xgrid_count => xgrid_count, &
+                       fms_xgrid_count => xgrid_count, &
                        fms_xgrid_some => some, &
                        fms_xgrid_conservation_check => conservation_check, &
-                       fms_xgrid_xgrid_init => xgrid_init, &
+                       fms_xgrid_init => xgrid_init, &
                        AREA_ATM_SPHERE, AREA_OCN_SPHERE, AREA_ATM_MODEL, AREA_OCN_MODEL, &
                        fms_xgrid_get_ocean_model_area_elements => get_ocean_model_area_elements, &
                        fms_xgrid_grid_box_type => grid_box_type, &
@@ -326,6 +327,9 @@ module fms
                          fms_fm_util_default_caller => fm_util_default_caller
 
   !> fms2_io
+  !! TODO need to see opinions on these
+  !! not sure if we need fms_ prefix for routines
+  !! types do not follow our typical naming convention(no _type and uses camel case instead of _ spacing)
   use fms2_io_mod, only: unlimited, FmsNetcdfFile_t, FmsNetcdfDomainFile_t, &
                          FmsNetcdfUnstructuredDomainFile_t, &
                          fms_fms2_io_open_file => open_file, &
@@ -359,7 +363,7 @@ module fms
                          fms_fms2_io_get_variable_size =>   get_variable_size, &
                          fms_fms2_io_get_compute_domain_dimension_indices => get_compute_domain_dimension_indices, &
                          fms_fms2_io_get_global_io_domain_indices => get_global_io_domain_indices, &
-                         Valid_t, &
+                         d_t, &
                          fms_fms2_io_get_valid => get_valid, &
                          fms_fms2_io_is_valid => is_valid, &
                          fms_fms2_io_get_unlimited_dimension_name => get_unlimited_dimension_name, &
@@ -411,11 +415,11 @@ module fms
 
   !> interpolator
   use interpolator_mod, only: fms_interpolator_init => interpolator_init, &
-                              fms_interpolator_interpolator => interpolator, &
+                              fms_interpolator => interpolator, &
                               fms_interpolate_type_eq => interpolate_type_eq, &
                               fms_interpolator_obtain_interpolator_time_slices => obtain_interpolator_time_slices, &
                               fms_interpolator_unset_interpolator_time_flag => unset_interpolator_time_flag, &
-                              fms_interpolator_interpolator_end => interpolator_end, &
+                              fms_interpolator_end => interpolator_end, &
                               fms_interpolator_init_clim_diag => init_clim_diag, &
                               fms_interpolator_query_interpolator => query_interpolator, &
                               fms_interpolate_type => interpolate_type, &
@@ -622,8 +626,8 @@ module fms
                              fms_mpp_domains_global_sum_tl => mpp_global_sum_tl, &
                              fms_mpp_domains_global_sum_ad => mpp_global_sum_ad, &
                              fms_mpp_domains_broadcast_domain => mpp_broadcast_domain, &
-                             fms_mpp_domains_domains_init => mpp_domains_init, &
-                             fms_mpp_domains_domains_exit => mpp_domains_exit, &
+                             fms_mpp_domains_init => mpp_domains_init, &
+                             fms_mpp_domains_exit => mpp_domains_exit, &
                              fms_mpp_domains_redistribute => mpp_redistribute, &
                              fms_mpp_domains_update_domains => mpp_update_domains, &
                              fms_mpp_domains_check_field => mpp_check_field, &
@@ -713,7 +717,7 @@ module fms
   !> sat_vapor_pres
   use sat_vapor_pres_mod, only: fms_sat_vapor_pres_lookup_es => lookup_es, &
                                 fms_sat_vapor_pres_lookup_des => lookup_des, &
-                                fms_sat_vapor_pres_sat_vapor_pres_init => sat_vapor_pres_init, &
+                                fms_sat_vapor_pres_init => sat_vapor_pres_init, &
                                 fms_sat_vapor_pres_lookup_es2 => lookup_es2, &
                                 fms_sat_vapor_pres_lookup_des2 => lookup_des2, &
                                 fms_sat_vapor_pres_lookup_es2_des2 => lookup_es2_des2, &

--- a/libFMS.F90
+++ b/libFMS.F90
@@ -729,9 +729,12 @@ module fms
   use fms_string_utils_mod, only: fms_string_utils_string => string, &
                                   fms_string_utils_array_to_pointer => fms_array_to_pointer, &
                                   fms_string_utils_fms_pointer_to_array => fms_pointer_to_array, &
-                                  fms_sort_this, &
-                                  fms_find_my_string, fms_find_unique, fms_c2f_string, fms_cstring2cpointer, &
-                                  string_copy
+                                  fms_string_utils_sort_this => fms_sort_this, &
+                                  fms_string_utils_find_my_string => fms_find_my_string, &
+                                  fms_string_utils_find_unique => fms_find_unique, &
+                                  fms_string_utils_c2f_string => fms_c2f_string, &
+                                  fms_string_utils_cstring2cpointer => fms_cstring2cpointer, &
+                                  fms_string_utils_copy => string_copy
 
   !> time_interp
   use time_interp_mod, only: fms_time_interp_init => time_interp_init, &

--- a/test_fms/mpp/test_domains_utility_mod.F90
+++ b/test_fms/mpp/test_domains_utility_mod.F90
@@ -22,9 +22,9 @@
 module test_domains_utility_mod
     use mpp_mod,         only : FATAL, WARNING, MPP_DEBUG, NOTE
     use mpp_mod, only : mpp_error
-    use mpp_domains_mod, only : ZERO, NINETY, MINUS_NINETY
+    use mpp_domains_mod, only : ZERO, NINETY, MINUS_NINETY, &
+                                domain2d, mpp_define_mosaic
     use platform_mod, only: r4_kind, r8_kind
-    use fms
 
   interface fill_coarse_data
     module procedure fill_coarse_data_r8

--- a/test_fms/mpp/test_mpp_chksum.F90
+++ b/test_fms/mpp/test_mpp_chksum.F90
@@ -23,7 +23,10 @@
 !> single pe and distributed checksums
 program test_mpp_chksum
 
-  use fms
+  use mpp_mod
+  use mpp_domains_mod
+  use fms_mod
+  use platform_mod
 
   implicit none
 

--- a/test_fms/mpp/test_mpp_domains.F90
+++ b/test_fms/mpp/test_mpp_domains.F90
@@ -54,7 +54,7 @@ program test_mpp_domains
                               NONSYMEDGEUPDATE
   use mpp_domains_mod, only : domainUG, mpp_define_unstruct_domain, mpp_get_UG_domain_tile_id
   use mpp_domains_mod, only : mpp_get_UG_compute_domain, mpp_pass_SG_to_UG, mpp_pass_UG_to_SG
-  use mpp_domains_mod, only : mpp_global_field_ug
+  use mpp_domains_mod, only : mpp_global_field_ug, mpp_get_ug_global_domain
 
   use compare_data_checksums
   use test_domains_utility_mod

--- a/test_fms/mpp/test_mpp_nesting.F90
+++ b/test_fms/mpp/test_mpp_nesting.F90
@@ -19,7 +19,9 @@
 !> Tests nested domain operations and routines in mpp_domains
 program test_mpp_nesting
 
-  use fms
+  use fms_mod
+  use mpp_domains_mod
+  use mpp_mod
   use compare_data_checksums
   use test_domains_utility_mod
   use platform_mod


### PR DESCRIPTION
**Description**
adds aliases for libFMS.F90 module to prefix routine names with fms and module names.

I left a comment for fms2_io, not 100% sure on what makes sense there renaming-wise.

parameter/constants were left the same, felt like they would get more confusing with the prefixes but open to any feedback.

will need coupler updated as well to pass CI

**How Has This Been Tested?**
oneapi 23

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

