### PR TITLE
Adds ifdef use_drifters in all drifter modules

### DIFF
--- a/drifters/cloud_interpolator.F90
+++ b/drifters/cloud_interpolator.F90
@@ -25,6 +25,7 @@
 !> @addtogroup cloud_interpolator_mod
 !> @{
 MODULE cloud_interpolator_mod
+#ifdef use_drifters
   implicit none
   private
 
@@ -284,6 +285,7 @@ pure subroutine cld_ntrp_get_cell_values(nsizes, fnodes, indices, fvals, ier)
 
   end subroutine cld_ntrp_get_cell_values
 
+#endif
 end MODULE cloud_interpolator_mod
 !===============================================================================
 !> @}

--- a/drifters/drifters.F90
+++ b/drifters/drifters.F90
@@ -60,6 +60,7 @@
 !> @addtogroup drifters_mod
 !> @{
 module drifters_mod
+#ifdef use_drifters
 
 #ifdef _SERIAL
 
@@ -947,7 +948,7 @@ contains
     endif
 
   end subroutine drifters_reset_rk4
-
+#endif
 end module drifters_mod
 !> @}
 ! close documentation grouping

--- a/drifters/drifters_comm.F90
+++ b/drifters/drifters_comm.F90
@@ -23,6 +23,7 @@
 !> @brief Routines and types to update drifter positions across processor domains
 
 module drifters_comm_mod
+#ifdef use_drifters
 
 #ifdef _SERIAL
 
@@ -769,7 +770,7 @@ contains
 
   end subroutine drifters_comm_gather
 
-
+#endif
 end module drifters_comm_mod
 
 !===============================================================================

--- a/drifters/drifters_core.F90
+++ b/drifters/drifters_core.F90
@@ -21,6 +21,7 @@
 !> @brief Handles the mechanics for adding and removing drifters
 
 module drifters_core_mod
+#ifdef use_drifters
   use platform_mod
   implicit none
   private
@@ -272,7 +273,7 @@ subroutine drifters_core_remove_and_add(self, indices_to_remove_in, &
 
   end subroutine drifters_core_print
 
-
+#endif
 end module drifters_core_mod
 !###############################################################################
 !> @}

--- a/drifters/drifters_input.F90
+++ b/drifters/drifters_input.F90
@@ -23,6 +23,7 @@
 !> @addtogroup drifters_input_mod
 !> @{
 module drifters_input_mod
+#ifdef use_drifters
   implicit none
   private
 
@@ -444,7 +445,7 @@ module drifters_input_mod
          & //nf_strerror(ier)
 
   end subroutine drifters_input_save
-
+#endif
 end module drifters_input_mod
 !> @}
 ! close documentation grouping

--- a/drifters/drifters_io.F90
+++ b/drifters/drifters_io.F90
@@ -23,6 +23,7 @@
 !> @addtogroup drifters_io_mod
 !> @{
 module drifters_io_mod
+#ifdef use_drifters
 
   use netcdf
   use netcdf_nf_data
@@ -307,7 +308,7 @@ contains
     self%it_id = self%it_id + np
 
   end subroutine drifters_io_write
-
+#endif
 end module drifters_io_mod
 !> @}
 ! close documentation grouping

--- a/test_fms/drifters/test_cloud_interpolator.F90
+++ b/test_fms/drifters/test_cloud_interpolator.F90
@@ -18,6 +18,7 @@
 !***********************************************************************
 
 program test_cloud_interpolator
+#ifdef use_drifters
   use cloud_interpolator_mod
   use mpp_mod, only : mpp_error, FATAL, stdout, mpp_init, mpp_exit
 
@@ -215,4 +216,5 @@ CONTAINS
 
 end subroutine test_get_node_values
 
+#endif
   end program test_cloud_interpolator

--- a/test_fms/drifters/test_drifters.F90
+++ b/test_fms/drifters/test_drifters.F90
@@ -18,6 +18,7 @@
 !***********************************************************************
 
 program test_drifters
