### PR TITLE
Update oneapi version for CI

### DIFF
--- a/.github/workflows/intel_pr.yml
+++ b/.github/workflows/intel_pr.yml
@@ -1,4 +1,4 @@
-on: pull_request
+on: push
 jobs:
   intel-autotools:
     runs-on: ubuntu-latest
@@ -49,4 +49,4 @@ jobs:
     - name: Compile
       run: make -j || make
     - name: Run test suite
-      run: make check LD_LIBRARY_PATH="/libs/lib:$LD_LIBRARY_PATH" SKIP_TESTS="$SKIP_TESTS" VERBOSE=1
+      run: make check LD_LIBRARY_PATH="/libs/lib:$LD_LIBRARY_PATH" TEST_VERBOSE=1

--- a/.github/workflows/intel_pr.yml
+++ b/.github/workflows/intel_pr.yml
@@ -1,4 +1,4 @@
-on: push
+on: pull_request
 jobs:
   intel-autotools:
     runs-on: ubuntu-latest

--- a/.github/workflows/intel_pr.yml
+++ b/.github/workflows/intel_pr.yml
@@ -20,6 +20,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: /libs
+        key: ${{ runner.os }}-intel-libs
     - name: Install packages for building
       run: apt update && apt install -y autoconf libtool automake zlibc zlib1g-dev
     - if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/intel_pr.yml
+++ b/.github/workflows/intel_pr.yml
@@ -3,7 +3,7 @@ jobs:
   intel-autotools:
     runs-on: ubuntu-latest
     container:
-      image: intel/oneapi-hpckit:2023.1.0-devel-ubuntu22.04
+      image: intel/oneapi-hpckit:2023.1.0-devel-ubuntu20.04
       env:
         CC: mpiicc
         FC: mpiifort
@@ -22,7 +22,7 @@ jobs:
         path: /libs
         key: ${{ runner.os }}-intel-libs
     - name: Install packages for building
-      run: apt update && apt install -y autoconf libtool automake zlibc zlib1g-dev
+      run: apt-get update && apt-get install -y autoconf libtool automake zlibc zlib1g-dev
     - if: steps.cache.outputs.cache-hit != 'true'
       name: Build netcdf
       run: |

--- a/.github/workflows/intel_pr.yml
+++ b/.github/workflows/intel_pr.yml
@@ -3,7 +3,7 @@ jobs:
   intel-autotools:
     runs-on: ubuntu-latest
     container:
-      image: intel/oneapi-hpckit:2022.2-devel-ubuntu20.04
+      image: intel/oneapi-hpckit:2023.1.0-devel-ubuntu22.04
       env:
         CC: mpiicc
         FC: mpiifort
@@ -20,7 +20,6 @@ jobs:
       uses: actions/cache@v3
       with:
         path: /libs
-        key: ${{ runner.os }}-intel-libs
     - name: Install packages for building
       run: apt update && apt install -y autoconf libtool automake zlibc zlib1g-dev
     - if: steps.cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
**Description**
updates the image to the most recent oneapi version avaialable. This fixes some intel ci failures from running out of storage that were happening last week when pulling the image.

**How Has This Been Tested?**
tested in my forks actions

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

