### PR TITLE
Yaml update

### DIFF
--- a/diag_manager/README.md
+++ b/diag_manager/README.md
@@ -1,6 +1,6 @@
 ## Diag Table Yaml Format:
 
-The purpose of this documents is to explain the diag_table yaml format. 
+The purpose of this documents is to explain the diag_table yaml format.
 
 ## Contents
 - [1. Coverting from legacy ascii diag_table format](README.md#1-coverting-from-legacy-ascii-diag_table-format)
@@ -44,7 +44,7 @@ The diag_yaml requires “title” and the “baseDate”.
 - The **title** is a string that labels the diag yaml.  The equivalent in the diag table would be the experiment.  It is recommended that each diag_yaml have a separate title label that is descriptive of the experiment that is using it.
 - The **basedate** is an array of 6 integer indicating the base_date in the format [year month day hour minute second].
 
-**Example:** 
+**Example:**
 
 In the YAML format:
 ```yaml
@@ -59,27 +59,27 @@ ESM4_piControl
 ```
 
 ### 2.2 File Section
-The files are listed under the diagFiles section as a dashed array. 
+The files are listed under the diagFiles section as a dashed array.
 
 Below are the **required** keys needed to define each file.
-- **file_name** is a string that defines the name of the file. Do not add ".nc" and "tileX" to the filename as this will handle by FMS. 
-- **freq** is an integer that defines the frequency that data will be written. The acceptable values are:
-  - =-1: output at the end of the run only 
-  - =0: output every timestep 
-  - \>0: output frequency
-- **freq_units** is a string that defines the units of the frequency from above. The acceptable values are seconds, minutes, hours, days, months, years. 
-- **time_units** is a string that defines units for time. The acceptable values are seconds, minutes, hours, days, months, years. 
+- **file_name** is a string that defines the name of the file. Do not add ".nc" and "tileX" to the filename as this will handle by FMS.
+- **freq** is a string that defines the frequency and the units that data will be written.
+  - The acceptable values for freq are:
+    - =-1: output at the end of the run only
+    - =0: output every timestep
+    - \>0: output frequency
+  - The acceptable values for units are seconds, minutes, hours, days, months, years.
+- **time_units** is a string that defines units for time. The acceptable values are seconds, minutes, hours, days, months, years.
 - **unlimdim** is a string that defines the name of the unlimited dimension in the output netcdf file, usually “time”.
 - **varlist** is a subsection that list all of the variable in the file
 
-**Example:** The following creates a file with data written every 6 hours. 
+**Example:** The following creates a file with data written every 6 hours.
 
 In the YAML format:
 ```yaml
 diag_files:
 - file_name: atmos_6hours
-  freq: 6
-  freq_units: hours
+  freq: 6 hours
   time_units: hours
   unlimdim: time
   varlist:
@@ -93,10 +93,9 @@ In the legacy ascii format:
 
 **NOTE:** The fourth column (file_format) has been deprecated. Netcdf files will always be written.
 
-Below are some *optional* keys that may be added. 
+Below are some *optional* keys that may be added.
 - **write_file** is a logical that indicates if you want the file to be created (default is true). This is a new feature that is not supported by the legacy ascii data_table.
-- **new_file_freq** is a integer that defines the frequency for closing the existing file
-- **new_file_freq_units** is a string that defines the time units for creating a new file. Required if “new_file_freq” used. The acceptable values are seconds, minuts, hours, days, months, years. 
+- **new_file_freq** is a string that defines the frequency and the frequency units for closing the existing file
 - **start_time** is an array of 6 integer indicating when to start the file for the first time. It is in the format [year month day hour minute second]. Requires “new_file_freq”
 - **filename_time** is the time used to set the name of new files when using new_file_freq. The acceptable values are begin (which will use the begining of the file's time bounds), middle (which will use the middle of the file's time bounds), and end (which will use the end of the file's time bounds). The default is middle
 
@@ -105,12 +104,10 @@ Below are some *optional* keys that may be added.
 In the YAML format:
 ```yaml
 - file_name: ocn%4yr%2mo%2dy%2hr
-  freq: 6
+  freq: 6 hours
   freq_units: hours
-  time_units: hours
   unlimdim: time
-  new_file_freq: 6
-  new_file_freq_units: hours
+  new_file_freq: 6 hours
   start_time: 2020 1 1 0 0 0
 ```
 
@@ -127,29 +124,25 @@ ocn_2020_01_01_15.nc for time_bnds [12,18]
 ocn_2020_01_01_21.nc for time_bnds [18,24]
 ```
 
-**NOTE** If using the new_file_freq, there must be a way to distinguish each file, as it was done in the example above. 
+**NOTE** If using the new_file_freq, there must be a way to distinguish each file, as it was done in the example above.
 
-- **file_duration** is an integer that defines how long the file should receive data after start time in “file_duration_units”.  This optional field can only  be used if the start_time field is present.  If this field is absent, then the file duration will be equal to the frequency for creating new files. The file_duration_units field must also be present if this field is present.
-- **file_duration_units** is a string that defines the file duration units. The acceptable values are seconds, minutes, hours, days, months, years. 
+- **file_duration** is a string that defines how long the file should receive data after start time in “file_duration_units”.  This optional field can only be used if the start_time field is present.  If this field is absent, then the file duration will be equal to the frequency for creating new files.
 - **global_meta** is a subsection that lists any additional global metadata to add to the file. This is a new feature that is not supported by the legacy ascii data_table.
 - **sub_region** is a subsection that defines the four corners of a subregional section to capture.
 
 ### 2.2.1 Flexible output timings
 
-In order to provide more flexibility in output timings, the new diag_table yaml format allows for different file frequencies for the same file by allowing the `freq`, `freq_units`, `new_file_freq`, `new_file_freq_units`, `file_duration`, `file_duration_units` keys to accept array of integers/strings. 
+In order to provide more flexibility in output timings, the new diag_table yaml format allows for different file frequencies for the same file by allowing the `freq`, `new_file_freq`, and  `file_duration` keys to accept a comma seperated list.
 
-For example, 
+For example,
 ``` yaml
 - file_name: flexible_timing%4yr%2mo%2dy%2hr
-  freq: 1 1 1
-  freq_units: hours hours hours
+  freq: 1 hours, 1 hours, 1 hours
   time_units: hours
   unlimdim: time
-  new_file_freq: 6 3 1
-  new_file_freq_units: hours hours hours
+  new_file_freq: 6 hours, 3 hours, 1 hours
   start_time: 2 1 1 0 0 0
-  file_duration: 12 3 9
-  file_duration_units: hours hours hours
+  file_duration: 12 hours, 3 hours, 9 hours
   filename_time: begin
   varlist:
   - module: ocn_mod
@@ -195,7 +188,7 @@ In the *yaml diag_table*:
 The variables in each file are listed under the varlist section as a dashed array.
 
 - **var_name:**  is a string that defines the variable name as it is defined in the register_diag_field call in the model
-- **reduction:** is a string that describes the data reduction method to perform prior to writing data to disk. Acceptable values are average, diurnalXX (where XX is the number of diurnal samples), powXX (whre XX is the power level), min, max, none, rms, and sum.  
+- **reduction:** is a string that describes the data reduction method to perform prior to writing data to disk. Acceptable values are average, diurnalXX (where XX is the number of diurnal samples), powXX (whre XX is the power level), min, max, none, rms, and sum.
 - **module:**  is a string that defines the module where the variable is registered in the model code
 - **kind:** is a string that defines the type of variable  as it will be written out in the file. Acceptable values are r4, r8, i4, and i8
 
@@ -214,7 +207,7 @@ In the legacy ascii format:
 ```
 "moist",     "precip",                         "precip",           "atmos_8xdaily",   "all", .true.,  "none", 2
 ```
-**NOTE:** The fifth column (time_sampling) has be deprecated. The reduction_method (`.true.`) has been replaced with `average`. The output name was not included in the yaml because it is the same as the var_name. 
+**NOTE:** The fifth column (time_sampling) has be deprecated. The reduction_method (`.true.`) has been replaced with `average`. The output name was not included in the yaml because it is the same as the var_name.
 
 which corresponds to the following model code
 ```F90
@@ -226,12 +219,12 @@ where:
 - `axes` are the ids of the axes the variable is a function of
 - `Time` is the model time
 
-Below are some *optional* keys that may be added. 
+Below are some *optional* keys that may be added.
 - **write_var:** is a logical that is set to false if the user doesn’t want the variable to be written to the file (default: true).
 - **out_name:** is a string that defines the name of the variable that will be written to the file (default same as var_name)
 - **long_name:** is a string defining the long_name attribute of the variable. It overwrites the long_name in the variable's register_diag_field call
 - **attributes:** is a subsection with any additional metadata to add to the variable in the netcdf file. This is a new feature that is not supported by the legacy ascii data_table.
-- **zbounds:** is a 2 member array of integers that define the bounds of the z axis (zmin, zmin), optional default is no limits. 
+- **zbounds:** is a 2 member array of integers that define the bounds of the z axis (zmin, zmin), optional default is no limits.
 
 ### 2.4 Variable Metadata Section
 Any aditional variable attributes can be added for each varible can be listed under the attributes section as a dashed array. The key is attribute name and the value is the attribute value.
@@ -286,15 +279,12 @@ title: test_diag_manager
 base_date: 2 1 1 0 0 0
 diag_files:
 - file_name: wild_card_name%4yr%2mo%2dy%2hr
-  freq: 6
-  freq_units: hours
+  freq: 6 hours
   time_units: hours
   unlimdim: time
-  new_file_freq: 6
-  new_file_freq_units: hours
+  new_file_freq: 6 hours
   start_time: 2 1 1 0 0 0
-  file_duration: 12
-  file_duration_units: hours
+  file_duration: 12 hours
   varlist:
   - module: test_diag_manager_mod
     var_name: sst
@@ -303,8 +293,7 @@ diag_files:
   global_meta:
   - is_a_file: true
 - file_name: normal
-  freq: 24
-  freq_units: days
+  freq: 24 days
   time_units: hours
   unlimdim: records
   varlist:
@@ -322,8 +311,7 @@ diag_files:
     corner3: -60, 0
     corner4: -60, 75
 - file_name: normal2
-  freq: -1
-  freq_units: days
+  freq: -1 days
   time_units: hours
   unlimdim: records
   write_file: true
@@ -346,8 +334,7 @@ diag_files:
     corner3: 10, 25
     corner4: 20, 25
 - file_name: normal3
-  freq: -1
-  freq_units: days
+  freq: -1 days
   time_units: hours
   unlimdim: records
   write_file: false

--- a/diag_manager/fms_diag_yaml.F90
+++ b/diag_manager/fms_diag_yaml.F90
@@ -698,8 +698,8 @@ subroutine parse_key(filename, buffer, file_freq, file_frequnit, var)
   character(len=*),         intent(inout)  :: buffer           !< Buffer that was read in from the yaml
   integer,                  intent(out)    :: file_freq(:)     !< buffer to store the freq, new_file_freq, or
                                                                !! file_duration after it is parsed
-  integer,                  intent(out)    :: file_frequnit(:) !< buffer to store the freq units, new_file_freq units, or
-                                                               !! file_duration units after it is parsed
+  integer,                  intent(out)    :: file_frequnit(:) !< buffer to store the freq units, new_file_freq units,
+                                                               !! or file_duration units after it is parsed
   character(len=*),         intent(in)     :: var              !< Name of the key parsing
 
   integer            :: j           !< location of the ",' in the buffer

--- a/diag_manager/fms_diag_yaml.F90
+++ b/diag_manager/fms_diag_yaml.F90
@@ -503,35 +503,31 @@ subroutine fill_in_diag_files(diag_yaml_id, diag_file_id, fileobj)
 
   integer, allocatable :: key_ids(:) !< Id of the gloabl atttributes key/value pairs
   character(len=:), ALLOCATABLE :: grid_type !< grid_type as it is read in from the yaml
-  character(len=:), ALLOCATABLE :: freq_buffer !< buffer to store any freq as it is read from the yaml
   character(len=:), ALLOCATABLE :: buffer      !< buffer to store any *_units as it is read from the yaml
 
   call diag_get_value_from_key(diag_yaml_id, diag_file_id, "file_name", fileobj%file_fname)
-  call diag_get_value_from_key(diag_yaml_id, diag_file_id, "freq_units", buffer)
-  call diag_get_value_from_key(diag_yaml_id, diag_file_id, "freq", freq_buffer)
-  call set_file_freq(fileobj, freq_buffer, buffer)
+  call diag_get_value_from_key(diag_yaml_id, diag_file_id, "freq", buffer)
+  call parse_key(fileobj%file_fname, buffer, fileobj%file_freq, fileobj%file_frequnit, "freq")
+  deallocate(buffer)
 
-  deallocate(freq_buffer, buffer)
   call diag_get_value_from_key(diag_yaml_id, diag_file_id, "unlimdim", fileobj%file_unlimdim)
   call diag_get_value_from_key(diag_yaml_id, diag_file_id, "time_units", buffer)
   call set_file_time_units(fileobj, buffer)
-
   deallocate(buffer)
-  call diag_get_value_from_key(diag_yaml_id, diag_file_id, "new_file_freq", freq_buffer, is_optional=.true.)
-  call diag_get_value_from_key(diag_yaml_id, diag_file_id, "new_file_freq_units", buffer, &
-         is_optional=.true.)
-  call set_new_file_freq(fileobj, freq_buffer, buffer)
 
+  call diag_get_value_from_key(diag_yaml_id, diag_file_id, "new_file_freq", buffer, is_optional=.true.)
+  call parse_key(fileobj%file_fname, buffer, fileobj%file_new_file_freq, fileobj%file_new_file_freq_units, &
+    "new_file_freq")
   deallocate(buffer)
+
   call diag_get_value_from_key(diag_yaml_id, diag_file_id, "filename_time", buffer, is_optional=.true.)
   call set_filename_time(fileobj, buffer)
+  deallocate(buffer)
 
-  deallocate(freq_buffer, buffer)
   call diag_get_value_from_key(diag_yaml_id, diag_file_id, "start_time", fileobj%file_start_time, is_optional=.true.)
-  call diag_get_value_from_key(diag_yaml_id, diag_file_id, "file_duration", freq_buffer, is_optional=.true.)
-  call diag_get_value_from_key(diag_yaml_id, diag_file_id, "file_duration_units", buffer, &
-    is_optional=.true.)
-  call set_file_duration(fileobj, freq_buffer, buffer)
+  call diag_get_value_from_key(diag_yaml_id, diag_file_id, "file_duration", buffer, is_optional=.true.)
+  call parse_key(fileobj%file_fname, buffer, fileobj%file_duration, fileobj%file_duration_units, &
+    "file_duration")
 
   nsubregion = 0
   nsubregion = get_num_blocks(diag_yaml_id, "sub_region", parent_block_id=diag_file_id)
@@ -696,34 +692,61 @@ result(total_nvars)
   end do
 end function
 
-!> @brief This checks if the file frequency and file frequency units in a diag file are valid and
-!! sets the integer equivalent
-subroutine set_file_freq(fileobj, file_freq, file_frequnit)
-  type(diagYamlFiles_type), intent(inout) :: fileobj         !< diagYamlFiles_type obj to check
-  character(len=*),         intent(in)    :: file_freq       !< File_freq as it is read from the diag_table
-  character(len=*),         intent(in)    :: file_frequnit   !< File_freq_units as it is read from the diag_table
+!> @brief This parses the freq, new_file_freq, or file_duration keys which are read in as a comma list
+subroutine parse_key(filename, buffer, file_freq, file_frequnit, var)
+  character(len=*),         intent(in)     :: filename         !< The name of the file (for error messages)
+  character(len=*),         intent(inout)  :: buffer           !< Buffer that was read in from the yaml
+  integer,                  intent(out)    :: file_freq(:)     !< buffer to store the freq, new_file_freq, or
+                                                               !! file_duration after it is parsed
+  integer,                  intent(out)    :: file_frequnit(:) !< buffer to store the freq units, new_file_freq units, or
+                                                               !! file_duration units after it is parsed
+  character(len=*),         intent(in)     :: var              !< Name of the key parsing
 
-  integer           :: i                         !< For do loops
-  character(len=10) :: file_freq_units(MAX_FREQ) !< Array of file frequencies as a string
-  integer           :: err_unit                  !< Dummy error unit
+  integer            :: j           !< location of the ",' in the buffer
+  integer            :: k           !< location of the " " that seperated the units
+  logical            :: finished    !< .true. if the parsing is complete
+  integer            :: count       !< Number of keys that have been parsed
+  character(len=255) :: str         !< Member of the comma seperated list
+  character(len=10)  :: units       !< String to hold the units
+  integer            :: err_unit    !< Error key
 
-  file_freq_units = ""
-  read(file_freq, *, iostat=err_unit) fileobj%file_freq
-  read(file_frequnit, *, iostat=err_unit) file_freq_units
+  if (buffer .eq. "") return
 
-  do i = 1, MAX_FREQ
-    if (fileobj%file_freq(i) >= -1) then
-      if (trim(file_freq_units(i)) .eq. "") &
-        call mpp_error(FATAL, "file_freq_units is required. &
-        &Check your entry for file:"//trim(fileobj%file_fname))
-
-      fileobj%file_frequnit(i) = set_valid_time_units(file_freq_units(i), &
-      "file_freq_units for file:"//trim(fileobj%file_fname))
-    else
-      return
+  finished = .false.
+  j = 0
+  count = 0
+  do while (.not. finished)
+    count = count + 1
+    buffer = buffer(j+1:len_trim(buffer))
+    j = index(buffer, ",")
+    if (j == 0) then
+      !< There is only 1 member in the list
+      j = len_trim(buffer)+1
+      finished = .true.
     endif
+
+    str = adjustl(buffer(1:j-1))
+
+    k = index(str, " ")
+    read(str(1:k-1), *, iostat=err_unit) file_freq(count)
+    units = str(k+1:len_trim(str))
+
+    if (err_unit .ne. 0) &
+      call mpp_error(FATAL, "Error parsing "//trim(var)//". Check your entry for file"//&
+        trim(filename))
+
+    if (file_freq(count) .lt. -1) &
+        call mpp_error(FATAL, trim(var)//" is not valid. &
+        &Check your entry for file:"//trim(filename))
+
+    if (trim(units) .eq. "") &
+        call mpp_error(FATAL, trim(var)//" is required. &
+        &Check your entry for file:"//trim(filename))
+
+    file_frequnit(count) = set_valid_time_units(units, &
+      trim(var)//" for file:"//trim(filename))
   enddo
-end subroutine set_file_freq
+end subroutine parse_key
 
 !> @brief This checks if the time unit in a diag file is valid and sets the integer equivalent
 subroutine set_file_time_units (fileobj, file_timeunit)
@@ -732,36 +755,6 @@ subroutine set_file_time_units (fileobj, file_timeunit)
 
  fileobj%file_timeunit = set_valid_time_units(file_timeunit, "timeunit for file:"//trim(fileobj%file_fname))
 end subroutine set_file_time_units
-
-!> @brief This checks if the new file frequency and the new file frequency units in a diag file are valid
-!! and sets the integer equivalent
-subroutine set_new_file_freq(fileobj, new_file_freq, new_file_freq_units)
-  type(diagYamlFiles_type), intent(inout) :: fileobj                  !< diagYamlFiles_type obj to check
-  character(len=*),         intent(in)    :: new_file_freq            !< new file freq units as it is read from
-                                                                      !! the diag_table
-  character(len=*),         intent(in)    :: new_file_freq_units      !< new file freq units as it is read from
-                                                                      !! the diag_table
-  integer           :: i                                  !< For do loops
-  character(len=10) :: file_new_file_freq_units(MAX_FREQ) !< Array of new file frequencies as string
-  integer           :: err_unit                           !< Dummy error unit
-
-  file_new_file_freq_units = ""
-  read(new_file_freq, *, iostat=err_unit) fileobj%file_new_file_freq
-  read(new_file_freq_units, *, iostat=err_unit) file_new_file_freq_units
-
-  do i = 1, MAX_FREQ
-    if (fileobj%file_new_file_freq(i) > 0) then
-      if (trim(file_new_file_freq_units(i)) .eq. "") &
-        call mpp_error(FATAL, "new_file_freq_units is required if using new_file_freq. &
-        &Check your entry for file:"//trim(fileobj%file_fname))
-
-      fileobj%file_new_file_freq_units(i) = set_valid_time_units(file_new_file_freq_units(i), &
-      "new_file_freq_units for file:"//trim(fileobj%file_fname))
-    else
-      return
-    endif
-  enddo
-end subroutine set_new_file_freq
 
 !> @brief This checks if the filename_time in a diag file is correct and sets the integer equivalent
 subroutine set_filename_time(fileobj, filename_time)
@@ -783,63 +776,6 @@ subroutine set_filename_time(fileobj, filename_time)
     &Check your entry for file "//trim(fileobj%file_fname))
   end select
 end subroutine set_filename_time
-
-!> @brief This checks if the file duration and the file duration units in a diag file are valid
-!! and sets the integer equivalent
-subroutine set_file_duration(fileobj, file_duration, file_duration_units)
-  type(diagYamlFiles_type), intent(inout) :: fileobj             !< diagYamlFiles_type obj to check
-  character(len=*),         intent(in)    :: file_duration       !< file_duration as it is read from the yaml
-  character(len=*),         intent(in)    :: file_duration_units !< file_duration units as it is read from the yaml
-
-  integer           :: i                                   !< For do loops
-  character(len=10) :: file_duration_units_array(MAX_FREQ) !< Array of file_duration_units as string
-  integer           :: err_unit                            !< Dummy error unit
-  logical           :: mask(MAX_FREQ)                      !< Array of logical
-  integer           :: nfile_duration                      !< Number of file durations defined
-  integer           :: nfile_freq                          !< Number of file frequencies defined
-  integer           :: nnew_file_freq                      !< Number of new file frequencies defined
-
-  file_duration_units_array = ""
-  read(file_duration, *, iostat=err_unit) fileobj%file_duration
-  read(file_duration_units, *, iostat=err_unit) file_duration_units_array
-
-  nfile_duration = 0
-  do i = 1, MAX_FREQ
-    if (fileobj%file_duration(i) > 0) then
-      if(trim(file_duration_units_array(i)) .eq. "") &
-      call mpp_error(FATAL, "file_duration_units is required if using file_duration. &
-        &Check your entry for file:"//trim(fileobj%file_fname))
-
-      fileobj%file_duration_units(i) = set_valid_time_units(file_duration_units_array(i), &
-      "file_duration_units for file:"//trim(fileobj%file_fname))
-      nfile_duration = nfile_duration + 1
-    else
-      exit
-    endif
-  enddo
-
-  !< Make sure the user send in the correct number of freq, new_file_freq, and file_duration
-  mask = .FALSE.
-  mask = fileobj%file_freq .ne. DIAG_NULL
-  nfile_freq = count(mask)
-
-  mask = .FALSE.
-  mask = fileobj%file_new_file_freq .ne. DIAG_NULL
-  nnew_file_freq = count(mask)
-
-  if (nfile_freq .ne. nfile_duration .and. nfile_freq-1 .ne. nfile_duration) &
-    call mpp_error(FATAL, "freq and file_duration do not have consistent size. &
-      &Check your entry for file:"//trim(fileobj%file_fname))
-
-  if (nfile_freq .ne. nnew_file_freq .and. nfile_freq-1 .ne. nnew_file_freq) &
-    call mpp_error(FATAL, "freq and new_file_freq do not have consistent size. &
-      &Check your entry for file:"//trim(fileobj%file_fname))
-
-  if (nnew_file_freq .ne. nfile_duration .and. nnew_file_freq-1 .ne. nfile_duration) &
-    call mpp_error(FATAL, "new_file_freq and file_duration do not have consistent size. &
-      &Check your entry for file:"//trim(fileobj%file_fname))
-
-end subroutine set_file_duration
 
 !> @brief This checks if the kind of a diag field is valid and sets it
 subroutine set_field_kind(field, skind)

--- a/test_fms/diag_manager/check_crashes.sh
+++ b/test_fms/diag_manager/check_crashes.sh
@@ -30,32 +30,32 @@ test_expect_failure "Missing tile when using the 'index' grid type" '
   mpirun -n 1 ../test_diag_yaml
 '
 
-sed '/new_file_freq_units/d' diag_table.yaml_base > diag_table.yaml
+sed '/new_file_freq: 6 hours/new_file_freq: 6/g' diag_table.yaml_base > diag_table.yaml
 test_expect_failure "Missing new_file_freq_units when using new_file_freq_units" '
   mpirun -n 1 ../test_diag_yaml
 '
 
-sed 's/new_file_freq_units: hours/new_file_freq_units: mullions/g' diag_table.yaml_base > diag_table.yaml
+sed 's/new_file_freq: 6 hours/new_file_freq: 6 mullions/g' diag_table.yaml_base > diag_table.yaml
 test_expect_failure "new_file_freq_units is not valid" '
   mpirun -n 1 ../test_diag_yaml
 '
 
-sed '/file_duration_units/d' diag_table.yaml_base > diag_table.yaml
+sed '/file_duration: 12 hours/file_duration: 12/g' diag_table.yaml_base > diag_table.yaml
 test_expect_failure "Missing file_duration_units when using file_duration" '
   mpirun -n 1 ../test_diag_yaml
 '
 
-sed 's/file_duration_units: hours/file_duration_units: mullions/g' diag_table.yaml_base > diag_table.yaml
+sed 's/file_duration: 12 hours/file_duration: 12 mullions/g' diag_table.yaml_base > diag_table.yaml
 test_expect_failure "file_duration_units is not valid" '
   mpirun -n 1 ../test_diag_yaml
 '
 
-sed 's/freq_units: hours/freq_units: mullions/g' diag_table.yaml_base > diag_table.yaml
+sed 's/freq: 6 hours/freq: 6 mullions/g' diag_table.yaml_base > diag_table.yaml
 test_expect_failure "freq units is not valid" '
   mpirun -n 1 ../test_diag_yaml
 '
 
-sed 's/freq: 6/freq: 6 6/g' diag_table.yaml_base > diag_table.yaml
+sed 's/freq: 6 hours/freq: -6 hours/g' diag_table.yaml_base > diag_table.yaml
 test_expect_failure "freq is less than -1" '
   mpirun -n 1 ../test_diag_yaml
 '

--- a/test_fms/diag_manager/test_diag_manager2.sh
+++ b/test_fms/diag_manager/test_diag_manager2.sh
@@ -523,15 +523,12 @@ base_date: 2 1 1 0 0 0
 diag_files:
 - file_name: wild_card_name%4yr%2mo%2dy%2hr
   filename_time: end
-  freq: 6
-  freq_units: hours
+  freq: 6 hours
   time_units: hours
   unlimdim: time
-  new_file_freq: 6
-  new_file_freq_units: hours
+  new_file_freq: 6 hours
   start_time: 2 1 1 0 0 0
-  file_duration: 12
-  file_duration_units: hours
+  file_duration: 12 hours
   varlist:
   - module: test_diag_manager_mod
     var_name: sst
@@ -541,8 +538,7 @@ diag_files:
   global_meta:
   - is_a_file: true
 - file_name: normal
-  freq: 24
-  freq_units: days
+  freq: 24 days
   time_units: hours
   unlimdim: records
   varlist:
@@ -561,8 +557,7 @@ diag_files:
     corner3: -60, 0
     corner4: -60, 75
 - file_name: normal2
-  freq: -1
-  freq_units: days
+  freq: -1 days
   time_units: hours
   unlimdim: records
   write_file: true
@@ -588,8 +583,7 @@ diag_files:
     corner3: 10, 25
     corner4: 20, 25
 - file_name: normal3
-  freq: -1
-  freq_units: days
+  freq: -1 days
   time_units: hours
   unlimdim: records
   write_file: false
@@ -609,8 +603,7 @@ title: test_diag_manager
 base_date: 2 1 1 0 0 0
 diag_files:
 - file_name: file1
-  freq: 6
-  freq_units: hours
+  freq: 6 hours
   time_units: hours
   unlimdim: time
   varlist:
@@ -620,8 +613,7 @@ diag_files:
     reduction: average
     kind: r4
 - file_name: file2
-  freq: 6
-  freq_units: hours
+  freq: 6 hours
   time_units: hours
   unlimdim: time
   is_ocean: True
@@ -632,8 +624,7 @@ diag_files:
     reduction: average
     kind: r4
 - file_name: file3
-  freq: 6
-  freq_units: hours
+  freq: 6 hours
   time_units: hours
   unlimdim: time
   varlist:
@@ -662,8 +653,7 @@ base_date: 2 1 1 0 0 0
 
 diag_files:
 - file_name: static_file
-  freq: -1
-  freq_units: hours
+  freq: -1 hours
   time_units: hours
   unlimdim: time
   varlist:
@@ -675,8 +665,7 @@ diag_files:
   - is_important: False
     has_important: True
 - file_name: file1
-  freq: 6
-  freq_units: hours
+  freq: 6 hours
   time_units: hours
   unlimdim: time
   varlist:
@@ -690,8 +679,7 @@ diag_files:
     reduction: average
     kind: r4
 - file_name: file2
-  freq: 6
-  freq_units: hours
+  freq: 6 hours
   time_units: hours
   unlimdim: time
   varlist:
@@ -715,8 +703,7 @@ diag_files:
     kind: r8
     zbounds: 2.0 3.0
 - file_name: file3
-  freq: 6
-  freq_units: hours
+  freq: 6 hours
   time_units: hours
   unlimdim: time
   varlist:
@@ -729,8 +716,7 @@ diag_files:
     reduction: average
     kind: r4
 - file_name: file4
-  freq: 6
-  freq_units: hours
+  freq: 6 hours
   time_units: hours
   unlimdim: time
   varlist:
@@ -739,8 +725,7 @@ diag_files:
     reduction: average
     kind: r4
 - file_name: file5
-  freq: 6
-  freq_units: hours
+  freq: 6 hours
   time_units: hours
   unlimdim: time
   varlist:
@@ -756,23 +741,19 @@ diag_files:
     corner3: 10, 25
     corner4: 20, 25
 - file_name: file6%4yr%2mo%2dy%2hr
-  freq: 6
-  freq_units: hours
+  freq: 6 hours
   time_units: hours
   unlimdim: time
-  new_file_freq: 6
-  new_file_freq_units: hours
+  new_file_freq: 6 hours
   start_time: 2 1 1 0 0 0
-  file_duration: 12
-  file_duration_units: hours
+  file_duration: 12 hours
   varlist:
   - module: ocn_mod
     var_name: var1
     reduction: average
     kind: r4
 - file_name: file7
-  freq: 6
-  freq_units: hours
+  freq: 6 hours
   time_units: hours
   unlimdim: time
   varlist:
@@ -783,15 +764,12 @@ diag_files:
     attributes:
     - GFDL_name: var_var
 - file_name: file8%4yr%2mo%2dy%2hr%2min
-  freq: 1 1 1
-  freq_units: hours hours hours
+  freq: 1 hours,1 hours,1 hours
   time_units: hours
   unlimdim: time
-  new_file_freq: 6 3 1
-  new_file_freq_units: hours hours hours
+  new_file_freq: 6 hours, 3 hours, 1 hours
   start_time: 2 1 1 0 0 0
-  file_duration: 12 3 9
-  file_duration_units: hours hours hours
+  file_duration: 12 hours, 3 hours, 9 hours
   varlist:
   - module: ocn_mod
     var_name: var1
@@ -799,23 +777,19 @@ diag_files:
     kind: r4
 - file_name: file9%4yr%2mo%2dy%2hr%2min
   filename_time: begin
-  freq: 1 1 1
-  freq_units: hours hours hours
+  freq: 1 hours,1 hours,1 hours
   time_units: hours
   unlimdim: time
-  new_file_freq: 6 3 1
-  new_file_freq_units: hours hours hours
+  new_file_freq: 6 hours, 3 hours, 1 hours
   start_time: 2 1 1 0 0 0
-  file_duration: 12 3 9
-  file_duration_units: hours hours hours
+  file_duration: 12 hours, 3 hours, 9 hours
   varlist:
   - module: ocn_mod
     var_name: var1
     reduction: average
     kind: r4
 - file_name: file10_diurnal
-  freq: 1
-  freq_units: days
+  freq: 1 days
   time_units: hours
   unlimdim: time
   varlist:
@@ -842,8 +816,7 @@ base_date: 2 1 1 0 0 0
 
 diag_files:
 - file_name: file1_clock
-  freq: 1
-  freq_units: days
+  freq: 1 days
   time_units: hours
   unlimdim: time
   varlist:
@@ -865,8 +838,7 @@ base_date: 2 1 1 0 0 0
 
 diag_files:
 - file_name: file1_forecast
-  freq: 1
-  freq_units: days
+  freq: 1 days
   time_units: hours
   unlimdim: time
   varlist:


### PR DESCRIPTION
**Description**
Removes the need for `freq_units`, `new_file_freq_units`, and `file_duration_units` by allowing `freq`, `new_file_freq`, and `file_duration` to accept both.
The tests and the documentation were also updated.

Fixes # (issue)

**How Has This Been Tested?**
CI

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

