### PR TITLE
remove fms2io_init in interpolator_mod 

### DIFF
--- a/interpolator/interpolator.F90
+++ b/interpolator/interpolator.F90
@@ -415,7 +415,6 @@ integer         , intent(in), optional  :: vert_interp(:)
 !--lwh
 character(len=*), intent(out), optional :: clim_units(:)
 logical,          intent(out), optional :: single_year_file
-
 !
 ! INTENT IN
 !  file_name  :: Climatology filename


### PR DESCRIPTION
**Description**
This PR removes the subroutine _fms2io_init_ .  All code in _fms2io_init_ is involved in initialization and  is moved to subroutine _interpolator_init_ instead.

Fixes #1309 

**How Has This Been Tested?**
Make passes with the latest Intel and GCC on the AMD box

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

