### PR TITLE
Fix test_read_input_nml2 failure and test_diag_update_buffer.F90 seg fault : Cray

### DIFF
--- a/test_fms/diag_manager/test_diag_manager2.sh
+++ b/test_fms/diag_manager/test_diag_manager2.sh
@@ -460,6 +460,7 @@ test_expect_success "Unstructured grid (test $my_test_count)" '
   mpirun -n 1 ../test_diag_manager
 '
 
+my_test_count=24
 # test_diag_manager_time
 cat <<_EOF > diag_table
 test_diag_manager
@@ -478,6 +479,7 @@ test_diag_manager
  "test_diag_manager_mod", "sst", "sst", "ocn_end%4yr%2mo%2dy%2hr",  "all", .true., "none", 2
 _EOF
 
+my_test_count=25
 rm -f input.nml && touch input.nml
 test_expect_success "wildcard filenames (test $my_test_count)" '
   mpirun -n 1 ../test_diag_manager_time
@@ -501,7 +503,7 @@ test_expect_success "diurnal test (test $my_test_count)" '
   mpirun -n 1 ../test_diag_manager_time
 '
 setup_test
-my_test_count=`expr $my_test_count + 1`
+my_test_count=26
 test_expect_success "Test the diag update_buffer (test $my_test_count)" '
   mpirun -n 1 ../test_diag_update_buffer
 '

--- a/test_fms/diag_manager/test_diag_update_buffer.F90
+++ b/test_fms/diag_manager/test_diag_update_buffer.F90
@@ -282,12 +282,12 @@ CONTAINS
          DO k = 1, NZ
             DO j = 1, NY
                DO i = 1, NX
+                  itemp = get_array_index_from_4D(i,j,k,l,NX,NY,NZ)
                   SELECT TYPE ( field)
                    TYPE IS (real(kind=r4_kind))
-                     itemp = get_array_index_from_4D(i,j,k,l,NX,NY,NZ)
-                     field(i,j,k,l) = get_array_index_from_4D(i,j,k,l,NX,NY,NZ)
-1                  TYPE IS (integer(kind=i8_kind))
-                     field(i,j,k,l) = get_array_index_from_4D(i,j,k,l,NX,NY,NZ)
+                     field(i,j,k,l) = real(itemp, kind=r4_kind)
+                   TYPE IS (integer(kind=i8_kind))
+                     field(i,j,k,l) = int(itemp, kind=i8_kind)
                   END SELECT
                END DO
             END DO

--- a/test_fms/mpp/test_read_input_nml.F90
+++ b/test_fms/mpp/test_read_input_nml.F90
@@ -36,14 +36,15 @@ integer :: stat !< IOSTAT output integer
 integer :: n, m !< Loop counting variable
 integer :: current_pelist_name_len_plus1 !< Current pelist name length plus 1
 integer :: ierr !< used by MPI_FINALIZE
+integer :: nml_unit_var !< stores nml file unit number for reads
 character(len=:), allocatable :: toobig !< String passed as argument into read_input_nml that is
                                         !!larger than pelis_name and should raise an error
 
 namelist /test_read_input_nml_nml/ test_numb
 
-open(10, file="test_numb.nml", form="formatted", status="old")
-read(10, nml = test_read_input_nml_nml)
-close(10)
+open(newunit=nml_unit_var, file="test_numb.nml", form="formatted", status="old")
+read(unit=nml_unit_var, nml = test_read_input_nml_nml)
+close(nml_unit_var)
 
 call mpp_init(test_level=mpp_init_test_peset_allocated)
 
@@ -64,11 +65,11 @@ if (test_numb == 1 .or. test_numb == 2 .or. test_numb == 4) then
     filename = "input_alternative.nml"
     call read_input_nml("alternative")
   end if
-  open(1, file=filename, iostat=stat) ! Open input nml or alternative
+  open(newunit=nml_unit_var, file=filename, iostat=stat) ! Open input nml or alternative
   n = 1
   do
-    read(1, '(A)', iostat=stat) line
-    if (stat.eq.-1) then
+    read(unit=nml_unit_var, '(A)', iostat=stat) line
+    if (stat < 0) then
       exit
     end if
     if (input_nml_file(n).ne.line) then
@@ -77,7 +78,7 @@ if (test_numb == 1 .or. test_numb == 2 .or. test_numb == 4) then
     end if
     n = n + 1
   end do
-  close(1)
+  close(nml_unit_var)
 
 else if (test_numb.eq.3) then
   ! Test 3: Tests with an invalid pelist_name_in pass as an argument. An invalid

--- a/test_fms/mpp/test_read_input_nml.F90
+++ b/test_fms/mpp/test_read_input_nml.F90
@@ -68,7 +68,7 @@ if (test_numb == 1 .or. test_numb == 2 .or. test_numb == 4) then
   n = 1
   do
     read(1, '(A)', iostat=stat) line
-    if (stat < 0) then
+    if (is_iostat_end(stat)) then
       exit
     end if
     if (input_nml_file(n).ne.line) then

