### PR TITLE
Update intel ci for build matrix with oneapi compilers

### DIFF
--- a/.github/workflows/github_autotools_intel.yml
+++ b/.github/workflows/github_autotools_intel.yml
@@ -1,6 +1,6 @@
 on: pull_request
 jobs:
-  intel-autotools:
+  build-dependencies:
     runs-on: ubuntu-latest
     container:
       image: intel/oneapi-hpckit:2023.1.0-devel-ubuntu20.04
@@ -10,10 +10,6 @@ jobs:
         CFLAGS:  "-I/libs/include"
         FCFLAGS: "-I/libs/include -g -traceback"
         LDFLAGS: "-L/libs/lib"
-        TEST_VERBOSE: 1
-        I_MPI_FABRICS: "shm" # needed for mpi in image
-        # intel bug causes some failures with shm option(required in container)
-        SKIP_TESTS: "test_mpp_update_domains.1 test_update_domains_performance.1 test_diag_manager2.23"
     steps:
     - name: Cache dependencies
       id: cache
@@ -43,6 +39,35 @@ jobs:
         tar xf yaml-0.2.5.tar.gz && cd yaml-0.2.5
         ./configure --prefix=/libs
         make -j install && cd
+  make-check-fms:
+    needs: build-dependencies
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        FC: ["ifx", "ifort"]
+        CC: ["icx", "icc"]
+        exclude:
+          - FC: "ifx"
+            CC: "icc"
+    container:
+      image: intel/oneapi-hpckit:2023.1.0-devel-ubuntu20.04
+      env:
+        CC: mpicc -cc=${{ matrix.CC }}
+        FC: mpifc -fc=${{ matrix.FC }}
+        CFLAGS:  "-I/libs/include"
+        FCFLAGS: "-I/libs/include -g -traceback"
+        LDFLAGS: "-L/libs/lib"
+        TEST_VERBOSE: 1
+        I_MPI_FABRICS: "shm" # needed for mpi in image
+        # intel bug causes some failures with shm option(required in container)
+        SKIP_TESTS: "test_mpp_update_domains.1 test_update_domains_performance.1 test_diag_manager2.23"
+    steps:
+    - name: Get dependencies from cache
+      id: cache
+      uses: actions/cache@v3
+      with:
+        path: /libs
+        key: ${{ runner.os }}-intel-libs
     - name: checkout
       uses: actions/checkout@v2
     - name: Configure

--- a/.github/workflows/github_autotools_intel.yml
+++ b/.github/workflows/github_autotools_intel.yml
@@ -2,16 +2,13 @@ on: pull_request
 jobs:
   build-dependencies:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        io-flag: ["--disable-deprecated-io", "--enable-deprecated-io"]
     container:
       image: intel/oneapi-hpckit:2023.1.0-devel-ubuntu20.04
       env:
         CC: mpiicc
         FC: mpiifort
         CFLAGS:  "-I/libs/include"
-        FCFLAGS: "-I/libs/include -g -traceback ${{ matrix.io-flag }}"
+        FCFLAGS: "-I/libs/include -g -traceback"
         LDFLAGS: "-L/libs/lib"
     steps:
     - name: Cache dependencies
@@ -19,7 +16,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: /libs
-        key: ${{ runner.os }}-intel-libs
+        key: ${{ runner.os }}-intel-libs${{ matrix.io-flag }}
     - name: Install packages for building
       run: apt-get update && apt-get install -y autoconf libtool automake zlibc zlib1g-dev
     - if: steps.cache.outputs.cache-hit != 'true'
@@ -49,6 +46,7 @@ jobs:
       matrix:
         FC: ["ifx", "ifort"]
         CC: ["icx", "icc"]
+        io-flag: ["--disable-deprecated-io", "--enable-deprecated-io"]
         exclude:
           - FC: "ifx"
             CC: "icc"
@@ -63,7 +61,8 @@ jobs:
         TEST_VERBOSE: 1
         I_MPI_FABRICS: "shm" # needed for mpi in image
         # intel bug causes some failures with shm option(required in container)
-        SKIP_TESTS: "test_mpp_update_domains.1 test_update_domains_performance.1 test_diag_manager2.23"
+        # test without skips
+        #SKIP_TESTS: "test_mpp_update_domains.1 test_update_domains_performance.1 test_diag_manager2.23"
     steps:
     - name: Get dependencies from cache
       id: cache
@@ -72,12 +71,12 @@ jobs:
         path: /libs
         key: ${{ runner.os }}-intel-libs
     - name: Install packages for building
-      run: apt-get update && apt-get install -y autoconf libtool automake zlibc zlib1g-dev
+      run: apt-get update && apt-get install -y autoconf libtool automake zlibc zlib1g-dev zip
     - name: checkout
       uses: actions/checkout@v2
     - name: Configure
-      run: autoreconf -if ./configure.ac && ./configure --with-yaml
+      run: autoreconf -if ./configure.ac && ./configure --with-yaml ${{ matrix.io-flag }}
     - name: Compile
       run: make -j || make
     - name: Run test suite
-      run: make check LD_LIBRARY_PATH="/libs/lib:$LD_LIBRARY_PATH" TEST_VERBOSE=1
+      run: make distcheck LD_LIBRARY_PATH="/libs/lib:$LD_LIBRARY_PATH" TEST_VERBOSE=1

--- a/.github/workflows/github_autotools_intel.yml
+++ b/.github/workflows/github_autotools_intel.yml
@@ -68,6 +68,8 @@ jobs:
       with:
         path: /libs
         key: ${{ runner.os }}-intel-libs
+    - name: Install packages for building
+      run: apt-get update && apt-get install -y autoconf libtool automake zlibc zlib1g-dev
     - name: checkout
       uses: actions/checkout@v2
     - name: Configure


### PR DESCRIPTION
**Description**
Adds a build matrix for the intel compilers and a separate job to build the dependencies so they aren't built 3 times.

**How Has This Been Tested?**
CI

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

