### PR TITLE
move containers to new registry and add basic link+run test for cmake

### DIFF
--- a/.github/workflows/Dockerfile.gnu
+++ b/.github/workflows/Dockerfile.gnu
@@ -55,7 +55,7 @@ COPY --from=builder /opt/deps/ /opt/deps/
 # need to be on the dev boxes if building
 COPY ./fms_test_input /home/unit_tests_input
 
-RUN dnf install -y autoconf make automake m4 libtool pkg-config zip
+RUN dnf install -y autoconf make automake m4 libtool pkg-config zip cmake
 
 ENV FC="mpifort"
 ENV CC="mpicc"

--- a/.github/workflows/Dockerfile.gnu
+++ b/.github/workflows/Dockerfile.gnu
@@ -55,7 +55,7 @@ COPY --from=builder /opt/deps/ /opt/deps/
 # need to be on the dev boxes if building
 COPY ./fms_test_input /home/unit_tests_input
 
-RUN dnf install -y autoconf make automake m4 libtool pkg-config zip cmake
+RUN dnf install -y autoconf make automake m4 libtool pkg-config zip cmake git
 
 ENV FC="mpifort"
 ENV CC="mpicc"

--- a/.github/workflows/github_autotools_gnu.yml
+++ b/.github/workflows/github_autotools_gnu.yml
@@ -15,7 +15,10 @@ jobs:
           - conf-flag: --with-mpi=no
             input-flag: --enable-test-input=/home/unit_tests_input
     container:
-      image: noaagfdl/fms-ci-rocky-gnu:12.3.0
+      image: ghcr.io/noaa-gfdl/FMS/fms-ci-rocky-gnu:12.3.0
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.github_token }}
       env:
         TEST_VERBOSE: 1
         DISTCHECK_CONFIGURE_FLAGS: "${{ matrix.conf-flag }} ${{ matrix.input-flag }} ${{ matrix.io-flag }}"

--- a/.github/workflows/github_autotools_gnu.yml
+++ b/.github/workflows/github_autotools_gnu.yml
@@ -15,7 +15,7 @@ jobs:
           - conf-flag: --with-mpi=no
             input-flag: --enable-test-input=/home/unit_tests_input
     container:
-      image: ghcr.io/noaa-gfdl/FMS/fms-ci-rocky-gnu:12.3.0
+      image: ghcr.io/noaa-gfdl/fms/fms-ci-rocky-gnu:12.3.0
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}

--- a/.github/workflows/github_cmake_gnu.yml
+++ b/.github/workflows/github_cmake_gnu.yml
@@ -33,5 +33,6 @@ jobs:
         echo "    call fms_end" >> test.F90
         echo "end program" >> test.F90
         mpifort -L/opt/view/lib `nf-config --flibs` -Iinclude_r4 -Iinclude_r8 test.F90 libfms_r4.a libfms_r8.a -o test.x
+        touch input.nml
     - name: Run executable
       run: ./test.x

--- a/.github/workflows/github_cmake_gnu.yml
+++ b/.github/workflows/github_cmake_gnu.yml
@@ -31,7 +31,7 @@ jobs:
         echo "    use fms_mod" >> test.F90
         echo "    call fms_init" >> test.F90
         echo "    call fms_end" >> test.F90
-        echo "program end" >> test.F90
+        echo "end program" >> test.F90
         mpifort `nf-config --flibs` -Iinclude_r4 -Iinclude_r8 test.F90 libfms_r4.a libfms_r8.a -o test.x
     - name: Run executable
       run: ./test.x

--- a/.github/workflows/github_cmake_gnu.yml
+++ b/.github/workflows/github_cmake_gnu.yml
@@ -32,7 +32,7 @@ jobs:
         echo "    call fms_init" >> test.F90
         echo "    call fms_end" >> test.F90
         echo "end program" >> test.F90
-        mpifort -L/opt/view/lib `nf-config --flibs` -Iinclude_r4 -Iinclude_r8 test.F90 libfms_r4.a libfms_r8.a -o test.x
+        mpifort -L/opt/view/lib -fopenmp `nf-config --flibs` -Iinclude_r4 -Iinclude_r8 test.F90 libfms_r4.a libfms_r8.a -o test.x
         touch input.nml
     - name: Run executable
       run: ./test.x

--- a/.github/workflows/github_cmake_gnu.yml
+++ b/.github/workflows/github_cmake_gnu.yml
@@ -17,6 +17,7 @@ jobs:
         password: ${{ secrets.github_token }}
       env:
         CMAKE_FLAGS: "${{ matrix.omp-flags }} ${{ matrix.io-flag  }} ${{ matrix.libyaml-flag }} -D64BIT=on"
+        LIBYAML_ROOT: "/opt/deps/linux-rocky9-haswell/gcc-12.3.0/libyaml-0.2.5-yiouvafr3qwcdrwdpumepit4wmqvh642/" # TODO should find better way for cmake to find this
     steps:
     - name: Checkout code
       uses: actions/checkout@v2

