### PR TITLE
diag_field_not_found

### DIFF
--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -163,7 +163,8 @@ end subroutine fms_diag_object_end
 
 !> @brief Registers a field.
 !! @description This to avoid having duplicate code in each of the _scalar, _array and _static register calls
-!! @return field index for subsequent call to send_data.
+!! @return field index to be used in subsequent calls to send_data or DIAG_FIELD_NOT_FOUND if the field is not
+!! in the diag_table.yaml
 integer function fms_register_diag_field_obj &
        (this, modname, varname, axes, init_time, &
        longname, units, missing_value, varRange, mask_variant, standname, &
@@ -280,8 +281,9 @@ CALL MPP_ERROR(FATAL,"You can not use the modern diag manager without compiling 
 #endif
 end function fms_register_diag_field_obj
 
-  !> @brief Registers a scalar field
-  !! @return field index for subsequent call to send_data.
+!> @brief Registers a scalar field
+!! @return field index to be used in subsequent calls to send_data or DIAG_FIELD_NOT_FOUND if the field is not
+!! in the diag_table.yaml
 INTEGER FUNCTION fms_register_diag_field_scalar(this,module_name, field_name, init_time, &
        & long_name, units, missing_value, var_range, standard_name, do_not_log, err_msg,&
        & area, volume, realm)
@@ -311,8 +313,9 @@ CALL MPP_ERROR(FATAL,"You can not use the modern diag manager without compiling 
 #endif
 end function fms_register_diag_field_scalar
 
-    !> @brief Registers an array field
-  !> @return field index for subsequent call to send_data.
+!> @brief Registers an array field
+!! @return field index to be used in subsequent calls to send_data or DIAG_FIELD_NOT_FOUND if the field is not
+!! in the diag_table.yaml
 INTEGER FUNCTION fms_register_diag_field_array(this, module_name, field_name, axes, init_time, &
        & long_name, units, missing_value, var_range, mask_variant, standard_name, verbose,&
        & do_not_log, err_msg, interp_method, tile_count, area, volume, realm)
@@ -352,7 +355,8 @@ CALL MPP_ERROR(FATAL,"You can not use the modern diag manager without compiling 
 end function fms_register_diag_field_array
 
 !> @brief Return field index for subsequent call to send_data.
-!! @return field index for subsequent call to send_data.
+!! @return field index to be used in subsequent calls to send_data or DIAG_FIELD_NOT_FOUND if the field is not
+!! in the diag_table.yaml
 INTEGER FUNCTION fms_register_static_field(this, module_name, field_name, axes, long_name, units,&
        & missing_value, range, mask_variant, standard_name, DYNAMIC, do_not_log, interp_method,&
        & tile_count, area, volume, realm)

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -206,8 +206,8 @@ CALL MPP_ERROR(FATAL,"You can not use the modern diag manager without compiling 
 #else
  diag_field_indices = find_diag_field(varname, modname)
  if (diag_field_indices(1) .eq. diag_null) then
-    !< The field was not found in the table, so return diag_null
-    fms_register_diag_field_obj = diag_null
+    !< The field was not found in the table, so return DIAG_FIELD_NOT_FOUND
+    fms_register_diag_field_obj = DIAG_FIELD_NOT_FOUND
     deallocate(diag_field_indices)
     return
   endif
@@ -300,7 +300,7 @@ INTEGER FUNCTION fms_register_diag_field_scalar(this,module_name, field_name, in
     INTEGER,          OPTIONAL, INTENT(in) :: volume        !< Id of the volume field
     CHARACTER(len=*), OPTIONAL, INTENT(in) :: realm         !< String to set as the modeling_realm attribute
 #ifndef use_yaml
-fms_register_diag_field_scalar=diag_null
+fms_register_diag_field_scalar=DIAG_FIELD_NOT_FOUND
 CALL MPP_ERROR(FATAL,"You can not use the modern diag manager without compiling with -Duse_yaml")
 #else
     fms_register_diag_field_scalar = this%register(&
@@ -340,7 +340,7 @@ INTEGER FUNCTION fms_register_diag_field_array(this, module_name, field_name, ax
     CHARACTER(len=*), OPTIONAL, INTENT(in) :: realm         !< String to set as the modeling_realm attribute
 
 #ifndef use_yaml
-fms_register_diag_field_array=diag_null
+fms_register_diag_field_array=DIAG_FIELD_NOT_FOUND
 CALL MPP_ERROR(FATAL,"You can not use the modern diag manager without compiling with -Duse_yaml")
 #else
     fms_register_diag_field_array = this%register( &
@@ -382,7 +382,7 @@ INTEGER FUNCTION fms_register_static_field(this, module_name, field_name, axes, 
                                                                           !! modeling_realm attribute
 
 #ifndef use_yaml
-fms_register_static_field=diag_null
+fms_register_static_field=DIAG_FIELD_NOT_FOUND
 CALL MPP_ERROR(FATAL,"You can not use the modern diag manager without compiling with -Duse_yaml")
 #else
   !TODO The register_static_field interface does not have the capabiliy to register a variable as a "scalar"


### PR DESCRIPTION
**Description**
Return diag_field_not_found if a field is not in the diag_table.yaml when registering fields. 

This is needed to reproduce previous behavior and because there is code in MOM that expects the result to be diag_field_not_found.

Fixes # (issue)

**How Has This Been Tested?**
CI

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

