### PR TITLE
fix yaml parser trim filename bug with gcc

### DIFF
--- a/parser/yaml_output_functions.c
+++ b/parser/yaml_output_functions.c
@@ -363,7 +363,7 @@ void write_yaml_from_struct_3 (char *yamlname, int asize, struct fmsyamloutkeys 
 
   // trim any trailing whitespace
   int ws_ind = strlen(yamlname)-1;
-  while(isspace(*(yamlname+ws_ind))) ws_ind--;
+  while(*(yamlname+ws_ind) == ' ') ws_ind--;
   if( ws_ind != strlen(yamlname)-1) yamlname[ws_ind+1] = '\0';
 
   /* open the yaml output file. Only 1 core should do this */


### PR DESCRIPTION
**Description**
fixes the parser output test failing from bad file names outputted with gcc + prod flags. Just needed to replace the function `isspace` with a char comparison and the trim works properly.

**How Has This Been Tested?**
make check on amd box with gcc 13 + prod flags

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