--- a/.github/workflows/github_cmake_gnu.yml
+++ b/.github/workflows/github_cmake_gnu.yml
@@ -11,13 +11,26 @@ jobs:
         libyaml-flag: [ "", -DWITH_YAML=on ]
         io-flag: [ "", -DUSE_DEPRECATED_IO=on ]
     container:
-      image: noaagfdl/hpc-me.ubuntu-minimal:cmake
+      image: ghcr.io/noaa-gfdl/fms/fms-ci-rocky-gnu:12.3.0
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.github_token }}
       env:
         CMAKE_FLAGS: "${{ matrix.omp-flags }} ${{ matrix.io-flag  }} ${{ matrix.libyaml-flag }} -D64BIT=on"
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Generate makefiles with CMake
-      run: cmake $CMAKE_FLAGS .
+      run: cmake -DNetCDF_INCLUDE_DIR=/opt/view/include/ -DCMAKE_Fortran_FLAGS="-fallow-argument-mismatch" $CMAKE_FLAGS .
     - name: Build the library
       run: make
+    - name: Link with basic executable
+      run: |
+        echo "program test" > test.F90
+        echo "    use fms_mod" >> test.F90
+        echo "    call fms_init" >> test.F90
+        echo "    call fms_end" >> test.F90
+        echo "program end" >> test.F90
+        mpifort `nf-config --flibs` -Iinclude_r4 -Iinclude_r8 test.F90 libfms_r4.a libfms_r8.a -o test.x
+    - name: Run executable
+      run: ./test.x

--- a/.github/workflows/github_coupler_gnu.yml
+++ b/.github/workflows/github_coupler_gnu.yml
@@ -5,7 +5,7 @@ jobs:
   coupler-build:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/rem1776/fms-ci-rocky-gnu:12.3.0
+      image: ghcr.io/noaa-gfdl/fms/fms-ci-rocky-gnu:12.3.0
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
@@ -14,7 +14,6 @@ jobs:
         FC: mpif90
         CPPFLAGS: '-I/usr/include -Duse_LARGEFILE -DMAXFIELDMETHODS_=500'
         FCFLAGS: '-fcray-pointer -fdefault-double-8 -fdefault-real-8 -Waliasing -ffree-line-length-none -fno-range-check -I/usr/include'
-        LDFLAGS: '-L/usr/lib'
         VERBOSE: 1
     steps:
     - name: Checkout FMS

--- a/.github/workflows/github_coupler_gnu.yml
+++ b/.github/workflows/github_coupler_gnu.yml
@@ -5,7 +5,10 @@ jobs:
   coupler-build:
     runs-on: ubuntu-latest
     container:
-      image: ryanmulhall/hpc-me.ubuntu-minimal:coupler
+      image: ghcr.io/rem1776/fms-ci-rocky-gnu:12.3.0
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.github_token }}
       env:
         CC: mpicc
         FC: mpif90

--- a/.github/workflows/github_coupler_gnu.yml
+++ b/.github/workflows/github_coupler_gnu.yml
@@ -13,7 +13,7 @@ jobs:
         CC: mpicc
         FC: mpif90
         CPPFLAGS: '-I/opt/view/include -Duse_LARGEFILE -DMAXFIELDMETHODS_=500'
-        FCFLAGS: '-fcray-pointer -fdefault-double-8 -fdefault-real-8 -Waliasing -ffree-line-length-none -fno-range-check -I/opt/view/include'
+        FCFLAGS: '-fallow-argument-mismatch -fcray-pointer -fdefault-double-8 -fdefault-real-8 -Waliasing -ffree-line-length-none -fno-range-check -I/opt/view/include'
         LDFLAGS: '-L/opt/view/lib'
         VERBOSE: 1
     steps:

--- a/.github/workflows/github_coupler_gnu.yml
+++ b/.github/workflows/github_coupler_gnu.yml
@@ -12,8 +12,9 @@ jobs:
       env:
         CC: mpicc
         FC: mpif90
-        CPPFLAGS: '-I/usr/include -Duse_LARGEFILE -DMAXFIELDMETHODS_=500'
-        FCFLAGS: '-fcray-pointer -fdefault-double-8 -fdefault-real-8 -Waliasing -ffree-line-length-none -fno-range-check -I/usr/include'
+        CPPFLAGS: '-I/opt/view/include -Duse_LARGEFILE -DMAXFIELDMETHODS_=500'
+        FCFLAGS: '-fcray-pointer -fdefault-double-8 -fdefault-real-8 -Waliasing -ffree-line-length-none -fno-range-check -I/opt/view/include'
+        LDFLAGS: '-L/opt/view/lib'
         VERBOSE: 1
     steps:
     - name: Checkout FMS


### PR DESCRIPTION
**Description**
Switch the CI containers to pull from the github container registry since docker is removing our account. Also adds a step to compile and run a file with the cmake-built libraries.

**How Has This Been Tested?**
CI

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x]  I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

