### PR TITLE
fix test errors from io flag

### DIFF
--- a/test_fms/diag_manager/test_diag_manager.F90
+++ b/test_fms/diag_manager/test_diag_manager.F90
@@ -232,6 +232,7 @@ PROGRAM test
 #ifdef use_deprecated_io
   USE fms_io_mod, ONLY: fms_io_init, file_exist, open_file
   USE fms_io_mod, ONLY: fms_io_exit, set_filename_appendix
+  use mpp_io_mod, only: mpp_io_init
 #endif
   USE constants_mod, ONLY: constants_init, PI, RAD_TO_DEG
 

--- a/test_fms/interpolator/test_interpolator.F90
+++ b/test_fms/interpolator/test_interpolator.F90
@@ -37,7 +37,11 @@ program test_interpolator
 
 use mpp_mod
 use mpp_domains_mod
+#ifdef use_deprecated_io
 use fms_mod, old_open_file => open_file
+#else
+use fms_mod
+#endif
 use time_manager_mod
 use diag_manager_mod
 use interpolator_mod

--- a/test_fms/interpolator/test_interpolator.F90
+++ b/test_fms/interpolator/test_interpolator.F90
@@ -37,7 +37,7 @@ program test_interpolator
 
 use mpp_mod
 use mpp_domains_mod
-use fms_mod
+use fms_mod, old_open_file => open_file
 use time_manager_mod
 use diag_manager_mod
 use interpolator_mod


### PR DESCRIPTION
**Description**
fixes two missed/conflicting imports in test files that slipped in with the io update and got caught by the ci.

**How Has This Been Tested?**
make check on amd, configured with deprecated io flag

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

