### PR TITLE
fix test_mpp_nesting 

### DIFF
--- a/mpp/mpp_domains.F90
+++ b/mpp/mpp_domains.F90
@@ -452,7 +452,7 @@ module mpp_domains_mod
   type :: nest_domain_type
      character(len=NAME_LENGTH)     :: name
      integer                        :: num_level
-     integer,               pointer :: nest_level(:)    !< Added for moving nest functionality
+     integer,               pointer :: nest_level(:) => NULL() !< Added for moving nest functionality
      type(nest_level_type), pointer :: nest(:) => NULL()
      integer                        :: num_nest
      integer,               pointer :: tile_fine(:), tile_coarse(:)


### PR DESCRIPTION
**Description**
test_mpp_nesting has been failing at the following line with a segmentation fault
https://github.com/NOAA-GFDL/FMS/blob/2be8aa452ad3e5f43e92c38a64f12d1ae6c43fb8/mpp/include/mpp_define_nest_domains.inc#L199

I debugged this and noticed that `associated(nest_domain%nest_level)` is `true` even when we have not yet allocated or set `nest_domain%nest_level` to anything.

I was able to fix this by initializing `nest_level`in the type declaration of `nest_domain_type` in mpp_domains.F90
https://github.com/NOAA-GFDL/FMS/blob/2be8aa452ad3e5f43e92c38a64f12d1ae6c43fb8/mpp/mpp_domains.F90#L452-L461

This fixes the failure of all 3 test_mpp_nesting tests

Fixes #1293 

**How Has This Been Tested?**
Tested with GCC 13.1.0 on GFDL dev box with make and make check

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

