### PR TITLE
change intel CI compiler to icx

### DIFF
--- a/.github/workflows/github_autotools_intel.yml
+++ b/.github/workflows/github_autotools_intel.yml
@@ -5,7 +5,7 @@ jobs:
     container:
       image: intel/oneapi-hpckit:2023.1.0-devel-ubuntu20.04
       env:
-        CC: mpiicc
+        CC: "mpicc -cc=icx"
         FC: mpiifort
         CFLAGS:  "-I/libs/include"
         FCFLAGS: "-I/libs/include -g -traceback"

--- a/.github/workflows/github_autotools_intel.yml
+++ b/.github/workflows/github_autotools_intel.yml
@@ -33,7 +33,7 @@ jobs:
         make -j install && cd ..
         wget https://github.com/Unidata/netcdf-c/archive/refs/tags/v4.8.1.tar.gz
         tar xf v4.8.1.tar.gz && cd netcdf-c-4.8.1
-        ./configure --prefix=/libs --enable-remote-fortran-bootstrap
+        ./configure --prefix=/libs --enable-remote-fortran-bootstrap CC=icc # build issue with icx, should be cross-compatible
         make -j install
         # sets this here to pass embeded configure checks
         export LD_LIBRARY_PATH="/libs/lib:$LD_LIBRARY_PATH"


### PR DESCRIPTION
**Description**
small update to use the newer c compiler when compiling in the CI since icc is deprecated now.

**How Has This Been Tested?**
ci

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x]  Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

