### PR TITLE
remove stack limit checks in scripts

### DIFF
--- a/test_fms/fms2_io/test_fms2_io.sh
+++ b/test_fms/fms2_io/test_fms2_io.sh
@@ -31,16 +31,6 @@
 # Create and enter output directory
 output_dir
 
-# use smaller arrays if system stack size is limited
-if [ $STACK_LIMITED ]; then
-  cat <<_EOF > input.nml
-&test_fms2_io_nml
-  nx = 32
-  ny = 32
-  nz = 10
-/
-_EOF
-fi
 touch input.nml
 
 # run the tests

--- a/test_fms/mpp/test_mpp_chksum.sh
+++ b/test_fms/mpp/test_mpp_chksum.sh
@@ -29,11 +29,6 @@
 
 echo "&test_mpp_chksum_nml" > input.nml
 echo "test_num = 1" >> input.nml
-# replaces defaults with smaller sizes if stack size is limited
-if [ $STACK_LIMITED ]; then
-  echo "nx = 64" >> input.nml
-  echo "ny = 64" >> input.nml
-fi
 echo "/" >> input.nml
 
 test_expect_success "mpp_chksum simple functionality" '

--- a/test_fms/test-lib.sh.in
+++ b/test_fms/test-lib.sh.in
@@ -33,11 +33,6 @@ TEST_NAME="$(basename "$0" .sh)"
 TEST_NUMBER="${TEST_NAME%%-*}"
 TEST_NUMBER="${TEST_NUMBER#t}"
 
-# if using intel with a limited stack size, sets to run smaller tests
-if [ "$($FC --version | grep ifort)" -a "$(ulimit -s)" != "unlimited" 2> /dev/null ]; then
-  STACK_LIMITED=1
-fi
-
 exec 7>&2
 # For now, write all output
 #if test -n "$VERBOSE"


### PR DESCRIPTION
**Description**
This should go in alongside #1233, it removes a check for system stack size in the test scripts that would run smaller tests if it was limited. The check won't be needed if stack size is set in the init routine, plus it was messing with ifx testing.

**How Has This Been Tested?**
make check on amd, oneapi 2023.1

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x ] `make distcheck` passes

