### PR TITLE
Fix to Makefile.am to have the diag_fieldbuff_update module

### DIFF
--- a/diag_manager/Makefile.am
+++ b/diag_manager/Makefile.am
@@ -57,8 +57,9 @@ fms_diag_axis_object_mod.$(FC_MODEXT): diag_data_mod.$(FC_MODEXT) fms_diag_time_
 fms_diag_time_reduction_mod.$(FC_MODEXT): diag_data_mod.$(FC_MODEXT)
 fms_diag_elem_weight_procs_mod.$(FC_MODEXT): diag_data_mod.$(FC_MODEXT)
 fms_diag_outfield_mod.$(FC_MODEXT): diag_data_mod.$(FC_MODEXT) fms_diag_elem_weight_procs_mod.$(FC_MODEXT)
-fms_diag_fieldbuff_update_mod.$(FC_MODEXT): diag_data_mod.$(FC_MODEXT) fms_diag_outfield_mod.$(FC_MODEXT) \
-                  fms_diag_elem_weight_procs_mod.$(FC_MODEXT) fms_diag_bbox_mod.$(FC_MODEXT)
+fms_diag_fieldbuff_update_mod.$(FC_MODEXT): diag_data_mod.$(FC_MODEXT) diag_util_mod.$(FC_MODEXT) \
+                  fms_diag_outfield_mod.$(FC_MODEXT) fms_diag_elem_weight_procs_mod.$(FC_MODEXT) \
+                  fms_diag_bbox_mod.$(FC_MODEXT)
 diag_manager_mod.$(FC_MODEXT): diag_axis_mod.$(FC_MODEXT) diag_data_mod.$(FC_MODEXT) diag_util_mod.$(FC_MODEXT) \
                   diag_output_mod.$(FC_MODEXT) diag_grid_mod.$(FC_MODEXT) diag_table_mod.$(FC_MODEXT) \
                   fms_diag_time_reduction_mod.$(FC_MODEXT) fms_diag_outfield_mod.$(FC_MODEXT) \


### PR DESCRIPTION
**Description**

This PR has a simple fix to Makefile.am to have the diag_fieldbuff_update module depend upon diag_utill module/


Fixes # (issue)

**How Has This Been Tested?**
The code has been compiled and make check was ran on various platforms.

**Checklist:**
- [ X] My code follows the style guidelines of this project
- [X ] I have performed a self-review of my own code
- [ X] I have commented my code, particularly in hard-to-understand areas
- [ X] I have made corresponding changes to the documentation
- [X ] My changes generate no new warnings
- [ X] Any dependent changes have been merged and published in downstream modules
- [ X] New check tests, if applicable, are included
- [ X] `make distcheck` passes

