### PR TITLE
Fix build failure with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,6 +196,7 @@ list(APPEND fms_fortran_src_files
 # Collect FMS C source files
 list(APPEND fms_c_src_files
   affinity/affinity.c
+  fms/fms_stacksize.c
   mosaic/create_xgrid.c
   mosaic/gradient_c2l.c
   mosaic/interp.c


### PR DESCRIPTION
**Description**
`fms/fms_stacksize.c` has been added to `fms_c_src_files` in `CMakeLists.txt`.

Fixes #1284

**How Has This Been Tested?**
Github CI

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes