### PR TITLE
Fix `sat_vapor_pres` unit test failure on Cray

### DIFF
--- a/test_fms/sat_vapor_pres/test_sat_vapor_pres.F90
+++ b/test_fms/sat_vapor_pres/test_sat_vapor_pres.F90
@@ -52,8 +52,8 @@ integer, parameter :: ESRES=10  !> taken from sat_vapor_pres_mod
 real(r8_kind), dimension(:), allocatable :: TABLE, DTABLE, TABLE2, DTABLE2, TABLE3, DTABLE3
 integer :: io, N
 
-integer, parameter :: nml_unit_var=100
-character(100) :: nml_file
+integer :: nml_unit_var
+character(*), parameter :: nml_file = 'test_sat_vapor_pres.nml'
 logical :: test1, test2, test3, test4, test5
 NAMELIST / test_sat_vapor_pres_nml/ test1, test2, test3, test4, test5
 
@@ -64,8 +64,7 @@ call fms_init()
 call sat_vapor_pres_init()  !> compute tables to be used for testing
 call compute_tables()       !> compute tables to generate answers/reference values
 
-nml_file='test_sat_vapor_pres.nml'
-open(unit=nml_unit_var, file=trim(nml_file), action='read')
+open(newunit=nml_unit_var, file=nml_file, action='read')
 read(unit=nml_unit_var, nml=test_sat_vapor_pres_nml,iostat=io)
 close(nml_unit_var)
 


### PR DESCRIPTION
All `sat_vapor_pres` unit tests fail on Cray due to Cray's aversion to `open(unit = 100, ...)`. This fixes the test failures by using `open(newunit = unit_var, ...)` instead of using unit 100.

Fixes #1298

**How Has This Been Tested?**
All `sat_vapor_pres` unit tests build and pass on Cray.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes