### PR TITLE
mpp_check_field fix for test_mpp_domains2

### DIFF
--- a/mpp/include/mpp_domains_misc.inc
+++ b/mpp/include/mpp_domains_misc.inc
@@ -413,12 +413,13 @@ end subroutine init_nonblock_type
     if(any(pelist2 == pe)) then
        call mpp_get_data_domain(domain2, isd, ied, jsd, jed)
        call mpp_get_compute_domain(domain2, is, ie, js, je)
-       allocate(field1(isd:ied, jsd:jed),field2(isd:ied, jsd:jed))
+       allocate(field2(isd:ied, jsd:jed))
       if((size(field_in,1) .ne. ied-isd+1) .or. (size(field_in,2) .ne. jed-jsd+1)) &
          call mpp_error(FATAL,'mpp_check_field: input field is not on the data domain')
       field2(isd:ied, jsd:jed) = field_in(:,:)
     endif
 
+    allocate(field1(isd:ied, jsd:jed))
 !  broadcast domain
     call mpp_broadcast_domain(domain1)
     call mpp_broadcast_domain(domain2)


### PR DESCRIPTION
**Description**
The test_mpp_domains2 test fails at line 234 in mpp_update_domains.fh with a seg fault.  Tracking through the backtrace of this error (you can see the full backtrace in issue #1290) I think I have found the root cause:

In file `mpp_domains_misc.inc` subroutine `mpp_check_field_2d_type2` we call `mpp_redistribute` at line 426 with the following arguments:
https://github.com/NOAA-GFDL/FMS/blob/2be8aa452ad3e5f43e92c38a64f12d1ae6c43fb8/mpp/include/mpp_domains_misc.inc#L426

Because `field1` and `field2` are 2D arrays, mpp_redistribute will use the subroutine `MPP_REDISTRIBUTE_2D_` from `mpp_update_domains2D.fh`

`field1` in `mpp_check_field_2d_type2` is `field_out` in `MPP_REDISTRIBUTE_2D_` and the program fails when we try to set `field_out = 0` [in MPP_REDISTRIBUTE_2D_](https://github.com/NOAA-GFDL/FMS/blob/main/mpp/include/mpp_update_domains2D.fh#L234)

I think that this is happening because `field1` was only allocated on `pelist2` but mpp_redistribute is called from all pes .  So pes from `pelist1` will not have allocated `field1`.

The solution I propose in this PR is to allocate `field1` outside of the `if(any(pelist2 == pe))` condition so that all pes allocate.

Fixes #1290 

**How Has This Been Tested?**
Tested with GCC 13.1.0 on GFDL dev box with openmpi make and make check

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

