### PR TITLE
Call `monin_obukhov_stable_mix` from `stable_mix_1d`

### DIFF
--- a/monin_obukhov/monin_obukhov.F90
+++ b/monin_obukhov/monin_obukhov.F90
@@ -274,7 +274,9 @@ subroutine stable_mix_3d(rich, mix)
 
 real, intent(in) , dimension(:,:,:)  :: rich
 real, intent(out), dimension(:,:,:)  :: mix
-integer :: n2, n3, i, j
+integer :: n2 !< Size of dimension 2 of mix and rich
+integer :: n3 !< Size of dimension 3 of mix and rich
+integer :: i, j !< Loop indices
 
 n2 = size(mix, 2)
 n3 = size(mix, 3)
@@ -943,7 +945,8 @@ subroutine stable_mix_2d(rich, mix)
 
 real, intent(in) , dimension(:,:)  :: rich
 real, intent(out), dimension(:,:)  :: mix
-integer :: n2, i
+integer :: n2 !< Size of dimension 2 of mix and rich
+integer :: i !< Loop index
 
 n2 = size(mix, 2)
 
@@ -960,7 +963,8 @@ subroutine stable_mix_1d(rich, mix)
 
 real, intent(in) , dimension(:)  :: rich
 real, intent(out), dimension(:)  :: mix
-integer :: n, ierr
+integer :: n !< Size of mix and rich
+integer :: ierr !< Error code set by monin_obukhov_stable_mix
 
 if (.not.module_is_initialized) call error_mesg('stable_mix in monin_obukhov_mod', &
      'monin_obukhov_init has not been called', FATAL)
@@ -979,7 +983,7 @@ subroutine stable_mix_0d(rich, mix)
 real, intent(in) :: rich
 real, intent(out) :: mix
 
-real, dimension(1) :: mix_1d
+real, dimension(1) :: mix_1d !< Representation of mix as a dimension(1) array
 
 call stable_mix([rich], mix_1d)
 

--- a/monin_obukhov/monin_obukhov.F90
+++ b/monin_obukhov/monin_obukhov.F90
@@ -274,16 +274,16 @@ subroutine stable_mix_3d(rich, mix)
 
 real, intent(in) , dimension(:,:,:)  :: rich
 real, intent(out), dimension(:,:,:)  :: mix
+integer :: n2, n3, i, j
 
-integer :: n, ier
+n2 = size(mix, 2)
+n3 = size(mix, 3)
 
-if(.not.module_is_initialized) call error_mesg('stable_mix_3d in monin_obukhov_mod', &
-     'monin_obukhov_init has not been called', FATAL)
-
-n = size(rich,1)*size(rich,2)*size(rich,3)
-call monin_obukhov_stable_mix(stable_option, rich_crit, zeta_trans, &
-     & n, rich, mix, ier)
-
+do j=1, n3
+  do i=1, n2
+    call stable_mix(rich(:, i, j), mix(:, i, j))
+  enddo
+enddo
 
 end subroutine stable_mix_3d
 
@@ -943,16 +943,14 @@ subroutine stable_mix_2d(rich, mix)
 
 real, intent(in) , dimension(:,:)  :: rich
 real, intent(out), dimension(:,:)  :: mix
+integer :: n2, i
 
-real, dimension(size(rich,1),size(rich,2),1) :: rich_3d, mix_3d
+n2 = size(mix, 2)
 
-rich_3d(:,:,1) = rich
+do i=1, n2
+  call stable_mix(rich(:, i), mix(:, i))
+enddo
 
-call stable_mix_3d(rich_3d, mix_3d)
-
-mix = mix_3d(:,:,1)
-
-return
 end subroutine stable_mix_2d
 
 
@@ -962,16 +960,16 @@ subroutine stable_mix_1d(rich, mix)
 
 real, intent(in) , dimension(:)  :: rich
 real, intent(out), dimension(:)  :: mix
+integer :: n, ierr
 
-real, dimension(size(rich),1,1) :: rich_3d, mix_3d
+if (.not.module_is_initialized) call error_mesg('stable_mix in monin_obukhov_mod', &
+     'monin_obukhov_init has not been called', FATAL)
 
-rich_3d(:,1,1) = rich
+n = size(mix)
 
-call stable_mix_3d(rich_3d, mix_3d)
+call monin_obukhov_stable_mix(stable_option, rich_crit, zeta_trans, &
+     & n, rich, mix, ierr)
 
-mix = mix_3d(:,1,1)
-
-return
 end subroutine stable_mix_1d
 
 !=======================================================================
@@ -981,15 +979,12 @@ subroutine stable_mix_0d(rich, mix)
 real, intent(in) :: rich
 real, intent(out) :: mix
 
-real, dimension(1,1,1) :: rich_3d, mix_3d
+real, dimension(1) :: mix_1d
 
-rich_3d(1,1,1) = rich
+call stable_mix([rich], mix_1d)
 
-call stable_mix_3d(rich_3d, mix_3d)
+mix = mix_1d(1)
 
-mix = mix_3d(1,1,1)
-
-return
 end subroutine stable_mix_0d
 !=======================================================================
 


### PR DESCRIPTION
Restructure the subroutines in the `stable_mix` interface of `monin_obukhov_mod` so that `stable_mix_1d` calls `monin_obukhov_stable_mix`, which is the underlying implementation. `stable_mix_2d` and `stable_mix_3d` now call `stable_mix_1d` on 1D slices of the data.

This change is needed for the mixed precision updates to `monin_obukhov_mod` because, with `monin_obukhov_stable_mix` being converted from a subroutine to an interface, arrays with mismatched ranks can no longer be passed directly.

**How Has This Been Tested?**
Builds with Intel on the AMD box

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes