### PR TITLE
test_mpp_domains2 GCC workaround

### DIFF
--- a/mpp/include/mpp_update_domains2D.fh
+++ b/mpp/include/mpp_update_domains2D.fh
@@ -225,13 +225,18 @@
       logical, intent(in), optional :: complete, free
       integer, intent(in), optional :: list_size
       integer, intent(in), optional :: position
+      integer :: i, j
       MPP_TYPE_ :: field3D_in (size(field_in, 1),size(field_in, 2),1)
       MPP_TYPE_ :: field3D_out(size(field_out,1),size(field_out,2),1)
       type(DomainCommunicator2D),pointer,optional :: dc_handle
       pointer( ptr_in,  field3D_in  )
       pointer( ptr_out, field3D_out )
 
-      field_out = 0
+      do j = 1, size(field_out, 2)
+        do i = 1, size(field_out, 1)
+          field_out(i,j) = 0
+        enddo
+      enddo
       ptr_in = 0
       ptr_out = 0
       if(domain_in%initialized) ptr_in  = LOC(field_in )


### PR DESCRIPTION
**Description**
The test_mpp_domains2 check-parallel test was failing with a seg fault at mpp_update_domains2D.fh line 234:
https://github.com/NOAA-GFDL/FMS/blob/2be8aa452ad3e5f43e92c38a64f12d1ae6c43fb8/mpp/include/mpp_update_domains2D.fh#L220-L236

I was able to fix the seg fault by looping over every element of the array and initializing those elements to 0.  

I have not yet been able to create a test program that reproduces it.  I have started with this test program, and it does not reproduce the seg fault (I will continue to find a reproducable test program to submit a bug with GNU): 
```
program arrayinit

real, dimension(:,:), allocatable :: field_1_alloc !< Allocatable array that will be initialized in subroutine
real, dimension(5,5) :: field_2 !< Array that will be initialized in subroutine

allocate(field_1_alloc(5, 5))
print *, "calling subroutine_test on field_1_alloc"
call subroutine_test(field_1_alloc)

print *, "calling subroutine_test on field_2"
call subroutine_test(field_2)

contains
  subroutine subroutine_test(field_out)
    real, intent(out) :: field_out(:,:)

    field_out = 0
  end subroutine
end program
```

Fixes #1290 

**How Has This Been Tested?**
Tested on the dev box at GFDL with same environment as described in issue.
used make check

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

