### PR TITLE
fix mpp_clock test failures

### DIFF
--- a/.github/workflows/github_autotools_gnu.yml
+++ b/.github/workflows/github_autotools_gnu.yml
@@ -19,7 +19,6 @@ jobs:
       env:
         TEST_VERBOSE: 1
         DISTCHECK_CONFIGURE_FLAGS: "${{ matrix.conf-flag }} ${{ matrix.input-flag }} ${{ matrix.io-flag }}"
-        SKIP_TESTS: "test_mpp_domains2.14 test_horiz_interp2.9 test_horiz_interp2.10 test_yaml_parser.5" # temporary till fixes are in
     steps:
     - name: Checkout code
       uses: actions/checkout@v2

--- a/.github/workflows/github_autotools_gnu.yml
+++ b/.github/workflows/github_autotools_gnu.yml
@@ -19,6 +19,7 @@ jobs:
       env:
         TEST_VERBOSE: 1
         DISTCHECK_CONFIGURE_FLAGS: "${{ matrix.conf-flag }} ${{ matrix.input-flag }} ${{ matrix.io-flag }}"
+        SKIP_TESTS: "test_yaml_parser.5" # temporary till fixes are in
     steps:
     - name: Checkout code
       uses: actions/checkout@v2

--- a/test_fms/mpp/test_mpp_clock_begin_end_id.sh
+++ b/test_fms/mpp/test_mpp_clock_begin_end_id.sh
@@ -26,6 +26,7 @@
 # Set common test settings.
 . ../test-lib.sh
 
+touch input.nml
 touch clock.nml
 echo "&test_mpp_clock_begin_end_id_nml" > clock.nml
 echo "test_number = 0" >> clock.nml


### PR DESCRIPTION
**Description**
fixes input.nml failures happening for three of the test_mpp_clock_begin_end_id.sh tests.

also removes some of the fixed tests that were skipped

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes. Please also note
any relevant details for your test configuration (e.g. compiler, OS).  Include
enough information so someone can reproduce your tests.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

