### PR TITLE
Add target flags for GNU CI

### DIFF
--- a/.github/workflows/github_autotools_gnu.yml
+++ b/.github/workflows/github_autotools_gnu.yml
@@ -20,6 +20,7 @@ jobs:
       env:
         TEST_VERBOSE: 1
         DISTCHECK_CONFIGURE_FLAGS: "${{ matrix.conf-flag }} ${{ matrix.input-flag }} ${{ matrix.io-flag }}"
+        TARGET_FLAGS: "${{ matrix.target-flags }}"
         SKIP_TESTS: "test_mpp_domains2.14 test_horiz_interp2.9 test_horiz_interp2.10 test_yaml_parser.5" # temporary till fixes are in
     steps:
     - name: Checkout code
@@ -28,7 +29,7 @@ jobs:
       run: autoreconf -if
     - name: Configure the build
       if: ${{ matrix.conf-flag != '--disable-setting-flags' }}
-      run: ./configure ${DISTCHECK_CONFIGURE_FLAGS} FCFLAGS="${matrix.target-flags} $FCFLAGS" || cat config.log
+      run: ./configure ${DISTCHECK_CONFIGURE_FLAGS} FCFLAGS="${TARGET_FLAGS} ${FCFLAGS}" || cat config.log
     - name: Configure the build with compiler flags
       if: ${{ matrix.conf-flag == '--disable-setting-flags' }}
       run: ./configure ${DISTCHECK_CONFIGURE_FLAGS} FCFLAGS="-fdefault-real-8 -fdefault-double-8 -fcray-pointer -ffree-line-length-none -I/usr/include $FCFLAGS" || cat config.log

--- a/.github/workflows/github_autotools_gnu.yml
+++ b/.github/workflows/github_autotools_gnu.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         conf-flag: [ --disable-openmp, --enable-mixed-mode, --disable-setting-flags, --with-mpi=no]
         input-flag: [--with-yaml, --enable-test-input=/home/unit_tests_input]
-        target-flags: [ "-O2 -fno-expensive-optimizations", "-O0 -g -W -fbounds-check -ffpe-trap=invalid,zero,overflow"]
+        target-flags: [ "-O2 -fno-expensive-optimizations", "-O0 -g -W -fbounds-check -ffpe-trap=invalid,zero,overflow", "-O2"] # prod, debug, repro
         exclude:
           - conf-flag: --with-mpi=no
             input-flag: --enable-test-input=/home/unit_tests_input

--- a/.github/workflows/github_autotools_gnu.yml
+++ b/.github/workflows/github_autotools_gnu.yml
@@ -19,7 +19,7 @@ jobs:
       image: noaagfdl/fms-ci-rocky-gnu:12.3.0
       env:
         TEST_VERBOSE: 1
-        DISTCHECK_CONFIGURE_FLAGS: "${{ matrix.conf-flag }} ${{ matrix.input-flag }} ${{ matrix.io-flag }} FCFLAGS='${{ matrix.target-flags }} $FCFLAGS'"
+        DISTCHECK_CONFIGURE_FLAGS: "${{ matrix.conf-flag }} ${{ matrix.input-flag }} ${{ matrix.io-flag }}"
         SKIP_TESTS: "test_mpp_domains2.14 test_horiz_interp2.9 test_horiz_interp2.10 test_yaml_parser.5" # temporary till fixes are in
     steps:
     - name: Checkout code
@@ -28,7 +28,7 @@ jobs:
       run: autoreconf -if
     - name: Configure the build
       if: ${{ matrix.conf-flag != '--disable-setting-flags' }}
-      run: ./configure ${DISTCHECK_CONFIGURE_FLAGS} || cat config.log
+      run: ./configure ${DISTCHECK_CONFIGURE_FLAGS} FCFLAGS="${matrix.target-flags} $FCFLAGS" || cat config.log
     - name: Configure the build with compiler flags
       if: ${{ matrix.conf-flag == '--disable-setting-flags' }}
       run: ./configure ${DISTCHECK_CONFIGURE_FLAGS} FCFLAGS="-fdefault-real-8 -fdefault-double-8 -fcray-pointer -ffree-line-length-none -I/usr/include $FCFLAGS" || cat config.log

--- a/.github/workflows/github_autotools_gnu.yml
+++ b/.github/workflows/github_autotools_gnu.yml
@@ -19,7 +19,7 @@ jobs:
       image: noaagfdl/fms-ci-rocky-gnu:12.3.0
       env:
         TEST_VERBOSE: 1
-        DISTCHECK_CONFIGURE_FLAGS: "${{ matrix.conf-flag }} ${{ matrix.input-flag }} ${{ matrix.io-flag }} ${{ matrix.target-flags }}"
+        DISTCHECK_CONFIGURE_FLAGS: "${{ matrix.conf-flag }} ${{ matrix.input-flag }} ${{ matrix.io-flag }} FCFLAGS='${{ matrix.target-flags }} $FCFLAGS'"
         SKIP_TESTS: "test_mpp_domains2.14 test_horiz_interp2.9 test_horiz_interp2.10 test_yaml_parser.5" # temporary till fixes are in
     steps:
     - name: Checkout code

--- a/.github/workflows/github_autotools_gnu.yml
+++ b/.github/workflows/github_autotools_gnu.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         conf-flag: [ --disable-openmp, --enable-mixed-mode, --disable-setting-flags, --with-mpi=no]
         input-flag: [--with-yaml, --enable-test-input=/home/unit_tests_input]
-        target-flags: [ "-O2 -fno-expensive-optimizations", "-O0 -g -W -fbounds-check -ffpe-trap=invalid,zero,overflow", "-O2"] # prod, debug, repro
+        target-flags: [ "-O2 -fno-expensive-optimizations", "-O0 -g -W -fbounds-check -ffpe-trap=invalid,zero,overflow"] # prod, debug
         exclude:
           - conf-flag: --with-mpi=no
             input-flag: --enable-test-input=/home/unit_tests_input

--- a/.github/workflows/github_autotools_gnu.yml
+++ b/.github/workflows/github_autotools_gnu.yml
@@ -11,6 +11,7 @@ jobs:
       matrix:
         conf-flag: [ --disable-openmp, --enable-mixed-mode, --disable-setting-flags, --with-mpi=no]
         input-flag: [--with-yaml, --enable-test-input=/home/unit_tests_input]
+        target-flags: [ "-O2 -fno-expensive-optimizations", "-O0 -g -W -fbounds-check -ffpe-trap=invalid,zero,overflow"]
         exclude:
           - conf-flag: --with-mpi=no
             input-flag: --enable-test-input=/home/unit_tests_input
@@ -18,7 +19,7 @@ jobs:
       image: noaagfdl/fms-ci-rocky-gnu:12.3.0
       env:
         TEST_VERBOSE: 1
-        DISTCHECK_CONFIGURE_FLAGS: "${{ matrix.conf-flag }} ${{ matrix.input-flag }} ${{ matrix.io-flag }}"
+        DISTCHECK_CONFIGURE_FLAGS: "${{ matrix.conf-flag }} ${{ matrix.input-flag }} ${{ matrix.io-flag }} ${{ matrix.target-flags }}"
         SKIP_TESTS: "test_mpp_domains2.14 test_horiz_interp2.9 test_horiz_interp2.10 test_yaml_parser.5" # temporary till fixes are in
     steps:
     - name: Checkout code


### PR DESCRIPTION
**Description**
adds the gnu mkmf template flags for prod and debug to the ci matrix

**How Has This Been Tested?**
CI, should be working properly. draft until all the tests are passing, needs one or two other fixes.


**Checklist:**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] `make distcheck` passes