+#ifdef use_drifters
 
 !* contents of input file: drifters_inp_test_3d.nc
 !!$netcdf drifters_inp_test_3d {
@@ -351,5 +352,5 @@ subroutine my_error_handler(mesg)
 !  print *, mesg
 !  stop
 !#endif
-
+#endif
 end subroutine my_error_handler

--- a/test_fms/drifters/test_drifters.F90
+++ b/test_fms/drifters/test_drifters.F90
@@ -337,7 +337,7 @@ program test_drifters
 !#ifndef _SERIAL
   call mpp_exit
 !#endif
-
+#endif
 end program test_drifters
 
 subroutine my_error_handler(mesg)
@@ -352,5 +352,5 @@ subroutine my_error_handler(mesg)
 !  print *, mesg
 !  stop
 !#endif
-#endif
+
 end subroutine my_error_handler

--- a/test_fms/drifters/test_drifters_comm.F90
+++ b/test_fms/drifters/test_drifters_comm.F90
@@ -19,6 +19,7 @@
 !**********************************************************************
 
 program test_drifters_comm
+#ifdef use_drifters     
 
   use drifters_core_mod
   use drifters_comm_mod
@@ -142,5 +143,6 @@ program test_drifters_comm
   call drifters_comm_del(drfts_com)
   call mpp_domains_exit
   call mpp_exit
-
+  
+#endif
 end program test_drifters_comm

--- a/test_fms/drifters/test_drifters_comm.F90
+++ b/test_fms/drifters/test_drifters_comm.F90
@@ -19,7 +19,7 @@
 !**********************************************************************
 
 program test_drifters_comm
-#ifdef use_drifters     
+#ifdef use_drifters
 
   use drifters_core_mod
   use drifters_comm_mod
@@ -143,6 +143,6 @@ program test_drifters_comm
   call drifters_comm_del(drfts_com)
   call mpp_domains_exit
   call mpp_exit
-  
+
 #endif
 end program test_drifters_comm

--- a/test_fms/drifters/test_drifters_core.F90
+++ b/test_fms/drifters/test_drifters_core.F90
@@ -19,6 +19,7 @@
 !**********************************************************************
 
 program test_drifters_core
+#ifdef use_drifters
 
   use drifters_core_mod
   use fms_mod, only : fms_init, fms_end
@@ -111,4 +112,5 @@ program test_drifters_core
 !!$     print *,'Sucessful test ier=', ier
 !!$  end if
   call fms_end()
+#endif
 end program test_drifters_core

--- a/test_fms/drifters/test_drifters_input.F90
+++ b/test_fms/drifters/test_drifters_input.F90
@@ -19,6 +19,7 @@
 !***********************************************************************
 
 program test_drifters_input
+#ifdef use_drifters
   use drifters_input_mod
   use fms_mod, only : fms_init, fms_end
   use mpp_mod, only : mpp_error, FATAL, stdout
@@ -54,4 +55,5 @@ program test_drifters_input
   call drifters_input_del(obj, ermesg)
 
   call fms_end()
+#endif
 end program test_drifters_input

--- a/test_fms/drifters/test_drifters_io.F90
+++ b/test_fms/drifters/test_drifters_io.F90
@@ -18,6 +18,7 @@
 !***********************************************************************
 
 program test_drifters_io
+#ifdef use_drifters
 
   use drifters_io_mod
   use mpp_mod, only : mpp_error, FATAL, stdout, mpp_init, mpp_exit
@@ -156,4 +157,5 @@ program test_drifters_io
       call mpp_error(FATAL, ermesg)
   endif
   call mpp_exit()
+#endif
 end program test_drifters_io

--- a/test_fms/drifters/test_quicksort.F90
+++ b/test_fms/drifters/test_quicksort.F90
@@ -19,9 +19,11 @@
 !***********************************************************************
 
       program test_quicksort
+#ifdef use_drifters
         implicit none
         integer :: list(16) = (/6, 2, 3, 4, 1, 45, 3432, 3245, 32545, 66555, 32, 1,3, -43254, 324, 54/)
         print *,'before list=', list
         call qksrt_quicksort(size(list), list, 1, size(list))
         print *,'after  list=', list
+#endif
       end program test_quicksort


### PR DESCRIPTION
**Description**
The mixed mode team has not been able to find references to any drifter modules or routines in the model components that use FMS. This pr adds the `#ifdef use_drifters` directive around all of the modules and unit tests within the drifters  and test_fms directories so that these modules and tests will not be compiled or used unless otherwise specified. 

Fixes # #1325

**How Has This Been Tested?**
autotools with  gcc/13.1.0,  netcdf/4.9.2,  mpich/4.1.2,  hdf5/1.14.1-2 , libyaml/0.2.5

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

