### PR TITLE
fix for horiz_interp gcc errors

### DIFF
--- a/horiz_interp/horiz_interp_type.F90
+++ b/horiz_interp/horiz_interp_type.F90
@@ -81,7 +81,7 @@ type horizInterpReals8_type
    real(kind=r8_kind),    dimension(:), allocatable     :: area_frac_dst !< area fraction in destination grid.
    real(kind=r8_kind),    dimension(:,:), allocatable   :: mask_in
    real(kind=r8_kind)                                   :: max_src_dist
-   logical                                              :: is_allocated !< set to true upon field allocation
+   logical                                              :: is_allocated = .false. !< set to true upon field allocation
 
 end type horizInterpReals8_type
 
@@ -108,7 +108,7 @@ type horizInterpReals4_type
    real(kind=r4_kind),    dimension(:), allocatable     :: area_frac_dst !< area fraction in destination grid.
    real(kind=r4_kind),    dimension(:,:), allocatable   :: mask_in
    real(kind=r4_kind)                                   :: max_src_dist
-   logical                                              :: is_allocated !< set to true upon field allocation
+   logical                                              :: is_allocated = .false. !< set to true upon field allocation
 
 end type horizInterpReals4_type
 


### PR DESCRIPTION
**Description**
fixes some unit test failures with later gcc versions, needed to initialize the logicals within the real types to false.

partial fix for #1276

**How Has This Been Tested?**
make check with gcc 13

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

