### PR TITLE
Add axis ids to the buffer object

### DIFF
--- a/diag_manager/Makefile.am
+++ b/diag_manager/Makefile.am
@@ -70,7 +70,7 @@ fms_diag_object_mod.$(FC_MODEXT): diag_data_mod.$(FC_MODEXT) fms_diag_file_objec
 fms_diag_field_object_mod.$(FC_MODEXT): diag_data_mod.$(FC_MODEXT) fms_diag_yaml_mod.$(FC_MODEXT) fms_diag_time_utils_mod.$(FC_MODEXT) \
                                         fms_diag_axis_object_mod.$(FC_MODEXT)
 fms_diag_file_object_mod.$(FC_MODEXT): diag_data_mod.$(FC_MODEXT) fms_diag_yaml_mod.$(FC_MODEXT) fms_diag_field_object_mod.$(FC_MODEXT) fms_diag_time_utils_mod.$(FC_MODEXT) \
-                                       fms_diag_axis_object_mod.$(FC_MODEXT)
+                                       fms_diag_axis_object_mod.$(FC_MODEXT) fms_diag_output_buffer_mod.$(FC_MODEXT)
 fms_diag_object_container_mod.$(FC_MODEXT): fms_diag_object_mod.$(FC_MODEXT) fms_diag_dlinked_list_mod.$(FC_MODEXT) fms_diag_time_utils_mod.$(FC_MODEXT)
 fms_diag_axis_object_mod.$(FC_MODEXT): diag_data_mod.$(FC_MODEXT) fms_diag_time_utils_mod.$(FC_MODEXT) fms_diag_yaml_mod.$(FC_MODEXT) \
                                        diag_grid_mod.$(FC_MODEXT)

--- a/diag_manager/fms_diag_field_object.F90
+++ b/diag_manager/fms_diag_field_object.F90
@@ -239,7 +239,7 @@ subroutine fms_register_diag_field_obj &
   if (present(axes)) then
     this%scalar = .false.
     this%axis_ids = axes
-    call get_domain_and_domain_type(diag_axis, this%axis_ids, this%type_of_domain, this%domain, this%varname)
+    call get_domain_and_domain_type(diag_axis, axes, this%type_of_domain, this%domain, this%varname)
   else
     !> The variable is a scalar
     this%scalar = .true.

--- a/diag_manager/fms_diag_field_object.F90
+++ b/diag_manager/fms_diag_field_object.F90
@@ -239,7 +239,7 @@ subroutine fms_register_diag_field_obj &
   if (present(axes)) then
     this%scalar = .false.
     this%axis_ids = axes
-    call get_domain_and_domain_type(diag_axis, axes, this%type_of_domain, this%domain, this%varname)
+    call get_domain_and_domain_type(diag_axis, this%axis_ids, this%type_of_domain, this%domain, this%varname)
   else
     !> The variable is a scalar
     this%scalar = .true.

--- a/diag_manager/fms_diag_file_object.F90
+++ b/diag_manager/fms_diag_file_object.F90
@@ -690,12 +690,14 @@ end subroutine set_file_domain
 
 !> @brief Loops through a variable's axis_ids and adds them to the FMSDiagFile object if they don't exist
 subroutine add_axes(this, axis_ids, diag_axis, naxis, yaml_id, output_buffers)
