### PR TITLE
Fix continuation line syntax for error messages

### DIFF
--- a/fms2_io/include/unpack_data.inc
+++ b/fms2_io/include/unpack_data.inc
@@ -59,8 +59,8 @@ subroutine unpack_data_0d(fileobj, varid, varname, var_data)
       var_data = var_data + buf_r8_kind
 
     class default
-      call error("If using the scale_factor and add_offset variable, the buffer reading the data to needs to be"&
-        "r4_kind or r8_kind."//trim(msg))
+      call error("If using the scale_factor and add_offset variable, the buffer reading the data to needs to be &
+        &r4_kind or r8_kind."//trim(msg))
     end select
   end if
 end subroutine
@@ -103,8 +103,8 @@ subroutine unpack_data_1d(fileobj, varid, varname, var_data)
       var_data = var_data + buf_r8_kind
 
     class default
-      call error("If using the scale_factor and add_offset variable, the buffer reading the data to needs to be"&
-        "r4_kind or r8_kind."//trim(msg))
+      call error("If using the scale_factor and add_offset variable, the buffer reading the data to needs to be &
+        &r4_kind or r8_kind."//trim(msg))
     end select
   end if
 end subroutine
@@ -147,8 +147,8 @@ subroutine unpack_data_2d(fileobj, varid, varname, var_data)
       var_data = var_data + buf_r8_kind
 
     class default
-      call error("If using the scale_factor and add_offset variable, the buffer reading the data to needs to be"&
-        "r4_kind or r8_kind."//trim(msg))
+      call error("If using the scale_factor and add_offset variable, the buffer reading the data to needs to be &
+        &r4_kind or r8_kind."//trim(msg))
     end select
   end if
 end subroutine
@@ -191,8 +191,8 @@ subroutine unpack_data_3d(fileobj, varid, varname, var_data)
       var_data = var_data + buf_r8_kind
 
     class default
-      call error("If using the scale_factor and add_offset variable, the buffer reading the data to needs to be"&
-        "r4_kind or r8_kind."//trim(msg))
+      call error("If using the scale_factor and add_offset variable, the buffer reading the data to needs to be &
+        &r4_kind or r8_kind."//trim(msg))
     end select
   end if
 end subroutine
@@ -235,8 +235,8 @@ subroutine unpack_data_4d(fileobj, varid, varname, var_data)
       var_data = var_data + buf_r8_kind
 
     class default
-      call error("If using the scale_factor and add_offset variable, the buffer reading the data to needs to be"&
-        "r4_kind or r8_kind."//trim(msg))
+      call error("If using the scale_factor and add_offset variable, the buffer reading the data to needs to be &
+        &r4_kind or r8_kind."//trim(msg))
     end select
   end if
 end subroutine
@@ -279,8 +279,8 @@ subroutine unpack_data_5d(fileobj, varid, varname, var_data)
       var_data = var_data + buf_r8_kind
 
     class default
-      call error("If using the scale_factor and add_offset variable, the buffer reading the data to needs to be"&
-        "r4_kind or r8_kind."//trim(msg))
+      call error("If using the scale_factor and add_offset variable, the buffer reading the data to needs to be &
+        &r4_kind or r8_kind."//trim(msg))
     end select
   end if
 end subroutine


### PR DESCRIPTION
This fixes the continuation line syntax for several error messages in `unpack_data.inc`.

**Description**
In `unpack_data.inc`, all occurrences of:
```
"Continuation"&
"line"
```
have been replaced with:
```
"Continuation &
&line"
```

Fixes #1264 (`netcdf_io_mod` compilation error with Cray)

**How Has This Been Tested?**
Builds with Cray 15.0.1 on C5.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes