### PR TITLE
Fix test_mpp_nesting unit test

### DIFF
--- a/test_fms/mpp/test_mpp_nesting.F90
+++ b/test_fms/mpp/test_mpp_nesting.F90
@@ -950,15 +950,15 @@ program test_mpp_nesting
     !--- loop over nest level
     do l = 1, num_nest_level
        npes_my_level = mpp_get_nest_npes(nest_domain, l)
-       npes_my_fine = mpp_get_nest_fine_npes(nest_domain,l)
        allocate(my_pelist(npes_my_level))
-       allocate(my_pelist_fine(npes_my_fine))
        call mpp_get_nest_pelist(nest_domain, l, my_pelist)
 
        call mpp_declare_pelist(my_pelist(:))
        write(type2, '(a,I2)')trim(type)//" nest_level = ",l
        if(ANY(my_pelist(:)==mpp_pe())) then
 
+          npes_my_fine = mpp_get_nest_fine_npes(nest_domain,l)
+          allocate(my_pelist_fine(npes_my_fine))
           call mpp_get_nest_fine_pelist(nest_domain, l, my_pelist_fine)
 
           call mpp_set_current_pelist(my_pelist)
@@ -2625,7 +2625,8 @@ program test_mpp_nesting
           deallocate(wbuffery2, ebuffery2, sbuffery2, nbuffery2)
        endif
        endif
-       deallocate(my_pelist, my_pelist_fine)
+       if(ANY(my_pelist(:)==mpp_pe())) deallocate(my_pelist_fine)
+       deallocate(my_pelist)
        call mpp_set_current_pelist()
 
     enddo
@@ -2984,15 +2985,15 @@ program test_mpp_nesting
     !--- loop over nest level
     do l = 1, num_nest_level
        npes_my_level = mpp_get_nest_npes(nest_domain, l)
-       npes_my_fine = mpp_get_nest_fine_npes(nest_domain,l)
        allocate(my_pelist(npes_my_level))
-       allocate(my_pelist_fine(npes_my_fine))
        call mpp_get_nest_pelist(nest_domain, l, my_pelist)
 
        call mpp_declare_pelist(my_pelist(:))
        write(type2, '(a,I2)')trim(type)//" nest_level = ",l
        if(ANY(my_pelist(:) == mpp_pe())) then
 
+          npes_my_fine = mpp_get_nest_fine_npes(nest_domain,l)
+          allocate(my_pelist_fine(npes_my_fine))
           call mpp_get_nest_fine_pelist(nest_domain, l, my_pelist_fine)
 
           call mpp_set_current_pelist(my_pelist)
@@ -4655,7 +4656,8 @@ program test_mpp_nesting
        endif
        endif
 
-       deallocate(my_pelist, my_pelist_fine)
+       if(ANY(my_pelist(:)==mpp_pe())) deallocate(my_pelist_fine)
+       deallocate(my_pelist)
        call mpp_set_current_pelist()
 
     enddo


### PR DESCRIPTION
**Description**
When testing with intel ifort and ifx, using the flags `-O0 -g -check all` we notice that the three test_mpp_nesting tests fail.  The failure was due to accessing an unallocated variable.  Moving some calls inside of the `if(ANY(my_pelist(:)==mpp_pe()))` section has resolved this issue.

Fixes #1337 

**How Has This Been Tested?**
tested on Amd development machine with intel oneapi ifort and ifx

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