-  class(fmsDiagFile_type),          intent(inout)       :: this          !< The file object
-  integer,                          INTENT(in)          :: axis_ids(:)   !< Array of axes_ids
-  class(fmsDiagAxisContainer_type), intent(inout)       :: diag_axis(:)  !< Diag_axis object
-  integer,                          intent(inout)       :: naxis         !< Number of axis that have been registered
-  integer,                          intent(in)          :: yaml_id       !< Yaml id of the yaml section for this var
-  type(fmsDiagOutputBufferContainer_type), intent(inout):: output_buffers(:)
+  class(fmsDiagFile_type),                 intent(inout) :: this              !< The file object
+  integer,                                 INTENT(in)    :: axis_ids(:)       !< Array of axes_ids
+  class(fmsDiagAxisContainer_type),        intent(inout) :: diag_axis(:)      !< Diag_axis object
+  integer,                                 intent(inout) :: naxis             !< Number of axis that have been
+                                                                              !! registered
+  integer,                                 intent(in)    :: yaml_id           !< Yaml id of the field section for
+                                                                              !! this var
+  type(fmsDiagOutputBufferContainer_type), intent(inout) :: output_buffers(:) !< Array of output buffers
 
   type(diagYamlFilesVar_type), pointer     :: field_yaml  !< pointer to the yaml entry
 

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -245,7 +245,8 @@ CALL MPP_ERROR(FATAL,"You can not use the modern diag manager without compiling 
      call fileptr%add_field_and_yaml_id(fieldptr%get_id(), diag_field_indices(i))
      call fileptr%set_file_domain(fieldptr%get_domain(), fieldptr%get_type_of_domain())
      call fileptr%init_diurnal_axis(this%diag_axis, this%registered_axis, diag_field_indices(i))
-     call fileptr%add_axes(axes, this%diag_axis, this%registered_axis, diag_field_indices(i))
+     call fileptr%add_axes(axes, this%diag_axis, this%registered_axis, diag_field_indices(i), &
+       this%FMS_diag_output_buffers)
      call fileptr%add_start_time(init_time, this%current_model_time)
      call fileptr%set_file_time_ops (fieldptr%diag_field(i), fieldptr%is_static())
     enddo
@@ -255,7 +256,8 @@ CALL MPP_ERROR(FATAL,"You can not use the modern diag manager without compiling 
      call fileptr%add_field_and_yaml_id(fieldptr%get_id(), diag_field_indices(i))
      call fileptr%init_diurnal_axis(this%diag_axis, this%registered_axis, diag_field_indices(i))
      call fileptr%set_file_domain(fieldptr%get_domain(), fieldptr%get_type_of_domain())
-     call fileptr%add_axes(axes, this%diag_axis, this%registered_axis, diag_field_indices(i))
+     call fileptr%add_axes(axes, this%diag_axis, this%registered_axis, diag_field_indices(i), &
+     this%FMS_diag_output_buffers)
      call fileptr%set_file_time_ops (fieldptr%diag_field(i), fieldptr%is_static())
     enddo
   elseif (present(init_time)) then !only inti time present
@@ -976,10 +978,11 @@ subroutine allocate_diag_field_output_buffers(this, field_data, field_id)
   integer :: i, j !< For looping
   class(fmsDiagOutputBuffer_class), pointer :: ptr_diag_buffer_obj !< Pointer to the buffer class
   class(DiagYamlFilesVar_type), pointer :: ptr_diag_field_yaml !< Pointer to a field from yaml fields
-  integer, pointer :: axis_ids(:) !< Pointer to indices of axes of the field variable
+  integer, allocatable :: axis_ids(:) !< Pointer to indices of axes of the field variable
   integer :: var_type !< Stores type of the field data (r4, r8, i4, i8, and string) represented as an integer.
   real :: missing_value !< Fill value to initialize output buffers
   character(len=128), allocatable :: var_name !< Field name to initialize output buffers
+  logical :: is_scalar !< Flag indicating that the variable is a scalar
 
   ! Determine the type of the field data
   var_type = get_var_type(field_data(1, 1, 1, 1))
@@ -1009,15 +1012,21 @@ subroutine allocate_diag_field_output_buffers(this, field_data, field_id)
   endif
 
   ! Determine dimensions of the field
-  ndims = 0
+  is_scalar = .True.
   if (this%FMS_diag_fields(field_id)%has_axis_ids()) then
-    axis_ids => this%FMS_diag_fields(field_id)%get_axis_id() !< Get ids of axes of the variable
-    ndims = size(axis_ids) !< Dimensions of the field
+    is_scalar = .False.
   endif
 
   ! Loop over a number of fields/buffers where this variable occurs
   do i = 1, size(this%FMS_diag_fields(field_id)%buffer_ids)
     buffer_id = this%FMS_diag_fields(field_id)%buffer_ids(i)
+
+    ndims = 0
+    if (.not. is_scalar) then
+      axis_ids = this%FMS_diag_output_buffers(buffer_id)%get_axis_ids()
+      ndims = size(axis_ids)
+    endif
+
     ptr_diag_field_yaml => diag_yaml%get_diag_field_from_id(buffer_id)
     num_diurnal_samples = ptr_diag_field_yaml%get_n_diurnal() !< Get number of diurnal samples
 

--- a/diag_manager/fms_diag_output_buffer.F90
+++ b/diag_manager/fms_diag_output_buffer.F90
@@ -61,6 +61,11 @@ end type fmsDiagOutputBuffer_class
 !> holds an allocated buffer0-5d object
 type :: fmsDiagOutputBufferContainer_type
   class(fmsDiagOutputBuffer_class), allocatable :: diag_buffer_obj !< any 0-5d buffer object
+  integer, allocatable :: axis_ids(:)
+
+  contains
+  procedure :: add_axis_ids
+  procedure :: get_axis_ids
 end type
 
 !> Scalar buffer type to extend fmsDiagBufferContainer_type
@@ -1425,5 +1430,30 @@ subroutine add_to_buffer_5d(this, input_data, field_name)
   if( type_error ) call mpp_error (FATAL,'add_to_buffer_5d: mismatch between allocated buffer and input data types'//&
                                          'for field:'// field_name)
 end subroutine add_to_buffer_5d
+
+!> @brief Adds the axis ids to the buffer object
+subroutine add_axis_ids(this, axis_ids)
+  class(fmsDiagOutputBufferContainer_type), intent(inout) :: this
+  integer,                                  intent(in)    :: axis_ids(:)
+
+  this%axis_ids = axis_ids
+end subroutine
+
+!> @brief Get the axis_ids for the buffer
+!! @return Axis_ids
+function get_axis_ids(this) &
+  result(res)
+
+  class(fmsDiagOutputBufferContainer_type), intent(inout) :: this
+  integer, allocatable :: res(:)
+
+  if (allocated(this%axis_ids)) then
+    res = this%axis_ids
+  else
+    allocate(res(1))
+    res = diag_null
+  endif
+end function
+
 #endif
 end module fms_diag_output_buffer_mod

--- a/diag_manager/fms_diag_output_buffer.F90
+++ b/diag_manager/fms_diag_output_buffer.F90
@@ -61,7 +61,7 @@ end type fmsDiagOutputBuffer_class
 !> holds an allocated buffer0-5d object
 type :: fmsDiagOutputBufferContainer_type
   class(fmsDiagOutputBuffer_class), allocatable :: diag_buffer_obj !< any 0-5d buffer object
-  integer, allocatable :: axis_ids(:)
+  integer,                          allocatable :: axis_ids(:)     !< Axis ids for the buffer
 
   contains
   procedure :: add_axis_ids
@@ -1433,18 +1433,18 @@ end subroutine add_to_buffer_5d
 
 !> @brief Adds the axis ids to the buffer object
 subroutine add_axis_ids(this, axis_ids)
-  class(fmsDiagOutputBufferContainer_type), intent(inout) :: this
-  integer,                                  intent(in)    :: axis_ids(:)
+  class(fmsDiagOutputBufferContainer_type), intent(inout) :: this        !< Buffer object
+  integer,                                  intent(in)    :: axis_ids(:) !< Axis ids to add
 
   this%axis_ids = axis_ids
 end subroutine
 
 !> @brief Get the axis_ids for the buffer
-!! @return Axis_ids
+!! @return Axis_ids, if the buffer doesn't have axis ids it returns diag_null
 function get_axis_ids(this) &
   result(res)
 
-  class(fmsDiagOutputBufferContainer_type), intent(inout) :: this
+  class(fmsDiagOutputBufferContainer_type), intent(inout) :: this        !< Buffer object
   integer, allocatable :: res(:)
 
   if (allocated(this%axis_ids)) then


### PR DESCRIPTION
**Description**
Adds axis_ids to the output buffers.

Before this update, the axis_ids were added to the field object but that is not enough because the axis_ids will be different depending on whether or not the file is subregional/has reduced k range.

The axis ids in the file object includes the (unique) axis ids of all of the variable in the file so it will be difficult to get the axis ids for the specific variable

There is more clean up that can be done, but this is enough for @ganganoaa to keep moving with his updates

Fixes # (issue)

**How Has This Been Tested?**
CI

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