--- a/test_fms/mpp/test_read_input_nml.F90
+++ b/test_fms/mpp/test_read_input_nml.F90
@@ -36,15 +36,14 @@ integer :: stat !< IOSTAT output integer
 integer :: n, m !< Loop counting variable
 integer :: current_pelist_name_len_plus1 !< Current pelist name length plus 1
 integer :: ierr !< used by MPI_FINALIZE
-integer :: nml_unit_var !< stores nml file unit number for reads
 character(len=:), allocatable :: toobig !< String passed as argument into read_input_nml that is
                                         !!larger than pelis_name and should raise an error
 
 namelist /test_read_input_nml_nml/ test_numb
 
-open(newunit=nml_unit_var, file="test_numb.nml", form="formatted", status="old")
-read(unit=nml_unit_var, nml = test_read_input_nml_nml)
-close(nml_unit_var)
+open(10, file="test_numb.nml", form="formatted", status="old")
+read(10, nml = test_read_input_nml_nml)
+close(10)
 
 call mpp_init(test_level=mpp_init_test_peset_allocated)
 
@@ -65,10 +64,10 @@ if (test_numb == 1 .or. test_numb == 2 .or. test_numb == 4) then
     filename = "input_alternative.nml"
     call read_input_nml("alternative")
   end if
-  open(newunit=nml_unit_var, file=filename, iostat=stat) ! Open input nml or alternative
+  open(1, file=filename, iostat=stat) ! Open input nml or alternative
   n = 1
   do
-    read(unit=nml_unit_var, '(A)', iostat=stat) line
+    read(1, '(A)', iostat=stat) line
     if (stat < 0) then
       exit
     end if
@@ -78,7 +77,7 @@ if (test_numb == 1 .or. test_numb == 2 .or. test_numb == 4) then
     end if
     n = n + 1
   end do
-  close(nml_unit_var)
+  close(1)
 
 else if (test_numb.eq.3) then
   ! Test 3: Tests with an invalid pelist_name_in pass as an argument. An invalid

--- a/test_fms/mpp/test_read_input_nml2.sh
+++ b/test_fms/mpp/test_read_input_nml2.sh
@@ -31,11 +31,11 @@
 # create and enter directory for in/output
 output_dir
 
-touch input.nml
 touch test_numb_base.nml
 echo "&test_read_input_nml_nml" > test_numb_base.nml
 echo "test_numb = 0" >> test_numb_base.nml
 echo "/" >> test_numb_base.nml
+cp test_numb_base.nml input.nml
 
 # Test 1
 sed "s/test_numb = [0-9]/test_numb = 1/" test_numb_base.nml > test_numb.nml
@@ -45,7 +45,7 @@ test_expect_success "read input nml" '
 
 # Test 2
 sed "s/test_numb = [0-9]/test_numb = 2/" test_numb_base.nml > test_numb.nml
-sed "s/1/2/" $top_srcdir/test_fms/mpp/input_base.nml > input_alternative.nml
+cp input.nml input_alternative.nml
 test_expect_success "read input nml with file name" '
     mpirun -n 1 ../test_read_input_nml
 '


### PR DESCRIPTION
**Description**

Cray uses an IOSTAT of -4001 for end of file while other compilers typically use -1.  Because of this, the do loop (shown below) will not exit on the condition `if (stat.eq.-1)` at Line 71

https://github.com/NOAA-GFDL/FMS/blob/2be8aa452ad3e5f43e92c38a64f12d1ae6c43fb8/test_fms/mpp/test_read_input_nml.F90#L68-L79

To fix: I took the approach seen in fortran standards (section 12.11.5 in the [J3/23-007draft spec](https://j3-fortran.org/doc/year/23/23-007.pdf)) and replaced `if (stat.eq.-1)` with `if (stat < 0)` to check for end of file and exit loop.

I also noticed that the tests were not matching the description here:
https://github.com/NOAA-GFDL/FMS/blob/2be8aa452ad3e5f43e92c38a64f12d1ae6c43fb8/test_fms/mpp/test_read_input_nml.F90#L51-L56

Previously, test 1 was reading a blank input.nml and test 2 was reading a blank input_alternate.nml.  I have modified this so that there is data inside of input.nml and input_alternate.nml.  Test 4 still tests a blank nml with the name input_blank.nml

Cray was failing to compile test_diag_update_buffer.F90 because of the `1` at the beginning of line 289
https://github.com/NOAA-GFDL/FMS/blob/2be8aa452ad3e5f43e92c38a64f12d1ae6c43fb8/test_fms/diag_manager/test_diag_update_buffer.F90#L288-L290

I have removed the `1` and refactored the code a little bit - I am open to feedback on the changes I made and will undo if they are not helpful.

Fixes #1300 

**How Has This Been Tested?**
make and make check on 
C5
cce/15.0.1
cray-hdf5/1.12.2.3
cray-netcdf/4.9.0.3

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

