### PR TITLE
copy fileobj in interpolator_type_eq

### DIFF
--- a/interpolator/interpolator.F90
+++ b/interpolator/interpolator.F90
@@ -346,6 +346,7 @@ type(interpolate_type), intent(inout) :: Out
 
      Out%interph = In%interph
      if (allocated(In%time_slice)) Out%time_slice =  In%time_slice
+     Out%fileobj   = In%fileobj
      Out%file_name = In%file_name
      Out%time_flag = In%time_flag
      Out%level_type = In%level_type


### PR DESCRIPTION
**Description**
In this PR, 

`Out%fileobj=In%fileobj`

is added to subroutine interpolator_type_eq

Fixes #1286 

**How Has This Been Tested?**
`make check` passes with Intel on the AMD box

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

