### PR TITLE
deallocate arrays in interpolator_end

### DIFF
--- a/interpolator/interpolator.F90
+++ b/interpolator/interpolator.F90
@@ -3423,6 +3423,8 @@ if (allocated (clim_type%has_level))  deallocate(clim_type%has_level)
 if (allocated (clim_type%field_name)) deallocate(clim_type%field_name)
 if (allocated (clim_type%time_init )) deallocate(clim_type%time_init)
 if (allocated (clim_type%mr        )) deallocate(clim_type%mr)
+if (allocated (clim_type%out_of_bounds )) deallocate(clim_type%out_of_bounds)
+if (allocated (clim_type%vert_interp )) deallocate(clim_type%vert_interp)
 if (allocated (clim_type%data)) then
   deallocate(clim_type%data)
 endif
@@ -3432,6 +3434,10 @@ if (allocated (clim_type%pmon_pyear)) then
   deallocate(clim_type%nmon_nyear)
   deallocate(clim_type%nmon_pyear)
 endif
+if (allocated(clim_type%indexm)) deallocate(clim_type%indexm)
+if (allocated(clim_type%indexp)) deallocate(clim_type%indexp)
+if (allocated(clim_type%climatology)) deallocate(clim_type%climatology)
+if (allocated(clim_type%clim_times)) deallocate(clim_type%clim_times)
 
 !! RSH mod
 if(  .not. (clim_type%TIME_FLAG .eq. LINEAR  .and.    &


### PR DESCRIPTION
**Description**
Only some arrays in _interpolate_type_ that have been allocated in the program are deallocated in `interpolator_end`.  This PR deallocates all the allocated arrays in _interpolate_type_


Fixes #1296 

**How Has This Been Tested?**
Make run successfully with Intel and GCC on the AMD Box.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

