### PR TITLE
Changes variables named `data` to other variable names

### DIFF
--- a/axis_utils/axis_utils.F90
+++ b/axis_utils/axis_utils.F90
@@ -150,7 +150,7 @@ contains
     character(len=*), intent(inout), optional :: bnd_name
     character(len=*), intent(out), optional :: err_msg
 
-    real, dimension(:), allocatable :: axis_data, tmp
+    real, dimension(:), allocatable :: data, tmp
 
     integer :: i, len
     character(len=128) :: name, units
@@ -165,9 +165,9 @@ contains
     call mpp_get_atts(axis,units=units,longname=longname,&
             cartesian=cartesian, len=len)
     if(len .LE. 0) return
-    allocate(axis_data(len+1))
+    allocate(data(len+1))
 
-    bounds_found = mpp_get_axis_bounds(axis, axis_data, name=name)
+    bounds_found = mpp_get_axis_bounds(axis, data, name=name)
     longname = trim(longname)//' bounds'
 
     if(.not.bounds_found .and. len>1 ) then
@@ -177,13 +177,13 @@ contains
        allocate(tmp(len))
        call mpp_get_axis_data(axis,tmp)
        do i=2,len
-          axis_data(i)= tmp(i-1)+fp5*(tmp(i)-tmp(i-1))
+          data(i)= tmp(i-1)+fp5*(tmp(i)-tmp(i-1))
        enddo
-       axis_data(1)= tmp(1)- fp5*(tmp(2)-tmp(1))
-       if (abs(axis_data(1)) < epsln) axis_data(1) = 0.0
-       axis_data(len+1)= tmp(len)+ fp5*(tmp(len)-tmp(len-1))
-       if (axis_data(1) == 0.0) then
-          if (abs(axis_data(len+1)-360.) > epsln) axis_data(len+1)=360.0
+       data(1)= tmp(1)- fp5*(tmp(2)-tmp(1))
+       if (abs(data(1)) < epsln) data(1) = 0.0
+       data(len+1)= tmp(len)+ fp5*(tmp(len)-tmp(len-1))
+       if (data(1) == 0.0) then
+          if (abs(data(len+1)-360.) > epsln) data(len+1)=360.0
        endif
     endif
     if(bounds_found .OR. len>1) then
@@ -191,7 +191,7 @@ contains
                  longname,cartesian=cartesian,data=data)
     endif
     if(allocated(tmp)) deallocate(tmp)
-    deallocate(axis_data)
+    deallocate(data)
 
     return
   end subroutine get_axis_bounds

--- a/axis_utils/axis_utils.F90
+++ b/axis_utils/axis_utils.F90
@@ -150,7 +150,7 @@ contains
     character(len=*), intent(inout), optional :: bnd_name
     character(len=*), intent(out), optional :: err_msg
 
-    real, dimension(:), allocatable :: data, tmp
+    real, dimension(:), allocatable :: axis_data, tmp
 
     integer :: i, len
     character(len=128) :: name, units
@@ -165,9 +165,9 @@ contains
     call mpp_get_atts(axis,units=units,longname=longname,&
             cartesian=cartesian, len=len)
     if(len .LE. 0) return
-    allocate(data(len+1))
+    allocate(axis_data(len+1))
 
-    bounds_found = mpp_get_axis_bounds(axis, data, name=name)
+    bounds_found = mpp_get_axis_bounds(axis, axis_data, name=name)
     longname = trim(longname)//' bounds'
 
     if(.not.bounds_found .and. len>1 ) then
@@ -177,13 +177,13 @@ contains
        allocate(tmp(len))
        call mpp_get_axis_data(axis,tmp)
        do i=2,len
-          data(i)= tmp(i-1)+fp5*(tmp(i)-tmp(i-1))
+          axis_data(i)= tmp(i-1)+fp5*(tmp(i)-tmp(i-1))
        enddo
-       data(1)= tmp(1)- fp5*(tmp(2)-tmp(1))
-       if (abs(data(1)) < epsln) data(1) = 0.0
-       data(len+1)= tmp(len)+ fp5*(tmp(len)-tmp(len-1))
-       if (data(1) == 0.0) then
-          if (abs(data(len+1)-360.) > epsln) data(len+1)=360.0
+       axis_data(1)= tmp(1)- fp5*(tmp(2)-tmp(1))
+       if (abs(axis_data(1)) < epsln) axis_data(1) = 0.0
+       axis_data(len+1)= tmp(len)+ fp5*(tmp(len)-tmp(len-1))
+       if (axis_data(1) == 0.0) then
+          if (abs(axis_data(len+1)-360.) > epsln) axis_data(len+1)=360.0
        endif
     endif
     if(bounds_found .OR. len>1) then
@@ -191,7 +191,7 @@ contains
                  longname,cartesian=cartesian,data=data)
     endif
     if(allocated(tmp)) deallocate(tmp)
-    deallocate(data)
+    deallocate(axis_data)
 
     return
   end subroutine get_axis_bounds

--- a/data_override/data_override.F90
+++ b/data_override/data_override.F90
@@ -1220,10 +1220,10 @@ subroutine data_override_0d(gridname,fieldname_code,output_data,time,override,da
 end subroutine data_override_0d
 
 !> @brief Data override for 2D unstructured grids
-subroutine data_override_UG_1d(gridname,fieldname,data,time,override)
+subroutine data_override_UG_1d(gridname,fieldname,return_data,time,override)
   character(len=3),   intent(in) :: gridname !< model grid ID
   character(len=*),   intent(in) :: fieldname !< field to override
-  real, dimension(:), intent(inout) :: data !< data returned by this call
+  real, dimension(:), intent(inout) :: return_data !< data returned by this call
   type(time_type),    intent(in) :: time !<  model time
   logical, intent(out), optional :: override !< true if the field has been overriden succesfully
   !local vars
@@ -1249,7 +1249,7 @@ subroutine data_override_UG_1d(gridname,fieldname,data,time,override)
 
   call data_override_2d(gridname,fieldname,data_SG,time,override)
 
-  call mpp_pass_SG_to_UG(UG_domain, data_SG(:,:), data(:))
+  call mpp_pass_SG_to_UG(UG_domain, data_SG(:,:), return_data(:))
 
   deallocate(data_SG)
 

--- a/data_override/data_override.F90
+++ b/data_override/data_override.F90
@@ -1256,10 +1256,10 @@ subroutine data_override_UG_1d(gridname,fieldname,return_data,time,override)
 end subroutine data_override_UG_1d
 
 !> @brief Data override for 2D unstructured grids
-subroutine data_override_UG_2d(gridname,fieldname,data,time,override)
+subroutine data_override_UG_2d(gridname,fieldname,return_data,time,override)
   character(len=3),     intent(in) :: gridname !< model grid ID
   character(len=*),     intent(in) :: fieldname !< field to override
-  real, dimension(:,:), intent(inout) :: data !< data returned by this call
+  real, dimension(:,:), intent(inout) :: return_data !< data returned by this call
   type(time_type),      intent(in) :: time !<  model time
   logical, intent(out), optional :: override !< true if the field has been overriden succesfully
   !local vars
@@ -1281,18 +1281,18 @@ subroutine data_override_UG_2d(gridname,fieldname,data,time,override)
   enddo
   if(index1 .eq. -1) return  ! NO override was performed
 
-  nlevel = size(data,2)
+  nlevel = size(return_data,2)
   nlevel_max = nlevel
   call mpp_max(nlevel_max)
 
   call get_domainUG(gridname,UG_domain,comp_domain)
   allocate(data_SG(comp_domain(1):comp_domain(2),comp_domain(3):comp_domain(4),nlevel_max))
-  allocate(data_UG(size(data,1), nlevel_max))
+  allocate(data_UG(size(return_data,1), nlevel_max))
   data_SG = 0.0
   call data_override_3d(gridname,fieldname,data_SG,time,override)
 
   call mpp_pass_SG_to_UG(UG_domain, data_SG(:,:,:), data_UG(:,:))
-  data(:,1:nlevel) = data_UG(:,1:nlevel)
+  return_data(:,1:nlevel) = data_UG(:,1:nlevel)
 
   deallocate(data_SG, data_UG)
 

--- a/diag_integral/diag_integral.F90
+++ b/diag_integral/diag_integral.F90
@@ -542,25 +542,25 @@ end subroutine sum_field_2d
 !! <b> Template: </b>
 !!
 !! @code{.f90}
-!! call sum_field_3d (name, data, is, js)
+!! call sum_field_3d (name, field_data, is, js)
 !! @endcode
 !!
 !! <b> Parameters: </b>
 !!
 !! @code{.f90}
 !! character(len=*),  intent(in) :: name
-!! real,              intent(in) :: data(:,:,:)
+!! real,              intent(in) :: field_data(:,:,:)
 !! integer, optional, intent(in) :: is, js
 !! @endcode
 !!
 !! @param [in] <name> Name of the field to be integrated
-!! @param [in] <data> field of integrands to be summed over
+!! @param [in] <field_data> field of integrands to be summed over
 !! @param [in] <is, js> starting i,j indices over which summation is to occur
 !!
-subroutine sum_field_3d (name, data, is, js)
+subroutine sum_field_3d (name, field_data, is, js)
 
 character(len=*),  intent(in) :: name !< Name of the field to be integrated
-real,              intent(in) :: data(:,:,:) !< field of integrands to be summed over
+real,              intent(in) :: field_data(:,:,:) !< field of integrands to be summed over
 integer, optional, intent(in) :: is !< starting i,j indices over which summation is to occur
 integer, optional, intent(in) :: js !< starting i,j indices over which summation is to occur
 
@@ -571,8 +571,8 @@ integer, optional, intent(in) :: js !< starting i,j indices over which summation
 !     i1, j1, i2, j2  ! location indices of current data in
 !                       processor-global coordinates
 !-------------------------------------------------------------------------------
-      real, dimension (size(data,1),  &
-                       size(data,2)) :: data2
+      real, dimension (size(field_data,1),  &
+                       size(field_data,2)) :: data2
 
       integer :: field !< index of desired integral
       integer :: i1 !< location indices of current data in
@@ -608,8 +608,8 @@ integer, optional, intent(in) :: js !< starting i,j indices over which summation
 !-------------------------------------------------------------------------------
       i1 = 1;  if (present(is)) i1 = is
       j1 = 1;  if (present(js)) j1 = js
-      i2 = i1 + size(data,1) - 1
-      j2 = j1 + size(data,2) - 1
+      i2 = i1 + size(field_data,1) - 1
+      j2 = j1 + size(field_data,2) - 1
 
 !-------------------------------------------------------------------------------
 !    increment the count of points toward this integral. sum first
@@ -618,8 +618,8 @@ integer, optional, intent(in) :: js !< starting i,j indices over which summation
 !-------------------------------------------------------------------------------
 !$OMP CRITICAL
       field_count (field) = field_count (field) +   &
-                            size(data,1)*size(data,2)
-      data2 = sum(data,3)
+                            size(field_data,1)*size(field_data,2)
+      data2 = sum(field_data,3)
       field_sum   (field) = field_sum   (field) +  &
                             sum (data2 * area(i1:i2,j1:j2))
 

--- a/diag_integral/diag_integral.F90
+++ b/diag_integral/diag_integral.F90
@@ -1420,31 +1420,31 @@ end function diag_integral_alarm
 !! <b> Template: </b>
 !!
 !! @code{.f90}
-!! data2 = vert_diag_integral (data, wt)
+!! data2 = vert_diag_integral (field_data, wt)
 !! @endcode
 !!
 !! <b> Parameters: </b>
 !!
 !! @code{.f90}
-!! real, dimension (:,:,:),         intent(in) :: data, wt
-!! real, dimension (size(data,1),size(data,2)) :: data2
+!! real, dimension (:,:,:),         intent(in) :: field_data, wt
+!! real, dimension (size(field_data,1),size(field_data,2)) :: data2
 !! @endcode
 !!
-!! @param [in] <data> integral field data arrays
+!! @param [in] <field_data> integral field data arrays
 !! @param [in] <wt> integral field weighting functions
 !! @param [out] <data2>
 !! @return real array data2
-function vert_diag_integral (data, wt) result (data2)
+function vert_diag_integral (field_data, wt) result (data2)
 
-real, dimension (:,:,:),         intent(in) :: data !< integral field data arrays
+real, dimension (:,:,:),         intent(in) :: field_data !< integral field data arrays
 real, dimension (:,:,:),         intent(in) :: wt !< integral field weighting functions
-real, dimension (size(data,1),size(data,2)) :: data2
+real, dimension (size(field_data,1),size(field_data,2)) :: data2
 
 !-------------------------------------------------------------------------------
 ! local variables:
 !       wt2
 !-------------------------------------------------------------------------------
-      real, dimension(size(data,1),size(data,2)) :: wt2
+      real, dimension(size(field_data,1),size(field_data,2)) :: wt2
 
 !-------------------------------------------------------------------------------
       wt2 = sum(wt,3)
@@ -1452,7 +1452,7 @@ real, dimension (size(data,1),size(data,2)) :: data2
         call error_mesg ('diag_integral_mod',  &
                              'vert sum of weights equals zero', FATAL)
       endif
-      data2 = sum(data*wt,3) / wt2
+      data2 = sum(field_data*wt,3) / wt2
 
 end function vert_diag_integral
 

--- a/diag_integral/diag_integral.F90
+++ b/diag_integral/diag_integral.F90
@@ -456,25 +456,25 @@ end subroutine diag_integral_field_init
 !! <b> Template: </b>
 !!
 !! @code{.f90}
-!! call sum_field_2d (name, data, is, js)
+!! call sum_field_2d (name, field_data, is, js)
 !! @endcode
 !!
 !! <b> Parameters: </b>
 !!
 !! @code{.f90}
 !! character(len=*),  intent(in) :: name
-!! real,              intent(in) :: data(:,:)
+!! real,              intent(in) :: field_data(:,:)
 !! integer, optional, intent(in) :: is, js
 !! @endcode
 !!
 !! @param [in] <name> Name of the field to be integrated
-!! @param [in] <data> field of integrands to be summed over
+!! @param [in] <field_data> field of integrands to be summed over
 !! @param [in] <is, js> starting i,j indices over which summation is to occur
 !!
-subroutine sum_field_2d (name, data, is, js)
+subroutine sum_field_2d (name, field_data, is, js)
 
 character(len=*),  intent(in) :: name !< Name of the field to be integrated
-real,              intent(in) :: data(:,:) !< field of integrands to be summed over
+real,              intent(in) :: field_data(:,:) !< field of integrands to be summed over
 integer, optional, intent(in) :: is !< starting i indices over which summation is to occur
 integer, optional, intent(in) :: js !< starting j indices over which summation is to occur
 
@@ -515,8 +515,8 @@ integer, optional, intent(in) :: js !< starting j indices over which summation i
 !-------------------------------------------------------------------------------
      i1 = 1;  if (present(is)) i1 = is
      j1 = 1;  if (present(js)) j1 = js
-     i2 = i1 + size(data,1) - 1
-     j2 = j1 + size(data,2) - 1
+     i2 = i1 + size(field_data,1) - 1
+     j2 = j1 + size(field_data,2) - 1
 
 !-------------------------------------------------------------------------------
 !    increment the count of points toward this integral and add the
@@ -524,9 +524,9 @@ integer, optional, intent(in) :: js !< starting j indices over which summation i
 !-------------------------------------------------------------------------------
 !$OMP CRITICAL
       field_count (field) = field_count(field) +   &
-                            size(data,1)*size(data,2)
+                            size(field_data,1)*size(field_data,2)
       field_sum   (field) = field_sum   (field) +  &
-                            sum (data * area(i1:i2,j1:j2))
+                            sum (field_data * area(i1:i2,j1:j2))
 
 !$OMP END CRITICAL
 

--- a/diag_integral/diag_integral.F90
+++ b/diag_integral/diag_integral.F90
@@ -637,26 +637,26 @@ end subroutine sum_field_3d
 !! <b> Template: </b>
 !!
 !! @code{.f90}
-!! call sum_field_wght_3d (name, data, wt, is, js)
+!! call sum_field_wght_3d (name, field_data, wt, is, js)
 !! @endcode
 !!
 !! <b> Parameters: </b>
 !!
 !! @code{.f90}
 !! character(len=*),  intent(in) :: name
-!! real,              intent(in) :: data(:,:,:), wt(:,:,:)
+!! real,              intent(in) :: field_data(:,:,:), wt(:,:,:)
 !! integer, optional, intent(in) :: is, js
 !! @endcode
 !!
 !! @param [in] <name> Name of the field to be integrated
-!! @param [in] <data> field of integrands to be summed over
+!! @param [in] <field_data> field of integrands to be summed over
 !! @param [in] <wt> the weight function to be evaluated at summation
 !! @param [in] <is, js> starting i,j indices over which summation is to occur
 !!
-subroutine sum_field_wght_3d (name, data, wt, is, js)
+subroutine sum_field_wght_3d (name, field_data, wt, is, js)
 
 character(len=*),  intent(in) :: name !< Name of the field to be integrated
-real,              intent(in) :: data(:,:,:) !< field of integrands to be summed over
+real,              intent(in) :: field_data(:,:,:) !< field of integrands to be summed over
 real,              intent(in) :: wt(:,:,:) !< the weight function to be evaluated at summation
 integer, optional, intent(in) :: is !< starting i indices over which summation is to occur
 integer, optional, intent(in) :: js !< starting j indices over which summation is to occur
@@ -668,7 +668,7 @@ integer, optional, intent(in) :: js !< starting j indices over which summation i
 !     i1, j1, i2, j2  ! location indices of current data in
 !                       processor-global coordinates
 !-------------------------------------------------------------------------------
-      real, dimension (size(data,1),size(data,2)) :: data2
+      real, dimension (size(field_data,1),size(field_data,2)) :: data2
       integer :: field !< index of desired integral
       integer :: i1 !< location indices of current data in
                                        !! processor-global coordinates
@@ -702,8 +702,8 @@ integer, optional, intent(in) :: js !< starting j indices over which summation i
 !-------------------------------------------------------------------------------
       i1 = 1;  if (present(is)) i1 = is
       j1 = 1;  if (present(js)) j1 = js
-      i2 = i1 + size(data,1) - 1
-      j2 = j1 + size(data,2) - 1
+      i2 = i1 + size(field_data,1) - 1
+      j2 = j1 + size(field_data,2) - 1
 
 !-------------------------------------------------------------------------------
 !    increment the count of points toward this integral. sum first
@@ -713,8 +713,8 @@ integer, optional, intent(in) :: js !< starting j indices over which summation i
 !-------------------------------------------------------------------------------
 !$OMP CRITICAL
       field_count (field) = field_count (field) +   &
-                            size(data,1)*size(data,2)
-      data2 = vert_diag_integral (data, wt)
+                            size(field_data,1)*size(field_data,2)
+      data2 = vert_diag_integral (field_data, wt)
       field_sum(field) = field_sum   (field) +  &
                          sum (data2 * area(i1:i2,j1:j2))
 

--- a/diag_integral/diag_integral.F90
+++ b/diag_integral/diag_integral.F90
@@ -732,26 +732,26 @@ end subroutine sum_field_wght_3d
 !! <b> Template: </b>
 !!
 !! @code{.f90}
-!! call sum_field_2d_hemi (name, data, is, ie, js, je)
+!! call sum_field_2d_hemi (name, field_data, is, ie, js, je)
 !! @endcode
 !!
 !! <b> Parameters: </b>
 !!
 !! @code{.f90}
 !! character(len=*),  intent(in) :: name
-!! real,              intent(in) :: data(:,:)
+!! real,              intent(in) :: field_data(:,:)
 !! integer,           intent(in) :: is, js, ie, je
 !! @endcode
 !!
 !! @param [in] <name> Name of the field to be integrated
-!! @param [in] <data> field of integrands to be summed over
+!! @param [in] <field_data> field of integrands to be summed over
 !! @param [in] <is, js, ie, je> starting/ending i,j indices over which summation
 !!        is to occur
 !!
-subroutine sum_field_2d_hemi (name, data, is, ie, js, je)
+subroutine sum_field_2d_hemi (name, field_data, is, ie, js, je)
 
 character(len=*),  intent(in) :: name !< Name of the field to be integrated
-real,              intent(in) :: data(:,:) !< field of integrands to be summed over
+real,              intent(in) :: field_data(:,:) !< field of integrands to be summed over
 integer,           intent(in) :: is !< starting/ending i,j indices over which summation
                                                 !! is to occur
 integer,           intent(in) :: js !< starting/ending i,j indices over which summation
@@ -799,14 +799,14 @@ integer,           intent(in) :: je !< starting/ending i,j indices over which su
 !    is needed to handle case of 2d domain decomposition with physics
 !    window smaller than processor domain size.
 !-------------------------------------------------------------------------------
-      i1 = mod ( (is-1), size(data,1) ) + 1
-      i2 = i1 + size(data,1) - 1
+      i1 = mod ( (is-1), size(field_data,1) ) + 1
+      i2 = i1 + size(field_data,1) - 1
 
 !-------------------------------------------------------------------------------
 !    for a hemispheric sum, sum one jrow at a time in case a processor
 !    has data from both hemispheres.
 !-------------------------------------------------------------------------------
-      j1 = mod ( (js-1) ,size(data,2) ) + 1
+      j1 = mod ( (js-1) ,size(field_data,2) ) + 1
       j2 = j1
 
 !-------------------------------------------------------------------------------
@@ -817,7 +817,7 @@ integer,           intent(in) :: je !< starting/ending i,j indices over which su
 !$OMP CRITICAL
       field_count (field) = field_count (field) + 2* (i2-i1+1)*(j2-j1+1)
       field_sum   (field) = field_sum   (field) +  &
-                            sum (data(i1:i2,j1:j2)*area(is:ie,js:je))
+                            sum (field_data(i1:i2,j1:j2)*area(is:ie,js:je))
 
 !$OMP END CRITICAL
 

--- a/diag_manager/diag_axis.F90
+++ b/diag_manager/diag_axis.F90
@@ -107,10 +107,10 @@ CONTAINS
   !! increments the axis counter and fills in the axes
   !!
   !! @return integer axis ID
-  INTEGER FUNCTION diag_axis_init(name, DATA, units, cart_name, long_name, direction,&
+  INTEGER FUNCTION diag_axis_init(name, array_data, units, cart_name, long_name, direction,&
        & set_name, edges, Domain, Domain2, DomainU, aux, req, tile_count, domain_position )
     CHARACTER(len=*), INTENT(in) :: name !< Short name for axis
-    CLASS(*), DIMENSION(:), INTENT(in) :: DATA !< Array of coordinate values
+    CLASS(*), DIMENSION(:), INTENT(in) :: array_data !< Array of coordinate values
     CHARACTER(len=*), INTENT(in) :: units !< Units for the axis
     CHARACTER(len=*), INTENT(in) :: cart_name !< Cartesian axis ("X", "Y", "Z", "T")
     CHARACTER(len=*), INTENT(in), OPTIONAL :: long_name !< Long name for the axis.
@@ -222,17 +222,17 @@ CONTAINS
     IF ( Axes(diag_axis_init)%cart_name == 'T' ) THEN
        axlen = 0
     ELSE
-       axlen = SIZE(DATA(:))
+       axlen = SIZE(array_data(:))
     END IF
-    ALLOCATE ( Axes(diag_axis_init)%data(1:axlen) )
+    ALLOCATE ( Axes(diag_axis_init)%diag_type_data(1:axlen) )
 
     ! Initialize Axes(diag_axis_init)
     Axes(diag_axis_init)%name   = TRIM(name)
-    SELECT TYPE (DATA)
+    SELECT TYPE (array_data)
     TYPE IS (real(kind=r4_kind))
-       Axes(diag_axis_init)%data = DATA(1:axlen)
+       Axes(diag_axis_init)%diag_type_data = array_data(1:axlen)
     TYPE IS (real(kind=r8_kind))
-       Axes(diag_axis_init)%data = real(DATA(1:axlen))
+       Axes(diag_axis_init)%diag_type_data = real(array_data(1:axlen))
     CLASS DEFAULT
        CALL error_mesg('diag_axis_mod::diag_axis_init',&
             & 'The axis data is not one of the supported types of real(kind=4) or real(kind=8)', FATAL)

--- a/diag_manager/diag_axis.F90
+++ b/diag_manager/diag_axis.F90
@@ -457,7 +457,7 @@ CONTAINS
   END FUNCTION diag_subaxes_init
   !> @brief Return information about the axis with index ID
   SUBROUTINE get_diag_axis(id, name, units, long_name, cart_name,&
-       & direction, edges, Domain, DomainU, DATA, num_attributes, attributes, domain_position)
+       & direction, edges, Domain, DomainU, array_data, num_attributes, attributes, domain_position)
     CHARACTER(len=*), INTENT(out) :: name, units, long_name, cart_name
     INTEGER, INTENT(in) :: id !< Axis ID
     TYPE(domain1d), INTENT(out) :: Domain
@@ -465,7 +465,7 @@ CONTAINS
     INTEGER, INTENT(out) :: direction !< Direction of data. (See <TT>@ref diag_axis_init</TT> for a description of
                                       !! allowed values)
     INTEGER, INTENT(out) :: edges !< Axis ID for the previously defined "edges axis".
-    CLASS(*), DIMENSION(:), INTENT(out) :: DATA !< Array of coordinate values for this axis.
+    CLASS(*), DIMENSION(:), INTENT(out) :: array_data !< Array of coordinate values for this axis.
     INTEGER, INTENT(out), OPTIONAL :: num_attributes
     TYPE(diag_atttype), ALLOCATABLE, DIMENSION(:), INTENT(out), OPTIONAL :: attributes
     INTEGER, INTENT(out), OPTIONAL :: domain_position
@@ -482,15 +482,15 @@ CONTAINS
     Domain    = Axes(id)%Domain
     DomainU   = Axes(id)%DomainUG
     if (present(domain_position)) domain_position = Axes(id)%domain_position
-    IF ( Axes(id)%length > SIZE(DATA(:)) ) THEN
+    IF ( Axes(id)%length > SIZE(array_data(:)) ) THEN
        ! <ERROR STATUS="FATAL">array data is too small.</ERROR>
        CALL error_mesg('diag_axis_mod::get_diag_axis', 'array data is too small', FATAL)
     ELSE
-       SELECT TYPE (DATA)
+       SELECT TYPE (array_data)
        TYPE IS (real(kind=r4_kind))
-          DATA(1:Axes(id)%length) = real(Axes(id)%data(1:Axes(id)%length), kind=r4_kind)
+          array_data(1:Axes(id)%length) = real(Axes(id)%diag_type_data(1:Axes(id)%length), kind=r4_kind)
        TYPE IS (real(kind=r8_kind))
-          DATA(1:Axes(id)%length) = Axes(id)%data(1:Axes(id)%length)
+          array_data(1:Axes(id)%length) = Axes(id)%diag_type_data(1:Axes(id)%length)
        CLASS DEFAULT
           CALL error_mesg('diag_axis_mod::get_diag_axis',&
                & 'The axis data is not one of the supported types of real(kind=4) or real(kind=8)', FATAL)

--- a/diag_manager/diag_axis.F90
+++ b/diag_manager/diag_axis.F90
@@ -564,16 +564,16 @@ CONTAINS
   END SUBROUTINE get_diag_axis_cart
 
   !> @brief Return the axis data.
-  SUBROUTINE get_diag_axis_data(id, DATA)
+  SUBROUTINE get_diag_axis_data(id, axis_data)
     INTEGER, INTENT(in) :: id !< Axis ID
-    REAL, DIMENSION(:), INTENT(out) :: DATA !< Axis data
+    REAL, DIMENSION(:), INTENT(out) :: axis_data !< Axis data
 
     CALL valid_id_check(id, 'get_diag_axis_data')
-    IF (Axes(id)%length > SIZE(DATA(:))) THEN
+    IF (Axes(id)%length > SIZE(axis_data(:))) THEN
        ! <ERROR STATUS="FATAL">array data is too small</ERROR>
        CALL error_mesg('diag_axis_mod::get_diag_axis_data', 'array data is too small', FATAL)
     ELSE
-       DATA(1:Axes(id)%length) = Axes(id)%data
+       axis_data(1:Axes(id)%length) = Axes(id)%diag_type_data
     END IF
   END SUBROUTINE get_diag_axis_data
 

--- a/diag_manager/diag_data.F90
+++ b/diag_manager/diag_data.F90
@@ -260,7 +260,7 @@ use platform_mod
      CHARACTER(len=128) :: name
      CHARACTER(len=256) :: units, long_name
      CHARACTER(len=1) :: cart_name
-     REAL, DIMENSION(:), POINTER :: data
+     REAL, DIMENSION(:), POINTER :: diag_type_data
      INTEGER, DIMENSION(MAX_SUBAXES) :: start
      INTEGER, DIMENSION(MAX_SUBAXES) :: end
      CHARACTER(len=128), DIMENSION(MAX_SUBAXES) :: subaxis_name

--- a/diag_manager/diag_data.F90
+++ b/diag_manager/diag_data.F90
@@ -260,7 +260,7 @@ use platform_mod
      CHARACTER(len=128) :: name
      CHARACTER(len=256) :: units, long_name
      CHARACTER(len=1) :: cart_name
-     REAL, DIMENSION(:), POINTER :: diag_type_data
+     REAL, DIMENSION(:), POINTER :: data
      INTEGER, DIMENSION(MAX_SUBAXES) :: start
      INTEGER, DIMENSION(MAX_SUBAXES) :: end
      CHARACTER(len=128), DIMENSION(MAX_SUBAXES) :: subaxis_name

--- a/diag_manager/diag_manager.F90
+++ b/diag_manager/diag_manager.F90
@@ -4035,7 +4035,8 @@ CONTAINS
     WRITE (name,'(a,i2.2)') 'time_of_day_', n_samples
     init_diurnal_axis = get_axis_num(name, 'diurnal')
     IF ( init_diurnal_axis <= 0 ) THEN
-       init_diurnal_axis = diag_axis_init(name, center_data, units, 'N', 'time of day', set_name='diurnal', edges=edges_id)
+       init_diurnal_axis = diag_axis_init(name, center_data, units, 'N', 'time of day', &
+                           set_name='diurnal', edges=edges_id)
     END IF
   END FUNCTION init_diurnal_axis
 

--- a/diag_manager/diag_manager.F90
+++ b/diag_manager/diag_manager.F90
@@ -3999,7 +3999,7 @@ CONTAINS
   INTEGER FUNCTION init_diurnal_axis(n_samples)
     INTEGER, INTENT(in) :: n_samples !< number of intervals during the day
 
-    REAL :: DATA  (n_samples)   !< central points of time intervals
+    REAL :: center_data  (n_samples)   !< central points of time intervals
     REAL :: edges (n_samples+1) !< boundaries of time intervals
     INTEGER :: edges_id !< id of the corresponding edges
     INTEGER :: i
@@ -4018,7 +4018,7 @@ CONTAINS
     ! compute central points and units
     edges(1) = 0.0
     DO i = 1, n_samples
-       DATA (i) = 24.0*(REAL(i)-0.5)/n_samples
+       center_data (i) = 24.0*(REAL(i)-0.5)/n_samples
        edges(i+1) = 24.0* REAL(i)/n_samples
     END DO
 
@@ -4035,7 +4035,7 @@ CONTAINS
     WRITE (name,'(a,i2.2)') 'time_of_day_', n_samples
     init_diurnal_axis = get_axis_num(name, 'diurnal')
     IF ( init_diurnal_axis <= 0 ) THEN
-       init_diurnal_axis = diag_axis_init(name, DATA, units, 'N', 'time of day', set_name='diurnal', edges=edges_id)
+       init_diurnal_axis = diag_axis_init(name, center_data, units, 'N', 'time of day', set_name='diurnal', edges=edges_id)
     END IF
   END FUNCTION init_diurnal_axis
 

--- a/diag_manager/diag_util.F90
+++ b/diag_manager/diag_util.F90
@@ -1708,7 +1708,7 @@ END SUBROUTINE check_bounds_are_exact_dynamic
                                                            !! writting periodic files
 
     TYPE(time_type) :: fname_time !< Time used in setting the filename when writting periodic files
-    REAL, DIMENSION(2) :: DATA
+    REAL, DIMENSION(2) :: open_file_data
     INTEGER :: j, field_num, input_field_num, num_axes, k
     INTEGER :: field_num1
     INTEGER :: position
@@ -2086,9 +2086,9 @@ END SUBROUTINE check_bounds_are_exact_dynamic
        time_axis_id(1) = files(file)%time_axis_id
        time_bounds_id(1) = files(file)%time_bounds_id
        CALL get_diag_axis( time_axis_id(1), time_name, time_units, time_longname,&
-            & cart_name, dir, edges, Domain, domainU, DATA)
+            & cart_name, dir, edges, Domain, domainU, open_file_data)
        CALL get_diag_axis( time_bounds_id(1), timeb_name, timeb_units, timeb_longname,&
-            & cart_name, dir, edges, Domain, domainU, DATA)
+            & cart_name, dir, edges, Domain, domainU, open_file_data)
        ! CF Compliance requires the unit on the _bnds axis is the same as 'time'
        files(file)%f_bounds =  write_field_meta_data(files(file)%file_unit,&
             & TRIM(time_name)//'_bnds', (/time_bounds_id,time_axis_id/),&

--- a/drifters/drifters_comm.F90
+++ b/drifters/drifters_comm.F90
@@ -640,7 +640,7 @@ contains
     integer, allocatable ::  nps(:)
     real    :: x, y
     real, allocatable :: lons0(:), lats0(:), recvbuf(:,:)
-    real    :: data(drfts%nd+3, drfts%np)
+    real    :: com_data(drfts%nd+3, drfts%np) !communication data
 
     comm    = MPI_COMM_WORLD
     if(present(mycomm)) comm = mycomm
@@ -667,10 +667,10 @@ contains
        if( x <= self%xcmax .and. x >= self%xcmin .and. &
         &  y <= self%ycmax .and. y >= self%ycmin) then
           npf = npf + 1
-          data(1       , npf)   = real(drfts%ids(ip))
-          data(1+1:1+nd, npf)   =      drfts%positions(:, ip)
-          data(    2+nd, npf)   = lons(ip)
-          data(    3+nd, npf)   = lats(ip)
+          com_data(1       , npf)   = real(drfts%ids(ip))
+          com_data(1+1:1+nd, npf)   =      drfts%positions(:, ip)
+          com_data(    2+nd, npf)   = lons(ip)
+          com_data(    3+nd, npf)   = lats(ip)
        endif
     enddo
 
@@ -699,12 +699,12 @@ contains
 
     ! Each PE sends data to recvbuf on root_pe.
 #ifdef _USE_MPI
-    call mpi_gather(         data  ,     npf*(nd+3), MPI_REAL8, &
+    call mpi_gather(         com_data  ,     npf*(nd+3), MPI_REAL8, &
          &                  recvbuf,   npmax*(nd+3), MPI_REAL8, &
          &          root_pe, comm, ier)
     !!if(ier/=0) ermesg = 'drifters_write_restart: ERROR while gathering "data"'
 #else
-    if(npf > 0) call mpp_send(data(1,1), plen=npf*(nd+3), to_pe=root_pe, tag=COMM_TAG_4)
+    if(npf > 0) call mpp_send(com_data(1,1), plen=npf*(nd+3), to_pe=root_pe, tag=COMM_TAG_4)
     if(pe==root_pe) then
        do i = self%pe_beg, self%pe_end
           if(nps(i) > 0) call mpp_recv(recvbuf(1, i), glen=nps(i)*(nd+3), from_pe=i, tag=COMM_TAG_4)

--- a/drifters/drifters_set_field.fh
+++ b/drifters/drifters_set_field.fh
@@ -22,7 +22,7 @@ subroutine drifters_set_field_XXX(self, index_field, x, y, &
 #if _DIMS >= 3
      & z, &
 #endif
-     & data, ermesg)
+     & set_field_data, ermesg)
   use cloud_interpolator_mod
   type(drifters_type) :: self
   ! field index must be consistent with field_names from input file
@@ -30,11 +30,11 @@ subroutine drifters_set_field_XXX(self, index_field, x, y, &
   real, intent(in)    :: x(:)
   real, intent(in)    :: y(:)
 #if _DIMS == 2
-  real, intent(in)    :: data(:,:)
+  real, intent(in)    :: set_field_data(:,:)
 #endif
 #if _DIMS == 3
   real, intent(in)    :: z(:)
-  real, intent(in)    :: data(:,:,:)
+  real, intent(in)    :: set_field_data(:,:,:)
 #endif
   character(len=*), intent(out) :: ermesg
 
@@ -52,12 +52,12 @@ subroutine drifters_set_field_XXX(self, index_field, x, y, &
   nsizes(3) = size(z)
 #endif
 
-  if(nsizes(1) /= size(data, 1) .or. nsizes(2) /= size(data, 2)) then
+  if(nsizes(1) /= size(set_field_data, 1) .or. nsizes(2) /= size(set_field_data, 2)) then
      ermesg = 'drifters_set_field_XXX: ERROR size mismatch between data and x or y'
      return
   end if
 #if _DIMS >=3
-  if(nsizes(3) /= size(data, 3)) then
+  if(nsizes(3) /= size(set_field_data, 3)) then
      ermesg = 'drifters_set_field_XXX: ERROR size mismatch between data and z'
      return
   endif
@@ -104,7 +104,7 @@ subroutine drifters_set_field_XXX(self, index_field, x, y, &
      ts(3) = (self%core%positions(3,ip) - z(j))/(z(j+1) - z(j))
 #endif
 
-     call cld_ntrp_get_cell_values(nsizes, _FLATTEN(data), ij, fvals, ier)
+     call cld_ntrp_get_cell_values(nsizes, _FLATTEN(set_field_data), ij, fvals, ier)
      call cld_ntrp_linear_cell_interp(fvals, ts, self%fields(index_field, ip), ier)
   enddo
 

--- a/exchange/xgrid.F90
+++ b/exchange/xgrid.F90
@@ -1458,18 +1458,18 @@ end subroutine get_grid_version2
 
 !#######################################################################
 !> @brief Read the area elements from NetCDF file
-subroutine get_area_elements_fms2_io(fileobj, name, data)
+subroutine get_area_elements_fms2_io(fileobj, name, get_area_data)
   type(FmsNetcdfDomainFile_t), intent(in) :: fileobj
   character(len=*), intent(in) :: name
-  real(r8_kind), intent(out)            :: data(:,:)
+  real(r8_kind), intent(out)            :: get_area_data(:,:)
 
   if(variable_exists(fileobj, name)) then
-     call read_data(fileobj, name, data)
+     call read_data(fileobj, name, get_area_data)
   else
      call error_mesg('xgrid_mod', 'no field named '//trim(name)//' in grid file '//trim(fileobj%path)// &
                      ' Will set data to negative values...', NOTE)
      ! area elements no present in grid_spec file, set to negative values....
-     data = -1.0
+     get_area_data = -1.0
   endif
 
 end subroutine get_area_elements_fms2_io

--- a/exchange/xgrid.F90
+++ b/exchange/xgrid.F90
@@ -4419,7 +4419,7 @@ end subroutine get_index_range
 !!   first grid, which typically is on the atmos side.
 !!   note that "from" and "to" are optional, the stocks will be subtracted, resp. added, only
 !!   if these are present.
-subroutine stock_move_3d(from, to, grid_index, data, xmap, &
+subroutine stock_move_3d(from, to, grid_index, stock_data, xmap, &
      & delta_t, from_side, to_side, radius, verbose, ier)
 
   ! this version takes rank 3 data, it can be used to compute the flux on anything but the
@@ -4432,7 +4432,7 @@ subroutine stock_move_3d(from, to, grid_index, data, xmap, &
 
   type(stock_type), intent(inout), optional :: from, to
   integer, intent(in)             :: grid_index        !< grid index
-  real(r8_kind), intent(in)                :: data(:,:,:)  !< data array is 3d
+  real(r8_kind), intent(in)                :: stock_data(:,:,:)  !< data array is 3d
   type(xmap_type), intent(in)     :: xmap
   real(r8_kind), intent(in)                :: delta_t
   integer, intent(in)             :: from_side !< ISTOCK_TOP, ISTOCK_BOTTOM, or ISTOCK_SIDE
@@ -4456,7 +4456,7 @@ subroutine stock_move_3d(from, to, grid_index, data, xmap, &
   endif
 
      from_dq = delta_t * 4.0*PI*radius**2 * sum( sum(xmap%grids(grid_index)%area * &
-          & sum(xmap%grids(grid_index)%frac_area * data, DIM=3), DIM=1))
+          & sum(xmap%grids(grid_index)%frac_area * stock_data, DIM=3), DIM=1))
      to_dq = from_dq
 
   ! update only if argument is present.
@@ -4479,7 +4479,7 @@ end subroutine stock_move_3d
 !> @brief this version takes rank 2 data, it can be used to compute the flux on the atmos side
 !!   note that "from" and "to" are optional, the stocks will be subtracted, resp. added, only
 !!   if these are present.
-subroutine stock_move_2d(from, to, grid_index, data, xmap, &
+subroutine stock_move_2d(from, to, grid_index, stock_data, xmap, &
      & delta_t, from_side, to_side, radius, verbose, ier)
 
   ! this version takes rank 2 data, it can be used to compute the flux on the atmos side
@@ -4491,7 +4491,7 @@ subroutine stock_move_2d(from, to, grid_index, data, xmap, &
 
   type(stock_type), intent(inout), optional :: from, to
   integer, optional, intent(in)   :: grid_index
-  real(r8_kind), intent(in)                :: data(:,:)    !< data array is 2d
+  real(r8_kind), intent(in)                :: stock_data(:,:)    !< data array is 2d
   type(xmap_type), intent(in)     :: xmap
   real(r8_kind), intent(in)                :: delta_t
   integer, intent(in)             :: from_side !< ISTOCK_TOP, ISTOCK_BOTTOM, or ISTOCK_SIDE
@@ -4512,7 +4512,7 @@ subroutine stock_move_2d(from, to, grid_index, data, xmap, &
   if( .not. present(grid_index) .or. grid_index==1 ) then
 
      ! only makes sense if grid_index == 1
-     from_dq = delta_t * 4.0*PI*radius**2 * sum(sum(xmap%grids(1)%area * data, DIM=1))
+     from_dq = delta_t * 4.0*PI*radius**2 * sum(sum(xmap%grids(1)%area * stock_data, DIM=1))
      to_dq = from_dq
 
   else
@@ -4543,7 +4543,7 @@ end subroutine stock_move_2d
 !!   first grid, which typically is on the atmos side.
 !!   note that "from" and "to" are optional, the stocks will be subtracted, resp. added, only
 !!   if these are present.
-subroutine stock_move_ug_3d(from, to, grid_index, data, xmap, &
+subroutine stock_move_ug_3d(from, to, grid_index, stock_data, xmap, &
      & delta_t, from_side, to_side, radius, verbose, ier)
 
   ! this version takes rank 3 data, it can be used to compute the flux on anything but the
@@ -4556,7 +4556,7 @@ subroutine stock_move_ug_3d(from, to, grid_index, data, xmap, &
 
   type(stock_type), intent(inout), optional :: from, to
   integer, intent(in)             :: grid_index        !< grid index
-  real(r8_kind), intent(in)                :: data(:,:)  !< data array is 3d
+  real(r8_kind), intent(in)                :: stock_data(:,:)  !< data array is 3d
   type(xmap_type), intent(in)     :: xmap
   real(r8_kind), intent(in)                :: delta_t
   integer, intent(in)             :: from_side !< ISTOCK_TOP, ISTOCK_BOTTOM, or ISTOCK_SIDE
@@ -4564,7 +4564,7 @@ subroutine stock_move_ug_3d(from, to, grid_index, data, xmap, &
   real(r8_kind), intent(in)                :: radius       !< earth radius
   character(len=*), intent(in), optional      :: verbose
   integer, intent(out)            :: ier
-  real(r8_kind), dimension(size(data,1),size(data,2)) :: tmp
+  real(r8_kind), dimension(size(stock_data,1),size(stock_data,2)) :: tmp
 
   real(r8_kind)    :: from_dq, to_dq
 
@@ -4580,7 +4580,7 @@ subroutine stock_move_ug_3d(from, to, grid_index, data, xmap, &
      return
   endif
 
-     tmp = xmap%grids(grid_index)%frac_area(:,1,:) * data
+     tmp = xmap%grids(grid_index)%frac_area(:,1,:) * stock_data
      from_dq = delta_t * 4.0*PI*radius**2 * sum( xmap%grids(grid_index)%area(:,1) * &
           & sum(tmp, DIM=2))
      to_dq = from_dq
@@ -4605,13 +4605,13 @@ end subroutine stock_move_ug_3d
 
 !#######################################################################
 !> @brief surface/time integral of a 2d array
-subroutine stock_integrate_2d(data, xmap, delta_t, radius, res, ier)
+subroutine stock_integrate_2d(stock_data, xmap, delta_t, radius, res, ier)
 
   ! surface/time integral of a 2d array
 
   use mpp_mod, only : mpp_sum
 
-  real(r8_kind), intent(in)                :: data(:,:)    !< data array is 2d
+  real(r8_kind), intent(in)                :: stock_data(:,:)    !< data array is 2d
   type(xmap_type), intent(in)     :: xmap
   real(r8_kind), intent(in)                :: delta_t
   real(r8_kind), intent(in)                :: radius       !< earth radius
@@ -4626,7 +4626,7 @@ subroutine stock_integrate_2d(data, xmap, delta_t, radius, res, ier)
      return
   endif
 
-  res = delta_t * 4.0*PI*radius**2 * sum(sum(xmap%grids(1)%area * data, DIM=1))
+  res = delta_t * 4.0*PI*radius**2 * sum(sum(xmap%grids(1)%area * stock_data, DIM=1))
 
 end subroutine stock_integrate_2d
 !#######################################################################

--- a/exchange/xgrid.F90
+++ b/exchange/xgrid.F90
@@ -4419,7 +4419,7 @@ end subroutine get_index_range
 !!   first grid, which typically is on the atmos side.
 !!   note that "from" and "to" are optional, the stocks will be subtracted, resp. added, only
 !!   if these are present.
-subroutine stock_move_3d(from, to, grid_index, stock_data, xmap, &
+subroutine stock_move_3d(from, to, grid_index, stock_data3d, xmap, &
      & delta_t, from_side, to_side, radius, verbose, ier)
 
   ! this version takes rank 3 data, it can be used to compute the flux on anything but the
@@ -4432,7 +4432,7 @@ subroutine stock_move_3d(from, to, grid_index, stock_data, xmap, &
 
   type(stock_type), intent(inout), optional :: from, to
   integer, intent(in)             :: grid_index        !< grid index
-  real(r8_kind), intent(in)                :: stock_data(:,:,:)  !< data array is 3d
+  real(r8_kind), intent(in)                :: stock_data3d(:,:,:)  !< data array is 3d
   type(xmap_type), intent(in)     :: xmap
   real(r8_kind), intent(in)                :: delta_t
   integer, intent(in)             :: from_side !< ISTOCK_TOP, ISTOCK_BOTTOM, or ISTOCK_SIDE
@@ -4456,7 +4456,7 @@ subroutine stock_move_3d(from, to, grid_index, stock_data, xmap, &
   endif
 
      from_dq = delta_t * 4.0*PI*radius**2 * sum( sum(xmap%grids(grid_index)%area * &
-          & sum(xmap%grids(grid_index)%frac_area * stock_data, DIM=3), DIM=1))
+          & sum(xmap%grids(grid_index)%frac_area * stock_data3d, DIM=3), DIM=1))
      to_dq = from_dq
 
   ! update only if argument is present.
@@ -4479,7 +4479,7 @@ end subroutine stock_move_3d
 !> @brief this version takes rank 2 data, it can be used to compute the flux on the atmos side
 !!   note that "from" and "to" are optional, the stocks will be subtracted, resp. added, only
 !!   if these are present.
-subroutine stock_move_2d(from, to, grid_index, stock_data, xmap, &
+subroutine stock_move_2d(from, to, grid_index, stock_data2d, xmap, &
      & delta_t, from_side, to_side, radius, verbose, ier)
 
   ! this version takes rank 2 data, it can be used to compute the flux on the atmos side
@@ -4491,7 +4491,7 @@ subroutine stock_move_2d(from, to, grid_index, stock_data, xmap, &
 
   type(stock_type), intent(inout), optional :: from, to
   integer, optional, intent(in)   :: grid_index
-  real(r8_kind), intent(in)                :: stock_data(:,:)    !< data array is 2d
+  real(r8_kind), intent(in)                :: stock_data2d(:,:)    !< data array is 2d
   type(xmap_type), intent(in)     :: xmap
   real(r8_kind), intent(in)                :: delta_t
   integer, intent(in)             :: from_side !< ISTOCK_TOP, ISTOCK_BOTTOM, or ISTOCK_SIDE
@@ -4512,7 +4512,7 @@ subroutine stock_move_2d(from, to, grid_index, stock_data, xmap, &
   if( .not. present(grid_index) .or. grid_index==1 ) then
 
      ! only makes sense if grid_index == 1
-     from_dq = delta_t * 4.0*PI*radius**2 * sum(sum(xmap%grids(1)%area * stock_data, DIM=1))
+     from_dq = delta_t * 4.0*PI*radius**2 * sum(sum(xmap%grids(1)%area * stock_data2d, DIM=1))
      to_dq = from_dq
 
   else
@@ -4543,7 +4543,7 @@ end subroutine stock_move_2d
 !!   first grid, which typically is on the atmos side.
 !!   note that "from" and "to" are optional, the stocks will be subtracted, resp. added, only
 !!   if these are present.
-subroutine stock_move_ug_3d(from, to, grid_index, stock_data, xmap, &
+subroutine stock_move_ug_3d(from, to, grid_index, stock_ug_data3d, xmap, &
      & delta_t, from_side, to_side, radius, verbose, ier)
 
   ! this version takes rank 3 data, it can be used to compute the flux on anything but the
@@ -4556,7 +4556,7 @@ subroutine stock_move_ug_3d(from, to, grid_index, stock_data, xmap, &
 
   type(stock_type), intent(inout), optional :: from, to
   integer, intent(in)             :: grid_index        !< grid index
-  real(r8_kind), intent(in)                :: stock_data(:,:)  !< data array is 3d
+  real(r8_kind), intent(in)                :: stock_ug_data3d(:,:)  !< data array is 3d
   type(xmap_type), intent(in)     :: xmap
   real(r8_kind), intent(in)                :: delta_t
   integer, intent(in)             :: from_side !< ISTOCK_TOP, ISTOCK_BOTTOM, or ISTOCK_SIDE
@@ -4564,7 +4564,7 @@ subroutine stock_move_ug_3d(from, to, grid_index, stock_data, xmap, &
   real(r8_kind), intent(in)                :: radius       !< earth radius
   character(len=*), intent(in), optional      :: verbose
   integer, intent(out)            :: ier
-  real(r8_kind), dimension(size(stock_data,1),size(stock_data,2)) :: tmp
+  real(r8_kind), dimension(size(stock_ug_data3d,1),size(stock_ug_data3d,2)) :: tmp
 
   real(r8_kind)    :: from_dq, to_dq
 
@@ -4580,7 +4580,7 @@ subroutine stock_move_ug_3d(from, to, grid_index, stock_data, xmap, &
      return
   endif
 
-     tmp = xmap%grids(grid_index)%frac_area(:,1,:) * stock_data
+     tmp = xmap%grids(grid_index)%frac_area(:,1,:) * stock_ug_data3d
      from_dq = delta_t * 4.0*PI*radius**2 * sum( xmap%grids(grid_index)%area(:,1) * &
           & sum(tmp, DIM=2))
      to_dq = from_dq
@@ -4605,13 +4605,13 @@ end subroutine stock_move_ug_3d
 
 !#######################################################################
 !> @brief surface/time integral of a 2d array
-subroutine stock_integrate_2d(stock_data, xmap, delta_t, radius, res, ier)
+subroutine stock_integrate_2d(integrate_data2d, xmap, delta_t, radius, res, ier)
 
   ! surface/time integral of a 2d array
 
   use mpp_mod, only : mpp_sum
 
-  real(r8_kind), intent(in)                :: stock_data(:,:)    !< data array is 2d
+  real(r8_kind), intent(in)                :: integrate_data2d(:,:)    !< data array is 2d
   type(xmap_type), intent(in)     :: xmap
   real(r8_kind), intent(in)                :: delta_t
   real(r8_kind), intent(in)                :: radius       !< earth radius
@@ -4626,7 +4626,7 @@ subroutine stock_integrate_2d(stock_data, xmap, delta_t, radius, res, ier)
      return
   endif
 
-  res = delta_t * 4.0*PI*radius**2 * sum(sum(xmap%grids(1)%area * stock_data, DIM=1))
+  res = delta_t * 4.0*PI*radius**2 * sum(sum(xmap%grids(1)%area * integrate_data2d, DIM=1))
 
 end subroutine stock_integrate_2d
 !#######################################################################

--- a/horiz_interp/horiz_interp_type.F90
+++ b/horiz_interp/horiz_interp_type.F90
@@ -81,7 +81,7 @@ type horizInterpReals8_type
    real(kind=r8_kind),    dimension(:), allocatable     :: area_frac_dst !< area fraction in destination grid.
    real(kind=r8_kind),    dimension(:,:), allocatable   :: mask_in
    real(kind=r8_kind)                                   :: max_src_dist
-   logical                                              :: is_allocated !< set to true upon field allocation
+   logical                                              :: is_allocated = .false. !< set to true upon field allocation
 
 end type horizInterpReals8_type
 
@@ -108,7 +108,7 @@ type horizInterpReals4_type
    real(kind=r4_kind),    dimension(:), allocatable     :: area_frac_dst !< area fraction in destination grid.
    real(kind=r4_kind),    dimension(:,:), allocatable   :: mask_in
    real(kind=r4_kind)                                   :: max_src_dist
-   logical                                              :: is_allocated !< set to true upon field allocation
+   logical                                              :: is_allocated = .false. !< set to true upon field allocation
 
 end type horizInterpReals4_type
 

--- a/horiz_interp/include/horiz_interp_conserve.inc
+++ b/horiz_interp/include/horiz_interp_conserve.inc
@@ -881,18 +881,18 @@ subroutine HORIZ_INTERP_CONSERVE_NEW_1DX1D_ ( Interp, lon_in, lat_in, lon_out, l
   !#######################################################################
 
   !> sums up the data and weights for a single output grid box
-  subroutine DATA_SUM_( data, area, facis, facie, facjs, facje,  &
+  subroutine DATA_SUM_( grid_data, area, facis, facie, facjs, facje,  &
        dwtsum, wtsum, arsum, mask )
 
     !-----------------------------------------------------------------------
-    real(FMS_HI_KIND_), intent(in), dimension(:,:) :: data, area
+    real(FMS_HI_KIND_), intent(in), dimension(:,:) :: grid_data, area
     real(FMS_HI_KIND_), intent(in)                 :: facis, facie, facjs, facje
     real(FMS_HI_KIND_), intent(inout)              :: dwtsum, wtsum, arsum
     real(FMS_HI_KIND_), intent(in), optional       :: mask(:,:)
 
     !  fac__ = fractional portion of each boundary grid box included
     !          in the integral
-    !  dwtsum = sum(data*area*mask)
+    !  dwtsum = sum(grid_data*area*mask)
     !  wtsum  = sum(area*mask)
     !  arsum  = sum(area)
     !-----------------------------------------------------------------------
@@ -914,10 +914,10 @@ subroutine HORIZ_INTERP_CONSERVE_NEW_1DX1D_ ( Interp, lon_in, lat_in, lon_out, l
 
     if (present(mask)) then
        wt = wt * mask
-       dwtsum = dwtsum + sum(wt*data)
+       dwtsum = dwtsum + sum(wt*grid_data)
        wtsum =  wtsum + sum(wt)
     else
-       dwtsum = dwtsum + sum(wt*data)
+       dwtsum = dwtsum + sum(wt*grid_data)
        wtsum =  wtsum + asum
     endif
     !-----------------------------------------------------------------------

--- a/interpolator/interpolator.F90
+++ b/interpolator/interpolator.F90
@@ -1188,16 +1188,16 @@ subroutine get_axis_latlon_data(fileobj, name, latlon_data)
 end subroutine get_axis_latlon_data
 
 
-subroutine get_axis_level_data(fileobj, name, data, level_type, vertical_indices)
+subroutine get_axis_level_data(fileobj, name, level_data, level_type, vertical_indices)
    type(FmsNetcdfFile_t), intent(in) :: fileobj
    character(len=*),      intent(in) :: name
-   real, dimension(:),   intent(out) :: data
+   real, dimension(:),   intent(out) :: level_data
    integer,              intent(out) :: level_type, vertical_indices
    real, dimension(:), allocatable   :: alpha
    integer                           :: n, nlev
 
    if(variable_exists(fileobj, name)) then
-      call fms2_io_read_data(fileobj, name, data)
+      call fms2_io_read_data(fileobj, name, level_data)
    else
       call mpp_error(FATAL,'get_axis_level_data: variable '// &
                      & trim(name)//' does not exist in file '//trim(fileobj%path) )
@@ -1206,9 +1206,9 @@ subroutine get_axis_level_data(fileobj, name, data, level_type, vertical_indices
    level_type = PRESSURE
    ! Convert to Pa
    if( trim(adjustl(lowercase(chomp(units)))) == "mb" .or. trim(adjustl(lowercase(chomp(units)))) == "hpa") then
-      data = data * 100.
+      level_data = level_data * 100.
    endif
-   nlev = size(data(:))
+   nlev = size(level_data(:))
    sense = get_variable_sense(fileobj, name)
 ! define the direction of the vertical data axis
 ! switch index order if necessary so that indx 1 is at lowest pressure,
@@ -1217,10 +1217,10 @@ subroutine get_axis_level_data(fileobj, name, data, level_type, vertical_indices
         vertical_indices = INCREASING_UPWARD
         allocate (alpha(nlev))
         do n = 1, nlev
-          alpha(n) = data(nlev-n+1)
+          alpha(n) = level_data(nlev-n+1)
         end do
         do n = 1, nlev
-          data(n) = alpha(n)
+          level_data(n) = alpha(n)
         end do
         deallocate (alpha)
       else

--- a/interpolator/interpolator.F90
+++ b/interpolator/interpolator.F90
@@ -1163,14 +1163,14 @@ endif
 
 end subroutine fms2io_interpolator_init
 
-subroutine get_axis_latlon_data(fileobj, name, data)
+subroutine get_axis_latlon_data(fileobj, name, latlon_data)
    type(FmsNetcdfFile_t), intent(in) :: fileobj
    character(len=*),      intent(in) :: name
-   real, dimension(:),   intent(out) :: data
+   real, dimension(:),   intent(out) :: latlon_data
 
 
    if(variable_exists(fileobj, name)) then
-      call fms2_io_read_data(fileobj, name, data)
+      call fms2_io_read_data(fileobj, name, latlon_data)
    else
       call mpp_error(FATAL,'get_axis_latlon_data: variable '// &
                      & trim(name)//' does not exist in file '//trim(fileobj%path) )
@@ -1178,7 +1178,7 @@ subroutine get_axis_latlon_data(fileobj, name, data)
    call get_variable_units(fileobj, name, units)
    select case(units(1:6))
    case('degree')
-      data = data*dtr
+      latlon_data = latlon_data*dtr
    case('radian')
    case default
       call mpp_error(FATAL, "get_axis_latlon_data : Units for '// &

--- a/mpp/include/mpp_comm_mpi.inc
+++ b/mpp/include/mpp_comm_mpi.inc
@@ -319,13 +319,13 @@ end subroutine mpp_exit
 !                                                                             !
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     !> Broadcasts a character string from the given pe to it's pelist
-    subroutine mpp_broadcast_char(data, length, from_pe, pelist )
-      character(len=*), intent(inout) :: data(:) !< Character string to send
+    subroutine mpp_broadcast_char(char_data, length, from_pe, pelist )
+      character(len=*), intent(inout) :: char_data(:) !< Character string to send
       integer, intent(in) :: length  !< length of given data to broadcast
       integer, intent(in) :: from_pe !< pe to broadcast from
       integer, intent(in), optional :: pelist(:) !< optional pelist to broadcast to
       integer :: n, i, from_rank
-      character    :: str1D(length*size(data(:)))
+      character    :: str1D(length*size(char_data(:)))
       pointer(lptr, str1D)
 
       if( .NOT.module_is_initialized )call mpp_error( FATAL, 'mpp_broadcast_text: You must first call mpp_init.' )
@@ -351,8 +351,9 @@ end subroutine mpp_exit
              exit
          endif
       enddo
-      lptr = LOC (data)
-      if( mpp_npes().GT.1 ) call MPI_BCAST( data, length*size(data(:)), MPI_CHARACTER, from_rank, peset(n)%id, error )
+      lptr = LOC (char_data)
+      if( mpp_npes().GT.1 ) call MPI_BCAST( char_data, length*size(char_data(:)), &
+         MPI_CHARACTER, from_rank, peset(n)%id, error )
       if( debug .and. (current_clock.NE.0) )call increment_current_clock( EVENT_BROADCAST, length )
       return
     end subroutine mpp_broadcast_char

--- a/mpp/include/mpp_comm_mpi.inc
+++ b/mpp/include/mpp_comm_mpi.inc
@@ -319,13 +319,13 @@ end subroutine mpp_exit
 !                                                                             !
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     !> Broadcasts a character string from the given pe to it's pelist
-    subroutine mpp_broadcast_char(char_data, length, from_pe, pelist )
-      character(len=*), intent(inout) :: char_data(:) !< Character string to send
+    subroutine mpp_broadcast_char(data, length, from_pe, pelist )
+      character(len=*), intent(inout) :: data(:) !< Character string to send
       integer, intent(in) :: length  !< length of given data to broadcast
       integer, intent(in) :: from_pe !< pe to broadcast from
       integer, intent(in), optional :: pelist(:) !< optional pelist to broadcast to
       integer :: n, i, from_rank
-      character    :: str1D(length*size(char_data(:)))
+      character    :: str1D(length*size(data(:)))
       pointer(lptr, str1D)
 
       if( .NOT.module_is_initialized )call mpp_error( FATAL, 'mpp_broadcast_text: You must first call mpp_init.' )
@@ -351,8 +351,8 @@ end subroutine mpp_exit
              exit
          endif
       enddo
-      lptr = LOC (char_data)
-      if( mpp_npes().GT.1 ) call MPI_BCAST( char_data, length*size(char_data(:)), MPI_CHARACTER, from_rank, peset(n)%id, error )
+      lptr = LOC (data)
+      if( mpp_npes().GT.1 ) call MPI_BCAST( data, length*size(data(:)), MPI_CHARACTER, from_rank, peset(n)%id, error )
       if( debug .and. (current_clock.NE.0) )call increment_current_clock( EVENT_BROADCAST, length )
       return
     end subroutine mpp_broadcast_char

--- a/mpp/include/mpp_comm_mpi.inc
+++ b/mpp/include/mpp_comm_mpi.inc
@@ -319,13 +319,13 @@ end subroutine mpp_exit
 !                                                                             !
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     !> Broadcasts a character string from the given pe to it's pelist
-    subroutine mpp_broadcast_char(data, length, from_pe, pelist )
-      character(len=*), intent(inout) :: data(:) !< Character string to send
+    subroutine mpp_broadcast_char(char_data, length, from_pe, pelist )
+      character(len=*), intent(inout) :: char_data(:) !< Character string to send
       integer, intent(in) :: length  !< length of given data to broadcast
       integer, intent(in) :: from_pe !< pe to broadcast from
       integer, intent(in), optional :: pelist(:) !< optional pelist to broadcast to
       integer :: n, i, from_rank
-      character    :: str1D(length*size(data(:)))
+      character    :: str1D(length*size(char_data(:)))
       pointer(lptr, str1D)
 
       if( .NOT.module_is_initialized )call mpp_error( FATAL, 'mpp_broadcast_text: You must first call mpp_init.' )
@@ -351,8 +351,8 @@ end subroutine mpp_exit
              exit
          endif
       enddo
-      lptr = LOC (data)
-      if( mpp_npes().GT.1 ) call MPI_BCAST( data, length*size(data(:)), MPI_CHARACTER, from_rank, peset(n)%id, error )
+      lptr = LOC (char_data)
+      if( mpp_npes().GT.1 ) call MPI_BCAST( char_data, length*size(char_data(:)), MPI_CHARACTER, from_rank, peset(n)%id, error )
       if( debug .and. (current_clock.NE.0) )call increment_current_clock( EVENT_BROADCAST, length )
       return
     end subroutine mpp_broadcast_char

--- a/mpp/include/mpp_comm_nocomm.inc
+++ b/mpp/include/mpp_comm_nocomm.inc
@@ -244,8 +244,8 @@ end subroutine mpp_exit
     return
   end subroutine mpp_set_stack_size
 
-    subroutine mpp_broadcast_char(data, length, from_pe, pelist )
-      character(len=*), intent(inout) :: data(:)
+    subroutine mpp_broadcast_char(char_data, length, from_pe, pelist )
+      character(len=*), intent(inout) :: char_data(:)
       integer, intent(in) :: length, from_pe
       integer, intent(in), optional :: pelist(:)
 

--- a/mpp/include/mpp_define_nest_domains.inc
+++ b/mpp/include/mpp_define_nest_domains.inc
@@ -1350,22 +1350,22 @@ subroutine compute_overlap_fine_to_coarse(nest_domain, overlap, position, name)
 
 end subroutine compute_overlap_fine_to_coarse
 
-function find_index(array, data, start_pos)
+function find_index(array, index_data, start_pos)
   integer, intent(in) :: array(:)
-  integer, intent(in) :: data
+  integer, intent(in) :: index_data
   integer, intent(in) :: start_pos
   integer             :: find_index
   integer             :: i
 
   find_index = 0
   do i = start_pos, size(array)
-     if(array(i) == data) then
+     if(array(i) == index_data) then
         find_index = i
         exit
      endif
   enddo
   if(find_index == 0) then
-     print*, "start_pos = ", start_pos, data, array
+     print*, "start_pos = ", start_pos, index_data, array
      call mpp_error(FATAL, "mpp_define_nest_domains.inc: can not find data in array")
   endif
 

--- a/mpp/include/mpp_do_get_boundary.fh
+++ b/mpp/include/mpp_do_get_boundary.fh
@@ -1012,7 +1012,7 @@ subroutine MPP_DO_GET_BOUNDARY_3D_V_(f_addrsx, f_addrsy, domain, boundx, boundy,
   tMe = 1
   if( BTEST(domain%fold,NORTH) .AND. (.NOT.BTEST(flags,SCALAR_BIT)) )then
      j = domain%y(1)%global%end+shift
-     if( domain%y(1)%data%begin.LE.j .AND. j.LE.domain%y(1)%data%end+shift )then !fold is within domain
+     if( domain%y(1)%domain_data%begin.LE.j .AND. j.LE.domain%y(1)%domain_data%end+shift )then !fold is within domain
         !poles set to 0: BGRID only
         if( gridtype.EQ.BGRID_NE )then
            midpoint = (domain%x(1)%global%begin+domain%x(1)%global%end-1+shift)/2

--- a/mpp/include/mpp_do_get_boundary_ad.fh
+++ b/mpp/include/mpp_do_get_boundary_ad.fh
@@ -580,7 +580,7 @@ subroutine MPP_DO_GET_BOUNDARY_AD_3D_V_(f_addrsx, f_addrsy, domain, boundx, boun
   tMe = 1
   if( BTEST(domain%fold,NORTH) .AND. (.NOT.BTEST(flags,SCALAR_BIT)) )then
      j = domain%y(1)%global%end+shift
-     if( domain%y(1)%data%begin.LE.j .AND. j.LE.domain%y(1)%data%end+shift )then !fold is within domain
+     if( domain%y(1)%domain_data%begin.LE.j .AND. j.LE.domain%y(1)%domain_data%end+shift )then !fold is within domain
         !poles set to 0: BGRID only
         if( gridtype.EQ.BGRID_NE )then
            midpoint = (domain%x(1)%global%begin+domain%x(1)%global%end-1+shift)/2

--- a/mpp/include/mpp_do_global_field.fh
+++ b/mpp/include/mpp_do_global_field.fh
@@ -107,8 +107,8 @@
       else if( size(local,1).EQ.(domain%x(tile)%memory%size+ishift) .AND. &
                size(local,2).EQ.(domain%y(tile)%memory%size+jshift) )then
          !local is on data domain
-         ioff = -domain%x(tile)%data%begin + 1
-         joff = -domain%y(tile)%data%begin + 1
+         ioff = -domain%x(tile)%domain_data%begin + 1
+         joff = -domain%y(tile)%domain_data%begin + 1
       else
          call mpp_error( FATAL, &
                        & 'MPP_GLOBAL_FIELD_: incoming field array must match either compute domain or memory domain.')
@@ -374,8 +374,8 @@
       else if( size(local,1).EQ.(domain%x(tile)%memory%size+ishift) .AND. &
                size(local,2).EQ.(domain%y(tile)%memory%size+jshift) )then
          !local is on data domain
-         ioff = -domain%x(tile)%data%begin
-         joff = -domain%y(tile)%data%begin
+         ioff = -domain%x(tile)%domain_data%begin
+         joff = -domain%y(tile)%domain_data%begin
       else
          call mpp_error( FATAL, &
                        & 'MPP_GLOBAL_FIELD_: incoming field array must match either compute domain or memory domain.' )

--- a/mpp/include/mpp_do_global_field_ad.fh
+++ b/mpp/include/mpp_do_global_field_ad.fh
@@ -109,8 +109,8 @@
       else if( size(local,1).EQ.(domain%x(tile)%memory%size+ishift) .AND. size(local, &
              & 2).EQ.(domain%y(tile)%memory%size+jshift) )then
          !local is on data domain
-         ioff = -domain%x(tile)%data%begin + 1
-         joff = -domain%y(tile)%data%begin + 1
+         ioff = -domain%x(tile)%domain_data%begin + 1
+         joff = -domain%y(tile)%domain_data%begin + 1
       else
          call mpp_error( FATAL, &
               & 'MPP_GLOBAL_FIELD_: incoming field array must match either compute domain or memory domain.')

--- a/mpp/include/mpp_do_redistribute.fh
+++ b/mpp/include/mpp_do_redistribute.fh
@@ -22,11 +22,11 @@
       integer(i8_kind), intent(in)         :: f_in(:), f_out(:)
       type(DomainCommunicator2D), intent(in) :: d_comm
       MPP_TYPE_, intent(in)                  :: d_type
-      MPP_TYPE_ :: field_in(d_comm%domain_in%x(1)%data%begin:d_comm%domain_in%x(1)%data%end, &
-                            d_comm%domain_in%y(1)%data%begin:d_comm%domain_in%y(1)%data%end,d_comm%ke)
+      MPP_TYPE_ :: field_in(d_comm%domain_in%x(1)%domain_data%begin:d_comm%domain_in%x(1)%domain_data%end, &
+                            d_comm%domain_in%y(1)%domain_data%begin:d_comm%domain_in%y(1)%domain_data%end,d_comm%ke)
       pointer( ptr_field_in, field_in)
-      MPP_TYPE_ :: field_out(d_comm%domain_out%x(1)%data%begin:d_comm%domain_out%x(1)%data%end, &
-                             d_comm%domain_out%y(1)%data%begin:d_comm%domain_out%y(1)%data%end,d_comm%ke)
+      MPP_TYPE_ :: field_out(d_comm%domain_out%x(1)%domain_data%begin:d_comm%domain_out%x(1)%domain_data%end, &
+                             d_comm%domain_out%y(1)%domain_data%begin:d_comm%domain_out%y(1)%domain_data%end,d_comm%ke)
       pointer( ptr_field_out, field_out)
       type(domain2D), pointer :: domain_in, domain_out
       integer :: i, j, k, l, n, l_size

--- a/mpp/include/mpp_do_updateV.fh
+++ b/mpp/include/mpp_do_updateV.fh
@@ -1101,7 +1101,7 @@
          ! NOTE: symmetry is assumed for fold-west boundary
          i = domain%x(1)%global%end+shift
          !fold is within domain
-         if( domain%x(1)%domain_data%begin.LE.i .AND. i.LE.domain%x(1)%domain_data%end+shift )then 
+         if( domain%x(1)%domain_data%begin.LE.i .AND. i.LE.domain%x(1)%domain_data%end+shift )then
             midpoint = (domain%y(1)%global%begin+domain%y(1)%global%end-1+shift)/2
             !poles set to 0: BGRID only
             if( gridtype.EQ.BGRID_NE )then

--- a/mpp/include/mpp_do_updateV.fh
+++ b/mpp/include/mpp_do_updateV.fh
@@ -843,7 +843,7 @@
                      is = domain%x(1)%global%begin - 1
                   end if
                   if( is.GT.isd )then
-                     if( 2*is-domain%x(1)%data%begin.GT.domain%x(1)%data%end+shift  ) &
+                     if( 2*is-domain%x(1)%domain_data%begin.GT.domain%x(1)%domain_data%end+shift  ) &
                           call mpp_error( FATAL, 'MPP_DO_UPDATE_V: folded-north BGRID_NE west edge ubound error.' )
                      do l=1,l_size
                         ptr_fieldx = f_addrsx(l, 1)
@@ -859,7 +859,7 @@
                case(CGRID_NE)
                   is = domain%x(1)%global%begin
                   if( is.GT.isd )then
-                     if( 2*is-domain%x(1)%data%begin-1.GT.domain%x(1)%data%end ) &
+                     if( 2*is-domain%x(1)%domain_data%begin-1.GT.domain%x(1)%domain_data%end ) &
                           call mpp_error( FATAL, 'MPP_DO_UPDATE_V: folded-north CGRID_NE west edge ubound error.' )
                      do l=1,l_size
                         ptr_fieldy = f_addrsy(l, 1)
@@ -908,14 +908,15 @@
                                                                                                !! boundary fold
          ! NOTE: symmetry is assumed for fold-south boundary
          j = domain%y(1)%global%begin
-         if( domain%y(1)%data%begin.LE.j .AND. j.LE.domain%y(1)%data%end+shift )then !fold is within domain
+         !fold is within domain
+         if( domain%y(1)%domain_data%begin.LE.j .AND. j.LE.domain%y(1)%domain_data%end+shift )then
             midpoint = (domain%x(1)%global%begin+domain%x(1)%global%end-1+shift)/2
             !poles set to 0: BGRID only
             if( gridtype.EQ.BGRID_NE )then
                j  = domain%y(1)%global%begin
                is = domain%x(1)%global%begin; ie = domain%x(1)%global%end+shift
                do i = is ,ie, midpoint
-                  if( domain%x(1)%data%begin.LE.i .AND. i.LE. domain%x(1)%data%end+shift )then
+                  if( domain%x(1)%domain_data%begin.LE.i .AND. i.LE. domain%x(1)%domain_data%end+shift )then
                      do l=1,l_size
                         ptr_fieldx = f_addrsx(l, 1)
                         ptr_fieldy = f_addrsy(l, 1)
@@ -936,15 +937,15 @@
                select case(gridtype)
                case(BGRID_NE)
                   is = domain%x(1)%global%begin
-                  if( is.GT.domain%x(1)%data%begin )then
+                  if( is.GT.domain%x(1)%domain_data%begin )then
 
-                     if( 2*is-domain%x(1)%data%begin.GT.domain%x(1)%data%end+shift ) &
+                     if( 2*is-domain%x(1)%domain_data%begin.GT.domain%x(1)%domain_data%end+shift ) &
                           call mpp_error( FATAL, 'MPP_DO_UPDATE_V: folded-south BGRID_NE west edge ubound error.' )
                      do l=1,l_size
                         ptr_fieldx = f_addrsx(l, 1)
                         ptr_fieldy = f_addrsy(l, 1)
                         do k = 1,ke
-                           do i = domain%x(1)%data%begin,is-1
+                           do i = domain%x(1)%domain_data%begin,is-1
                               fieldx(i,j,k) = fieldx(2*is-i,j,k)
                               fieldy(i,j,k) = fieldy(2*is-i,j,k)
                            end do
@@ -953,13 +954,13 @@
                   end if
                case(CGRID_NE)
                   is = domain%x(1)%global%begin
-                  if( is.GT.domain%x(1)%data%begin )then
-                     if( 2*is-domain%x(1)%data%begin-1.GT.domain%x(1)%data%end ) &
+                  if( is.GT.domain%x(1)%domain_data%begin )then
+                     if( 2*is-domain%x(1)%domain_data%begin-1.GT.domain%x(1)%domain_data%end ) &
                           call mpp_error( FATAL, 'MPP_DO_UPDATE_V: folded-south CGRID_NE west edge ubound error.' )
                      do l=1,l_size
                         ptr_fieldy = f_addrsy(l, 1)
                         do k = 1,ke
-                           do i = domain%x(1)%data%begin,is-1
+                           do i = domain%x(1)%domain_data%begin,is-1
                               fieldy(i,j,k) = fieldy(2*is-i-1,j,k)
                            end do
                         end do
@@ -970,8 +971,8 @@
 
             !off east edge
             is = domain%x(1)%global%end
-            if(domain%x(1)%cyclic .AND. is.LT.domain%x(1)%data%end )then
-               ie = domain%x(1)%data%end
+            if(domain%x(1)%cyclic .AND. is.LT.domain%x(1)%domain_data%end )then
+               ie = domain%x(1)%domain_data%end
                is = is + 1
                select case(gridtype)
                case(BGRID_NE)
@@ -1003,14 +1004,15 @@
                                                                                               !! boundary fold
          ! NOTE: symmetry is assumed for fold-west boundary
          i = domain%x(1)%global%begin
-         if( domain%x(1)%data%begin.LE.i .AND. i.LE.domain%x(1)%data%end+shift )then !fold is within domain
+         !fold is within domain
+         if( domain%x(1)%domain_data%begin.LE.i .AND. i.LE.domain%x(1)%domain_data%end+shift )then
             midpoint = (domain%y(1)%global%begin+domain%y(1)%global%end-1+shift)/2
             !poles set to 0: BGRID only
             if( gridtype.EQ.BGRID_NE )then
                i  = domain%x(1)%global%begin
                js = domain%y(1)%global%begin; je = domain%y(1)%global%end+shift
                do j = js ,je, midpoint
-                  if( domain%y(1)%data%begin.LE.j .AND. j.LE. domain%y(1)%data%end+shift )then
+                  if( domain%y(1)%domain_data%begin.LE.j .AND. j.LE. domain%y(1)%domain_data%end+shift )then
                      do l=1,l_size
                         ptr_fieldx = f_addrsx(l, 1)
                         ptr_fieldy = f_addrsy(l, 1)
@@ -1031,15 +1033,15 @@
                select case(gridtype)
                case(BGRID_NE)
                   js = domain%y(1)%global%begin
-                  if( js.GT.domain%y(1)%data%begin )then
+                  if( js.GT.domain%y(1)%domain_data%begin )then
 
-                     if( 2*js-domain%y(1)%data%begin.GT.domain%y(1)%data%end+shift ) &
+                     if( 2*js-domain%y(1)%domain_data%begin.GT.domain%y(1)%domain_data%end+shift ) &
                           call mpp_error( FATAL, 'MPP_DO_UPDATE_V: folded-west BGRID_NE west edge ubound error.' )
                      do l=1,l_size
                         ptr_fieldx = f_addrsx(l, 1)
                         ptr_fieldy = f_addrsy(l, 1)
                         do k = 1,ke
-                           do j = domain%y(1)%data%begin,js-1
+                           do j = domain%y(1)%domain_data%begin,js-1
                               fieldx(i,j,k) = fieldx(i,2*js-j,k)
                               fieldy(i,j,k) = fieldy(i,2*js-j,k)
                            end do
@@ -1048,13 +1050,13 @@
                   end if
                case(CGRID_NE)
                   js = domain%y(1)%global%begin
-                  if( js.GT.domain%y(1)%data%begin )then
-                     if( 2*js-domain%y(1)%data%begin-1.GT.domain%y(1)%data%end ) &
+                  if( js.GT.domain%y(1)%domain_data%begin )then
+                     if( 2*js-domain%y(1)%domain_data%begin-1.GT.domain%y(1)%domain_data%end ) &
                           call mpp_error( FATAL, 'MPP_DO_UPDATE_V: folded-west CGRID_NE west edge ubound error.' )
                      do l=1,l_size
                         ptr_fieldx = f_addrsx(l, 1)
                         do k = 1,ke
-                           do j = domain%y(1)%data%begin,js-1
+                           do j = domain%y(1)%domain_data%begin,js-1
                               fieldx(i,j,k) = fieldx(i, 2*js-j-1,k)
                            end do
                         end do
@@ -1065,8 +1067,8 @@
 
             !off north edge
             js = domain%y(1)%global%end
-            if(domain%y(1)%cyclic .AND. js.LT.domain%y(1)%data%end )then
-               je = domain%y(1)%data%end
+            if(domain%y(1)%cyclic .AND. js.LT.domain%y(1)%domain_data%end )then
+               je = domain%y(1)%domain_data%end
                js = js + 1
                select case(gridtype)
                case(BGRID_NE)
@@ -1098,14 +1100,15 @@
                                                                                               !! boundary fold
          ! NOTE: symmetry is assumed for fold-west boundary
          i = domain%x(1)%global%end+shift
-         if( domain%x(1)%data%begin.LE.i .AND. i.LE.domain%x(1)%data%end+shift )then !fold is within domain
+         !fold is within domain
+         if( domain%x(1)%domain_data%begin.LE.i .AND. i.LE.domain%x(1)%domain_data%end+shift )then 
             midpoint = (domain%y(1)%global%begin+domain%y(1)%global%end-1+shift)/2
             !poles set to 0: BGRID only
             if( gridtype.EQ.BGRID_NE )then
                i  = domain%x(1)%global%end+shift
                js = domain%y(1)%global%begin; je = domain%y(1)%global%end+shift
                do j = js ,je, midpoint
-                  if( domain%y(1)%data%begin.LE.j .AND. j.LE. domain%y(1)%data%end+shift )then
+                  if( domain%y(1)%domain_data%begin.LE.j .AND. j.LE. domain%y(1)%domain_data%end+shift )then
                      do l=1,l_size
                         ptr_fieldx = f_addrsx(l, 1)
                         ptr_fieldy = f_addrsy(l, 1)
@@ -1126,15 +1129,15 @@
                select case(gridtype)
                case(BGRID_NE)
                   js = domain%y(1)%global%begin
-                  if( js.GT.domain%y(1)%data%begin )then
+                  if( js.GT.domain%y(1)%domain_data%begin )then
 
-                     if( 2*js-domain%y(1)%data%begin.GT.domain%y(1)%data%end+shift ) &
+                     if( 2*js-domain%y(1)%domain_data%begin.GT.domain%y(1)%domain_data%end+shift ) &
                           call mpp_error( FATAL, 'MPP_DO_UPDATE_V: folded-east BGRID_NE west edge ubound error.' )
                      do l=1,l_size
                         ptr_fieldx = f_addrsx(l, 1)
                         ptr_fieldy = f_addrsy(l, 1)
                         do k = 1,ke
-                           do j = domain%y(1)%data%begin,js-1
+                           do j = domain%y(1)%domain_data%begin,js-1
                               fieldx(i,j,k) = fieldx(i,2*js-j,k)
                               fieldy(i,j,k) = fieldy(i,2*js-j,k)
                            end do
@@ -1143,13 +1146,13 @@
                   end if
                case(CGRID_NE)
                   js = domain%y(1)%global%begin
-                  if( js.GT.domain%y(1)%data%begin )then
-                     if( 2*js-domain%y(1)%data%begin-1.GT.domain%y(1)%data%end ) &
+                  if( js.GT.domain%y(1)%domain_data%begin )then
+                     if( 2*js-domain%y(1)%domain_data%begin-1.GT.domain%y(1)%domain_data%end ) &
                           call mpp_error( FATAL, 'MPP_DO_UPDATE_V: folded-east CGRID_NE west edge ubound error.' )
                      do l=1,l_size
                         ptr_fieldx = f_addrsx(l, 1)
                         do k = 1,ke
-                           do j = domain%y(1)%data%begin,js-1
+                           do j = domain%y(1)%domain_data%begin,js-1
                               fieldx(i,j,k) = fieldx(i, 2*js-j-1,k)
                            end do
                         end do
@@ -1160,8 +1163,8 @@
 
             !off north edge
             js = domain%y(1)%global%end
-            if(domain%y(1)%cyclic .AND. js.LT.domain%y(1)%data%end )then
-               je = domain%y(1)%data%end
+            if(domain%y(1)%cyclic .AND. js.LT.domain%y(1)%domain_data%end )then
+               je = domain%y(1)%domain_data%end
                js = js + 1
                select case(gridtype)
                case(BGRID_NE)

--- a/mpp/include/mpp_do_updateV_ad.fh
+++ b/mpp/include/mpp_do_updateV_ad.fh
@@ -403,7 +403,8 @@
       if(domain%symmetry) shift = 1
       if( BTEST(domain%fold,NORTH) .AND. (.NOT.BTEST(update_flags,SCALAR_BIT)) )then
          j = domain%y(1)%global%end+shift
-         if( domain%y(1)%data%begin.LE.j .AND. j.LE.domain%y(1)%data%end+shift )then !fold is within domain
+         !fold is within domain
+         if( domain%y(1)%domain_data%begin.LE.j .AND. j.LE.domain%y(1)%domain_data%end+shift ) then
             !poles set to 0: BGRID only
             if( gridtype.EQ.BGRID_NE )then
                midpoint = (domain%x(1)%global%begin+domain%x(1)%global%end-1+shift)/2
@@ -411,7 +412,7 @@
                is = domain%x(1)%global%begin; ie = domain%x(1)%global%end+shift
                if( .NOT. domain%symmetry ) is = is - 1
                do i = is ,ie, midpoint
-                  if( domain%x(1)%data%begin.LE.i .AND. i.LE. domain%x(1)%data%end+shift )then
+                  if( domain%x(1)%domain_data%begin.LE.i .AND. i.LE. domain%x(1)%domain_data%end+shift )then
                      do l=1,l_size
                         ptr_fieldx = f_addrsx(l, 1)
                         ptr_fieldy = f_addrsy(l, 1)
@@ -436,15 +437,15 @@
                   else
                      is = domain%x(1)%global%begin - 1
                   end if
-                  if( is.GT.domain%x(1)%data%begin )then
+                  if( is.GT.domain%x(1)%domain_data%begin )then
 
-                     if( 2*is-domain%x(1)%data%begin.GT.domain%x(1)%data%end+shift ) &
+                     if( 2*is-domain%x(1)%domain_data%begin.GT.domain%x(1)%domain_data%end+shift ) &
                           call mpp_error( FATAL, 'MPP_DO_UPDATE_AD_V: folded-north BGRID_NE west edge ubound error.' )
                      do l=1,l_size
                         ptr_fieldx = f_addrsx(l, 1)
                         ptr_fieldy = f_addrsy(l, 1)
                         do k = 1,ke
-                           do i = domain%x(1)%data%begin,is-1
+                           do i = domain%x(1)%domain_data%begin,is-1
                               fieldx(2*is-i,j,k) = fieldx(2*is-i,j,k) + fieldx(i,j,k)
                               fieldy(2*is-i,j,k) = fieldy(2*is-i,j,k) + fieldy(i,j,k)
                            end do
@@ -453,13 +454,13 @@
                   end if
                case(CGRID_NE)
                   is = domain%x(1)%global%begin
-                  if( is.GT.domain%x(1)%data%begin )then
-                     if( 2*is-domain%x(1)%data%begin-1.GT.domain%x(1)%data%end ) &
+                  if( is.GT.domain%x(1)%domain_data%begin )then
+                     if( 2*is-domain%x(1)%domain_data%begin-1.GT.domain%x(1)%domain_data%end ) &
                           call mpp_error( FATAL, 'MPP_DO_UPDATE_AD_V: folded-north CGRID_NE west edge ubound error.' )
                      do l=1,l_size
                         ptr_fieldy = f_addrsy(l, 1)
                         do k = 1,ke
-                           do i = domain%x(1)%data%begin,is-1
+                           do i = domain%x(1)%domain_data%begin,is-1
                               fieldy(2*is-i-1,j,k) = fieldy(2*is-i-1,j,k) + fieldy(i,j,k)
                            end do
                         end do
@@ -470,8 +471,8 @@
 
             !off east edge
             is = domain%x(1)%global%end
-            if(domain%x(1)%cyclic .AND. is.LT.domain%x(1)%data%end )then
-               ie = domain%x(1)%data%end
+            if(domain%x(1)%cyclic .AND. is.LT.domain%x(1)%domain_data%end )then
+               ie = domain%x(1)%domain_data%end
                is = is + 1
                select case(gridtype)
                case(BGRID_NE)
@@ -503,14 +504,15 @@
                                                                                                !! boundary fold
          ! NOTE: symmetry is assumed for fold-south boundary
          j = domain%y(1)%global%begin
-         if( domain%y(1)%data%begin.LE.j .AND. j.LE.domain%y(1)%data%end+shift )then !fold is within domain
+         !fold is within domain
+         if( domain%y(1)%domain_data%begin.LE.j .AND. j.LE.domain%y(1)%domain_data%end+shift )then
             midpoint = (domain%x(1)%global%begin+domain%x(1)%global%end-1+shift)/2
             !poles set to 0: BGRID only
             if( gridtype.EQ.BGRID_NE )then
                j  = domain%y(1)%global%begin
                is = domain%x(1)%global%begin; ie = domain%x(1)%global%end+shift
                do i = is ,ie, midpoint
-                  if( domain%x(1)%data%begin.LE.i .AND. i.LE. domain%x(1)%data%end+shift )then
+                  if( domain%x(1)%domain_data%begin.LE.i .AND. i.LE. domain%x(1)%domain_data%end+shift )then
                      do l=1,l_size
                         ptr_fieldx = f_addrsx(l, 1)
                         ptr_fieldy = f_addrsy(l, 1)
@@ -531,15 +533,15 @@
                select case(gridtype)
                case(BGRID_NE)
                   is = domain%x(1)%global%begin
-                  if( is.GT.domain%x(1)%data%begin )then
+                  if( is.GT.domain%x(1)%domain_data%begin )then
 
-                     if( 2*is-domain%x(1)%data%begin.GT.domain%x(1)%data%end+shift ) &
+                     if( 2*is-domain%x(1)%domain_data%begin.GT.domain%x(1)%domain_data%end+shift ) &
                           call mpp_error( FATAL, 'MPP_DO_UPDATE_AD_V: folded-south BGRID_NE west edge ubound error.' )
                      do l=1,l_size
                         ptr_fieldx = f_addrsx(l, 1)
                         ptr_fieldy = f_addrsy(l, 1)
                         do k = 1,ke
-                           do i = domain%x(1)%data%begin,is-1
+                           do i = domain%x(1)%domain_data%begin,is-1
                               fieldx(2*is-i,j,k) = fieldx(2*is-i,j,k) + fieldx(i,j,k)
                               fieldy(2*is-i,j,k) = fieldy(2*is-i,j,k) + fieldy(i,j,k)
                            end do
@@ -548,13 +550,13 @@
                   end if
                case(CGRID_NE)
                   is = domain%x(1)%global%begin
-                  if( is.GT.domain%x(1)%data%begin )then
-                     if( 2*is-domain%x(1)%data%begin-1.GT.domain%x(1)%data%end ) &
+                  if( is.GT.domain%x(1)%domain_data%begin )then
+                     if( 2*is-domain%x(1)%domain_data%begin-1.GT.domain%x(1)%domain_data%end ) &
                           call mpp_error( FATAL, 'MPP_DO_UPDATE_AD_V: folded-south CGRID_NE west edge ubound error.' )
                      do l=1,l_size
                         ptr_fieldy = f_addrsy(l, 1)
                         do k = 1,ke
-                           do i = domain%x(1)%data%begin,is-1
+                           do i = domain%x(1)%domain_data%begin,is-1
                               fieldy(2*is-i-1,j,k) = fieldy(2*is-i-1,j,k) + fieldy(i,j,k)
                            end do
                         end do
@@ -565,8 +567,8 @@
 
             !off east edge
             is = domain%x(1)%global%end
-            if(domain%x(1)%cyclic .AND. is.LT.domain%x(1)%data%end )then
-               ie = domain%x(1)%data%end
+            if(domain%x(1)%cyclic .AND. is.LT.domain%x(1)%domain_data%end )then
+               ie = domain%x(1)%domain_data%end
                is = is + 1
                select case(gridtype)
                case(BGRID_NE)
@@ -598,14 +600,15 @@
                                                                                               !! boundary fold
          ! NOTE: symmetry is assumed for fold-west boundary
          i = domain%x(1)%global%begin
-         if( domain%x(1)%data%begin.LE.i .AND. i.LE.domain%x(1)%data%end+shift )then !fold is within domain
+         !fold is within domain
+         if( domain%x(1)%domain_data%begin.LE.i .AND. i.LE.domain%x(1)%domain_data%end+shift )then
             midpoint = (domain%y(1)%global%begin+domain%y(1)%global%end-1+shift)/2
             !poles set to 0: BGRID only
             if( gridtype.EQ.BGRID_NE )then
                i  = domain%x(1)%global%begin
                js = domain%y(1)%global%begin; je = domain%y(1)%global%end+shift
                do j = js ,je, midpoint
-                  if( domain%y(1)%data%begin.LE.j .AND. j.LE. domain%y(1)%data%end+shift )then
+                  if( domain%y(1)%domain_data%begin.LE.j .AND. j.LE. domain%y(1)%domain_data%end+shift )then
                      do l=1,l_size
                         ptr_fieldx = f_addrsx(l, 1)
                         ptr_fieldy = f_addrsy(l, 1)
@@ -626,15 +629,15 @@
                select case(gridtype)
                case(BGRID_NE)
                   js = domain%y(1)%global%begin
-                  if( js.GT.domain%y(1)%data%begin )then
+                  if( js.GT.domain%y(1)%domain_data%begin )then
 
-                     if( 2*js-domain%y(1)%data%begin.GT.domain%y(1)%data%end+shift ) &
+                     if( 2*js-domain%y(1)%domain_data%begin.GT.domain%y(1)%domain_data%end+shift ) &
                           call mpp_error( FATAL, 'MPP_DO_UPDATE_AD_V: folded-west BGRID_NE west edge ubound error.' )
                      do l=1,l_size
                         ptr_fieldx = f_addrsx(l, 1)
                         ptr_fieldy = f_addrsy(l, 1)
                         do k = 1,ke
-                           do j = domain%y(1)%data%begin,js-1
+                           do j = domain%y(1)%domain_data%begin,js-1
                               fieldx(i,2*js-j,k) = fieldx(i,2*js-j,k) + fieldx(i,j,k)
                               fieldy(i,2*js-j,k) = fieldy(i,2*js-j,k) + fieldy(i,j,k)
                            end do
@@ -643,13 +646,13 @@
                   end if
                case(CGRID_NE)
                   js = domain%y(1)%global%begin
-                  if( js.GT.domain%y(1)%data%begin )then
-                     if( 2*js-domain%y(1)%data%begin-1.GT.domain%y(1)%data%end ) &
+                  if( js.GT.domain%y(1)%domain_data%begin )then
+                     if( 2*js-domain%y(1)%domain_data%begin-1.GT.domain%y(1)%domain_data%end ) &
                           call mpp_error( FATAL, 'MPP_DO_UPDATE_AD_V: folded-west CGRID_NE west edge ubound error.' )
                      do l=1,l_size
                         ptr_fieldx = f_addrsx(l, 1)
                         do k = 1,ke
-                           do j = domain%y(1)%data%begin,js-1
+                           do j = domain%y(1)%domain_data%begin,js-1
                               fieldx(i, 2*js-j-1,k) = fieldx(i, 2*js-j-1,k) + fieldx(i,j,k)
                            end do
                         end do
@@ -660,8 +663,8 @@
 
             !off north edge
             js = domain%y(1)%global%end
-            if(domain%y(1)%cyclic .AND. js.LT.domain%y(1)%data%end )then
-               je = domain%y(1)%data%end
+            if(domain%y(1)%cyclic .AND. js.LT.domain%y(1)%domain_data%end )then
+               je = domain%y(1)%domain_data%end
                js = js + 1
                select case(gridtype)
                case(BGRID_NE)
@@ -693,14 +696,14 @@
                                                                                               !! boundary fold
          ! NOTE: symmetry is assumed for fold-west boundary
          i = domain%x(1)%global%end+shift
-         if( domain%x(1)%data%begin.LE.i .AND. i.LE.domain%x(1)%data%end+shift )then !fold is within domain
+         if( domain%x(1)%domain_data%begin.LE.i .AND. i.LE.domain%x(1)%domain_data%end+shift )then !fold is within domain
             midpoint = (domain%y(1)%global%begin+domain%y(1)%global%end-1+shift)/2
             !poles set to 0: BGRID only
             if( gridtype.EQ.BGRID_NE )then
                i  = domain%x(1)%global%end+shift
                js = domain%y(1)%global%begin; je = domain%y(1)%global%end+shift
                do j = js ,je, midpoint
-                  if( domain%y(1)%data%begin.LE.j .AND. j.LE. domain%y(1)%data%end+shift )then
+                  if( domain%y(1)%domain_data%begin.LE.j .AND. j.LE. domain%y(1)%domain_data%end+shift )then
                      do l=1,l_size
                         ptr_fieldx = f_addrsx(l, 1)
                         ptr_fieldy = f_addrsy(l, 1)
@@ -721,15 +724,15 @@
                select case(gridtype)
                case(BGRID_NE)
                   js = domain%y(1)%global%begin
-                  if( js.GT.domain%y(1)%data%begin )then
+                  if( js.GT.domain%y(1)%domain_data%begin )then
 
-                     if( 2*js-domain%y(1)%data%begin.GT.domain%y(1)%data%end+shift ) &
+                     if( 2*js-domain%y(1)%domain_data%begin.GT.domain%y(1)%domain_data%end+shift ) &
                           call mpp_error( FATAL, 'MPP_DO_UPDATE_AD_V: folded-east BGRID_NE west edge ubound error.' )
                      do l=1,l_size
                         ptr_fieldx = f_addrsx(l, 1)
                         ptr_fieldy = f_addrsy(l, 1)
                         do k = 1,ke
-                           do j = domain%y(1)%data%begin,js-1
+                           do j = domain%y(1)%domain_data%begin,js-1
                               fieldx(i,2*js-j,k) = fieldx(i,2*js-j,k) + fieldx(i,j,k)
                               fieldy(i,2*js-j,k) = fieldy(i,2*js-j,k) + fieldy(i,j,k)
                            end do
@@ -738,13 +741,13 @@
                   end if
                case(CGRID_NE)
                   js = domain%y(1)%global%begin
-                  if( js.GT.domain%y(1)%data%begin )then
-                     if( 2*js-domain%y(1)%data%begin-1.GT.domain%y(1)%data%end ) &
+                  if( js.GT.domain%y(1)%domain_data%begin )then
+                     if( 2*js-domain%y(1)%domain_data%begin-1.GT.domain%y(1)%domain_data%end ) &
                           call mpp_error( FATAL, 'MPP_DO_UPDATE_AD_V: folded-east CGRID_NE west edge ubound error.' )
                      do l=1,l_size
                         ptr_fieldx = f_addrsx(l, 1)
                         do k = 1,ke
-                           do j = domain%y(1)%data%begin,js-1
+                           do j = domain%y(1)%domain_data%begin,js-1
                               fieldx(i, 2*js-j-1,k) = fieldx(i, 2*js-j-1,k) + fieldx(i,j,k)
                            end do
                         end do
@@ -755,8 +758,8 @@
 
             !off north edge
             js = domain%y(1)%global%end
-            if(domain%y(1)%cyclic .AND. js.LT.domain%y(1)%data%end )then
-               je = domain%y(1)%data%end
+            if(domain%y(1)%cyclic .AND. js.LT.domain%y(1)%domain_data%end )then
+               je = domain%y(1)%domain_data%end
                js = js + 1
                select case(gridtype)
                case(BGRID_NE)

--- a/mpp/include/mpp_do_updateV_ad.fh
+++ b/mpp/include/mpp_do_updateV_ad.fh
@@ -696,7 +696,8 @@
                                                                                               !! boundary fold
          ! NOTE: symmetry is assumed for fold-west boundary
          i = domain%x(1)%global%end+shift
-         if( domain%x(1)%domain_data%begin.LE.i .AND. i.LE.domain%x(1)%domain_data%end+shift )then !fold is within domain
+         !fold is within domain
+         if( domain%x(1)%domain_data%begin.LE.i .AND. i.LE.domain%x(1)%domain_data%end+shift )then
             midpoint = (domain%y(1)%global%begin+domain%y(1)%global%end-1+shift)/2
             !poles set to 0: BGRID only
             if( gridtype.EQ.BGRID_NE )then

--- a/mpp/include/mpp_do_updateV_nonblock.fh
+++ b/mpp/include/mpp_do_updateV_nonblock.fh
@@ -707,7 +707,7 @@ subroutine MPP_COMPLETE_DO_UPDATE_3D_V_(id_update, f_addrsx, f_addrsy, domain, u
   if(domain%symmetry) shift = 1
   if( BTEST(domain%fold,NORTH) .AND. (.NOT.BTEST(flags,SCALAR_BIT)) )then
      j = domain%y(1)%global%end+shift
-     if( domain%y(1)%data%begin.LE.j .AND. j.LE.domain%y(1)%data%end+shift )then !fold is within domain
+     if( domain%y(1)%domain_data%begin.LE.j .AND. j.LE.domain%y(1)%domain_data%end+shift )then !fold is within domain
         !poles set to 0: BGRID only
         if( gridtype.EQ.BGRID_NE )then
            midpoint = (domain%x(1)%global%begin+domain%x(1)%global%end-1+shift)/2
@@ -715,7 +715,7 @@ subroutine MPP_COMPLETE_DO_UPDATE_3D_V_(id_update, f_addrsx, f_addrsy, domain, u
            is = domain%x(1)%global%begin; ie = domain%x(1)%global%end+shift
            if( .NOT. domain%symmetry ) is = is - 1
            do i = is ,ie, midpoint
-              if( domain%x(1)%data%begin.LE.i .AND. i.LE. domain%x(1)%data%end+shift )then
+              if( domain%x(1)%domain_data%begin.LE.i .AND. i.LE. domain%x(1)%domain_data%end+shift )then
                  do l=1,l_size
                     ptr_fieldx = f_addrsx(l, 1)
                     ptr_fieldy = f_addrsy(l, 1)
@@ -740,9 +740,9 @@ subroutine MPP_COMPLETE_DO_UPDATE_3D_V_(id_update, f_addrsx, f_addrsy, domain, u
               else
                  is = domain%x(1)%global%begin - 1
               end if
-              if( is.GT.domain%x(1)%data%begin )then
+              if( is.GT.domain%x(1)%domain_data%begin )then
 
-                 if( 2*is-domain%x(1)%data%begin.GT.domain%x(1)%data%end+shift ) &
+                 if( 2*is-domain%x(1)%domain_data%begin.GT.domain%x(1)%domain_data%end+shift ) &
                       call mpp_error( FATAL, &
                                      &  'MPP_COMPLETE_DO_UPDATE_V: folded-north BGRID_NE west edge ubound error.' )
                      do l=1,l_size
@@ -750,7 +750,7 @@ subroutine MPP_COMPLETE_DO_UPDATE_3D_V_(id_update, f_addrsx, f_addrsy, domain, u
                         ptr_fieldy = f_addrsy(l, 1)
 
                         do k = 1,ke_list(l,tMe)
-                           do i = domain%x(1)%data%begin,is-1
+                           do i = domain%x(1)%domain_data%begin,is-1
                               fieldx(i,j,k) = fieldx(2*is-i,j,k)
                               fieldy(i,j,k) = fieldy(2*is-i,j,k)
                            end do
@@ -759,14 +759,14 @@ subroutine MPP_COMPLETE_DO_UPDATE_3D_V_(id_update, f_addrsx, f_addrsy, domain, u
               end if
            case(CGRID_NE)
               is = domain%x(1)%global%begin
-              if( is.GT.domain%x(1)%data%begin )then
-                 if( 2*is-domain%x(1)%data%begin-1.GT.domain%x(1)%data%end ) &
+              if( is.GT.domain%x(1)%domain_data%begin )then
+                 if( 2*is-domain%x(1)%domain_data%begin-1.GT.domain%x(1)%domain_data%end ) &
                       call mpp_error( FATAL, &
                                      &  'MPP_COMPLETE_DO_UPDATE_V: folded-north CGRID_NE west edge ubound error.' )
                  do l=1,l_size
                     ptr_fieldy = f_addrsy(l, 1)
                     do k = 1,ke_list(l,tMe)
-                       do i = domain%x(1)%data%begin,is-1
+                       do i = domain%x(1)%domain_data%begin,is-1
                           fieldy(i,j,k) = fieldy(2*is-i-1,j,k)
                        end do
                     end do
@@ -777,8 +777,8 @@ subroutine MPP_COMPLETE_DO_UPDATE_3D_V_(id_update, f_addrsx, f_addrsy, domain, u
 
         !off east edge
         is = domain%x(1)%global%end
-        if(domain%x(1)%cyclic .AND. is.LT.domain%x(1)%data%end )then
-           ie = domain%x(1)%data%end
+        if(domain%x(1)%cyclic .AND. is.LT.domain%x(1)%domain_data%end )then
+           ie = domain%x(1)%domain_data%end
            is = is + 1
            select case(gridtype)
            case(BGRID_NE)
@@ -809,14 +809,14 @@ subroutine MPP_COMPLETE_DO_UPDATE_3D_V_(id_update, f_addrsx, f_addrsy, domain, u
   else if( BTEST(domain%fold,SOUTH) .AND. (.NOT.BTEST(flags,SCALAR_BIT)) )then      ! ---southern boundary fold
      ! NOTE: symmetry is assumed for fold-south boundary
      j = domain%y(1)%global%begin
-     if( domain%y(1)%data%begin.LE.j .AND. j.LE.domain%y(1)%data%end+shift )then !fold is within domain
+     if( domain%y(1)%domain_data%begin.LE.j .AND. j.LE.domain%y(1)%domain_data%end+shift )then !fold is within domain
         midpoint = (domain%x(1)%global%begin+domain%x(1)%global%end-1+shift)/2
         !poles set to 0: BGRID only
         if( gridtype.EQ.BGRID_NE )then
            j  = domain%y(1)%global%begin
            is = domain%x(1)%global%begin; ie = domain%x(1)%global%end+shift
            do i = is ,ie, midpoint
-              if( domain%x(1)%data%begin.LE.i .AND. i.LE. domain%x(1)%data%end+shift )then
+              if( domain%x(1)%domain_data%begin.LE.i .AND. i.LE. domain%x(1)%domain_data%end+shift )then
                  do l=1,l_size
                     ptr_fieldx = f_addrsx(l, 1)
                     ptr_fieldy = f_addrsy(l, 1)
@@ -837,15 +837,15 @@ subroutine MPP_COMPLETE_DO_UPDATE_3D_V_(id_update, f_addrsx, f_addrsy, domain, u
            select case(gridtype)
            case(BGRID_NE)
               is = domain%x(1)%global%begin
-              if( is.GT.domain%x(1)%data%begin )then
-                 if( 2*is-domain%x(1)%data%begin.GT.domain%x(1)%data%end+shift ) &
+              if( is.GT.domain%x(1)%domain_data%begin )then
+                 if( 2*is-domain%x(1)%domain_data%begin.GT.domain%x(1)%domain_data%end+shift ) &
                       call mpp_error( FATAL, &
                                      &  'MPP_COMPLETE_DO_UPDATE_V: folded-south BGRID_NE west edge ubound error.' )
                  do l=1,l_size
                     ptr_fieldx = f_addrsx(l, 1)
                     ptr_fieldy = f_addrsy(l, 1)
                     do k = 1,ke_list(l,tMe)
-                       do i = domain%x(1)%data%begin,is-1
+                       do i = domain%x(1)%domain_data%begin,is-1
                           fieldx(i,j,k) = fieldx(2*is-i,j,k)
                           fieldy(i,j,k) = fieldy(2*is-i,j,k)
                        end do
@@ -854,14 +854,14 @@ subroutine MPP_COMPLETE_DO_UPDATE_3D_V_(id_update, f_addrsx, f_addrsy, domain, u
               end if
            case(CGRID_NE)
               is = domain%x(1)%global%begin
-              if( is.GT.domain%x(1)%data%begin )then
-                 if( 2*is-domain%x(1)%data%begin-1.GT.domain%x(1)%data%end ) &
+              if( is.GT.domain%x(1)%domain_data%begin )then
+                 if( 2*is-domain%x(1)%domain_data%begin-1.GT.domain%x(1)%domain_data%end ) &
                       call mpp_error( FATAL, &
                                      &  'MPP_COMPLETE_DO_UPDATE_V: folded-south CGRID_NE west edge ubound error.' )
                  do l=1,l_size
                     ptr_fieldy = f_addrsy(l, 1)
                     do k = 1,ke_list(l,tMe)
-                       do i = domain%x(1)%data%begin,is-1
+                       do i = domain%x(1)%domain_data%begin,is-1
                           fieldy(i,j,k) = fieldy(2*is-i-1,j,k)
                        end do
                     end do
@@ -872,8 +872,8 @@ subroutine MPP_COMPLETE_DO_UPDATE_3D_V_(id_update, f_addrsx, f_addrsy, domain, u
 
         !off east edge
         is = domain%x(1)%global%end
-        if(domain%x(1)%cyclic .AND. is.LT.domain%x(1)%data%end )then
-           ie = domain%x(1)%data%end
+        if(domain%x(1)%cyclic .AND. is.LT.domain%x(1)%domain_data%end )then
+           ie = domain%x(1)%domain_data%end
            is = is + 1
            select case(gridtype)
            case(BGRID_NE)
@@ -904,14 +904,14 @@ subroutine MPP_COMPLETE_DO_UPDATE_3D_V_(id_update, f_addrsx, f_addrsy, domain, u
   else if( BTEST(domain%fold,WEST) .AND. (.NOT.BTEST(flags,SCALAR_BIT)) )then      ! ---eastern boundary fold
      ! NOTE: symmetry is assumed for fold-west boundary
      i = domain%x(1)%global%begin
-     if( domain%x(1)%data%begin.LE.i .AND. i.LE.domain%x(1)%data%end+shift )then !fold is within domain
+     if( domain%x(1)%domain_data%begin.LE.i .AND. i.LE.domain%x(1)%domain_data%end+shift )then !fold is within domain
         midpoint = (domain%y(1)%global%begin+domain%y(1)%global%end-1+shift)/2
         !poles set to 0: BGRID only
         if( gridtype.EQ.BGRID_NE )then
            i  = domain%x(1)%global%begin
            js = domain%y(1)%global%begin; je = domain%y(1)%global%end+shift
            do j = js ,je, midpoint
-              if( domain%y(1)%data%begin.LE.j .AND. j.LE. domain%y(1)%data%end+shift )then
+              if( domain%y(1)%domain_data%begin.LE.j .AND. j.LE. domain%y(1)%domain_data%end+shift )then
                  do l=1,l_size
                     ptr_fieldx = f_addrsx(l, 1)
                     ptr_fieldy = f_addrsy(l, 1)
@@ -932,16 +932,16 @@ subroutine MPP_COMPLETE_DO_UPDATE_3D_V_(id_update, f_addrsx, f_addrsy, domain, u
            select case(gridtype)
            case(BGRID_NE)
               js = domain%y(1)%global%begin
-              if( js.GT.domain%y(1)%data%begin )then
+              if( js.GT.domain%y(1)%domain_data%begin )then
 
-                 if( 2*js-domain%y(1)%data%begin.GT.domain%y(1)%data%end+shift ) &
+                 if( 2*js-domain%y(1)%domain_data%begin.GT.domain%y(1)%domain_data%end+shift ) &
                       call mpp_error( FATAL, &
                                      &  'MPP_COMPLETE_DO__UPDATE_V: folded-west BGRID_NE west edge ubound error.' )
                  do l=1,l_size
                     ptr_fieldx = f_addrsx(l, 1)
                     ptr_fieldy = f_addrsy(l, 1)
                     do k = 1,ke_list(l,tMe)
-                       do j = domain%y(1)%data%begin,js-1
+                       do j = domain%y(1)%domain_data%begin,js-1
                           fieldx(i,j,k) = fieldx(i,2*js-j,k)
                           fieldy(i,j,k) = fieldy(i,2*js-j,k)
                        end do
@@ -950,14 +950,14 @@ subroutine MPP_COMPLETE_DO_UPDATE_3D_V_(id_update, f_addrsx, f_addrsy, domain, u
               end if
            case(CGRID_NE)
               js = domain%y(1)%global%begin
-              if( js.GT.domain%y(1)%data%begin )then
-                 if( 2*js-domain%y(1)%data%begin-1.GT.domain%y(1)%data%end ) &
+              if( js.GT.domain%y(1)%domain_data%begin )then
+                 if( 2*js-domain%y(1)%domain_data%begin-1.GT.domain%y(1)%domain_data%end ) &
                       call mpp_error( FATAL, &
                                      &  'MPP_COMPLETE_DO__UPDATE_V: folded-west CGRID_NE west edge ubound error.' )
                  do l=1,l_size
                     ptr_fieldx = f_addrsx(l, 1)
                     do k = 1,ke_list(l,tMe)
-                       do j = domain%y(1)%data%begin,js-1
+                       do j = domain%y(1)%domain_data%begin,js-1
                           fieldx(i,j,k) = fieldx(i, 2*js-j-1,k)
                        end do
                     end do
@@ -968,8 +968,8 @@ subroutine MPP_COMPLETE_DO_UPDATE_3D_V_(id_update, f_addrsx, f_addrsy, domain, u
 
         !off north edge
         js = domain%y(1)%global%end
-        if(domain%y(1)%cyclic .AND. js.LT.domain%y(1)%data%end )then
-           je = domain%y(1)%data%end
+        if(domain%y(1)%cyclic .AND. js.LT.domain%y(1)%domain_data%end )then
+           je = domain%y(1)%domain_data%end
            js = js + 1
            select case(gridtype)
            case(BGRID_NE)
@@ -1000,14 +1000,14 @@ subroutine MPP_COMPLETE_DO_UPDATE_3D_V_(id_update, f_addrsx, f_addrsy, domain, u
   else if( BTEST(domain%fold,EAST) .AND. (.NOT.BTEST(flags,SCALAR_BIT)) )then      ! ---eastern boundary fold
      ! NOTE: symmetry is assumed for fold-west boundary
      i = domain%x(1)%global%end+shift
-     if( domain%x(1)%data%begin.LE.i .AND. i.LE.domain%x(1)%data%end+shift )then !fold is within domain
+     if( domain%x(1)%domain_data%begin.LE.i .AND. i.LE.domain%x(1)%domain_data%end+shift )then !fold is within domain
         midpoint = (domain%y(1)%global%begin+domain%y(1)%global%end-1+shift)/2
         !poles set to 0: BGRID only
         if( gridtype.EQ.BGRID_NE )then
            i  = domain%x(1)%global%end+shift
            js = domain%y(1)%global%begin; je = domain%y(1)%global%end+shift
            do j = js ,je, midpoint
-              if( domain%y(1)%data%begin.LE.j .AND. j.LE. domain%y(1)%data%end+shift )then
+              if( domain%y(1)%domain_data%begin.LE.j .AND. j.LE. domain%y(1)%domain_data%end+shift )then
                  do l=1,l_size
                     ptr_fieldx = f_addrsx(l, 1)
                     ptr_fieldy = f_addrsy(l, 1)
@@ -1028,16 +1028,16 @@ subroutine MPP_COMPLETE_DO_UPDATE_3D_V_(id_update, f_addrsx, f_addrsy, domain, u
            select case(gridtype)
            case(BGRID_NE)
               js = domain%y(1)%global%begin
-              if( js.GT.domain%y(1)%data%begin )then
+              if( js.GT.domain%y(1)%domain_data%begin )then
 
-                 if( 2*js-domain%y(1)%data%begin.GT.domain%y(1)%data%end+shift ) &
+                 if( 2*js-domain%y(1)%domain_data%begin.GT.domain%y(1)%domain_data%end+shift ) &
                       call mpp_error( FATAL, &
                                      &  'MPP_COMPLETE_DO__UPDATE_V: folded-east BGRID_NE west edge ubound error.' )
                  do l=1,l_size
                     ptr_fieldx = f_addrsx(l, 1)
                     ptr_fieldy = f_addrsy(l, 1)
                     do k = 1,ke_list(l,tMe)
-                       do j = domain%y(1)%data%begin,js-1
+                       do j = domain%y(1)%domain_data%begin,js-1
                           fieldx(i,j,k) = fieldx(i,2*js-j,k)
                           fieldy(i,j,k) = fieldy(i,2*js-j,k)
                        end do
@@ -1046,14 +1046,14 @@ subroutine MPP_COMPLETE_DO_UPDATE_3D_V_(id_update, f_addrsx, f_addrsy, domain, u
               end if
            case(CGRID_NE)
               js = domain%y(1)%global%begin
-              if( js.GT.domain%y(1)%data%begin )then
-                 if( 2*js-domain%y(1)%data%begin-1.GT.domain%y(1)%data%end ) &
+              if( js.GT.domain%y(1)%domain_data%begin )then
+                 if( 2*js-domain%y(1)%domain_data%begin-1.GT.domain%y(1)%domain_data%end ) &
                       call mpp_error( FATAL, &
                                      &  'MPP_COMPLETE_DO__UPDATE_V: folded-east CGRID_NE west edge ubound error.' )
                  do l=1,l_size
                     ptr_fieldx = f_addrsx(l, 1)
                     do k = 1,ke_list(l,tMe)
-                       do j = domain%y(1)%data%begin,js-1
+                       do j = domain%y(1)%domain_data%begin,js-1
                           fieldx(i,j,k) = fieldx(i, 2*js-j-1,k)
                        end do
                     end do
@@ -1064,8 +1064,8 @@ subroutine MPP_COMPLETE_DO_UPDATE_3D_V_(id_update, f_addrsx, f_addrsy, domain, u
 
         !off north edge
         js = domain%y(1)%global%end
-        if(domain%y(1)%cyclic .AND. js.LT.domain%y(1)%data%end )then
-           je = domain%y(1)%data%end
+        if(domain%y(1)%cyclic .AND. js.LT.domain%y(1)%domain_data%end )then
+           je = domain%y(1)%domain_data%end
            js = js + 1
            select case(gridtype)
            case(BGRID_NE)

--- a/mpp/include/mpp_domains_comm.inc
+++ b/mpp/include/mpp_domains_comm.inc
@@ -71,11 +71,11 @@
          &  'MPP_REDISTRIBUTE_INIT_COMM: either domain_in or domain_out must be native.' )
 !check sizes
       if( domain_in%pe /= NULL_PE )then
-          if( isize_in /= domain_in%x(1)%data%size .OR. jsize_in /= domain_in%y(1)%data%size ) &
+          if( isize_in /= domain_in%x(1)%domain_data%size .OR. jsize_in /= domain_in%y(1)%domain_data%size ) &
                call mpp_error( FATAL, 'MPP_REDISTRIBUTE_INIT_COMM: field_in must be on data domain of domain_in.' )
       end if
       if( domain_out%pe /= NULL_PE )then
-          if( isize_out /= domain_out%x(1)%data%size .OR. jsize_out /= domain_out%y(1)%data%size ) &
+          if( isize_out /= domain_out%x(1)%domain_data%size .OR. jsize_out /= domain_out%y(1)%domain_data%size ) &
                call mpp_error( FATAL, 'MPP_REDISTRIBUTE_INIT_COMM: field_out must be on data domain of domain_out.' )
       end if
 
@@ -115,8 +115,8 @@
       d_comm%S_msize=0
       d_comm%S_do_buf=.false.
 
-      ioff = domain_in%x(1)%data%begin
-      joff = domain_in%y(1)%data%begin
+      ioff = domain_in%x(1)%domain_data%begin
+      joff = domain_in%y(1)%domain_data%begin
       mytile = domain_in%tile_id(1)
 
       call mpp_get_compute_domain( domain_in, isc, iec, jsc, jec )
@@ -256,8 +256,8 @@
         joff = -domain%y(1)%compute%begin + 1
       elseif( isize_l == (domain%x(1)%memory%size+ishift) .AND. jsize_l == (domain%y(1)%memory%size+jshift) )then
 !local is on data domain
-        ioff = -domain%x(1)%data%begin + 1
-        joff = -domain%y(1)%data%begin + 1
+        ioff = -domain%x(1)%domain_data%begin + 1
+        joff = -domain%y(1)%domain_data%begin + 1
       else
         call mpp_error(FATAL, &
                  & 'MPP_GLOBAL_FIELD_INIT_COMM: incoming field array must match either compute domain or data domain.')

--- a/mpp/include/mpp_domains_define.inc
+++ b/mpp/include/mpp_domains_define.inc
@@ -408,41 +408,41 @@
 
     !get data domain
     !data domain is at least equal to compute domain
-    domain%list(:)%data%begin = domain%list(:)%compute%begin
-    domain%list(:)%data%end   = domain%list(:)%compute%end
-    domain%list(:)%data%is_global = .FALSE.
+    domain%list(:)%domain_data%begin = domain%list(:)%compute%begin
+    domain%list(:)%domain_data%end   = domain%list(:)%compute%end
+    domain%list(:)%domain_data%is_global = .FALSE.
     !apply global flags
     if( data_domain_is_global )then
-       domain%list(:)%data%begin  = isg
-       domain%list(:)%data%end    = ieg
-       domain%list(:)%data%is_global = .TRUE.
+       domain%list(:)%domain_data%begin  = isg
+       domain%list(:)%domain_data%end    = ieg
+       domain%list(:)%domain_data%is_global = .TRUE.
     end if
     !apply margins
-    domain%list(:)%data%begin = domain%list(:)%data%begin - halobegin
-    domain%list(:)%data%end   = domain%list(:)%data%end   + haloend
-    domain%list(:)%data%size  = domain%list(:)%data%end - domain%list(:)%data%begin + 1
+    domain%list(:)%domain_data%begin = domain%list(:)%domain_data%begin - halobegin
+    domain%list(:)%domain_data%end   = domain%list(:)%domain_data%end   + haloend
+    domain%list(:)%domain_data%size  = domain%list(:)%domain_data%end - domain%list(:)%domain_data%begin + 1
 
     !--- define memory domain, if memory_size is not present or memory size is 0, memory domain size
     !--- will be the same as data domain size. if momory_size is present, memory_size should greater than
     !--- or equal to data size. The begin of memory domain will be always the same as data domain.
-    domain%list(:)%memory%begin = domain%list(:)%data%begin
-    domain%list(:)%memory%end   = domain%list(:)%data%end
+    domain%list(:)%memory%begin = domain%list(:)%domain_data%begin
+    domain%list(:)%memory%end   = domain%list(:)%domain_data%end
     if( present(memory_size) ) then
        if(memory_size > 0) then
-          if( domain%list(domain%pos)%data%size > memory_size ) call mpp_error(FATAL, &
+          if( domain%list(domain%pos)%domain_data%size > memory_size ) call mpp_error(FATAL, &
                "mpp_domains_define.inc: data domain size is larger than memory domain size on this pe")
           domain%list(:)%memory%end   = domain%list(:)%memory%begin + memory_size - 1
        end if
     end if
     domain%list(:)%memory%size = domain%list(:)%memory%end - domain%list(:)%memory%begin + 1
-    domain%list(:)%memory%is_global = domain%list(:)%data%is_global
+    domain%list(:)%memory%is_global = domain%list(:)%domain_data%is_global
 
     domain%compute = domain%list(domain%pos)%compute
-    domain%data    = domain%list(domain%pos)%data
+    domain%domain_data    = domain%list(domain%pos)%domain_data
     domain%global  = domain%list(domain%pos)%global
     domain%memory  = domain%list(domain%pos)%memory
     domain%compute%max_size = MAXVAL( domain%list(:)%compute%size )
-    domain%data%max_size    = MAXVAL( domain%list(:)%data%size )
+    domain%domain_data%max_size    = MAXVAL( domain%list(:)%domain_data%size )
     domain%global%max_size  = domain%global%size
     domain%memory%max_size  = domain%memory%size
 
@@ -565,10 +565,10 @@
     enddo
     io_domain%pos          = n
     io_domain%x(1)%compute = domain%x(1)%compute
-    io_domain%x(1)%data    = domain%x(1)%data
+    io_domain%x(1)%domain_data    = domain%x(1)%domain_data
     io_domain%x(1)%memory  = domain%x(1)%memory
     io_domain%y(1)%compute = domain%y(1)%compute
-    io_domain%y(1)%data    = domain%y(1)%data
+    io_domain%y(1)%domain_data    = domain%y(1)%domain_data
     io_domain%y(1)%memory  = domain%y(1)%memory
     io_domain%x(1)%global%begin     = domain%x(1)%list(ipos_beg)%compute%begin
     io_domain%x(1)%global%end       = domain%x(1)%list(ipos_end)%compute%end
@@ -907,7 +907,7 @@
        if( PRESENT(xflags) )then
           if( BTEST(xflags,WEST) ) then
              !--- make sure no cross-domain in y-direction
-             if(domain%x(tile)%data%begin .LE. domain%x(tile)%global%begin .AND. &
+             if(domain%x(tile)%domain_data%begin .LE. domain%x(tile)%global%begin .AND. &
                 domain%x(tile)%compute%begin > domain%x(tile)%global%begin ) then
                 call mpp_error(FATAL, &
                  'MPP_DEFINE_DOMAINS: the domain could not be crossed when west is folded')
@@ -919,7 +919,7 @@
           endif
           if( BTEST(xflags,EAST) ) then
              !--- make sure no cross-domain in y-direction
-             if(domain%x(tile)%data%end .GE. domain%x(tile)%global%end .AND. &
+             if(domain%x(tile)%domain_data%end .GE. domain%x(tile)%global%end .AND. &
                 domain%x(tile)%compute%end < domain%x(tile)%global%end ) then
                 call mpp_error(FATAL, &
                  'MPP_DEFINE_DOMAINS: the domain could not be crossed when north is folded')
@@ -933,7 +933,7 @@
        if( PRESENT(yflags) )then
           if( BTEST(yflags,SOUTH) ) then
              !--- make sure no cross-domain in y-direction
-             if(domain%y(tile)%data%begin .LE. domain%y(tile)%global%begin .AND. &
+             if(domain%y(tile)%domain_data%begin .LE. domain%y(tile)%global%begin .AND. &
                 domain%y(tile)%compute%begin > domain%y(tile)%global%begin ) then
                 call mpp_error(FATAL, &
                  'MPP_DEFINE_DOMAINS: the domain could not be crossed when south is folded')
@@ -3267,7 +3267,7 @@ end subroutine check_message_size
           !--- Now calculate the overlapping for fold-edge.
           !--- only position at NORTH and CORNER need to be considered
           if( ( position == NORTH .OR. position == CORNER) ) then
-             if( domain%y(tMe)%data%begin .LE. jsg .AND. jsg .LE. domain%y(tMe)%data%end+jshift )then !fold
+             if( domain%y(tMe)%domain_data%begin .LE. jsg .AND. jsg .LE. domain%y(tMe)%domain_data%end+jshift )then !fold
                                                                                                     !! is within domain
                 dir = 3
                 !--- calculate the overlapping for sending
@@ -3367,7 +3367,7 @@ end subroutine check_message_size
           jsc = domain%list(m)%y(1)%compute%begin; jec = domain%list(m)%y(1)%compute%end+jshift
           !recv_e
           dir = 1
-          isd = domain%x(tMe)%compute%end+1+ishift; ied = domain%x(tMe)%data%end+ishift
+          isd = domain%x(tMe)%compute%end+1+ishift; ied = domain%x(tMe)%domain_data%end+ishift
           jsd = domain%y(tMe)%compute%begin; jed = domain%y(tMe)%compute%end+jshift
           is=isc; ie=iec; js=jsc; je=jec
           if( (position == NORTH .OR. position == CORNER ) .AND. ( jsd == je .or. jed == js ) ) then
@@ -3402,8 +3402,8 @@ end subroutine check_message_size
           !recv_se
           dir = 2
           folded = .false.
-          isd = domain%x(tMe)%compute%end+1+ishift; ied = domain%x(tMe)%data%end+ishift
-          jsd = domain%y(tMe)%data%begin;    jed = domain%y(tMe)%compute%begin-1
+          isd = domain%x(tMe)%compute%end+1+ishift; ied = domain%x(tMe)%domain_data%end+ishift
+          jsd = domain%y(tMe)%domain_data%begin;    jed = domain%y(tMe)%compute%begin-1
           is=isc; ie=iec; js=jsc; je=jec
           if( jsd.LT.jsg )then
              folded = .true.
@@ -3419,7 +3419,7 @@ end subroutine check_message_size
           dir = 3
           folded = .false.
           isd = domain%x(tMe)%compute%begin; ied = domain%x(tMe)%compute%end+ishift
-          jsd = domain%y(tMe)%data%begin;    jed = domain%y(tMe)%compute%begin-1
+          jsd = domain%y(tMe)%domain_data%begin;    jed = domain%y(tMe)%compute%begin-1
           is=isc; ie=iec; js=jsc; je=jec
           if( jsd.LT.jsg )then
              folded = .true.
@@ -3441,8 +3441,8 @@ end subroutine check_message_size
           !recv_sw
           dir = 4
           folded = .false.
-          isd = domain%x(tMe)%data%begin; ied = domain%x(tMe)%compute%begin-1
-          jsd = domain%y(tMe)%data%begin; jed = domain%y(tMe)%compute%begin-1
+          isd = domain%x(tMe)%domain_data%begin; ied = domain%x(tMe)%compute%begin-1
+          jsd = domain%y(tMe)%domain_data%begin; jed = domain%y(tMe)%compute%begin-1
           is=isc; ie=iec; js=jsc; je=jec
           if( jsd.LT.jsg )then
              folded = .true.
@@ -3462,7 +3462,7 @@ end subroutine check_message_size
 
           !recv_w
           dir = 5
-          isd = domain%x(tMe)%data%begin;    ied = domain%x(tMe)%compute%begin-1
+          isd = domain%x(tMe)%domain_data%begin;    ied = domain%x(tMe)%compute%begin-1
           jsd = domain%y(tMe)%compute%begin; jed = domain%y(tMe)%compute%end+jshift
           is=isc; ie=iec; js=jsc; je=jec
           if( (position == NORTH .OR. position == CORNER ) .AND. ( jsd == je .or. jed == js ) ) then
@@ -3506,8 +3506,8 @@ end subroutine check_message_size
 
           !recv_nw
           dir = 6
-          isd = domain%x(tMe)%data%begin;    ied = domain%x(tMe)%compute%begin-1
-          jsd = domain%y(tMe)%compute%end+1+jshift; jed = domain%y(tMe)%data%end+jshift
+          isd = domain%x(tMe)%domain_data%begin;    ied = domain%x(tMe)%compute%begin-1
+          jsd = domain%y(tMe)%compute%end+1+jshift; jed = domain%y(tMe)%domain_data%end+jshift
           is=isc; ie=iec; js=jsc; je=jec
           if( isd.LT.isg .AND. is.GE.ied )then !cyclic offset
              is = is-ioff; ie = ie-ioff
@@ -3519,15 +3519,15 @@ end subroutine check_message_size
           !recv_n
           dir = 7
           isd = domain%x(tMe)%compute%begin; ied = domain%x(tMe)%compute%end+ishift
-          jsd = domain%y(tMe)%compute%end+1+jshift; jed = domain%y(tMe)%data%end+jshift
+          jsd = domain%y(tMe)%compute%end+1+jshift; jed = domain%y(tMe)%domain_data%end+jshift
           is=isc; ie=iec; js=jsc; je=jec
           call insert_update_overlap( overlap, domain%list(m)%pe, &
                                       is, ie, js, je, isd, ied, jsd, jed, dir, symmetry=domain%symmetry)
 
           !recv_ne
           dir = 8
-          isd = domain%x(tMe)%compute%end+1+ishift; ied = domain%x(tMe)%data%end+ishift
-          jsd = domain%y(tMe)%compute%end+1+jshift; jed = domain%y(tMe)%data%end+jshift
+          isd = domain%x(tMe)%compute%end+1+ishift; ied = domain%x(tMe)%domain_data%end+ishift
+          jsd = domain%y(tMe)%compute%end+1+jshift; jed = domain%y(tMe)%domain_data%end+jshift
           is=isc; ie=iec; js=jsc; je=jec
           if(  ied.GT.ieg .AND. ie.LT.isd )then ! cyclic offset
              is = is+ioff; ie = ie+ioff
@@ -3539,8 +3539,8 @@ end subroutine check_message_size
           !--- for folded-south-edge, only need to consider to_pe's south(3) direction
           !--- only position at NORTH and CORNER need to be considered
           if( ( position == NORTH .OR. position == CORNER) ) then
-             if( domain%y(tMe)%data%begin .LE. jsg .AND. jsg .LE. domain%y(tMe)%data%end+jshift )then !fold
-                                                                                                    !! is within domain
+            !fold is within domain
+             if( domain%y(tMe)%domain_data%begin .LE. jsg .AND. jsg .LE. domain%y(tMe)%domain_data%end+jshift )then
                 dir = 3
                 !--- calculating overlapping for receving on north
                 if( domain%x(tMe)%pos .GE. size(domain%x(tMe)%list(:))/2 )then
@@ -3907,8 +3907,8 @@ end subroutine check_message_size
           !--- Now calculate the overlapping for fold-edge.
           !--- only position at EAST and CORNER need to be considered
           if( ( position == EAST .OR. position == CORNER) ) then
-             if( domain%x(tMe)%compute%begin-whalo .LE. isg .AND. isg .LE. domain%x(tMe)%data%end+ishift )then !fold
-                                                                                                    !! is within domain
+            !fold is within domain
+             if( domain%x(tMe)%compute%begin-whalo .LE. isg .AND. isg .LE. domain%x(tMe)%domain_data%end+ishift )then
                 dir = 5
                 !--- calculate the overlapping for sending
                 if( domain%y(tMe)%pos .LT. (size(domain%y(tMe)%list(:))+1)/2 )then
@@ -4000,7 +4000,7 @@ end subroutine check_message_size
           jsc = domain%list(m)%y(1)%compute%begin; jec = domain%list(m)%y(1)%compute%end+jshift
           !recv_e
           dir = 1
-          isd = domain%x(tMe)%compute%end+1+ishift; ied = domain%x(tMe)%data%end+ishift
+          isd = domain%x(tMe)%compute%end+1+ishift; ied = domain%x(tMe)%domain_data%end+ishift
           jsd = domain%y(tMe)%compute%begin; jed = domain%y(tMe)%compute%end+jshift
           is=isc; ie=iec; js=jsc; je=jec
           call insert_update_overlap( overlap, domain%list(m)%pe, &
@@ -4008,8 +4008,8 @@ end subroutine check_message_size
 
           !recv_se
           dir = 2
-          isd = domain%x(tMe)%compute%end+1+ishift; ied = domain%x(tMe)%data%end+ishift
-          jsd = domain%y(tMe)%data%begin;    jed = domain%y(tMe)%compute%begin-1
+          isd = domain%x(tMe)%compute%end+1+ishift; ied = domain%x(tMe)%domain_data%end+ishift
+          jsd = domain%y(tMe)%domain_data%begin;    jed = domain%y(tMe)%compute%begin-1
           is=isc; ie=iec; js=jsc; je=jec
           if( jsd.LT.jsg .AND. js.GE.jed )then ! cyclic is assumed
              js = js-joff; je = je-joff
@@ -4021,7 +4021,7 @@ end subroutine check_message_size
           dir = 3
           folded = .false.
           isd = domain%x(tMe)%compute%begin; ied = domain%x(tMe)%compute%end+ishift
-          jsd = domain%y(tMe)%data%begin;    jed = domain%y(tMe)%compute%begin-1
+          jsd = domain%y(tMe)%domain_data%begin;    jed = domain%y(tMe)%compute%begin-1
           is=isc; ie=iec; js=jsc; je=jec
 
           if( (position == EAST .OR. position == CORNER ) .AND. ( isd == ie .or. ied == is ) ) then
@@ -4065,8 +4065,8 @@ end subroutine check_message_size
           !recv_sw
           dir = 4
           folded = .false.
-          isd = domain%x(tMe)%data%begin; ied = domain%x(tMe)%compute%begin-1
-          jsd = domain%y(tMe)%data%begin; jed = domain%y(tMe)%compute%begin-1
+          isd = domain%x(tMe)%domain_data%begin; ied = domain%x(tMe)%compute%begin-1
+          jsd = domain%y(tMe)%domain_data%begin; jed = domain%y(tMe)%compute%begin-1
           is=isc; ie=iec; js=jsc; je=jec
           if( isd.LT.isg )then
              folded = .true.
@@ -4087,7 +4087,7 @@ end subroutine check_message_size
           !recv_w
           dir = 5
           folded = .false.
-          isd = domain%x(tMe)%data%begin;    ied = domain%x(tMe)%compute%begin-1
+          isd = domain%x(tMe)%domain_data%begin;    ied = domain%x(tMe)%compute%begin-1
           jsd = domain%y(tMe)%compute%begin; jed = domain%y(tMe)%compute%end+jshift
           is=isc; ie=iec; js=jsc; je=jec
           if( isd.LT.isg )then
@@ -4110,8 +4110,8 @@ end subroutine check_message_size
           !recv_nw
           dir = 6
           folded = .false.
-          isd = domain%x(tMe)%data%begin;    ied = domain%x(tMe)%compute%begin-1
-          jsd = domain%y(tMe)%compute%end+1+jshift; jed = domain%y(tMe)%data%end+jshift
+          isd = domain%x(tMe)%domain_data%begin;    ied = domain%x(tMe)%compute%begin-1
+          jsd = domain%y(tMe)%compute%end+1+jshift; jed = domain%y(tMe)%domain_data%end+jshift
           is=isc; ie=iec; js=jsc; je=jec
           if( isd.LT.isg) then
              folded = .true.
@@ -4128,7 +4128,7 @@ end subroutine check_message_size
           dir = 7
           folded = .false.
           isd = domain%x(tMe)%compute%begin; ied = domain%x(tMe)%compute%end+ishift
-          jsd = domain%y(tMe)%compute%end+1+jshift; jed = domain%y(tMe)%data%end+jshift
+          jsd = domain%y(tMe)%compute%end+1+jshift; jed = domain%y(tMe)%domain_data%end+jshift
           is=isc; ie=iec; js=jsc; je=jec
           if( (position == EAST .OR. position == CORNER ) .AND. ( isd == ie .or. ied == is ) ) then
              !--- do nothing, this point will come from other pe
@@ -4159,8 +4159,8 @@ end subroutine check_message_size
 
           !recv_ne
           dir = 8
-          isd = domain%x(tMe)%compute%end+1+ishift; ied = domain%x(tMe)%data%end+ishift
-          jsd = domain%y(tMe)%compute%end+1+jshift; jed = domain%y(tMe)%data%end+jshift
+          isd = domain%x(tMe)%compute%end+1+ishift; ied = domain%x(tMe)%domain_data%end+ishift
+          jsd = domain%y(tMe)%compute%end+1+jshift; jed = domain%y(tMe)%domain_data%end+jshift
           is=isc; ie=iec; js=jsc; je=jec
           if(  jed.GT.jeg .AND. je.LT.jsd )then ! cyclic offset
              js = js+joff; je = je+joff
@@ -4172,8 +4172,8 @@ end subroutine check_message_size
           !--- for folded-south-edge, only need to consider to_pe's south(3) direction
           !--- only position at EAST and CORNER need to be considered
           if( ( position == EAST .OR. position == CORNER) ) then
-             if( domain%x(tMe)%data%begin .LE. isg .AND. isg .LE. domain%x(tMe)%data%end+ishift )then !fold
-                                                                                                    !! is within domain
+            !fold is within domain
+             if( domain%x(tMe)%domain_data%begin .LE. isg .AND. isg .LE. domain%x(tMe)%domain_data%end+ishift )then
                 dir = 5
                 !--- calculating overlapping for receving on north
                 if( domain%y(tMe)%pos .GE. size(domain%y(tMe)%list(:))/2 )then
@@ -4536,8 +4536,8 @@ end subroutine check_message_size
           !--- Now calculate the overlapping for fold-edge.
           !--- only position at EAST and CORNER need to be considered
           if( ( position == EAST .OR. position == CORNER) ) then
-             if( domain%x(tMe)%data%begin .LE. ieg .AND. ieg .LE. domain%x(tMe)%data%end+ishift )then !fold
-                                                                                                    !! is within domain
+            !fold is within domain
+             if( domain%x(tMe)%domain_data%begin .LE. ieg .AND. ieg .LE. domain%x(tMe)%domain_data%end+ishift )then
                 dir = 1
                 !--- calculate the overlapping for sending
                 if( domain%y(tMe)%pos .LT. (size(domain%y(tMe)%list(:))+1)/2 )then
@@ -4617,7 +4617,7 @@ end subroutine check_message_size
           !recv_e
           dir = 1
           folded = .false.
-          isd = domain%x(tMe)%compute%end+1+ishift; ied = domain%x(tMe)%data%end+ishift
+          isd = domain%x(tMe)%compute%end+1+ishift; ied = domain%x(tMe)%domain_data%end+ishift
           jsd = domain%y(tMe)%compute%begin; jed = domain%y(tMe)%compute%end+jshift
           is=isc; ie=iec; js=jsc; je=jec
           if( ied.GT.ieg )then
@@ -4640,8 +4640,8 @@ end subroutine check_message_size
           !recv_se
           dir = 2
           folded = .false.
-          isd = domain%x(tMe)%compute%end+1+ishift; ied = domain%x(tMe)%data%end+ishift
-          jsd = domain%y(tMe)%data%begin;    jed = domain%y(tMe)%compute%begin-1
+          isd = domain%x(tMe)%compute%end+1+ishift; ied = domain%x(tMe)%domain_data%end+ishift
+          jsd = domain%y(tMe)%domain_data%begin;    jed = domain%y(tMe)%compute%begin-1
           is=isc; ie=iec; js=jsc; je=jec
           if( ied.GT.ieg )then
              folded = .true.
@@ -4663,7 +4663,7 @@ end subroutine check_message_size
           dir = 3
           folded = .false.
           isd = domain%x(tMe)%compute%begin; ied = domain%x(tMe)%compute%end+ishift
-          jsd = domain%y(tMe)%data%begin;    jed = domain%y(tMe)%compute%begin-1
+          jsd = domain%y(tMe)%domain_data%begin;    jed = domain%y(tMe)%compute%begin-1
           is=isc; ie=iec; js=jsc; je=jec
 
           if( (position == EAST .OR. position == CORNER ) .AND. ( isd == ie .or. ied == is ) ) then
@@ -4706,8 +4706,8 @@ end subroutine check_message_size
 
           !recv_sw
           dir = 4
-          isd = domain%x(tMe)%data%begin; ied = domain%x(tMe)%compute%begin-1
-          jsd = domain%y(tMe)%data%begin; jed = domain%y(tMe)%compute%begin-1
+          isd = domain%x(tMe)%domain_data%begin; ied = domain%x(tMe)%compute%begin-1
+          jsd = domain%y(tMe)%domain_data%begin; jed = domain%y(tMe)%compute%begin-1
           is=isc; ie=iec; js=jsc; je=jec
           if( jsd.LT.jsg .AND. js.GE.jed )then ! cyclic is assumed
              js = js-joff; je = je-joff
@@ -4717,7 +4717,7 @@ end subroutine check_message_size
 
           !recv_w
           dir = 5
-          isd = domain%x(tMe)%data%begin;    ied = domain%x(tMe)%compute%begin-1
+          isd = domain%x(tMe)%domain_data%begin;    ied = domain%x(tMe)%compute%begin-1
           jsd = domain%y(tMe)%compute%begin; jed = domain%y(tMe)%compute%end+jshift
           is=isc; ie=iec; js=jsc; je=jec
           call insert_update_overlap( overlap, domain%list(m)%pe, &
@@ -4726,8 +4726,8 @@ end subroutine check_message_size
           !recv_nw
           dir = 6
           folded = .false.
-          isd = domain%x(tMe)%data%begin;    ied = domain%x(tMe)%compute%begin-1
-          jsd = domain%y(tMe)%compute%end+1+jshift; jed = domain%y(tMe)%data%end+jshift
+          isd = domain%x(tMe)%domain_data%begin;    ied = domain%x(tMe)%compute%begin-1
+          jsd = domain%y(tMe)%compute%end+1+jshift; jed = domain%y(tMe)%domain_data%end+jshift
           is=isc; ie=iec; js=jsc; je=jec
           if(  jed.GT.jeg .AND. je.LT.jsd )then ! cyclic offset
              js = js+joff; je = je+joff
@@ -4739,7 +4739,7 @@ end subroutine check_message_size
           dir = 7
           folded = .false.
           isd = domain%x(tMe)%compute%begin; ied = domain%x(tMe)%compute%end+ishift
-          jsd = domain%y(tMe)%compute%end+1+jshift; jed = domain%y(tMe)%data%end+jshift
+          jsd = domain%y(tMe)%compute%end+1+jshift; jed = domain%y(tMe)%domain_data%end+jshift
           is=isc; ie=iec; js=jsc; je=jec
           if( (position == EAST .OR. position == CORNER ) .AND. ( isd == ie .or. ied == is ) ) then
              !--- do nothing, this point will come from other pe
@@ -4771,8 +4771,8 @@ end subroutine check_message_size
           !recv_ne
           dir = 8
           folded = .false.
-          isd = domain%x(tMe)%compute%end+1+ishift; ied = domain%x(tMe)%data%end+ishift
-          jsd = domain%y(tMe)%compute%end+1+jshift; jed = domain%y(tMe)%data%end+jshift
+          isd = domain%x(tMe)%compute%end+1+ishift; ied = domain%x(tMe)%domain_data%end+ishift
+          jsd = domain%y(tMe)%compute%end+1+jshift; jed = domain%y(tMe)%domain_data%end+jshift
           is=isc; ie=iec; js=jsc; je=jec
           if( ied.GT.ieg) then
              folded = .true.
@@ -4788,8 +4788,8 @@ end subroutine check_message_size
           !--- for folded-south-edge, only need to consider to_pe's south(3) direction
           !--- only position at EAST and CORNER need to be considered
           if( ( position == EAST .OR. position == CORNER) ) then
-             if( domain%x(tMe)%data%begin .LE. ieg .AND. ieg .LE. domain%x(tMe)%data%end+ishift )then !fold
-                                                                                                    !! is within domain
+            !fold is within domain
+             if( domain%x(tMe)%domain_data%begin .LE. ieg .AND. ieg .LE. domain%x(tMe)%domain_data%end+ishift )then
                 dir = 1
                 !--- calculating overlapping for receving on north
                 if( domain%y(tMe)%pos .GE. size(domain%y(tMe)%list(:))/2 )then
@@ -5702,32 +5702,32 @@ end subroutine check_message_size
                    select case ( dir )
                    case ( 1 )  ! eastern halo
                       if( align1Recv(n) .NE. EAST ) cycle
-                      isd2 = domain%x(tMe)%compute%end+1; ied2 = domain%x(tMe)%data%end
+                      isd2 = domain%x(tMe)%compute%end+1; ied2 = domain%x(tMe)%domain_data%end
                       jsd2 = domain%y(tMe)%compute%begin; jed2 = domain%y(tMe)%compute%end
                    case ( 2 )  ! southeast halo
-                      isd2 = domain%x(tMe)%compute%end+1; ied2 = domain%x(tMe)%data%end
-                      jsd2 = domain%y(tMe)%data%begin;    jed2 = domain%y(tMe)%compute%begin-1
+                      isd2 = domain%x(tMe)%compute%end+1; ied2 = domain%x(tMe)%domain_data%end
+                      jsd2 = domain%y(tMe)%domain_data%begin;    jed2 = domain%y(tMe)%compute%begin-1
                    case ( 3 )  ! southern halo
                       if( align1Recv(n) .NE. SOUTH ) cycle
                       isd2 = domain%x(tMe)%compute%begin; ied2 = domain%x(tMe)%compute%end
-                      jsd2 = domain%y(tMe)%data%begin;    jed2 = domain%y(tMe)%compute%begin-1
+                      jsd2 = domain%y(tMe)%domain_data%begin;    jed2 = domain%y(tMe)%compute%begin-1
                    case ( 4 )  ! southwest halo
-                      isd2 = domain%x(tMe)%data%begin;    ied2 = domain%x(tMe)%compute%begin-1
-                      jsd2 = domain%y(tMe)%data%begin;    jed2 = domain%y(tMe)%compute%begin-1
+                      isd2 = domain%x(tMe)%domain_data%begin;    ied2 = domain%x(tMe)%compute%begin-1
+                      jsd2 = domain%y(tMe)%domain_data%begin;    jed2 = domain%y(tMe)%compute%begin-1
                    case ( 5 )  ! western halo
                       if( align1Recv(n) .NE. WEST ) cycle
-                      isd2 = domain%x(tMe)%data%begin;    ied2 = domain%x(tMe)%compute%begin-1
+                      isd2 = domain%x(tMe)%domain_data%begin;    ied2 = domain%x(tMe)%compute%begin-1
                       jsd2 = domain%y(tMe)%compute%begin; jed2 = domain%y(tMe)%compute%end
                    case ( 6 )  ! northwest halo
-                      isd2 = domain%x(tMe)%data%begin;    ied2 = domain%x(tMe)%compute%begin-1
-                      jsd2 = domain%y(tMe)%compute%end+1; jed2 = domain%y(tMe)%data%end
+                      isd2 = domain%x(tMe)%domain_data%begin;    ied2 = domain%x(tMe)%compute%begin-1
+                      jsd2 = domain%y(tMe)%compute%end+1; jed2 = domain%y(tMe)%domain_data%end
                    case ( 7 )  ! northern halo
                       if( align1Recv(n) .NE. NORTH ) cycle
                       isd2 = domain%x(tMe)%compute%begin; ied2 = domain%x(tMe)%compute%end
-                      jsd2 = domain%y(tMe)%compute%end+1; jed2 = domain%y(tMe)%data%end
+                      jsd2 = domain%y(tMe)%compute%end+1; jed2 = domain%y(tMe)%domain_data%end
                    case ( 8 )  ! northeast halo
-                      isd2 = domain%x(tMe)%compute%end+1; ied2 = domain%x(tMe)%data%end
-                      jsd2 = domain%y(tMe)%compute%end+1; jed2 = domain%y(tMe)%data%end
+                      isd2 = domain%x(tMe)%compute%end+1; ied2 = domain%x(tMe)%domain_data%end
+                      jsd2 = domain%y(tMe)%compute%end+1; jed2 = domain%y(tMe)%domain_data%end
                    end select
                    is = max(isd1,isd2); ie = min(ied1,ied2)
                    js = max(jsd1,jsd2); je = min(jed1,jed2)
@@ -7554,7 +7554,7 @@ ndivs = size(domain_in%list(:))
 ! get the flag
 flag = 0
 if(domain_in%cyclic) flag = flag + CYCLIC_GLOBAL_DOMAIN
-if(domain_in%data%is_global) flag = flag + GLOBAL_DATA_DOMAIN
+if(domain_in%domain_data%is_global) flag = flag + GLOBAL_DATA_DOMAIN
 
 call mpp_define_domains( global_indices, ndivs, domain_out, pelist = domain_in%list(:)%pe, &
    flags = flag, begin_halo = hbegin, end_halo = hend, extent = domain_in%list(:)%compute%size )
@@ -7594,9 +7594,9 @@ if(present(whalo) .or. present(ehalo) .or. present(shalo) .or. present(nhalo) ) 
  ! get the flag
  xflag = 0; yflag = 0
  if(domain_in%x(1)%cyclic) xflag = xflag + CYCLIC_GLOBAL_DOMAIN
- if(domain_in%x(1)%data%is_global) xflag = xflag + GLOBAL_DATA_DOMAIN
+ if(domain_in%x(1)%domain_data%is_global) xflag = xflag + GLOBAL_DATA_DOMAIN
  if(domain_in%y(1)%cyclic) yflag = yflag + CYCLIC_GLOBAL_DOMAIN
- if(domain_in%y(1)%data%is_global) yflag = yflag + GLOBAL_DATA_DOMAIN
+ if(domain_in%y(1)%domain_data%is_global) yflag = yflag + GLOBAL_DATA_DOMAIN
 
  call mpp_define_domains( global_indices, layout, domain_out, pelist = domain_in%list(:)%pe, &
       xflags = xflag, yflags = yflag,  whalo = whalo, ehalo = ehalo,     &
@@ -7632,7 +7632,7 @@ subroutine mpp_define_null_domain1D(domain)
 type(domain1D), intent(inout) :: domain
 
 domain%global%begin  = -1; domain%global%end  = -1; domain%global%size = 0
-domain%data%begin    = -1; domain%data%end    = -1; domain%data%size = 0
+domain%domain_data%begin    = -1; domain%domain_data%end    = -1; domain%domain_data%size = 0
 domain%compute%begin = -1; domain%compute%end = -1; domain%compute%size = 0
 domain%pe = NULL_PE
 

--- a/mpp/include/mpp_domains_define.inc
+++ b/mpp/include/mpp_domains_define.inc
@@ -3267,8 +3267,8 @@ end subroutine check_message_size
           !--- Now calculate the overlapping for fold-edge.
           !--- only position at NORTH and CORNER need to be considered
           if( ( position == NORTH .OR. position == CORNER) ) then
-             if( domain%y(tMe)%domain_data%begin .LE. jsg .AND. jsg .LE. domain%y(tMe)%domain_data%end+jshift )then !fold
-                                                                                                    !! is within domain
+             !fold is within domain
+             if( domain%y(tMe)%domain_data%begin .LE. jsg .AND. jsg .LE. domain%y(tMe)%domain_data%end+jshift )then
                 dir = 3
                 !--- calculate the overlapping for sending
                 if( domain%x(tMe)%pos .LT. (size(domain%x(tMe)%list(:))+1)/2 )then

--- a/mpp/include/mpp_domains_misc.inc
+++ b/mpp/include/mpp_domains_misc.inc
@@ -498,10 +498,10 @@ end subroutine init_nonblock_type
           domain%x%compute%end   = -1
           domain%y%compute%begin =  1
           domain%y%compute%end   = -1
-          domain%x%data   %begin = -1
-          domain%x%data   %end   = -1
-          domain%y%data   %begin = -1
-          domain%y%data   %end   = -1
+          domain%x%domain_data   %begin = -1
+          domain%x%domain_data   %end   = -1
+          domain%y%domain_data   %begin = -1
+          domain%y%domain_data   %end   = -1
           domain%x%global %begin = -1
           domain%x%global %end   = -1
           domain%y%global %begin = -1
@@ -543,10 +543,10 @@ end subroutine init_nonblock_type
              domain%list(listpos)%y%compute%end   = msg(5)
              domain%list(listpos)%tile_id(1)      = msg(6)
              if(domain%x(1)%global%begin < 0) then
-                domain%x(1)%data  %begin = msg(2)
-                domain%x(1)%data  %end   = msg(3)
-                domain%y(1)%data  %begin = msg(4)
-                domain%y(1)%data  %end   = msg(5)
+                domain%x(1)%domain_data  %begin = msg(2)
+                domain%x(1)%domain_data  %end   = msg(3)
+                domain%y(1)%domain_data  %begin = msg(4)
+                domain%y(1)%domain_data  %end   = msg(5)
                 domain%x(1)%global%begin = msg(2)
                 domain%x(1)%global%end   = msg(3)
                 domain%y(1)%global%begin = msg(4)
@@ -562,10 +562,10 @@ end subroutine init_nonblock_type
                 endif
                 domain%ntiles = msg(12)
              else
-                domain%x(1)%data  %begin = msg(2) - msg(7)
-                domain%x(1)%data  %end   = msg(3) + msg(8)
-                domain%y(1)%data  %begin = msg(4) - msg(9)
-                domain%y(1)%data  %end   = msg(5) + msg(10)
+                domain%x(1)%domain_data  %begin = msg(2) - msg(7)
+                domain%x(1)%domain_data  %end   = msg(3) + msg(8)
+                domain%y(1)%domain_data  %begin = msg(4) - msg(9)
+                domain%y(1)%domain_data  %end   = msg(5) + msg(10)
                 domain%x(1)%global%begin = min(domain%x(1)%global%begin, msg(2))
                 domain%x(1)%global%end   = max(domain%x(1)%global%end,   msg(3))
                 domain%y(1)%global%begin = min(domain%y(1)%global%begin, msg(4))
@@ -624,10 +624,10 @@ end subroutine init_nonblock_type
       domain_out%x%compute%end   = -1
       domain_out%y%compute%begin =  1
       domain_out%y%compute%end   = -1
-      domain_out%x%data   %begin = -1
-      domain_out%x%data   %end   = -1
-      domain_out%y%data   %begin = -1
-      domain_out%y%data   %end   = -1
+      domain_out%x%domain_data   %begin = -1
+      domain_out%x%domain_data   %end   = -1
+      domain_out%y%domain_data   %begin = -1
+      domain_out%y%domain_data   %end   = -1
       domain_out%x%global %begin = -1
       domain_out%x%global %end   = -1
       domain_out%y%global %begin = -1
@@ -675,10 +675,10 @@ end subroutine init_nonblock_type
              domain_out%list(listpos)%y%compute%end   = msg(5)
              domain_out%list(listpos)%tile_id(1)      = msg(6)
              if(domain_out%x(1)%global%begin < 0) then
-                domain_out%x(1)%data  %begin = msg(2)
-                domain_out%x(1)%data  %end   = msg(3)
-                domain_out%y(1)%data  %begin = msg(4)
-                domain_out%y(1)%data  %end   = msg(5)
+                domain_out%x(1)%domain_data  %begin = msg(2)
+                domain_out%x(1)%domain_data  %end   = msg(3)
+                domain_out%y(1)%domain_data  %begin = msg(4)
+                domain_out%y(1)%domain_data  %end   = msg(5)
                 domain_out%x(1)%global%begin = msg(2)
                 domain_out%x(1)%global%end   = msg(3)
                 domain_out%y(1)%global%begin = msg(4)
@@ -694,10 +694,10 @@ end subroutine init_nonblock_type
                 endif
                 domain_out%ntiles            = msg(12)
              else
-                domain_out%x(1)%data  %begin = msg(2) - msg(7)
-                domain_out%x(1)%data  %end   = msg(3) + msg(8)
-                domain_out%y(1)%data  %begin = msg(4) - msg(9)
-                domain_out%y(1)%data  %end   = msg(5) + msg(10)
+                domain_out%x(1)%domain_data  %begin = msg(2) - msg(7)
+                domain_out%x(1)%domain_data  %end   = msg(3) + msg(8)
+                domain_out%y(1)%domain_data  %begin = msg(4) - msg(9)
+                domain_out%y(1)%domain_data  %end   = msg(5) + msg(10)
                 domain_out%x(1)%global%begin = min(domain_out%x(1)%global%begin, msg(2))
                 domain_out%x(1)%global%end   = max(domain_out%x(1)%global%end,   msg(3))
                 domain_out%y(1)%global%begin = min(domain_out%y(1)%global%begin, msg(4))
@@ -762,10 +762,10 @@ end subroutine init_nonblock_type
           domain%x%compute%end   = -1
           domain%y%compute%begin =  0
           domain%y%compute%end   = -1
-          domain%x%data   %begin =  0
-          domain%x%data   %end   = -1
-          domain%y%data   %begin =  0
-          domain%y%data   %end   = -1
+          domain%x%domain_data   %begin =  0
+          domain%x%domain_data   %end   = -1
+          domain%y%domain_data   %begin =  0
+          domain%y%domain_data   %end   = -1
           domain%x%global %begin =  0
           domain%x%global %end   = -1
           domain%y%global %begin =  0
@@ -879,10 +879,10 @@ end subroutine init_nonblock_type
           domain%x%compute%end   = -1
           domain%y%compute%begin =  0
           domain%y%compute%end   = -1
-          domain%x%data   %begin =  0
-          domain%x%data   %end   = -1
-          domain%y%data   %begin =  0
-          domain%y%data   %end   = -1
+          domain%x%domain_data   %begin =  0
+          domain%x%domain_data   %end   = -1
+          domain%y%domain_data   %begin =  0
+          domain%y%domain_data   %end   = -1
           domain%x%global %begin =  0
           domain%x%global %end   = -1
           domain%y%global %begin =  0
@@ -921,10 +921,10 @@ end subroutine init_nonblock_type
          if( .NOT.native .AND. msg(1).NE.NULL_PE .AND. tile_coarse==msg(16) )then
              domain%list(listpos)%pe = msg(1)
              if(domain%x(1)%compute%begin == 0) then
-                domain%x(1)%data  %begin = msg(2) - msg(7)
-                domain%x(1)%data  %end   = msg(3) + msg(8)
-                domain%y(1)%data  %begin = msg(4) - msg(9)
-                domain%y(1)%data  %end   = msg(5) + msg(10)
+                domain%x(1)%domain_data  %begin = msg(2) - msg(7)
+                domain%x(1)%domain_data  %end   = msg(3) + msg(8)
+                domain%y(1)%domain_data  %begin = msg(4) - msg(9)
+                domain%y(1)%domain_data  %end   = msg(5) + msg(10)
                 domain%x(1)%global%begin = msg(12)
                 domain%x(1)%global%end   = msg(13)
                 domain%y(1)%global%begin = msg(14)

--- a/mpp/include/mpp_domains_util.inc
+++ b/mpp/include/mpp_domains_util.inc
@@ -63,8 +63,8 @@
 
     mpp_domain1D_eq = ( a%compute%begin.EQ.b%compute%begin .AND. &
          a%compute%end  .EQ.b%compute%end   .AND. &
-         a%data%begin   .EQ.b%data%begin    .AND. &
-         a%data%end     .EQ.b%data%end      .AND. &
+         a%domain_data%begin   .EQ.b%domain_data%begin    .AND. &
+         a%domain_data%end     .EQ.b%domain_data%end      .AND. &
          a%global%begin .EQ.b%global%begin  .AND. &
          a%global%end   .EQ.b%global%end    )
     !compare pelists
@@ -140,11 +140,11 @@
     integer, intent(out), optional :: begin, end, size, max_size
     logical, intent(out), optional :: is_global
 
-    if( PRESENT(begin)     )begin     = domain%data%begin
-    if( PRESENT(end)       )end       = domain%data%end
-    if( PRESENT(size)      )size      = domain%data%size
-    if( PRESENT(max_size)  )max_size  = domain%data%max_size
-    if( PRESENT(is_global) )is_global = domain%data%is_global
+    if( PRESENT(begin)     )begin     = domain%domain_data%begin
+    if( PRESENT(end)       )end       = domain%domain_data%end
+    if( PRESENT(size)      )size      = domain%domain_data%size
+    if( PRESENT(max_size)  )max_size  = domain%domain_data%max_size
+    if( PRESENT(is_global) )is_global = domain%domain_data%is_global
     return
   end subroutine mpp_get_data_domain1D
 
@@ -320,8 +320,8 @@
         call mpp_set_super_grid_indices(domain%list(i-1)%y(1)%compute)
 
         !< There is no data domain in domain%list
-        !call mpp_set_super_grid_indices(domain%list(i-1)%x(1)%data)
-        !call mpp_set_super_grid_indices(domain%list(i-1)%y(1)%data)
+        !call mpp_set_super_grid_indices(domain%list(i-1)%x(1)%domain_data)
+        !call mpp_set_super_grid_indices(domain%list(i-1)%y(1)%domain_data)
     enddo
 
     do i=1, size(domain%x(1)%list)
@@ -370,10 +370,10 @@
     integer, intent(in), optional :: begin, end, size
     logical, intent(in), optional :: is_global
 
-    if(present(begin)) domain%data%begin = begin
-    if(present(end))   domain%data%end   = end
-    if(present(size))  domain%data%size  = size
-    if(present(is_global)) domain%data%is_global = is_global
+    if(present(begin)) domain%domain_data%begin = begin
+    if(present(end))   domain%domain_data%end   = end
+    if(present(size))  domain%domain_data%size  = size
+    if(present(is_global)) domain%domain_data%is_global = is_global
 
   end subroutine mpp_set_data_domain1D
 
@@ -1728,7 +1728,7 @@ end subroutine mpp_get_tile_compute_domains
      integer                       :: ending   !< Ending bounds
 
      domain_out%compute = domain_in%compute
-     domain_out%data    = domain_in%data
+     domain_out%domain_data    = domain_in%domain_data
      domain_out%global  = domain_in%global
      domain_out%memory  = domain_in%memory
      domain_out%cyclic  = domain_in%cyclic

--- a/mpp/include/mpp_gather.fh
+++ b/mpp/include/mpp_gather.fh
@@ -109,21 +109,21 @@ subroutine MPP_GATHER_1DV_(sbuf, ssize, rbuf, rsize, pelist)
 end subroutine MPP_GATHER_1DV_
 
 
-subroutine MPP_GATHER_PELIST_2D_(is, ie, js, je, pelist, array_seg, data, is_root_pe, &
+subroutine MPP_GATHER_PELIST_2D_(is, ie, js, je, pelist, array_seg, gather_data, is_root_pe, &
                                  ishift, jshift)
    integer,                           intent(in)    :: is, ie, js, je
    integer,   dimension(:),           intent(in)    :: pelist
    MPP_TYPE_, dimension(is:ie,js:je), intent(in)    :: array_seg
-   MPP_TYPE_, dimension(:,:),         intent(inout) :: data
+   MPP_TYPE_, dimension(:,:),         intent(inout) :: gather_data
    logical,                           intent(in)    :: is_root_pe
    integer,   optional,               intent(in)    :: ishift, jshift
 
    MPP_TYPE_ ::  arr3D(size(array_seg,1),size(array_seg,2),1)
-   MPP_TYPE_ :: data3D(size(     data,1),size(     data,2),1)
+   MPP_TYPE_ :: data3D(size(     gather_data,1),size(     gather_data,2),1)
    pointer( aptr,  arr3D )
    pointer( dptr, data3D )
    aptr = LOC(array_seg)
-   dptr = LOC(     data)
+   dptr = LOC(     gather_data)
 
    call mpp_gather(is, ie, js, je, 1, pelist, arr3D, data3D, is_root_pe, &
                    ishift, jshift)
@@ -132,12 +132,12 @@ subroutine MPP_GATHER_PELIST_2D_(is, ie, js, je, pelist, array_seg, data, is_roo
 end subroutine MPP_GATHER_PELIST_2D_
 
 
-subroutine MPP_GATHER_PELIST_3D_(is, ie, js, je, nk, pelist, array_seg, data, is_root_pe, &
+subroutine MPP_GATHER_PELIST_3D_(is, ie, js, je, nk, pelist, array_seg, gather_data, is_root_pe, &
                                  ishift, jshift)
    integer,                                intent(in)    :: is, ie, js, je, nk
    integer,   dimension(:),                intent(in)    :: pelist
    MPP_TYPE_, dimension(is:ie,js:je,1:nk), intent(in)    :: array_seg
-   MPP_TYPE_, dimension(:,:,:),            intent(inout) :: data
+   MPP_TYPE_, dimension(:,:,:),            intent(inout) :: gather_data
    logical,                                intent(in)    :: is_root_pe
    integer,   optional,                    intent(in)    :: ishift, jshift
 
@@ -197,7 +197,8 @@ subroutine MPP_GATHER_PELIST_3D_(is, ie, js, je, nk, pelist, array_seg, data, is
      gind(3,:)=gind(3,:)+joff
      gind(4,:)=gind(4,:)+joff
 ! check indices to make sure they are within the range of "data"
-     if ((minval(gind).lt.1) .OR. (maxval(gind(1:2,:)).gt.size(data,1)) .OR. (maxval(gind(3:4,:)).gt.size(data,2))) &
+     if ((minval(gind).lt.1) .OR. (maxval(gind(1:2,:)).gt.size(gather_data,1)) .OR. &
+         (maxval(gind(3:4,:)).gt.size(gather_data,2))) &
          call mpp_error(FATAL,"fms_io(mpp_gather_pelist): specified indices (with shift) are outside of the &
                         &range of the receiving array")
    else
@@ -224,13 +225,13 @@ subroutine MPP_GATHER_PELIST_3D_(is, ie, js, je, nk, pelist, array_seg, data, is
      do i = 1, size(pelist)
        if (pelist(i).eq.root_pe) then
 !        data copy - no send to self
-         data(is+ioff:ie+ioff,js+joff:je+joff,1:nk) = array_seg(is:ie,js:je,1:nk)
+         gather_data(is+ioff:ie+ioff,js+joff:je+joff,1:nk) = array_seg(is:ie,js:je,1:nk)
        else
          i1 = gind(1,i)
          i2 = gind(2,i)
          j1 = gind(3,i)
          j2 = gind(4,i)
-         data(i1:i2,j1:j2,1:nk)=temp(i)%data(i1:i2,j1:j2,1:nk)
+         gather_data(i1:i2,j1:j2,1:nk)=temp(i)%data(i1:i2,j1:j2,1:nk)
          deallocate(temp(i)%data)
        endif
      enddo

--- a/mpp/include/mpp_gather.fh
+++ b/mpp/include/mpp_gather.fh
@@ -145,7 +145,7 @@ subroutine MPP_GATHER_PELIST_3D_(is, ie, js, je, nk, pelist, array_seg, gather_d
    integer :: i1, i2, j1, j2, ioff, joff
    integer :: my_ind(4), gind(4,size(pelist))
    type array3D
-     MPP_TYPE_, dimension(:,:,:), allocatable :: data
+     MPP_TYPE_, dimension(:,:,:), allocatable :: data3D_type
    endtype array3D
    type(array3d), dimension(:), allocatable :: temp
 
@@ -216,8 +216,8 @@ subroutine MPP_GATHER_PELIST_3D_(is, ie, js, je, nk, pelist, array_seg, gather_d
          j1 = gind(3,i)
          j2 = gind(4,i)
          msgsize = (i2-i1+1)*(j2-j1+1)*nk
-         allocate(temp(i)%data(i1:i2,j1:j2,1:nk))
-         call mpp_recv(temp(i)%data(i1:i2,j1:j2,1:nk), msgsize, pelist(i), .FALSE., COMM_TAG_2)
+         allocate(temp(i)%data3D_type(i1:i2,j1:j2,1:nk))
+         call mpp_recv(temp(i)%data3D_type(i1:i2,j1:j2,1:nk), msgsize, pelist(i), .FALSE., COMM_TAG_2)
        endif
      enddo
      call mpp_sync_self(check=EVENT_RECV)
@@ -231,8 +231,8 @@ subroutine MPP_GATHER_PELIST_3D_(is, ie, js, je, nk, pelist, array_seg, gather_d
          i2 = gind(2,i)
          j1 = gind(3,i)
          j2 = gind(4,i)
-         gather_data(i1:i2,j1:j2,1:nk)=temp(i)%data(i1:i2,j1:j2,1:nk)
-         deallocate(temp(i)%data)
+         gather_data(i1:i2,j1:j2,1:nk)=temp(i)%data3D_type(i1:i2,j1:j2,1:nk)
+         deallocate(temp(i)%data3D_type)
        endif
      enddo
      deallocate(temp)

--- a/mpp/include/mpp_global_field.fh
+++ b/mpp/include/mpp_global_field.fh
@@ -67,8 +67,8 @@
       ! Also worth noting that many of the nD->3D conversion also assumes
       ! contiguity, so there many be other issues here.
 
-      isize = domain%x(tile)%data%size + ishift
-      jsize = domain%y(tile)%data%size + jshift
+      isize = domain%x(tile)%domain_data%size + ishift
+      jsize = domain%y(tile)%domain_data%size + jshift
       if ((size(local, 1) .eq. isize) .and. (size(local, 2) .eq. jsize) &
               .and. use_alltoallw) then
           call mpp_do_global_field_a2a(domain, local, global, tile, &

--- a/mpp/include/mpp_global_reduce.fh
+++ b/mpp/include/mpp_global_reduce.fh
@@ -63,8 +63,8 @@
         joff = jsc
     else if( size(field,1).EQ.domain%x(1)%memory%size+ishift .AND. size(field,2).EQ.domain%y(1)%memory%size+jshift)then
 !field is on data domain
-        ioff = domain%x(1)%data%begin
-        joff = domain%y(1)%data%begin
+        ioff = domain%x(1)%domain_data%begin
+        joff = domain%y(1)%domain_data%begin
     else
         call mpp_error( FATAL, &
                        &  'MPP_GLOBAL_REDUCE_: incoming field array must match either compute domain or data domain.' )

--- a/mpp/include/mpp_global_sum.fh
+++ b/mpp/include/mpp_global_sum.fh
@@ -53,8 +53,8 @@
     else if( size(field,1).EQ.domain%x(tile)%memory%size+ishift .AND. &
            & size(field,2).EQ.domain%y(tile)%memory%size+jshift )then
 !field is on data domain
-        ioff = -domain%x(tile)%data%begin + 1
-        joff = -domain%y(tile)%data%begin + 1
+        ioff = -domain%x(tile)%domain_data%begin + 1
+        joff = -domain%y(tile)%domain_data%begin + 1
     else
         call mpp_error( FATAL, &
                        &  'MPP_GLOBAL_SUM_: incoming field array must match either compute domain or data domain.' )

--- a/mpp/include/mpp_global_sum_ad.fh
+++ b/mpp/include/mpp_global_sum_ad.fh
@@ -57,8 +57,8 @@ subroutine MPP_GLOBAL_SUM_AD_( domain, field, gsum_, flags, position, tile_count
     else if( size(field,1).EQ.domain%x(tile)%memory%size+ishift .AND. &
            & size(field,2).EQ.domain%y(tile)%memory%size+jshift )then
 !field is on data domain
-        ioff = -domain%x(tile)%data%begin + 1
-        joff = -domain%y(tile)%data%begin + 1
+        ioff = -domain%x(tile)%domain_data%begin + 1
+        joff = -domain%y(tile)%domain_data%begin + 1
     else
         call mpp_error( FATAL, &
                        &  'MPP_GLOBAL_SUM_: incoming field array must match either compute domain or data domain.' )

--- a/mpp/include/mpp_group_update.fh
+++ b/mpp/include/mpp_group_update.fh
@@ -526,7 +526,7 @@ subroutine MPP_DO_GROUP_UPDATE_(group, domain, d_type)
   if(domain%symmetry) shift = 1
   if( nvector >0 .AND. BTEST(domain%fold,NORTH) .AND. (.NOT.BTEST(flags_v,SCALAR_BIT)) )then
      j = domain%y(1)%global%end+shift
-     if( domain%y(1)%data%begin.LE.j .AND. j.LE.domain%y(1)%data%end+shift )then !fold is within domain
+     if( domain%y(1)%domain_data%begin.LE.j .AND. j.LE.domain%y(1)%domain_data%end+shift )then !fold is within domain
         !poles set to 0: BGRID only
         if( gridtype.EQ.BGRID_NE )then
            midpoint = (domain%x(1)%global%begin+domain%x(1)%global%end-1+shift)/2
@@ -534,7 +534,7 @@ subroutine MPP_DO_GROUP_UPDATE_(group, domain, d_type)
            is = domain%x(1)%global%begin; ie = domain%x(1)%global%end+shift
            if( .NOT. domain%symmetry ) is = is - 1
            do i = is ,ie, midpoint
-              if( domain%x(1)%data%begin.LE.i .AND. i.LE. domain%x(1)%data%end+shift )then
+              if( domain%x(1)%domain_data%begin.LE.i .AND. i.LE. domain%x(1)%domain_data%end+shift )then
                  do l=1,nvector
                     ptr_fieldx = group%addrs_x(l)
                     ptr_fieldy = group%addrs_y(l)
@@ -558,15 +558,15 @@ subroutine MPP_DO_GROUP_UPDATE_(group, domain, d_type)
               else
                  is = domain%x(1)%global%begin - 1
               end if
-              if( is.GT.domain%x(1)%data%begin )then
+              if( is.GT.domain%x(1)%domain_data%begin )then
 
-                 if( 2*is-domain%x(1)%data%begin.GT.domain%x(1)%data%end+shift ) &
+                 if( 2*is-domain%x(1)%domain_data%begin.GT.domain%x(1)%domain_data%end+shift ) &
                       call mpp_error( FATAL, 'MPP_DO_UPDATE_V: folded-north BGRID_NE west edge ubound error.' )
                  do l=1,nvector
                     ptr_fieldx = group%addrs_x(l)
                     ptr_fieldy = group%addrs_y(l)
                     do k = 1,ksize
-                       do i = domain%x(1)%data%begin,is-1
+                       do i = domain%x(1)%domain_data%begin,is-1
                           fieldx(i,j,k) = fieldx(2*is-i,j,k)
                           fieldy(i,j,k) = fieldy(2*is-i,j,k)
                        end do
@@ -577,7 +577,7 @@ subroutine MPP_DO_GROUP_UPDATE_(group, domain, d_type)
               is = domain%x(1)%global%begin
               isd = domain%x(1)%compute%begin - group%whalo_v
               if( is.GT.isd )then
-                 if( 2*is-domain%x(1)%data%begin-1.GT.domain%x(1)%data%end ) &
+                 if( 2*is-domain%x(1)%domain_data%begin-1.GT.domain%x(1)%domain_data%end ) &
                       call mpp_error( FATAL, 'MPP_DO_UPDATE_V: folded-north CGRID_NE west edge ubound error.' )
                  do l=1,nvector
                     ptr_fieldy = group%addrs_y(l)
@@ -592,7 +592,7 @@ subroutine MPP_DO_GROUP_UPDATE_(group, domain, d_type)
         end if
         !off east edge
         is = domain%x(1)%global%end
-        if(domain%x(1)%cyclic .AND. is.LT.domain%x(1)%data%end )then
+        if(domain%x(1)%cyclic .AND. is.LT.domain%x(1)%domain_data%end )then
            ie = domain%x(1)%compute%end+group%ehalo_v
            is = is + 1
            select case(gridtype)
@@ -802,7 +802,7 @@ subroutine MPP_COMPLETE_GROUP_UPDATE_(group, domain, d_type)
   if(domain%symmetry) shift = 1
   if( nvector >0 .AND. BTEST(domain%fold,NORTH) .AND. (.NOT.BTEST(flags_v,SCALAR_BIT)) )then
      j = domain%y(1)%global%end+shift
-     if( domain%y(1)%data%begin.LE.j .AND. j.LE.domain%y(1)%data%end+shift )then !fold is within domain
+     if( domain%y(1)%domain_data%begin.LE.j .AND. j.LE.domain%y(1)%domain_data%end+shift )then !fold is within domain
         !poles set to 0: BGRID only
         if( gridtype.EQ.BGRID_NE )then
            midpoint = (domain%x(1)%global%begin+domain%x(1)%global%end-1+shift)/2
@@ -810,7 +810,7 @@ subroutine MPP_COMPLETE_GROUP_UPDATE_(group, domain, d_type)
            is = domain%x(1)%global%begin; ie = domain%x(1)%global%end+shift
            if( .NOT. domain%symmetry ) is = is - 1
            do i = is ,ie, midpoint
-              if( domain%x(1)%data%begin.LE.i .AND. i.LE. domain%x(1)%data%end+shift )then
+              if( domain%x(1)%domain_data%begin.LE.i .AND. i.LE. domain%x(1)%domain_data%end+shift )then
                  do l=1,nvector
                     ptr_fieldx = group%addrs_x(l)
                     ptr_fieldy = group%addrs_y(l)
@@ -834,15 +834,15 @@ subroutine MPP_COMPLETE_GROUP_UPDATE_(group, domain, d_type)
               else
                  is = domain%x(1)%global%begin - 1
               end if
-              if( is.GT.domain%x(1)%data%begin )then
+              if( is.GT.domain%x(1)%domain_data%begin )then
 
-                 if( 2*is-domain%x(1)%data%begin.GT.domain%x(1)%data%end+shift ) &
+                 if( 2*is-domain%x(1)%domain_data%begin.GT.domain%x(1)%domain_data%end+shift ) &
                       call mpp_error( FATAL, 'MPP_DO_UPDATE_V: folded-north BGRID_NE west edge ubound error.' )
                  do l=1,nvector
                     ptr_fieldx = group%addrs_x(l)
                     ptr_fieldy = group%addrs_y(l)
                     do k = 1,ksize
-                       do i = domain%x(1)%data%begin,is-1
+                       do i = domain%x(1)%domain_data%begin,is-1
                           fieldx(i,j,k) = fieldx(2*is-i,j,k)
                           fieldy(i,j,k) = fieldy(2*is-i,j,k)
                        end do
@@ -853,7 +853,7 @@ subroutine MPP_COMPLETE_GROUP_UPDATE_(group, domain, d_type)
               is = domain%x(1)%global%begin
               isd = domain%x(1)%compute%begin - group%whalo_v
               if( is.GT.isd)then
-                 if( 2*is-domain%x(1)%data%begin-1.GT.domain%x(1)%data%end ) &
+                 if( 2*is-domain%x(1)%domain_data%begin-1.GT.domain%x(1)%domain_data%end ) &
                       call mpp_error( FATAL, 'MPP_DO_UPDATE_V: folded-north CGRID_NE west edge ubound error.' )
                  do l=1,nvector
                     ptr_fieldy = group%addrs_y(l)
@@ -868,7 +868,7 @@ subroutine MPP_COMPLETE_GROUP_UPDATE_(group, domain, d_type)
         end if
         !off east edge
         is = domain%x(1)%global%end
-        if(domain%x(1)%cyclic .AND. is.LT.domain%x(1)%data%end )then
+        if(domain%x(1)%cyclic .AND. is.LT.domain%x(1)%domain_data%end )then
            ie = domain%x(1)%compute%end+group%ehalo_v
            is = is + 1
            select case(gridtype)

--- a/mpp/include/mpp_scatter.fh
+++ b/mpp/include/mpp_scatter.fh
@@ -61,7 +61,7 @@ subroutine MPP_SCATTER_PELIST_3D_(is, ie, js, je, nk, pelist, array_seg, input_d
    integer :: i1, i2, j1, j2, ioff, joff
    integer :: my_ind(4), gind(4,size(pelist))
    type array3D
-     MPP_TYPE_, dimension(:,:,:), allocatable :: data
+     MPP_TYPE_, dimension(:,:,:), allocatable :: data3D_type
    endtype array3D
    type(array3d), dimension(size(pelist)) :: temp
 
@@ -132,9 +132,9 @@ subroutine MPP_SCATTER_PELIST_3D_(is, ie, js, je, nk, pelist, array_seg, input_d
          j2 = gind(4,i)
          msgsize = (i2-i1+1)*(j2-j1+1)*nk
 ! allocate and copy data into a contiguous memory space
-         allocate(temp(i)%data(i1:i2,j1:j2,1:nk))
-         temp(i)%data(i1:i2,j1:j2,1:nk)=input_data(i1:i2,j1:j2,1:nk)
-         call mpp_send(temp(i)%data, msgsize, pelist(i), COMM_TAG_2)
+         allocate(temp(i)%data3D_type(i1:i2,j1:j2,1:nk))
+         temp(i)%data3D_type(i1:i2,j1:j2,1:nk)=input_data(i1:i2,j1:j2,1:nk)
+         call mpp_send(temp(i)%data3D_type, msgsize, pelist(i), COMM_TAG_2)
        else
 !        data copy - no send to self
          array_seg(is:ie,js:je,1:nk) = input_data(is+ioff:ie+ioff,js+joff:je+joff,1:nk)
@@ -143,7 +143,7 @@ subroutine MPP_SCATTER_PELIST_3D_(is, ie, js, je, nk, pelist, array_seg, input_d
      call mpp_sync_self(check=EVENT_SEND)
 ! deallocate the temporary array used for the send
      do i = 1, size(pelist)
-       if (allocated(temp(i)%data)) deallocate(temp(i)%data)
+       if (allocated(temp(i)%data3D_type)) deallocate(temp(i)%data3D_type)
      enddo
    else
 !    non root_pe's recv data from root_pe

--- a/mpp/include/mpp_scatter.fh
+++ b/mpp/include/mpp_scatter.fh
@@ -24,22 +24,22 @@
 !!
 !> Scatter (ie - is) * (je - js) contiguous elements of array data from the designated root pe
 !! into contigous members of array segment in each pe that is included in the pelist argument.
-subroutine MPP_SCATTER_PELIST_2D_(is, ie, js, je, pelist, array_seg, data, is_root_pe, &
+subroutine MPP_SCATTER_PELIST_2D_(is, ie, js, je, pelist, array_seg, input_data, is_root_pe, &
                                   ishift, jshift)
    integer,                           intent(in)    :: is, ie, js, je !< indices of segment array
    integer,   dimension(:),           intent(in)    :: pelist !<PE list of target pes,
                                                               !! must be in monotonic increasing order
    MPP_TYPE_, dimension(is:ie,js:je), intent(inout)    :: array_seg !< 2D array of output data
-   MPP_TYPE_, dimension(:,:),         intent(in) :: data !< 2D array of input data
+   MPP_TYPE_, dimension(:,:),         intent(in) :: input_data !< 2D array of input data
    logical,                           intent(in)    :: is_root_pe !< true if calling from root
    integer,   optional,               intent(in)    :: ishift, jshift !< Offsets of array elements
 
    MPP_TYPE_ ::  arr3D(size(array_seg,1),size(array_seg,2),1)
-   MPP_TYPE_ :: data3D(size(     data,1),size(     data,2),1)
+   MPP_TYPE_ :: data3D(size(     input_data,1),size(     input_data,2),1)
    pointer( aptr,  arr3D )
    pointer( dptr, data3D )
    aptr = LOC(array_seg)
-   dptr = LOC(     data)
+   dptr = LOC(     input_data)
 
    call mpp_scatter(is, ie, js, je, 1, pelist, arr3D, data3D, is_root_pe, &
                     ishift, jshift)
@@ -48,12 +48,12 @@ subroutine MPP_SCATTER_PELIST_2D_(is, ie, js, je, pelist, array_seg, data, is_ro
 end subroutine MPP_SCATTER_PELIST_2D_
 
 
-subroutine MPP_SCATTER_PELIST_3D_(is, ie, js, je, nk, pelist, array_seg, data, is_root_pe, &
+subroutine MPP_SCATTER_PELIST_3D_(is, ie, js, je, nk, pelist, array_seg, input_data, is_root_pe, &
                                   ishift, jshift)
    integer,                                intent(in)    :: is, ie, js, je, nk
    integer,   dimension(:),                intent(in)    :: pelist
    MPP_TYPE_, dimension(is:ie,js:je,1:nk), intent(inout)    :: array_seg
-   MPP_TYPE_, dimension(:,:,:),            intent(in) :: data
+   MPP_TYPE_, dimension(:,:,:),            intent(in) :: input_data
    logical,                                intent(in)    :: is_root_pe
    integer,   optional,                    intent(in)    :: ishift, jshift
 
@@ -112,7 +112,8 @@ subroutine MPP_SCATTER_PELIST_3D_(is, ie, js, je, nk, pelist, array_seg, data, i
      gind(3,:)=gind(3,:)+joff
      gind(4,:)=gind(4,:)+joff
 ! check indices to make sure they are within the range of "data"
-     if ((minval(gind).lt.1) .OR. (maxval(gind(1:2,:)).gt.size(data,1)) .OR. (maxval(gind(3:4,:)).gt.size(data,2))) &
+     if ((minval(gind).lt.1) .OR. (maxval(gind(1:2,:)).gt.size(input_data,1)) &
+     .OR. (maxval(gind(3:4,:)).gt.size(input_data,2))) &
          call mpp_error(FATAL,"fms_io(mpp_scatter_pelist): specified indices (with shift) are outside of the &
                         &range of the receiving array")
    else
@@ -132,11 +133,11 @@ subroutine MPP_SCATTER_PELIST_3D_(is, ie, js, je, nk, pelist, array_seg, data, i
          msgsize = (i2-i1+1)*(j2-j1+1)*nk
 ! allocate and copy data into a contiguous memory space
          allocate(temp(i)%data(i1:i2,j1:j2,1:nk))
-         temp(i)%data(i1:i2,j1:j2,1:nk)=data(i1:i2,j1:j2,1:nk)
+         temp(i)%data(i1:i2,j1:j2,1:nk)=input_data(i1:i2,j1:j2,1:nk)
          call mpp_send(temp(i)%data, msgsize, pelist(i), COMM_TAG_2)
        else
 !        data copy - no send to self
-         array_seg(is:ie,js:je,1:nk) = data(is+ioff:ie+ioff,js+joff:je+joff,1:nk)
+         array_seg(is:ie,js:je,1:nk) = input_data(is+ioff:ie+ioff,js+joff:je+joff,1:nk)
        endif
      enddo
      call mpp_sync_self(check=EVENT_SEND)

--- a/mpp/include/mpp_transmit.inc
+++ b/mpp/include/mpp_transmit.inc
@@ -305,79 +305,79 @@
 !                                                                             !
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-    subroutine MPP_BROADCAST_SCALAR_( data, from_pe, pelist )
-      MPP_TYPE_, intent(inout) :: data
+    subroutine MPP_BROADCAST_SCALAR_( broadcast_data, from_pe, pelist )
+      MPP_TYPE_, intent(inout) :: broadcast_data
       integer, intent(in) :: from_pe
       integer, intent(in), optional :: pelist(:)
       MPP_TYPE_ :: data1D(1)
 
       pointer( ptr, data1D )
 
-      ptr = LOC(data)
+      ptr = LOC(broadcast_data)
       call MPP_BROADCAST_( data1D, 1, from_pe, pelist )
 
       return
     end subroutine MPP_BROADCAST_SCALAR_
 
-    subroutine MPP_BROADCAST_2D_( data, length, from_pe, pelist )
+    subroutine MPP_BROADCAST_2D_( broadcast_data, length, from_pe, pelist )
 !this call was originally bundled in with mpp_transmit, but that doesn't allow
 !broadcast to a subset of PEs. This version will, and mpp_transmit will remain
 !backward compatible.
-      MPP_TYPE_, intent(inout) :: data(:,:)
+      MPP_TYPE_, intent(inout) :: broadcast_data(:,:)
       integer, intent(in) :: length, from_pe
       integer, intent(in), optional :: pelist(:)
       MPP_TYPE_ :: data1D(length)
 
       pointer( ptr, data1D )
-      ptr = LOC(data)
+      ptr = LOC(broadcast_data)
       call mpp_broadcast( data1D, length, from_pe, pelist )
 
       return
     end subroutine MPP_BROADCAST_2D_
 
-    subroutine MPP_BROADCAST_3D_( data, length, from_pe, pelist )
+    subroutine MPP_BROADCAST_3D_( broadcast_data, length, from_pe, pelist )
 !this call was originally bundled in with mpp_transmit, but that doesn't allow
 !broadcast to a subset of PEs. This version will, and mpp_transmit will remain
 !backward compatible.
-      MPP_TYPE_, intent(inout) :: data(:,:,:)
+      MPP_TYPE_, intent(inout) :: broadcast_data(:,:,:)
       integer, intent(in) :: length, from_pe
       integer, intent(in), optional :: pelist(:)
       MPP_TYPE_ :: data1D(length)
 
       pointer( ptr, data1D )
-      ptr = LOC(data)
+      ptr = LOC(broadcast_data)
       call mpp_broadcast( data1D, length, from_pe, pelist )
 
       return
    end subroutine MPP_BROADCAST_3D_
 
-    subroutine MPP_BROADCAST_4D_( data, length, from_pe, pelist )
+    subroutine MPP_BROADCAST_4D_( broadcast_data, length, from_pe, pelist )
 !this call was originally bundled in with mpp_transmit, but that doesn't allow
 !broadcast to a subset of PEs. This version will, and mpp_transmit will remain
 !backward compatible.
-      MPP_TYPE_, intent(inout) :: data(:,:,:,:)
+      MPP_TYPE_, intent(inout) :: broadcast_data(:,:,:,:)
       integer, intent(in) :: length, from_pe
       integer, intent(in), optional :: pelist(:)
       MPP_TYPE_ :: data1D(length)
 
       pointer( ptr, data1D )
-      ptr = LOC(data)
+      ptr = LOC(broadcast_data)
       call mpp_broadcast( data1D, length, from_pe, pelist )
 
       return
     end subroutine MPP_BROADCAST_4D_
 
-    subroutine MPP_BROADCAST_5D_( data, length, from_pe, pelist )
+    subroutine MPP_BROADCAST_5D_( broadcast_data, length, from_pe, pelist )
 !this call was originally bundled in with mpp_transmit, but that doesn't allow
 !broadcast to a subset of PEs. This version will, and mpp_transmit will remain
 !backward compatible.
-      MPP_TYPE_, intent(inout) :: data(:,:,:,:,:)
+      MPP_TYPE_, intent(inout) :: broadcast_data(:,:,:,:,:)
       integer, intent(in) :: length, from_pe
       integer, intent(in), optional :: pelist(:)
       MPP_TYPE_ :: data1D(length)
 
       pointer( ptr, data1D )
-      ptr = LOC(data)
+      ptr = LOC(broadcast_data)
       call mpp_broadcast( data1D, length, from_pe, pelist )
 
       return

--- a/mpp/include/mpp_transmit_mpi.fh
+++ b/mpp/include/mpp_transmit_mpi.fh
@@ -164,11 +164,11 @@
 !                                                                             !
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     !> Broadcasts data to a pelist
-    subroutine MPP_BROADCAST_( data, length, from_pe, pelist )
+    subroutine MPP_BROADCAST_( broadcast_data, length, from_pe, pelist )
 !this call was originally bundled in with mpp_transmit, but that doesn't allow
 !broadcast to a subset of PEs. This version will, and mpp_transmit will remain
 !backward compatible.
-      MPP_TYPE_, intent(inout) :: data(*)
+      MPP_TYPE_, intent(inout) :: broadcast_data(*)
       integer, intent(in) :: length, from_pe
       integer, intent(in), optional :: pelist(:)
       integer :: n, i, from_rank, stdout_unit
@@ -193,7 +193,7 @@
              exit
          endif
       enddo
-      if( mpp_npes().GT.1 )call MPI_BCAST( data, length, MPI_TYPE_, from_rank, peset(n)%id, error )
+      if( mpp_npes().GT.1 )call MPI_BCAST( broadcast_data, length, MPI_TYPE_, from_rank, peset(n)%id, error )
       if( debug .and. (current_clock.NE.0) )call increment_current_clock( EVENT_BROADCAST, length*MPP_TYPE_BYTELEN_ )
       return
     end subroutine MPP_BROADCAST_

--- a/mpp/include/mpp_unstruct_pass_data.fh
+++ b/mpp/include/mpp_unstruct_pass_data.fh
@@ -50,10 +50,10 @@ SUBROUTINE mpp_pass_SG_to_UG_3D_(UG_domain, field_SG, field_UG)
      size(field_SG,2) .EQ. UG_domain%SG_domain%y(1)%compute%size) then
      ioff = 1 - UG_domain%SG_domain%x(1)%compute%begin
      joff = 1 - UG_domain%SG_domain%y(1)%compute%begin
-  else if(size(field_SG,1) .EQ. UG_domain%SG_domain%x(1)%data%size .AND.  &
-          size(field_SG,2) .EQ. UG_domain%SG_domain%y(1)%data%size) then
-     ioff = 1 - UG_domain%SG_domain%x(1)%data%begin
-     joff = 1 - UG_domain%SG_domain%y(1)%data%begin
+  else if(size(field_SG,1) .EQ. UG_domain%SG_domain%x(1)%domain_data%size .AND.  &
+          size(field_SG,2) .EQ. UG_domain%SG_domain%y(1)%domain_data%size) then
+     ioff = 1 - UG_domain%SG_domain%x(1)%domain_data%begin
+     joff = 1 - UG_domain%SG_domain%y(1)%domain_data%begin
   else
      call mpp_error( FATAL, 'mpp_pass_SG_to_UG_3D_: field_SG must match either compute domain or data domain.' )
   endif
@@ -154,10 +154,10 @@ SUBROUTINE mpp_pass_UG_to_SG_3D_(UG_domain, field_UG, field_SG)
      size(field_SG,2) .EQ. UG_domain%SG_domain%y(1)%compute%size) then
      ioff = 1 - UG_domain%SG_domain%x(1)%compute%begin
      joff = 1 - UG_domain%SG_domain%y(1)%compute%begin
-  else if(size(field_SG,1) .EQ. UG_domain%SG_domain%x(1)%data%size .AND.  &
-          size(field_SG,2) .EQ. UG_domain%SG_domain%y(1)%data%size) then
-     ioff = 1 - UG_domain%SG_domain%x(1)%data%begin
-     joff = 1 - UG_domain%SG_domain%y(1)%data%begin
+  else if(size(field_SG,1) .EQ. UG_domain%SG_domain%x(1)%domain_data%size .AND.  &
+          size(field_SG,2) .EQ. UG_domain%SG_domain%y(1)%domain_data%size) then
+     ioff = 1 - UG_domain%SG_domain%x(1)%domain_data%begin
+     joff = 1 - UG_domain%SG_domain%y(1)%domain_data%begin
   else
      call mpp_error( FATAL, 'mpp_pass_UG_to_SG_3D_: field_SG must match either compute domain or data domain.' )
   endif

--- a/mpp/include/mpp_update_domains2D_nonblock.fh
+++ b/mpp/include/mpp_update_domains2D_nonblock.fh
@@ -45,7 +45,7 @@ function MPP_START_UPDATE_DOMAINS_3D_( field, domain, flags, position, &
                                        whalo, ehalo, shalo, nhalo, name, tile_count, update_id, complete )
 
   type(domain2D),   intent(inout)        :: domain
-  MPP_TYPE_,        intent(inout)        :: field(domain%x(1)%data%begin:,domain%y(1)%data%begin:,:)
+  MPP_TYPE_,        intent(inout)        :: field(domain%x(1)%domain_data%begin:,domain%y(1)%domain_data%begin:,:)
   integer,          intent(in), optional :: flags
   integer,          intent(in), optional :: position
   integer,          intent(in), optional :: whalo, ehalo, shalo, nhalo ! specify halo region to be updated.
@@ -316,7 +316,7 @@ subroutine MPP_COMPLETE_UPDATE_DOMAINS_3D_( id_update, field, domain, flags, pos
                                             whalo, ehalo, shalo, nhalo, name, tile_count, complete )
   integer,          intent(in)           :: id_update
   type(domain2D),   intent(inout)        :: domain
-  MPP_TYPE_,        intent(inout)        :: field(domain%x(1)%data%begin:,domain%y(1)%data%begin:,:)
+  MPP_TYPE_,        intent(inout)        :: field(domain%x(1)%domain_data%begin:,domain%y(1)%domain_data%begin:,:)
   integer,          intent(in), optional :: flags
   integer,          intent(in), optional :: position
   integer,          intent(in), optional :: whalo, ehalo, shalo, nhalo ! specify halo region to be updated.

--- a/mpp/mpp_domains.F90
+++ b/mpp/mpp_domains.F90
@@ -628,7 +628,7 @@ module mpp_domains_mod
   type :: domain1D
      private
      type(domain_axis_spec) :: compute !< index limits for compute domain
-     type(domain_axis_spec) :: data    !< index limits for data domain
+     type(domain_axis_spec) :: domain_data !< index limits for data domain
      type(domain_axis_spec) :: global  !< index limits for global domain
      type(domain_axis_spec) :: memory  !< index limits for memory domain
      logical :: cyclic !< true if domain is cyclic

--- a/mpp/mpp_domains.F90
+++ b/mpp/mpp_domains.F90
@@ -452,7 +452,7 @@ module mpp_domains_mod
   type :: nest_domain_type
      character(len=NAME_LENGTH)     :: name
      integer                        :: num_level
-     integer,               pointer :: nest_level(:)    !< Added for moving nest functionality
+     integer,               pointer :: nest_level(:) => NULL() !< Added for moving nest functionality
      type(nest_level_type), pointer :: nest(:) => NULL()
      integer                        :: num_nest
      integer,               pointer :: tile_fine(:), tile_coarse(:)

--- a/test_fms/mpp/fill_halo.F90
+++ b/test_fms/mpp/fill_halo.F90
@@ -90,285 +90,285 @@ end interface fill_folded_west_halo
 contains
 
   !> fill the halo region of a 64-bit real array with zeros
-  subroutine fill_halo_zero_r8(data, whalo, ehalo, shalo, nhalo, xshift, yshift, isc, iec, jsc, jec, isd, ied, &
+  subroutine fill_halo_zero_r8(halo_data, whalo, ehalo, shalo, nhalo, xshift, yshift, isc, iec, jsc, jec, isd, ied, &
                               &  jsd, jed)
-    real(kind=r8_kind), dimension(isd:,jsd:,:), intent(inout) :: data
+    real(kind=r8_kind), dimension(isd:,jsd:,:), intent(inout) :: halo_data
     integer,                         intent(in) :: isc, iec, jsc, jec, isd, ied, jsd, jed
     integer,                         intent(in) :: whalo, ehalo, shalo, nhalo, xshift, yshift
 
     if(whalo >=0) then
-       data(iec+ehalo+1+xshift:ied+xshift,jsd:jed+yshift,:) = 0
-       data(isd:isc-whalo-1,jsd:jed+yshift,:) = 0
+       halo_data(iec+ehalo+1+xshift:ied+xshift,jsd:jed+yshift,:) = 0
+       halo_data(isd:isc-whalo-1,jsd:jed+yshift,:) = 0
     else
-       data(iec+1+xshift:iec-ehalo+xshift,jsc+shalo:jec-nhalo+yshift,:) = 0
-       data(isc+whalo:isc-1,jsc+shalo:jec-nhalo+yshift,:) = 0
+       halo_data(iec+1+xshift:iec-ehalo+xshift,jsc+shalo:jec-nhalo+yshift,:) = 0
+       halo_data(isc+whalo:isc-1,jsc+shalo:jec-nhalo+yshift,:) = 0
     end if
 
     if(shalo>=0) then
-       data(isd:ied+xshift, jec+nhalo+1+yshift:jed+yshift,:) = 0
-       data(isd:ied+xshift, jsd:jsc-shalo-1,:) = 0
+       halo_data(isd:ied+xshift, jec+nhalo+1+yshift:jed+yshift,:) = 0
+       halo_data(isd:ied+xshift, jsd:jsc-shalo-1,:) = 0
     else
-       data(isc+whalo:iec-ehalo+xshift,jec+1+yshift:jec-nhalo+yshift,:) = 0
-       data(isc+whalo:iec-ehalo+xshift,jsc+shalo:jsc-1,:) = 0
+       halo_data(isc+whalo:iec-ehalo+xshift,jec+1+yshift:jec-nhalo+yshift,:) = 0
+       halo_data(isc+whalo:iec-ehalo+xshift,jsc+shalo:jsc-1,:) = 0
     end if
   end subroutine fill_halo_zero_r8
 
   !> fill the halo region of a 32-bit real array with zeros
-  subroutine fill_halo_zero_r4(data, whalo, ehalo, shalo, nhalo, xshift, yshift, isc, iec, jsc, jec, isd, ied, &
+  subroutine fill_halo_zero_r4(halo_data, whalo, ehalo, shalo, nhalo, xshift, yshift, isc, iec, jsc, jec, isd, ied, &
                               &  jsd, jed)
-    real(kind=r4_kind), dimension(isd:,jsd:,:), intent(inout) :: data
+    real(kind=r4_kind), dimension(isd:,jsd:,:), intent(inout) :: halo_data
     integer,                         intent(in) :: isc, iec, jsc, jec, isd, ied, jsd, jed
     integer,                         intent(in) :: whalo, ehalo, shalo, nhalo, xshift, yshift
 
     if(whalo >=0) then
-       data(iec+ehalo+1+xshift:ied+xshift,jsd:jed+yshift,:) = 0
-       data(isd:isc-whalo-1,jsd:jed+yshift,:) = 0
+      halo_data(iec+ehalo+1+xshift:ied+xshift,jsd:jed+yshift,:) = 0
+      halo_data(isd:isc-whalo-1,jsd:jed+yshift,:) = 0
     else
-       data(iec+1+xshift:iec-ehalo+xshift,jsc+shalo:jec-nhalo+yshift,:) = 0
-       data(isc+whalo:isc-1,jsc+shalo:jec-nhalo+yshift,:) = 0
+      halo_data(iec+1+xshift:iec-ehalo+xshift,jsc+shalo:jec-nhalo+yshift,:) = 0
+      halo_data(isc+whalo:isc-1,jsc+shalo:jec-nhalo+yshift,:) = 0
     end if
 
     if(shalo>=0) then
-       data(isd:ied+xshift, jec+nhalo+1+yshift:jed+yshift,:) = 0
-       data(isd:ied+xshift, jsd:jsc-shalo-1,:) = 0
+      halo_data(isd:ied+xshift, jec+nhalo+1+yshift:jed+yshift,:) = 0
+      halo_data(isd:ied+xshift, jsd:jsc-shalo-1,:) = 0
     else
-       data(isc+whalo:iec-ehalo+xshift,jec+1+yshift:jec-nhalo+yshift,:) = 0
-       data(isc+whalo:iec-ehalo+xshift,jsc+shalo:jsc-1,:) = 0
+      halo_data(isc+whalo:iec-ehalo+xshift,jec+1+yshift:jec-nhalo+yshift,:) = 0
+      halo_data(isc+whalo:iec-ehalo+xshift,jsc+shalo:jsc-1,:) = 0
     end if
   end subroutine fill_halo_zero_r4
 
 !> fill the halo region of a 64-bit integer array with zeros
-  subroutine fill_halo_zero_i8(data, whalo, ehalo, shalo, nhalo, xshift, yshift, isc, iec, jsc, jec, isd, ied, &
+  subroutine fill_halo_zero_i8(halo_data, whalo, ehalo, shalo, nhalo, xshift, yshift, isc, iec, jsc, jec, isd, ied, &
                               &  jsd, jed)
-    integer(kind=i8_kind), dimension(isd:,jsd:,:), intent(inout) :: data
+    integer(kind=i8_kind), dimension(isd:,jsd:,:), intent(inout) :: halo_data
     integer,                         intent(in) :: isc, iec, jsc, jec, isd, ied, jsd, jed
     integer,                         intent(in) :: whalo, ehalo, shalo, nhalo, xshift, yshift
 
     if(whalo >=0) then
-       data(iec+ehalo+1+xshift:ied+xshift,jsd:jed+yshift,:) = 0
-       data(isd:isc-whalo-1,jsd:jed+yshift,:) = 0
+      halo_data(iec+ehalo+1+xshift:ied+xshift,jsd:jed+yshift,:) = 0
+      halo_data(isd:isc-whalo-1,jsd:jed+yshift,:) = 0
     else
-       data(iec+1+xshift:iec-ehalo+xshift,jsc+shalo:jec-nhalo+yshift,:) = 0
-       data(isc+whalo:isc-1,jsc+shalo:jec-nhalo+yshift,:) = 0
+      halo_data(iec+1+xshift:iec-ehalo+xshift,jsc+shalo:jec-nhalo+yshift,:) = 0
+      halo_data(isc+whalo:isc-1,jsc+shalo:jec-nhalo+yshift,:) = 0
     end if
 
     if(shalo>=0) then
-       data(isd:ied+xshift, jec+nhalo+1+yshift:jed+yshift,:) = 0
-       data(isd:ied+xshift, jsd:jsc-shalo-1,:) = 0
+      halo_data(isd:ied+xshift, jec+nhalo+1+yshift:jed+yshift,:) = 0
+      halo_data(isd:ied+xshift, jsd:jsc-shalo-1,:) = 0
     else
-       data(isc+whalo:iec-ehalo+xshift,jec+1+yshift:jec-nhalo+yshift,:) = 0
-       data(isc+whalo:iec-ehalo+xshift,jsc+shalo:jsc-1,:) = 0
+      halo_data(isc+whalo:iec-ehalo+xshift,jec+1+yshift:jec-nhalo+yshift,:) = 0
+      halo_data(isc+whalo:iec-ehalo+xshift,jsc+shalo:jsc-1,:) = 0
     end if
   end subroutine fill_halo_zero_i8
 
 !> fill the halo region of a 32-bit integer array with zeros
-  subroutine fill_halo_zero_i4(data, whalo, ehalo, shalo, nhalo, xshift, yshift, isc, iec, jsc, jec, isd, ied, &
+  subroutine fill_halo_zero_i4(halo_data, whalo, ehalo, shalo, nhalo, xshift, yshift, isc, iec, jsc, jec, isd, ied, &
                               &  jsd, jed)
-    integer(kind=i4_kind), dimension(isd:,jsd:,:), intent(inout) :: data
+    integer(kind=i4_kind), dimension(isd:,jsd:,:), intent(inout) :: halo_data
     integer,                         intent(in) :: isc, iec, jsc, jec, isd, ied, jsd, jed
     integer,                         intent(in) :: whalo, ehalo, shalo, nhalo, xshift, yshift
 
     if(whalo >=0) then
-       data(iec+ehalo+1+xshift:ied+xshift,jsd:jed+yshift,:) = 0
-       data(isd:isc-whalo-1,jsd:jed+yshift,:) = 0
+      halo_data(iec+ehalo+1+xshift:ied+xshift,jsd:jed+yshift,:) = 0
+      halo_data(isd:isc-whalo-1,jsd:jed+yshift,:) = 0
     else
-       data(iec+1+xshift:iec-ehalo+xshift,jsc+shalo:jec-nhalo+yshift,:) = 0
-       data(isc+whalo:isc-1,jsc+shalo:jec-nhalo+yshift,:) = 0
+      halo_data(iec+1+xshift:iec-ehalo+xshift,jsc+shalo:jec-nhalo+yshift,:) = 0
+      halo_data(isc+whalo:isc-1,jsc+shalo:jec-nhalo+yshift,:) = 0
     end if
 
     if(shalo>=0) then
-       data(isd:ied+xshift, jec+nhalo+1+yshift:jed+yshift,:) = 0
-       data(isd:ied+xshift, jsd:jsc-shalo-1,:) = 0
+      halo_data(isd:ied+xshift, jec+nhalo+1+yshift:jed+yshift,:) = 0
+      halo_data(isd:ied+xshift, jsd:jsc-shalo-1,:) = 0
     else
-       data(isc+whalo:iec-ehalo+xshift,jec+1+yshift:jec-nhalo+yshift,:) = 0
-       data(isc+whalo:iec-ehalo+xshift,jsc+shalo:jsc-1,:) = 0
+      halo_data(isc+whalo:iec-ehalo+xshift,jec+1+yshift:jec-nhalo+yshift,:) = 0
+      halo_data(isc+whalo:iec-ehalo+xshift,jsc+shalo:jsc-1,:) = 0
     end if
   end subroutine fill_halo_zero_i4
 
 
   !> fill the halo region of 64-bit array on a regular grid
-  subroutine fill_regular_refinement_halo_r8( data, data_all, ni, nj, tm, te, tse, ts, &
+  subroutine fill_regular_refinement_halo_r8( halo_data, data_all, ni, nj, tm, te, tse, ts, &
                                              tsw, tw, tnw, tn, tne, ioff, joff )
-    real(kind=r8_kind), dimension(1-whalo:,1-shalo:,:), intent(inout) :: data
+    real(kind=r8_kind), dimension(1-whalo:,1-shalo:,:), intent(inout) :: halo_data
     real(kind=r8_kind), dimension(:,:,:,:),             intent(in)    :: data_all
     integer, dimension(:),                intent(in)    :: ni, nj
     integer,                              intent(in)    :: tm, te, tse, ts, tsw, tw, tnw, tn, tne
     integer,                              intent(in)    :: ioff, joff
 
 
-    if(te>0) data    (ni(tm)+1+ioff:ni(tm)+ehalo+ioff, 1:nj(tm)+joff,                   :) = &
+    if(te>0) halo_data    (ni(tm)+1+ioff:ni(tm)+ehalo+ioff, 1:nj(tm)+joff,                   :) = &
              data_all(1+ioff:ehalo+ioff,               1:nj(te)+joff,                   :,te)  ! east
-    if(ts>0) data    (1:ni(tm)+ioff,                   1-shalo:0,                       :) = &
+    if(ts>0) halo_data    (1:ni(tm)+ioff,                   1-shalo:0,                       :) = &
              data_all(1:ni(ts)+ioff,                   nj(ts)-shalo+1:nj(ts),           :,ts)  ! south
-    if(tw>0) data    (1-whalo:0,                       1:nj(tm)+joff,                   :) = &
+    if(tw>0) halo_data    (1-whalo:0,                       1:nj(tm)+joff,                   :) = &
              data_all(ni(tw)-whalo+1:ni(tw),           1:nj(tw)+joff,                   :,tw)  ! west
-    if(tn>0) data    (1:ni(tm)+ioff,                   nj(tm)+1+joff:nj(tm)+nhalo+joff, :) = &
+    if(tn>0) halo_data    (1:ni(tm)+ioff,                   nj(tm)+1+joff:nj(tm)+nhalo+joff, :) = &
              data_all(1:ni(tn)+ioff,                   1+joff:nhalo+joff,               :,tn)  ! north
-    if(tse>0)data    (ni(tm)+1+ioff:ni(tm)+ehalo+ioff, 1-shalo:0,                       :) = &
+    if(tse>0)halo_data    (ni(tm)+1+ioff:ni(tm)+ehalo+ioff, 1-shalo:0,                       :) = &
              data_all(1+ioff:ehalo+ioff,               nj(tse)-shalo+1:nj(tse),         :,tse) ! southeast
-    if(tsw>0)data    (1-whalo:0,                       1-shalo:0,                       :) = &
+    if(tsw>0)halo_data    (1-whalo:0,                       1-shalo:0,                       :) = &
              data_all(ni(tsw)-whalo+1:ni(tsw),         nj(tsw)-shalo+1:nj(tsw),         :,tsw) ! southwest
-    if(tne>0)data    (ni(tm)+1+ioff:ni(tm)+ehalo+ioff, nj(tm)+1+joff:nj(tm)+nhalo+joff, :) = &
+    if(tne>0)halo_data    (ni(tm)+1+ioff:ni(tm)+ehalo+ioff, nj(tm)+1+joff:nj(tm)+nhalo+joff, :) = &
              data_all(1+ioff:ehalo+ioff,               1+joff:nhalo+joff,               :,tnw) ! northeast
-    if(tnw>0)data    (1-whalo:0,                       nj(tm)+1+joff:nj(tm)+nhalo+joff, :) = &
+    if(tnw>0)halo_data    (1-whalo:0,                       nj(tm)+1+joff:nj(tm)+nhalo+joff, :) = &
              data_all(ni(tnw)-whalo+1:ni(tnw),         1+joff:nhalo+joff,               :,tne) ! northwest
 
   end subroutine fill_regular_refinement_halo_r8
 
   !> fill the halo region of 32-bit array on a regular grid
-  subroutine fill_regular_refinement_halo_r4( data, data_all, ni, nj, tm, te, tse, ts, tsw, tw, tnw, tn, tne, &
+  subroutine fill_regular_refinement_halo_r4( halo_data, data_all, ni, nj, tm, te, tse, ts, tsw, tw, tnw, tn, tne, &
                                             &  ioff, joff )
-    real(kind=r4_kind), dimension(1-whalo:,1-shalo:,:), intent(inout) :: data
+    real(kind=r4_kind), dimension(1-whalo:,1-shalo:,:), intent(inout) :: halo_data
     real(kind=r4_kind), dimension(:,:,:,:),             intent(in)    :: data_all
     integer, dimension(:),                intent(in)    :: ni, nj
     integer,                              intent(in)    :: tm, te, tse, ts, tsw, tw, tnw, tn, tne
     integer,                              intent(in)    :: ioff, joff
 
 
-    if(te>0) data    (ni(tm)+1+ioff:ni(tm)+ehalo+ioff, 1:nj(tm)+joff,                   :) = &
+    if(te>0) halo_data    (ni(tm)+1+ioff:ni(tm)+ehalo+ioff, 1:nj(tm)+joff,                   :) = &
              data_all(1+ioff:ehalo+ioff,               1:nj(te)+joff,                   :,te)  ! east
-    if(ts>0) data    (1:ni(tm)+ioff,                   1-shalo:0,                       :) = &
+    if(ts>0) halo_data    (1:ni(tm)+ioff,                   1-shalo:0,                       :) = &
              data_all(1:ni(ts)+ioff,                   nj(ts)-shalo+1:nj(ts),           :,ts)  ! south
-    if(tw>0) data    (1-whalo:0,                       1:nj(tm)+joff,                   :) = &
+    if(tw>0) halo_data    (1-whalo:0,                       1:nj(tm)+joff,                   :) = &
              data_all(ni(tw)-whalo+1:ni(tw),           1:nj(tw)+joff,                   :,tw)  ! west
-    if(tn>0) data    (1:ni(tm)+ioff,                   nj(tm)+1+joff:nj(tm)+nhalo+joff, :) = &
+    if(tn>0) halo_data    (1:ni(tm)+ioff,                   nj(tm)+1+joff:nj(tm)+nhalo+joff, :) = &
              data_all(1:ni(tn)+ioff,                   1+joff:nhalo+joff,               :,tn)  ! north
-    if(tse>0)data    (ni(tm)+1+ioff:ni(tm)+ehalo+ioff, 1-shalo:0,                       :) = &
+    if(tse>0)halo_data    (ni(tm)+1+ioff:ni(tm)+ehalo+ioff, 1-shalo:0,                       :) = &
              data_all(1+ioff:ehalo+ioff,               nj(tse)-shalo+1:nj(tse),         :,tse) ! southeast
-    if(tsw>0)data    (1-whalo:0,                       1-shalo:0,                       :) = &
+    if(tsw>0)halo_data    (1-whalo:0,                       1-shalo:0,                       :) = &
              data_all(ni(tsw)-whalo+1:ni(tsw),         nj(tsw)-shalo+1:nj(tsw),         :,tsw) ! southwest
-    if(tne>0)data    (ni(tm)+1+ioff:ni(tm)+ehalo+ioff, nj(tm)+1+joff:nj(tm)+nhalo+joff, :) = &
+    if(tne>0)halo_data    (ni(tm)+1+ioff:ni(tm)+ehalo+ioff, nj(tm)+1+joff:nj(tm)+nhalo+joff, :) = &
              data_all(1+ioff:ehalo+ioff,               1+joff:nhalo+joff,               :,tnw) ! northeast
-    if(tnw>0)data    (1-whalo:0,                       nj(tm)+1+joff:nj(tm)+nhalo+joff, :) = &
+    if(tnw>0)halo_data    (1-whalo:0,                       nj(tm)+1+joff:nj(tm)+nhalo+joff, :) = &
              data_all(ni(tnw)-whalo+1:ni(tnw),         1+joff:nhalo+joff,               :,tne) ! northwest
 
   end subroutine fill_regular_refinement_halo_r4
 
 !> fill the halo region of 64-bit integer array on a regular grid
-  subroutine fill_regular_refinement_halo_i8( data, data_all, ni, nj, tm, te, tse, ts, tsw, &
+  subroutine fill_regular_refinement_halo_i8( halo_data, data_all, ni, nj, tm, te, tse, ts, tsw, &
                                              tw, tnw, tn, tne, ioff, joff )
-    integer(kind=i8_kind), dimension(1-whalo:,1-shalo:,:), intent(inout) :: data
+    integer(kind=i8_kind), dimension(1-whalo:,1-shalo:,:), intent(inout) :: halo_data
     integer(kind=i8_kind), dimension(:,:,:,:),             intent(in)    :: data_all
     integer, dimension(:),                intent(in)    :: ni, nj
     integer,                              intent(in)    :: tm, te, tse, ts, tsw, tw, tnw, tn, tne
     integer,                              intent(in)    :: ioff, joff
 
 
-    if(te>0) data    (ni(tm)+1+ioff:ni(tm)+ehalo+ioff, 1:nj(tm)+joff,                   :) = &
+    if(te>0) halo_data    (ni(tm)+1+ioff:ni(tm)+ehalo+ioff, 1:nj(tm)+joff,                   :) = &
              data_all(1+ioff:ehalo+ioff,               1:nj(te)+joff,                   :,te)  ! east
-    if(ts>0) data    (1:ni(tm)+ioff,                   1-shalo:0,                       :) = &
+    if(ts>0) halo_data    (1:ni(tm)+ioff,                   1-shalo:0,                       :) = &
              data_all(1:ni(ts)+ioff,                   nj(ts)-shalo+1:nj(ts),           :,ts)  ! south
-    if(tw>0) data    (1-whalo:0,                       1:nj(tm)+joff,                   :) = &
+    if(tw>0) halo_data    (1-whalo:0,                       1:nj(tm)+joff,                   :) = &
              data_all(ni(tw)-whalo+1:ni(tw),           1:nj(tw)+joff,                   :,tw)  ! west
-    if(tn>0) data    (1:ni(tm)+ioff,                   nj(tm)+1+joff:nj(tm)+nhalo+joff, :) = &
+    if(tn>0) halo_data    (1:ni(tm)+ioff,                   nj(tm)+1+joff:nj(tm)+nhalo+joff, :) = &
              data_all(1:ni(tn)+ioff,                   1+joff:nhalo+joff,               :,tn)  ! north
-    if(tse>0)data    (ni(tm)+1+ioff:ni(tm)+ehalo+ioff, 1-shalo:0,                       :) = &
+    if(tse>0)halo_data    (ni(tm)+1+ioff:ni(tm)+ehalo+ioff, 1-shalo:0,                       :) = &
              data_all(1+ioff:ehalo+ioff,               nj(tse)-shalo+1:nj(tse),         :,tse) ! southeast
-    if(tsw>0)data    (1-whalo:0,                       1-shalo:0,                       :) = &
+    if(tsw>0)halo_data    (1-whalo:0,                       1-shalo:0,                       :) = &
              data_all(ni(tsw)-whalo+1:ni(tsw),         nj(tsw)-shalo+1:nj(tsw),         :,tsw) ! southwest
-    if(tne>0)data    (ni(tm)+1+ioff:ni(tm)+ehalo+ioff, nj(tm)+1+joff:nj(tm)+nhalo+joff, :) = &
+    if(tne>0)halo_data    (ni(tm)+1+ioff:ni(tm)+ehalo+ioff, nj(tm)+1+joff:nj(tm)+nhalo+joff, :) = &
              data_all(1+ioff:ehalo+ioff,               1+joff:nhalo+joff,               :,tnw) ! northeast
-    if(tnw>0)data    (1-whalo:0,                       nj(tm)+1+joff:nj(tm)+nhalo+joff, :) = &
+    if(tnw>0)halo_data    (1-whalo:0,                       nj(tm)+1+joff:nj(tm)+nhalo+joff, :) = &
              data_all(ni(tnw)-whalo+1:ni(tnw),         1+joff:nhalo+joff,               :,tne) ! northwest
 
   end subroutine fill_regular_refinement_halo_i8
 
 !> fill the halo region of 32-bit integer array on a regular grid
-  subroutine fill_regular_refinement_halo_i4( data, data_all, ni, nj, tm, te, tse, ts, tsw, tw, tnw, tn, tne, &
+  subroutine fill_regular_refinement_halo_i4( halo_data, data_all, ni, nj, tm, te, tse, ts, tsw, tw, tnw, tn, tne, &
                                             &  ioff, joff )
-    integer(kind=i4_kind), dimension(1-whalo:,1-shalo:,:), intent(inout) :: data
+    integer(kind=i4_kind), dimension(1-whalo:,1-shalo:,:), intent(inout) :: halo_data
     integer(kind=i4_kind), dimension(:,:,:,:),             intent(in)    :: data_all
     integer, dimension(:),                intent(in)    :: ni, nj
     integer,                              intent(in)    :: tm, te, tse, ts, tsw, tw, tnw, tn, tne
     integer,                              intent(in)    :: ioff, joff
 
 
-    if(te>0) data    (ni(tm)+1+ioff:ni(tm)+ehalo+ioff, 1:nj(tm)+joff,                   :) = &
+    if(te>0) halo_data    (ni(tm)+1+ioff:ni(tm)+ehalo+ioff, 1:nj(tm)+joff,                   :) = &
              data_all(1+ioff:ehalo+ioff,               1:nj(te)+joff,                   :,te)  ! east
-    if(ts>0) data    (1:ni(tm)+ioff,                   1-shalo:0,                       :) = &
+    if(ts>0) halo_data    (1:ni(tm)+ioff,                   1-shalo:0,                       :) = &
              data_all(1:ni(ts)+ioff,                   nj(ts)-shalo+1:nj(ts),           :,ts)  ! south
-    if(tw>0) data    (1-whalo:0,                       1:nj(tm)+joff,                   :) = &
+    if(tw>0) halo_data    (1-whalo:0,                       1:nj(tm)+joff,                   :) = &
              data_all(ni(tw)-whalo+1:ni(tw),           1:nj(tw)+joff,                   :,tw)  ! west
-    if(tn>0) data    (1:ni(tm)+ioff,                   nj(tm)+1+joff:nj(tm)+nhalo+joff, :) = &
+    if(tn>0) halo_data    (1:ni(tm)+ioff,                   nj(tm)+1+joff:nj(tm)+nhalo+joff, :) = &
              data_all(1:ni(tn)+ioff,                   1+joff:nhalo+joff,               :,tn)  ! north
-    if(tse>0)data    (ni(tm)+1+ioff:ni(tm)+ehalo+ioff, 1-shalo:0,                       :) = &
+    if(tse>0)halo_data    (ni(tm)+1+ioff:ni(tm)+ehalo+ioff, 1-shalo:0,                       :) = &
              data_all(1+ioff:ehalo+ioff,               nj(tse)-shalo+1:nj(tse),         :,tse) ! southeast
-    if(tsw>0)data    (1-whalo:0,                       1-shalo:0,                       :) = &
+    if(tsw>0)halo_data    (1-whalo:0,                       1-shalo:0,                       :) = &
              data_all(ni(tsw)-whalo+1:ni(tsw),         nj(tsw)-shalo+1:nj(tsw),         :,tsw) ! southwest
-    if(tne>0)data    (ni(tm)+1+ioff:ni(tm)+ehalo+ioff, nj(tm)+1+joff:nj(tm)+nhalo+joff, :) = &
+    if(tne>0)halo_data    (ni(tm)+1+ioff:ni(tm)+ehalo+ioff, nj(tm)+1+joff:nj(tm)+nhalo+joff, :) = &
              data_all(1+ioff:ehalo+ioff,               1+joff:nhalo+joff,               :,tnw) ! northeast
-    if(tnw>0)data    (1-whalo:0,                       nj(tm)+1+joff:nj(tm)+nhalo+joff, :) = &
+    if(tnw>0)halo_data    (1-whalo:0,                       nj(tm)+1+joff:nj(tm)+nhalo+joff, :) = &
              data_all(ni(tnw)-whalo+1:ni(tnw),         1+joff:nhalo+joff,               :,tne) ! northwest
 
   end subroutine fill_regular_refinement_halo_i4
 
   ! Fill the halo points of a 64-bit real array on the regular mosaic grid
-  subroutine fill_regular_mosaic_halo_r8(data, data_all, te, tse, ts, tsw, tw, tnw, tn, tne)
-    real(kind=r8_kind), dimension(1-whalo:,1-shalo:,:), intent(inout) :: data
+  subroutine fill_regular_mosaic_halo_r8(halo_data, data_all, te, tse, ts, tsw, tw, tnw, tn, tne)
+    real(kind=r8_kind), dimension(1-whalo:,1-shalo:,:), intent(inout) :: halo_data
     real(kind=r8_kind), dimension(:,:,:,:),             intent(in)    :: data_all
     integer, intent(in)    :: te, tse, ts, tsw, tw, tnw, tn, tne
 
-    data(nx+1:nx+ehalo, 1:ny,          :) = data_all(1:ehalo,       1:ny,          :, te) ! east
-    data(1:nx,          1-shalo:0,     :) = data_all(1:nx,          ny-shalo+1:ny, :, ts) ! south
-    data(1-whalo:0,     1:ny,          :) = data_all(nx-whalo+1:nx, 1:ny,          :, tw) ! west
-    data(1:nx,          ny+1:ny+nhalo, :) = data_all(1:nx,          1:nhalo,       :, tn) ! north
-    data(nx+1:nx+ehalo, 1-shalo:0,     :) = data_all(1:ehalo,       ny-shalo+1:ny, :,tse) ! southeast
-    data(1-whalo:0,     1-shalo:0,     :) = data_all(nx-whalo+1:nx, ny-shalo+1:ny, :,tsw) ! southwest
-    data(nx+1:nx+ehalo, ny+1:ny+nhalo, :) = data_all(1:ehalo,       1:nhalo,       :,tnw) ! northeast
-    data(1-whalo:0,     ny+1:ny+nhalo, :) = data_all(nx-whalo+1:nx, 1:nhalo,       :,tne) ! northwest
+    halo_data(nx+1:nx+ehalo, 1:ny,          :) = data_all(1:ehalo,       1:ny,          :, te) ! east
+    halo_data(1:nx,          1-shalo:0,     :) = data_all(1:nx,          ny-shalo+1:ny, :, ts) ! south
+    halo_data(1-whalo:0,     1:ny,          :) = data_all(nx-whalo+1:nx, 1:ny,          :, tw) ! west
+    halo_data(1:nx,          ny+1:ny+nhalo, :) = data_all(1:nx,          1:nhalo,       :, tn) ! north
+    halo_data(nx+1:nx+ehalo, 1-shalo:0,     :) = data_all(1:ehalo,       ny-shalo+1:ny, :,tse) ! southeast
+    halo_data(1-whalo:0,     1-shalo:0,     :) = data_all(nx-whalo+1:nx, ny-shalo+1:ny, :,tsw) ! southwest
+    halo_data(nx+1:nx+ehalo, ny+1:ny+nhalo, :) = data_all(1:ehalo,       1:nhalo,       :,tnw) ! northeast
+    halo_data(1-whalo:0,     ny+1:ny+nhalo, :) = data_all(nx-whalo+1:nx, 1:nhalo,       :,tne) ! northwest
   end subroutine fill_regular_mosaic_halo_r8
 
   !> Fill the halo points of a 32-bit real array on the regular mosaic grid
-  subroutine fill_regular_mosaic_halo_r4(data, data_all, te, tse, ts, tsw, tw, tnw, tn, tne)
-    real(kind=r4_kind), dimension(1-whalo:,1-shalo:,:), intent(inout) :: data
+  subroutine fill_regular_mosaic_halo_r4(halo_data, data_all, te, tse, ts, tsw, tw, tnw, tn, tne)
+    real(kind=r4_kind), dimension(1-whalo:,1-shalo:,:), intent(inout) :: halo_data
     real(kind=r4_kind), dimension(:,:,:,:),             intent(in)    :: data_all
     integer, intent(in)    :: te, tse, ts, tsw, tw, tnw, tn, tne
 
-    data(nx+1:nx+ehalo, 1:ny,          :) = data_all(1:ehalo,       1:ny,          :, te) ! east
-    data(1:nx,          1-shalo:0,     :) = data_all(1:nx,          ny-shalo+1:ny, :, ts) ! south
-    data(1-whalo:0,     1:ny,          :) = data_all(nx-whalo+1:nx, 1:ny,          :, tw) ! west
-    data(1:nx,          ny+1:ny+nhalo, :) = data_all(1:nx,          1:nhalo,       :, tn) ! north
-    data(nx+1:nx+ehalo, 1-shalo:0,     :) = data_all(1:ehalo,       ny-shalo+1:ny, :,tse) ! southeast
-    data(1-whalo:0,     1-shalo:0,     :) = data_all(nx-whalo+1:nx, ny-shalo+1:ny, :,tsw) ! southwest
-    data(nx+1:nx+ehalo, ny+1:ny+nhalo, :) = data_all(1:ehalo,       1:nhalo,       :,tnw) ! northeast
-    data(1-whalo:0,     ny+1:ny+nhalo, :) = data_all(nx-whalo+1:nx, 1:nhalo,       :,tne) ! northwest
+    halo_data(nx+1:nx+ehalo, 1:ny,          :) = data_all(1:ehalo,       1:ny,          :, te) ! east
+    halo_data(1:nx,          1-shalo:0,     :) = data_all(1:nx,          ny-shalo+1:ny, :, ts) ! south
+    halo_data(1-whalo:0,     1:ny,          :) = data_all(nx-whalo+1:nx, 1:ny,          :, tw) ! west
+    halo_data(1:nx,          ny+1:ny+nhalo, :) = data_all(1:nx,          1:nhalo,       :, tn) ! north
+    halo_data(nx+1:nx+ehalo, 1-shalo:0,     :) = data_all(1:ehalo,       ny-shalo+1:ny, :,tse) ! southeast
+    halo_data(1-whalo:0,     1-shalo:0,     :) = data_all(nx-whalo+1:nx, ny-shalo+1:ny, :,tsw) ! southwest
+    halo_data(nx+1:nx+ehalo, ny+1:ny+nhalo, :) = data_all(1:ehalo,       1:nhalo,       :,tnw) ! northeast
+    halo_data(1-whalo:0,     ny+1:ny+nhalo, :) = data_all(nx-whalo+1:nx, 1:nhalo,       :,tne) ! northwest
   end subroutine fill_regular_mosaic_halo_r4
 
   ! Fill the halo points of a 64-bit integer array on the regular mosaic grid
-  subroutine fill_regular_mosaic_halo_i8(data, data_all, te, tse, ts, tsw, tw, tnw, tn, tne)
-    integer(kind=i8_kind), dimension(1-whalo:,1-shalo:,:), intent(inout) :: data
+  subroutine fill_regular_mosaic_halo_i8(halo_data, data_all, te, tse, ts, tsw, tw, tnw, tn, tne)
+    integer(kind=i8_kind), dimension(1-whalo:,1-shalo:,:), intent(inout) :: halo_data
     integer(kind=i8_kind), dimension(:,:,:,:),             intent(in)    :: data_all
     integer, intent(in)    :: te, tse, ts, tsw, tw, tnw, tn, tne
 
-    data(nx+1:nx+ehalo, 1:ny,          :) = data_all(1:ehalo,       1:ny,          :, te) ! east
-    data(1:nx,          1-shalo:0,     :) = data_all(1:nx,          ny-shalo+1:ny, :, ts) ! south
-    data(1-whalo:0,     1:ny,          :) = data_all(nx-whalo+1:nx, 1:ny,          :, tw) ! west
-    data(1:nx,          ny+1:ny+nhalo, :) = data_all(1:nx,          1:nhalo,       :, tn) ! north
-    data(nx+1:nx+ehalo, 1-shalo:0,     :) = data_all(1:ehalo,       ny-shalo+1:ny, :,tse) ! southeast
-    data(1-whalo:0,     1-shalo:0,     :) = data_all(nx-whalo+1:nx, ny-shalo+1:ny, :,tsw) ! southwest
-    data(nx+1:nx+ehalo, ny+1:ny+nhalo, :) = data_all(1:ehalo,       1:nhalo,       :,tnw) ! northeast
-    data(1-whalo:0,     ny+1:ny+nhalo, :) = data_all(nx-whalo+1:nx, 1:nhalo,       :,tne) ! northwest
+    halo_data(nx+1:nx+ehalo, 1:ny,          :) = data_all(1:ehalo,       1:ny,          :, te) ! east
+    halo_data(1:nx,          1-shalo:0,     :) = data_all(1:nx,          ny-shalo+1:ny, :, ts) ! south
+    halo_data(1-whalo:0,     1:ny,          :) = data_all(nx-whalo+1:nx, 1:ny,          :, tw) ! west
+    halo_data(1:nx,          ny+1:ny+nhalo, :) = data_all(1:nx,          1:nhalo,       :, tn) ! north
+    halo_data(nx+1:nx+ehalo, 1-shalo:0,     :) = data_all(1:ehalo,       ny-shalo+1:ny, :,tse) ! southeast
+    halo_data(1-whalo:0,     1-shalo:0,     :) = data_all(nx-whalo+1:nx, ny-shalo+1:ny, :,tsw) ! southwest
+    halo_data(nx+1:nx+ehalo, ny+1:ny+nhalo, :) = data_all(1:ehalo,       1:nhalo,       :,tnw) ! northeast
+    halo_data(1-whalo:0,     ny+1:ny+nhalo, :) = data_all(nx-whalo+1:nx, 1:nhalo,       :,tne) ! northwest
   end subroutine fill_regular_mosaic_halo_i8
 
   !> Fill the halo points of a 64-bit integer array on the regular mosaic grid
-  subroutine fill_regular_mosaic_halo_i4(data, data_all, te, tse, ts, tsw, tw, tnw, tn, tne)
-    integer(kind=i4_kind), dimension(1-whalo:,1-shalo:,:), intent(inout) :: data
+  subroutine fill_regular_mosaic_halo_i4(halo_data, data_all, te, tse, ts, tsw, tw, tnw, tn, tne)
+    integer(kind=i4_kind), dimension(1-whalo:,1-shalo:,:), intent(inout) :: halo_data
     integer(kind=i4_kind), dimension(:,:,:,:),             intent(in)    :: data_all
     integer, intent(in)    :: te, tse, ts, tsw, tw, tnw, tn, tne
 
-    data(nx+1:nx+ehalo, 1:ny,          :) = data_all(1:ehalo,       1:ny,          :, te) ! east
-    data(1:nx,          1-shalo:0,     :) = data_all(1:nx,          ny-shalo+1:ny, :, ts) ! south
-    data(1-whalo:0,     1:ny,          :) = data_all(nx-whalo+1:nx, 1:ny,          :, tw) ! west
-    data(1:nx,          ny+1:ny+nhalo, :) = data_all(1:nx,          1:nhalo,       :, tn) ! north
-    data(nx+1:nx+ehalo, 1-shalo:0,     :) = data_all(1:ehalo,       ny-shalo+1:ny, :,tse) ! southeast
-    data(1-whalo:0,     1-shalo:0,     :) = data_all(nx-whalo+1:nx, ny-shalo+1:ny, :,tsw) ! southwest
-    data(nx+1:nx+ehalo, ny+1:ny+nhalo, :) = data_all(1:ehalo,       1:nhalo,       :,tnw) ! northeast
-    data(1-whalo:0,     ny+1:ny+nhalo, :) = data_all(nx-whalo+1:nx, 1:nhalo,       :,tne) ! northwest
+    halo_data(nx+1:nx+ehalo, 1:ny,          :) = data_all(1:ehalo,       1:ny,          :, te) ! east
+    halo_data(1:nx,          1-shalo:0,     :) = data_all(1:nx,          ny-shalo+1:ny, :, ts) ! south
+    halo_data(1-whalo:0,     1:ny,          :) = data_all(nx-whalo+1:nx, 1:ny,          :, tw) ! west
+    halo_data(1:nx,          ny+1:ny+nhalo, :) = data_all(1:nx,          1:nhalo,       :, tn) ! north
+    halo_data(nx+1:nx+ehalo, 1-shalo:0,     :) = data_all(1:ehalo,       ny-shalo+1:ny, :,tse) ! southeast
+    halo_data(1-whalo:0,     1-shalo:0,     :) = data_all(nx-whalo+1:nx, ny-shalo+1:ny, :,tsw) ! southwest
+    halo_data(nx+1:nx+ehalo, ny+1:ny+nhalo, :) = data_all(1:ehalo,       1:nhalo,       :,tnw) ! northeast
+    halo_data(1-whalo:0,     ny+1:ny+nhalo, :) = data_all(nx-whalo+1:nx, 1:nhalo,       :,tne) ! northwest
   end subroutine fill_regular_mosaic_halo_i4
 
   !> Fill the halo region of a 64-bit array real on a domain with a folded north edge
-  subroutine fill_folded_north_halo_r8(data, ioff, joff, ishift, jshift, sign)
-    real(kind=r8_kind), dimension(1-whalo:,1-shalo:,:), intent(inout) :: data
+  subroutine fill_folded_north_halo_r8(halo_data, ioff, joff, ishift, jshift, sign)
+    real(kind=r8_kind), dimension(1-whalo:,1-shalo:,:), intent(inout) :: halo_data
     integer, intent(in) :: ioff, joff, ishift, jshift, sign
     ! local
     integer :: nxp, nyp, m1, m2
@@ -378,18 +378,19 @@ contains
     m1 = ishift - ioff
     m2 = 2*ishift - ioff
 
-    data(1-whalo:0,1:nyp,:) = data(nx-whalo+1:nx,1:ny+jshift,:) ! west
-    data(nx+1:nx+ehalo+ishift,1:nyp,:) = data(1:ehalo+ishift,1:ny+jshift,:) ! east
+    halo_data(1-whalo:0,1:nyp,:) = halo_data(nx-whalo+1:nx,1:ny+jshift,:) ! west
+    halo_data(nx+1:nx+ehalo+ishift,1:nyp,:) = halo_data(1:ehalo+ishift,1:ny+jshift,:) ! east
     if(m1 .GE. 1-whalo) &
-      data(1-whalo:m1,nyp+1:nyp+nhalo,:) = sign*data(whalo+m2:1+ishift:-1,nyp-joff:nyp-nhalo-joff+1:-1,:)
-    data(m1+1:nx+m2,nyp+1:nyp+nhalo,:) = sign*data(nx+ishift:1:-1,nyp-joff:nyp-nhalo-joff+1:-1,:)
-    data(nx+m2+1:nxp+ehalo,nyp+1:nyp+nhalo,:) = sign*data(nx:nx-ehalo+m1+1:-1,nyp-joff:nyp-nhalo-joff+1:-1,:)
+      halo_data(1-whalo:m1,nyp+1:nyp+nhalo,:) = sign*halo_data(whalo+m2:1+ishift:-1,nyp-joff:nyp-nhalo-joff+1:-1,:)
+    halo_data(m1+1:nx+m2,nyp+1:nyp+nhalo,:) = sign*halo_data(nx+ishift:1:-1,nyp-joff:nyp-nhalo-joff+1:-1,:)
+    halo_data(nx+m2+1:nxp+ehalo,nyp+1:nyp+nhalo,:) = &
+        sign*halo_data(nx:nx-ehalo+m1+1:-1,nyp-joff:nyp-nhalo-joff+1:-1,:)
 
   end subroutine fill_folded_north_halo_r8
 
   !> Fill the halo region of a 32-bit real array on a domain with a folded north edge
-  subroutine fill_folded_north_halo_r4(data, ioff, joff, ishift, jshift, sign)
-    real(kind=r4_kind), dimension(1-whalo:,1-shalo:,:), intent(inout) :: data
+  subroutine fill_folded_north_halo_r4(halo_data, ioff, joff, ishift, jshift, sign)
+    real(kind=r4_kind), dimension(1-whalo:,1-shalo:,:), intent(inout) :: halo_data
     integer, intent(in) :: ioff, joff, ishift, jshift, sign
     ! local
     integer :: nxp, nyp, m1, m2
@@ -399,19 +400,20 @@ contains
     m1 = ishift - ioff
     m2 = 2*ishift - ioff
 
-    data(1-whalo:0,1:nyp,:) = data(nx-whalo+1:nx,1:ny+jshift,:) ! west
-    data(nx+1:nx+ehalo+ishift,1:nyp,:) = data(1:ehalo+ishift,1:ny+jshift,:) ! east
+    halo_data(1-whalo:0,1:nyp,:) = halo_data(nx-whalo+1:nx,1:ny+jshift,:) ! west
+    halo_data(nx+1:nx+ehalo+ishift,1:nyp,:) = halo_data(1:ehalo+ishift,1:ny+jshift,:) ! east
 
     if(m1 .GE. 1-whalo) &
-      data(1-whalo:m1,nyp+1:nyp+nhalo,:) = sign*data(whalo+m2:1+ishift:-1,nyp-joff:nyp-nhalo-joff+1:-1,:)
-    data(m1+1:nx+m2,nyp+1:nyp+nhalo,:) = sign*data(nx+ishift:1:-1,nyp-joff:nyp-nhalo-joff+1:-1,:)
-    data(nx+m2+1:nxp+ehalo,nyp+1:nyp+nhalo,:) = sign*data(nx:nx-ehalo+m1+1:-1,nyp-joff:nyp-nhalo-joff+1:-1,:)
+      halo_data(1-whalo:m1,nyp+1:nyp+nhalo,:) = sign*halo_data(whalo+m2:1+ishift:-1,nyp-joff:nyp-nhalo-joff+1:-1,:)
+    halo_data(m1+1:nx+m2,nyp+1:nyp+nhalo,:) = sign*halo_data(nx+ishift:1:-1,nyp-joff:nyp-nhalo-joff+1:-1,:)
+    halo_data(nx+m2+1:nxp+ehalo,nyp+1:nyp+nhalo,:) = &
+        sign*halo_data(nx:nx-ehalo+m1+1:-1,nyp-joff:nyp-nhalo-joff+1:-1,:)
 
   end subroutine fill_folded_north_halo_r4
 
   !> Fill the halo region of a 64-bit integer array on a domain with a folded north edge
-  subroutine fill_folded_north_halo_i8(data, ioff, joff, ishift, jshift, sign)
-    integer(kind=i8_kind), dimension(1-whalo:,1-shalo:,:), intent(inout) :: data
+  subroutine fill_folded_north_halo_i8(halo_data, ioff, joff, ishift, jshift, sign)
+    integer(kind=i8_kind), dimension(1-whalo:,1-shalo:,:), intent(inout) :: halo_data
     integer, intent(in) :: ioff, joff, ishift, jshift, sign
     ! local
     integer :: nxp, nyp, m1, m2
@@ -421,18 +423,19 @@ contains
     m1 = ishift - ioff
     m2 = 2*ishift - ioff
 
-    data(1-whalo:0,1:nyp,:) = data(nx-whalo+1:nx,1:ny+jshift,:) ! west
-    data(nx+1:nx+ehalo+ishift,1:nyp,:) = data(1:ehalo+ishift,1:ny+jshift,:) ! east
+    halo_data(1-whalo:0,1:nyp,:) = halo_data(nx-whalo+1:nx,1:ny+jshift,:) ! west
+    halo_data(nx+1:nx+ehalo+ishift,1:nyp,:) = halo_data(1:ehalo+ishift,1:ny+jshift,:) ! east
     if(m1 .GE. 1-whalo) &
-      data(1-whalo:m1,nyp+1:nyp+nhalo,:) = sign*data(whalo+m2:1+ishift:-1,nyp-joff:nyp-nhalo-joff+1:-1,:)
-    data(m1+1:nx+m2,nyp+1:nyp+nhalo,:) = sign*data(nx+ishift:1:-1,nyp-joff:nyp-nhalo-joff+1:-1,:)
-    data(nx+m2+1:nxp+ehalo,nyp+1:nyp+nhalo,:) = sign*data(nx:nx-ehalo+m1+1:-1,nyp-joff:nyp-nhalo-joff+1:-1,:)
+      halo_data(1-whalo:m1,nyp+1:nyp+nhalo,:) = sign*halo_data(whalo+m2:1+ishift:-1,nyp-joff:nyp-nhalo-joff+1:-1,:)
+    halo_data(m1+1:nx+m2,nyp+1:nyp+nhalo,:) = sign*halo_data(nx+ishift:1:-1,nyp-joff:nyp-nhalo-joff+1:-1,:)
+    halo_data(nx+m2+1:nxp+ehalo,nyp+1:nyp+nhalo,:) = &
+        sign*halo_data(nx:nx-ehalo+m1+1:-1,nyp-joff:nyp-nhalo-joff+1:-1,:)
 
   end subroutine fill_folded_north_halo_i8
 
   !> Fill the halo region of a 32-bit integer array on a domain with a folded north edge
-  subroutine fill_folded_north_halo_i4(data, ioff, joff, ishift, jshift, sign)
-    integer(kind=i4_kind), dimension(1-whalo:,1-shalo:,:), intent(inout) :: data
+  subroutine fill_folded_north_halo_i4(halo_data, ioff, joff, ishift, jshift, sign)
+    integer(kind=i4_kind), dimension(1-whalo:,1-shalo:,:), intent(inout) :: halo_data
     integer, intent(in) :: ioff, joff, ishift, jshift, sign
     ! local
     integer :: nxp, nyp, m1, m2
@@ -442,19 +445,20 @@ contains
     m1 = ishift - ioff
     m2 = 2*ishift - ioff
 
-    data(1-whalo:0,1:nyp,:) = data(nx-whalo+1:nx,1:ny+jshift,:) ! west
-    data(nx+1:nx+ehalo+ishift,1:nyp,:) = data(1:ehalo+ishift,1:ny+jshift,:) ! east
+    halo_data(1-whalo:0,1:nyp,:) = halo_data(nx-whalo+1:nx,1:ny+jshift,:) ! west
+    halo_data(nx+1:nx+ehalo+ishift,1:nyp,:) = halo_data(1:ehalo+ishift,1:ny+jshift,:) ! east
 
     if(m1 .GE. 1-whalo) &
-      data(1-whalo:m1,nyp+1:nyp+nhalo,:) = sign*data(whalo+m2:1+ishift:-1,nyp-joff:nyp-nhalo-joff+1:-1,:)
-    data(m1+1:nx+m2,nyp+1:nyp+nhalo,:) = sign*data(nx+ishift:1:-1,nyp-joff:nyp-nhalo-joff+1:-1,:)
-    data(nx+m2+1:nxp+ehalo,nyp+1:nyp+nhalo,:) = sign*data(nx:nx-ehalo+m1+1:-1,nyp-joff:nyp-nhalo-joff+1:-1,:)
+      halo_data(1-whalo:m1,nyp+1:nyp+nhalo,:) = sign*halo_data(whalo+m2:1+ishift:-1,nyp-joff:nyp-nhalo-joff+1:-1,:)
+    halo_data(m1+1:nx+m2,nyp+1:nyp+nhalo,:) = sign*halo_data(nx+ishift:1:-1,nyp-joff:nyp-nhalo-joff+1:-1,:)
+    halo_data(nx+m2+1:nxp+ehalo,nyp+1:nyp+nhalo,:) = &
+        sign*halo_data(nx:nx-ehalo+m1+1:-1,nyp-joff:nyp-nhalo-joff+1:-1,:)
 
   end subroutine fill_folded_north_halo_i4
 
   !> Fill the halo region of a 64-bit real array on a domain with a folded south edge
-  subroutine fill_folded_south_halo_r8(data, ioff, joff, ishift, jshift, sign)
-    real(kind=r8_kind), dimension(1-whalo:,1-shalo:,:), intent(inout) :: data
+  subroutine fill_folded_south_halo_r8(halo_data, ioff, joff, ishift, jshift, sign)
+    real(kind=r8_kind), dimension(1-whalo:,1-shalo:,:), intent(inout) :: halo_data
     integer, intent(in) :: ioff, joff, ishift, jshift, sign
     ! local
     integer  :: nxp, nyp, m1, m2
@@ -464,19 +468,19 @@ contains
     m1 = ishift - ioff
     m2 = 2*ishift - ioff
 
-    data(1-whalo:0,1:nyp,:) = data(nx-whalo+1:nx,1:nyp,:) ! west
-    data(nx+1:nx+ehalo+ishift,1:nyp,:) = data(1:ehalo+ishift, 1:nyp,:) ! east
+    halo_data(1-whalo:0,1:nyp,:) = halo_data(nx-whalo+1:nx,1:nyp,:) ! west
+    halo_data(nx+1:nx+ehalo+ishift,1:nyp,:) = halo_data(1:ehalo+ishift, 1:nyp,:) ! east
     if(m1 .GE. 1-whalo) &
-      data(1-whalo:m1,1-shalo:0,:) = sign*data(whalo+m2:1+ishift:-1, shalo+jshift:1+jshift:-1,:)
+      halo_data(1-whalo:m1,1-shalo:0,:) = sign*halo_data(whalo+m2:1+ishift:-1, shalo+jshift:1+jshift:-1,:)
 
-    data(m1+1:nx+m2,1-shalo:0,:) = sign*data(nxp:1:-1,shalo+jshift:1+jshift:-1,:)
-    data(nx+m2+1:nxp+ehalo,1-shalo:0,:) = sign*data(nx:nx-ehalo+m1+1:-1,shalo+jshift:1+jshift:-1,:)
+    halo_data(m1+1:nx+m2,1-shalo:0,:) = sign*halo_data(nxp:1:-1,shalo+jshift:1+jshift:-1,:)
+    halo_data(nx+m2+1:nxp+ehalo,1-shalo:0,:) = sign*halo_data(nx:nx-ehalo+m1+1:-1,shalo+jshift:1+jshift:-1,:)
 
   end subroutine fill_folded_south_halo_r8
 
   !> Fill the halo region of a 32-bit real array on a domain with a folded south edge
-  subroutine fill_folded_south_halo_r4(data, ioff, joff, ishift, jshift, sign)
-    real(kind=r4_kind), dimension(1-whalo:,1-shalo:,:), intent(inout) :: data
+  subroutine fill_folded_south_halo_r4(halo_data, ioff, joff, ishift, jshift, sign)
+    real(kind=r4_kind), dimension(1-whalo:,1-shalo:,:), intent(inout) :: halo_data
     integer, intent(in) :: ioff, joff, ishift, jshift, sign
     ! local
     integer  :: nxp, nyp, m1, m2
@@ -486,19 +490,19 @@ contains
     m1 = ishift - ioff
     m2 = 2*ishift - ioff
 
-    data(1-whalo:0,1:nyp,:) = data(nx-whalo+1:nx,1:nyp,:) ! west
-    data(nx+1:nx+ehalo+ishift,1:nyp,:) = data(1:ehalo+ishift, 1:nyp,:) ! east
+    halo_data(1-whalo:0,1:nyp,:) = halo_data(nx-whalo+1:nx,1:nyp,:) ! west
+    halo_data(nx+1:nx+ehalo+ishift,1:nyp,:) = halo_data(1:ehalo+ishift, 1:nyp,:) ! east
     if(m1 .GE. 1-whalo) &
-      data(1-whalo:m1,1-shalo:0,:) = sign*data(whalo+m2:1+ishift:-1, shalo+jshift:1+jshift:-1,:)
+      halo_data(1-whalo:m1,1-shalo:0,:) = sign*halo_data(whalo+m2:1+ishift:-1, shalo+jshift:1+jshift:-1,:)
 
-    data(m1+1:nx+m2,1-shalo:0,:) = sign*data(nxp:1:-1,shalo+jshift:1+jshift:-1,:)
-    data(nx+m2+1:nxp+ehalo,1-shalo:0,:) = sign*data(nx:nx-ehalo+m1+1:-1,shalo+jshift:1+jshift:-1,:)
+    halo_data(m1+1:nx+m2,1-shalo:0,:) = sign*halo_data(nxp:1:-1,shalo+jshift:1+jshift:-1,:)
+    halo_data(nx+m2+1:nxp+ehalo,1-shalo:0,:) = sign*halo_data(nx:nx-ehalo+m1+1:-1,shalo+jshift:1+jshift:-1,:)
 
   end subroutine fill_folded_south_halo_r4
 
   !> Fill the halo region of a 64-bit intger array on a domain with a folded south edge
-  subroutine fill_folded_south_halo_i8(data, ioff, joff, ishift, jshift, sign)
-    integer(kind=i8_kind), dimension(1-whalo:,1-shalo:,:), intent(inout) :: data
+  subroutine fill_folded_south_halo_i8(halo_data, ioff, joff, ishift, jshift, sign)
+    integer(kind=i8_kind), dimension(1-whalo:,1-shalo:,:), intent(inout) :: halo_data
     integer, intent(in) :: ioff, joff, ishift, jshift, sign
     ! local
     integer  :: nxp, nyp, m1, m2
@@ -508,19 +512,19 @@ contains
     m1 = ishift - ioff
     m2 = 2*ishift - ioff
 
-    data(1-whalo:0,1:nyp,:) = data(nx-whalo+1:nx,1:nyp,:) ! west
-    data(nx+1:nx+ehalo+ishift,1:nyp,:) = data(1:ehalo+ishift, 1:nyp,:) ! east
+    halo_data(1-whalo:0,1:nyp,:) = halo_data(nx-whalo+1:nx,1:nyp,:) ! west
+    halo_data(nx+1:nx+ehalo+ishift,1:nyp,:) = halo_data(1:ehalo+ishift, 1:nyp,:) ! east
     if(m1 .GE. 1-whalo) &
-      data(1-whalo:m1,1-shalo:0,:) = sign*data(whalo+m2:1+ishift:-1, shalo+jshift:1+jshift:-1,:)
+      halo_data(1-whalo:m1,1-shalo:0,:) = sign*halo_data(whalo+m2:1+ishift:-1, shalo+jshift:1+jshift:-1,:)
 
-    data(m1+1:nx+m2,1-shalo:0,:) = sign*data(nxp:1:-1,shalo+jshift:1+jshift:-1,:)
-    data(nx+m2+1:nxp+ehalo,1-shalo:0,:) = sign*data(nx:nx-ehalo+m1+1:-1,shalo+jshift:1+jshift:-1,:)
+    halo_data(m1+1:nx+m2,1-shalo:0,:) = sign*halo_data(nxp:1:-1,shalo+jshift:1+jshift:-1,:)
+    halo_data(nx+m2+1:nxp+ehalo,1-shalo:0,:) = sign*halo_data(nx:nx-ehalo+m1+1:-1,shalo+jshift:1+jshift:-1,:)
 
   end subroutine fill_folded_south_halo_i8
 
   !> Fill the halo region of a 32-bit integer array on a domain with a folded south edge
-  subroutine fill_folded_south_halo_i4(data, ioff, joff, ishift, jshift, sign)
-    integer(kind=i4_kind), dimension(1-whalo:,1-shalo:,:), intent(inout) :: data
+  subroutine fill_folded_south_halo_i4(halo_data, ioff, joff, ishift, jshift, sign)
+    integer(kind=i4_kind), dimension(1-whalo:,1-shalo:,:), intent(inout) :: halo_data
     integer, intent(in) :: ioff, joff, ishift, jshift, sign
     ! local
     integer  :: nxp, nyp, m1, m2
@@ -530,19 +534,19 @@ contains
     m1 = ishift - ioff
     m2 = 2*ishift - ioff
 
-    data(1-whalo:0,1:nyp,:) = data(nx-whalo+1:nx,1:nyp,:) ! west
-    data(nx+1:nx+ehalo+ishift,1:nyp,:) = data(1:ehalo+ishift, 1:nyp,:) ! east
+    halo_data(1-whalo:0,1:nyp,:) = halo_data(nx-whalo+1:nx,1:nyp,:) ! west
+    halo_data(nx+1:nx+ehalo+ishift,1:nyp,:) = halo_data(1:ehalo+ishift, 1:nyp,:) ! east
     if(m1 .GE. 1-whalo) &
-      data(1-whalo:m1,1-shalo:0,:) = sign*data(whalo+m2:1+ishift:-1, shalo+jshift:1+jshift:-1,:)
+      halo_data(1-whalo:m1,1-shalo:0,:) = sign*halo_data(whalo+m2:1+ishift:-1, shalo+jshift:1+jshift:-1,:)
 
-    data(m1+1:nx+m2,1-shalo:0,:) = sign*data(nxp:1:-1,shalo+jshift:1+jshift:-1,:)
-    data(nx+m2+1:nxp+ehalo,1-shalo:0,:) = sign*data(nx:nx-ehalo+m1+1:-1,shalo+jshift:1+jshift:-1,:)
+    halo_data(m1+1:nx+m2,1-shalo:0,:) = sign*halo_data(nxp:1:-1,shalo+jshift:1+jshift:-1,:)
+    halo_data(nx+m2+1:nxp+ehalo,1-shalo:0,:) = sign*halo_data(nx:nx-ehalo+m1+1:-1,shalo+jshift:1+jshift:-1,:)
 
   end subroutine fill_folded_south_halo_i4
 
   !> Fill the halo region of a 64-bit real array on a domain with a folded west edge
-  subroutine fill_folded_west_halo_r8(data, ioff, joff, ishift, jshift, sign)
-    real(kind=r8_kind), dimension(1-whalo:,1-shalo:,:), intent(inout) :: data
+  subroutine fill_folded_west_halo_r8(halo_data, ioff, joff, ishift, jshift, sign)
+    real(kind=r8_kind), dimension(1-whalo:,1-shalo:,:), intent(inout) :: halo_data
     integer, intent(in) :: ioff, joff, ishift, jshift, sign
     ! local
     integer :: nxp, nyp, m1, m2
@@ -552,18 +556,18 @@ contains
     m1 = jshift - joff
     m2 = 2*jshift - joff
 
-    data(1:nxp, 1-shalo:0,:) = data(1:nxp, ny-shalo+1:ny, :) ! south
-    data(1:nxp, ny+1:nyp+nhalo,:) = data(1:nxp, 1:nhalo+jshift,:) ! north
+    halo_data(1:nxp, 1-shalo:0,:) = halo_data(1:nxp, ny-shalo+1:ny, :) ! south
+    halo_data(1:nxp, ny+1:nyp+nhalo,:) = halo_data(1:nxp, 1:nhalo+jshift,:) ! north
     if(m1 .GE. 1-shalo) &
-      data(1-whalo:0, 1-shalo:m1,:) = sign*data(whalo+ishift:1+ishift:-1,shalo+m2:1+jshift:-1,:)
-    data(1-whalo:0, m1+1:ny+m2,:) = sign*data(whalo+ishift:1+ishift:-1, nyp:1:-1, :)
-    data(1-whalo:0, ny+m2+1:nyp+nhalo,:) = sign*data(whalo+ishift:1+ishift:-1, ny:ny-nhalo+m1+1:-1,:)
+      halo_data(1-whalo:0, 1-shalo:m1,:) = sign*halo_data(whalo+ishift:1+ishift:-1,shalo+m2:1+jshift:-1,:)
+    halo_data(1-whalo:0, m1+1:ny+m2,:) = sign*halo_data(whalo+ishift:1+ishift:-1, nyp:1:-1, :)
+    halo_data(1-whalo:0, ny+m2+1:nyp+nhalo,:) = sign*halo_data(whalo+ishift:1+ishift:-1, ny:ny-nhalo+m1+1:-1,:)
 
   end subroutine fill_folded_west_halo_r8
 
   !> Fill the halo region of a 32-bit real array on a domain with a folded west edge
-  subroutine fill_folded_west_halo_r4(data, ioff, joff, ishift, jshift, sign)
-    real(kind=r4_kind), dimension(1-whalo:,1-shalo:,:), intent(inout) :: data
+  subroutine fill_folded_west_halo_r4(halo_data, ioff, joff, ishift, jshift, sign)
+    real(kind=r4_kind), dimension(1-whalo:,1-shalo:,:), intent(inout) :: halo_data
     integer, intent(in) :: ioff, joff, ishift, jshift, sign
     ! local
     integer :: nxp, nyp, m1, m2
@@ -573,18 +577,18 @@ contains
     m1 = jshift - joff
     m2 = 2*jshift - joff
 
-    data(1:nxp, 1-shalo:0,:) = data(1:nxp, ny-shalo+1:ny, :) ! south
-    data(1:nxp, ny+1:nyp+nhalo,:) = data(1:nxp, 1:nhalo+jshift,:) ! north
+    halo_data(1:nxp, 1-shalo:0,:) = halo_data(1:nxp, ny-shalo+1:ny, :) ! south
+    halo_data(1:nxp, ny+1:nyp+nhalo,:) = halo_data(1:nxp, 1:nhalo+jshift,:) ! north
     if(m1 .GE. 1-shalo) &
-      data(1-whalo:0, 1-shalo:m1,:) = sign*data(whalo+ishift:1+ishift:-1,shalo+m2:1+jshift:-1,:)
-    data(1-whalo:0, m1+1:ny+m2,:) = sign*data(whalo+ishift:1+ishift:-1, nyp:1:-1, :)
-    data(1-whalo:0, ny+m2+1:nyp+nhalo,:) = sign*data(whalo+ishift:1+ishift:-1, ny:ny-nhalo+m1+1:-1,:)
+      halo_data(1-whalo:0, 1-shalo:m1,:) = sign*halo_data(whalo+ishift:1+ishift:-1,shalo+m2:1+jshift:-1,:)
+    halo_data(1-whalo:0, m1+1:ny+m2,:) = sign*halo_data(whalo+ishift:1+ishift:-1, nyp:1:-1, :)
+    halo_data(1-whalo:0, ny+m2+1:nyp+nhalo,:) = sign*halo_data(whalo+ishift:1+ishift:-1, ny:ny-nhalo+m1+1:-1,:)
 
   end subroutine fill_folded_west_halo_r4
 
   !> Fill the halo region of a 64-bit integer array on a domain with a folded west edge
-  subroutine fill_folded_west_halo_i8(data, ioff, joff, ishift, jshift, sign)
-    integer(kind=i8_kind), dimension(1-whalo:,1-shalo:,:), intent(inout) :: data
+  subroutine fill_folded_west_halo_i8(halo_data, ioff, joff, ishift, jshift, sign)
+    integer(kind=i8_kind), dimension(1-whalo:,1-shalo:,:), intent(inout) :: halo_data
     integer, intent(in) :: ioff, joff, ishift, jshift, sign
     ! local
     integer :: nxp, nyp, m1, m2
@@ -594,18 +598,18 @@ contains
     m1 = jshift - joff
     m2 = 2*jshift - joff
 
-    data(1:nxp, 1-shalo:0,:) = data(1:nxp, ny-shalo+1:ny, :) ! south
-    data(1:nxp, ny+1:nyp+nhalo,:) = data(1:nxp, 1:nhalo+jshift,:) ! north
+    halo_data(1:nxp, 1-shalo:0,:) = halo_data(1:nxp, ny-shalo+1:ny, :) ! south
+    halo_data(1:nxp, ny+1:nyp+nhalo,:) = halo_data(1:nxp, 1:nhalo+jshift,:) ! north
     if(m1 .GE. 1-shalo) &
-      data(1-whalo:0, 1-shalo:m1,:) = sign*data(whalo+ishift:1+ishift:-1,shalo+m2:1+jshift:-1,:)
-    data(1-whalo:0, m1+1:ny+m2,:) = sign*data(whalo+ishift:1+ishift:-1, nyp:1:-1, :)
-    data(1-whalo:0, ny+m2+1:nyp+nhalo,:) = sign*data(whalo+ishift:1+ishift:-1, ny:ny-nhalo+m1+1:-1,:)
+      halo_data(1-whalo:0, 1-shalo:m1,:) = sign*halo_data(whalo+ishift:1+ishift:-1,shalo+m2:1+jshift:-1,:)
+    halo_data(1-whalo:0, m1+1:ny+m2,:) = sign*halo_data(whalo+ishift:1+ishift:-1, nyp:1:-1, :)
+    halo_data(1-whalo:0, ny+m2+1:nyp+nhalo,:) = sign*halo_data(whalo+ishift:1+ishift:-1, ny:ny-nhalo+m1+1:-1,:)
 
   end subroutine fill_folded_west_halo_i8
 
   !> Fill the halo region of a 32-bit integer array on a domain with a folded west edge
-  subroutine fill_folded_west_halo_i4(data, ioff, joff, ishift, jshift, sign)
-    integer(kind=i4_kind), dimension(1-whalo:,1-shalo:,:), intent(inout) :: data
+  subroutine fill_folded_west_halo_i4(halo_data, ioff, joff, ishift, jshift, sign)
+    integer(kind=i4_kind), dimension(1-whalo:,1-shalo:,:), intent(inout) :: halo_data
     integer, intent(in) :: ioff, joff, ishift, jshift, sign
     ! local
     integer :: nxp, nyp, m1, m2
@@ -615,18 +619,18 @@ contains
     m1 = jshift - joff
     m2 = 2*jshift - joff
 
-    data(1:nxp, 1-shalo:0,:) = data(1:nxp, ny-shalo+1:ny, :) ! south
-    data(1:nxp, ny+1:nyp+nhalo,:) = data(1:nxp, 1:nhalo+jshift,:) ! north
+    halo_data(1:nxp, 1-shalo:0,:) = halo_data(1:nxp, ny-shalo+1:ny, :) ! south
+    halo_data(1:nxp, ny+1:nyp+nhalo,:) = halo_data(1:nxp, 1:nhalo+jshift,:) ! north
     if(m1 .GE. 1-shalo) &
-      data(1-whalo:0, 1-shalo:m1,:) = sign*data(whalo+ishift:1+ishift:-1,shalo+m2:1+jshift:-1,:)
-    data(1-whalo:0, m1+1:ny+m2,:) = sign*data(whalo+ishift:1+ishift:-1, nyp:1:-1, :)
-    data(1-whalo:0, ny+m2+1:nyp+nhalo,:) = sign*data(whalo+ishift:1+ishift:-1, ny:ny-nhalo+m1+1:-1,:)
+      halo_data(1-whalo:0, 1-shalo:m1,:) = sign*halo_data(whalo+ishift:1+ishift:-1,shalo+m2:1+jshift:-1,:)
+    halo_data(1-whalo:0, m1+1:ny+m2,:) = sign*halo_data(whalo+ishift:1+ishift:-1, nyp:1:-1, :)
+    halo_data(1-whalo:0, ny+m2+1:nyp+nhalo,:) = sign*halo_data(whalo+ishift:1+ishift:-1, ny:ny-nhalo+m1+1:-1,:)
 
   end subroutine fill_folded_west_halo_i4
 
   !> Fill the halo region of a 64-bit real array on a domain with a folded east edge
-  subroutine fill_folded_east_halo_r8(data, ioff, joff, ishift, jshift, sign)
-    real(kind=r8_kind), dimension(1-whalo:,1-shalo:,:), intent(inout) :: data
+  subroutine fill_folded_east_halo_r8(halo_data, ioff, joff, ishift, jshift, sign)
+    real(kind=r8_kind), dimension(1-whalo:,1-shalo:,:), intent(inout) :: halo_data
     integer, intent(in) :: ioff, joff, ishift, jshift, sign
     ! local
     integer :: nxp, nyp, m1, m2
@@ -636,19 +640,20 @@ contains
     m1 = jshift - joff
     m2 = 2*jshift - joff
 
-    data(1:nxp, 1-shalo:0, :)  = data(1:nxp, ny-shalo+1:ny, :) ! south
-    data(1:nxp, ny+1:nyp+nhalo, :) = data(1:nxp, 1:nhalo+jshift,:) ! north
+    halo_data(1:nxp, 1-shalo:0, :)  = halo_data(1:nxp, ny-shalo+1:ny, :) ! south
+    halo_data(1:nxp, ny+1:nyp+nhalo, :) = halo_data(1:nxp, 1:nhalo+jshift,:) ! north
     if(m1 .GE. 1-shalo) &
-      data(nxp+1:nxp+ehalo, 1-shalo:m1, :) = sign*data(nxp-ioff:nxp-ehalo-ioff+1:-1, shalo+m2:1+jshift:-1,:)
+      halo_data(nxp+1:nxp+ehalo, 1-shalo:m1, :) = sign*halo_data(nxp-ioff:nxp-ehalo-ioff+1:-1, shalo+m2:1+jshift:-1,:)
 
-    data(nxp+1:nxp+ehalo, m1+1:ny+m2, :) = sign*data(nxp-ioff:nxp-ehalo-ioff+1:-1, nyp:1:-1, :)
-    data(nxp+1:nxp+ehalo, ny+m2+1:nyp+nhalo,:) = sign*data(nxp-ioff:nxp-ehalo-ioff+1:-1, ny:ny-nhalo+m1+1:-1,:)
+    halo_data(nxp+1:nxp+ehalo, m1+1:ny+m2, :) = sign*halo_data(nxp-ioff:nxp-ehalo-ioff+1:-1, nyp:1:-1, :)
+    halo_data(nxp+1:nxp+ehalo, ny+m2+1:nyp+nhalo,:) = &
+      sign*halo_data(nxp-ioff:nxp-ehalo-ioff+1:-1, ny:ny-nhalo+m1+1:-1,:)
 
   end subroutine fill_folded_east_halo_r8
 
   !> Fill the halo region of a 32-bit real array on a domain with a folded east edge
-  subroutine fill_folded_east_halo_r4(data, ioff, joff, ishift, jshift, sign)
-    real(kind=r4_kind), dimension(1-whalo:,1-shalo:,:), intent(inout) :: data
+  subroutine fill_folded_east_halo_r4(halo_data, ioff, joff, ishift, jshift, sign)
+    real(kind=r4_kind), dimension(1-whalo:,1-shalo:,:), intent(inout) :: halo_data
     integer, intent(in) :: ioff, joff, ishift, jshift, sign
     ! local
     integer :: nxp, nyp, m1, m2
@@ -658,19 +663,20 @@ contains
     m1 = jshift - joff
     m2 = 2*jshift - joff
 
-    data(1:nxp, 1-shalo:0, :)  = data(1:nxp, ny-shalo+1:ny, :) ! south
-    data(1:nxp, ny+1:nyp+nhalo, :) = data(1:nxp, 1:nhalo+jshift,:) ! north
+    halo_data(1:nxp, 1-shalo:0, :)  = halo_data(1:nxp, ny-shalo+1:ny, :) ! south
+    halo_data(1:nxp, ny+1:nyp+nhalo, :) = halo_data(1:nxp, 1:nhalo+jshift,:) ! north
     if(m1 .GE. 1-shalo) &
-      data(nxp+1:nxp+ehalo, 1-shalo:m1, :) = sign*data(nxp-ioff:nxp-ehalo-ioff+1:-1, shalo+m2:1+jshift:-1,:)
+      halo_data(nxp+1:nxp+ehalo, 1-shalo:m1, :) = sign*halo_data(nxp-ioff:nxp-ehalo-ioff+1:-1, shalo+m2:1+jshift:-1,:)
 
-    data(nxp+1:nxp+ehalo, m1+1:ny+m2, :) = sign*data(nxp-ioff:nxp-ehalo-ioff+1:-1, nyp:1:-1, :)
-    data(nxp+1:nxp+ehalo, ny+m2+1:nyp+nhalo,:) = sign*data(nxp-ioff:nxp-ehalo-ioff+1:-1, ny:ny-nhalo+m1+1:-1,:)
+    halo_data(nxp+1:nxp+ehalo, m1+1:ny+m2, :) = sign*halo_data(nxp-ioff:nxp-ehalo-ioff+1:-1, nyp:1:-1, :)
+    halo_data(nxp+1:nxp+ehalo, ny+m2+1:nyp+nhalo,:) = &
+      sign*halo_data(nxp-ioff:nxp-ehalo-ioff+1:-1, ny:ny-nhalo+m1+1:-1,:)
 
   end subroutine fill_folded_east_halo_r4
 
   !> Fill the halo region of a 64-bit integer array on a domain with a folded east edge
-  subroutine fill_folded_east_halo_i8(data, ioff, joff, ishift, jshift, sign)
-    integer(kind=i8_kind), dimension(1-whalo:,1-shalo:,:), intent(inout) :: data
+  subroutine fill_folded_east_halo_i8(halo_data, ioff, joff, ishift, jshift, sign)
+    integer(kind=i8_kind), dimension(1-whalo:,1-shalo:,:), intent(inout) :: halo_data
     integer, intent(in) :: ioff, joff, ishift, jshift, sign
     ! local
     integer :: nxp, nyp, m1, m2
@@ -680,19 +686,20 @@ contains
     m1 = jshift - joff
     m2 = 2*jshift - joff
 
-    data(1:nxp, 1-shalo:0, :)  = data(1:nxp, ny-shalo+1:ny, :) ! south
-    data(1:nxp, ny+1:nyp+nhalo, :) = data(1:nxp, 1:nhalo+jshift,:) ! north
+    halo_data(1:nxp, 1-shalo:0, :)  = halo_data(1:nxp, ny-shalo+1:ny, :) ! south
+    halo_data(1:nxp, ny+1:nyp+nhalo, :) = halo_data(1:nxp, 1:nhalo+jshift,:) ! north
     if(m1 .GE. 1-shalo) &
-      data(nxp+1:nxp+ehalo, 1-shalo:m1, :) = sign*data(nxp-ioff:nxp-ehalo-ioff+1:-1, shalo+m2:1+jshift:-1,:)
+      halo_data(nxp+1:nxp+ehalo, 1-shalo:m1, :) = sign*halo_data(nxp-ioff:nxp-ehalo-ioff+1:-1, shalo+m2:1+jshift:-1,:)
 
-    data(nxp+1:nxp+ehalo, m1+1:ny+m2, :) = sign*data(nxp-ioff:nxp-ehalo-ioff+1:-1, nyp:1:-1, :)
-    data(nxp+1:nxp+ehalo, ny+m2+1:nyp+nhalo,:) = sign*data(nxp-ioff:nxp-ehalo-ioff+1:-1, ny:ny-nhalo+m1+1:-1,:)
+    halo_data(nxp+1:nxp+ehalo, m1+1:ny+m2, :) = sign*halo_data(nxp-ioff:nxp-ehalo-ioff+1:-1, nyp:1:-1, :)
+    halo_data(nxp+1:nxp+ehalo, ny+m2+1:nyp+nhalo,:) = &
+      sign*halo_data(nxp-ioff:nxp-ehalo-ioff+1:-1, ny:ny-nhalo+m1+1:-1,:)
 
   end subroutine fill_folded_east_halo_i8
 
   !> Fill the halo region of a 32-bit integer array on a domain with a folded east edge
-  subroutine fill_folded_east_halo_i4(data, ioff, joff, ishift, jshift, sign)
-    integer(kind=i4_kind), dimension(1-whalo:,1-shalo:,:), intent(inout) :: data
+  subroutine fill_folded_east_halo_i4(halo_data, ioff, joff, ishift, jshift, sign)
+    integer(kind=i4_kind), dimension(1-whalo:,1-shalo:,:), intent(inout) :: halo_data
     integer, intent(in) :: ioff, joff, ishift, jshift, sign
     ! local
     integer :: nxp, nyp, m1, m2
@@ -702,13 +709,14 @@ contains
     m1 = jshift - joff
     m2 = 2*jshift - joff
 
-    data(1:nxp, 1-shalo:0, :)  = data(1:nxp, ny-shalo+1:ny, :) ! south
-    data(1:nxp, ny+1:nyp+nhalo, :) = data(1:nxp, 1:nhalo+jshift,:) ! north
+    halo_data(1:nxp, 1-shalo:0, :)  = halo_data(1:nxp, ny-shalo+1:ny, :) ! south
+    halo_data(1:nxp, ny+1:nyp+nhalo, :) = halo_data(1:nxp, 1:nhalo+jshift,:) ! north
     if(m1 .GE. 1-shalo) &
-      data(nxp+1:nxp+ehalo, 1-shalo:m1, :) = sign*data(nxp-ioff:nxp-ehalo-ioff+1:-1, shalo+m2:1+jshift:-1,:)
+      halo_data(nxp+1:nxp+ehalo, 1-shalo:m1, :) = sign*halo_data(nxp-ioff:nxp-ehalo-ioff+1:-1, shalo+m2:1+jshift:-1,:)
 
-    data(nxp+1:nxp+ehalo, m1+1:ny+m2, :) = sign*data(nxp-ioff:nxp-ehalo-ioff+1:-1, nyp:1:-1, :)
-    data(nxp+1:nxp+ehalo, ny+m2+1:nyp+nhalo,:) = sign*data(nxp-ioff:nxp-ehalo-ioff+1:-1, ny:ny-nhalo+m1+1:-1,:)
+    halo_data(nxp+1:nxp+ehalo, m1+1:ny+m2, :) = sign*halo_data(nxp-ioff:nxp-ehalo-ioff+1:-1, nyp:1:-1, :)
+    halo_data(nxp+1:nxp+ehalo, ny+m2+1:nyp+nhalo,:) = &
+      sign*halo_data(nxp-ioff:nxp-ehalo-ioff+1:-1, ny:ny-nhalo+m1+1:-1,:)
 
   end subroutine fill_folded_east_halo_i4
 

--- a/test_fms/mpp/test_domains_utility_mod.F90
+++ b/test_fms/mpp/test_domains_utility_mod.F90
@@ -38,11 +38,11 @@ module test_domains_utility_mod
 
   contains
 
-subroutine fill_coarse_data_r8(data, rotate, iadd, jadd, is_c, ie_c, js_c, je_c, nz, isd, jsd, nx, ny, &
+subroutine fill_coarse_data_r8(coarse_data, rotate, iadd, jadd, is_c, ie_c, js_c, je_c, nz, isd, jsd, nx, ny, &
                               ishift, jshift, x_add, y_add, sign1, sign2, x_cyclic, y_cyclic, ieg, jeg)
     integer, intent(in)    :: rotate, is_c, ie_c, js_c, je_c, nz, isd, jsd, iadd, jadd, nx, ny, ishift, jshift
     integer, intent(in)    :: sign1, sign2
-    real(kind=r8_kind),    intent(inout) :: data(isd:, jsd:, :)
+    real(kind=r8_kind),    intent(inout) :: coarse_data(isd:, jsd:, :)
     real(kind=r8_kind),    intent(in)    :: x_add, y_add
     logical, intent(in)    :: x_cyclic, y_cyclic
     integer, intent(in)    :: ieg, jeg
@@ -54,7 +54,7 @@ subroutine fill_coarse_data_r8(data, rotate, iadd, jadd, is_c, ie_c, js_c, je_c,
        do k = 1, nz
           do j = js_c, je_c+jshift
              do i = is_c, ie_c+ishift
-                data(i,j,k) = dble(i+iadd)*1.d+6 + dble(j+jadd)*1.d+3 + dble(k) + x_add
+               coarse_data(i,j,k) = dble(i+iadd)*1.d+6 + dble(j+jadd)*1.d+3 + dble(k) + x_add
              enddo
           enddo
        enddo
@@ -63,7 +63,7 @@ subroutine fill_coarse_data_r8(data, rotate, iadd, jadd, is_c, ie_c, js_c, je_c,
        do k = 1, nz
           do j = js_c, je_c+jshift
              do i = is_c, ie_c+ishift
-                data(i,j,k) = sign1*( dble(nx-j+1+iadd+jshift)*1.d+6 + dble(i+jadd)*1.d+3 + dble(k) + y_add)
+               coarse_data(i,j,k) = sign1*( dble(nx-j+1+iadd+jshift)*1.d+6 + dble(i+jadd)*1.d+3 + dble(k) + y_add)
              enddo
           enddo
        enddo
@@ -72,7 +72,7 @@ subroutine fill_coarse_data_r8(data, rotate, iadd, jadd, is_c, ie_c, js_c, je_c,
        do k = 1, nz
           do j = js_c, je_c+jshift
              do i = is_c, ie_c+ishift
-                data(i,j,k) = sign2*( dble(j+iadd)*1.d+6 + dble(ny-i+1+jadd+ishift)*1.d+3 + dble(k) + y_add)
+               coarse_data(i,j,k) = sign2*( dble(j+iadd)*1.d+6 + dble(ny-i+1+jadd+ishift)*1.d+3 + dble(k) + y_add)
              enddo
           enddo
        enddo
@@ -86,7 +86,7 @@ subroutine fill_coarse_data_r8(data, rotate, iadd, jadd, is_c, ie_c, js_c, je_c,
           i = ie_c+ishift
           do k = 1, nz
              do j = js_c, je_c+jshift
-                data(i,j,k) = dble(i)*1.d+6 + dble(j+jadd)*1.d+3 + dble(k) + x_add
+               coarse_data(i,j,k) = dble(i)*1.d+6 + dble(j+jadd)*1.d+3 + dble(k) + x_add
              enddo
           enddo
        endif
@@ -98,7 +98,7 @@ subroutine fill_coarse_data_r8(data, rotate, iadd, jadd, is_c, ie_c, js_c, je_c,
           j = je_c+jshift
           do k = 1, nz
              do j = js_c, je_c+jshift
-                data(i,j,k) = dble(i+iadd)*1.d+6 + j*1.d+3 + dble(k) + x_add
+               coarse_data(i,j,k) = dble(i+iadd)*1.d+6 + j*1.d+3 + dble(k) + x_add
              enddo
           enddo
        endif
@@ -107,11 +107,11 @@ subroutine fill_coarse_data_r8(data, rotate, iadd, jadd, is_c, ie_c, js_c, je_c,
   end subroutine fill_coarse_data_r8
 
 
-subroutine fill_coarse_data_r4(data, rotate, iadd, jadd, is_c, ie_c, js_c, je_c, nz, isd, jsd, nx, ny, &
+subroutine fill_coarse_data_r4(coarse_data, rotate, iadd, jadd, is_c, ie_c, js_c, je_c, nz, isd, jsd, nx, ny, &
                               ishift, jshift, x_add, y_add, sign1, sign2, x_cyclic, y_cyclic, ieg, jeg)
     integer, intent(in)    :: rotate, is_c, ie_c, js_c, je_c, nz, isd, jsd, iadd, jadd, nx, ny, ishift, jshift
     integer, intent(in)    :: sign1, sign2
-    real(kind=r4_kind),    intent(inout) :: data(isd:, jsd:, :)
+    real(kind=r4_kind),    intent(inout) :: coarse_data(isd:, jsd:, :)
     real(kind=r4_kind),    intent(in)    :: x_add, y_add
     logical, intent(in)    :: x_cyclic, y_cyclic
     integer, intent(in)    :: ieg, jeg
@@ -123,7 +123,7 @@ subroutine fill_coarse_data_r4(data, rotate, iadd, jadd, is_c, ie_c, js_c, je_c,
        do k = 1, nz
           do j = js_c, je_c+jshift
              do i = is_c, ie_c+ishift
-                data(i,j,k) = (i+iadd)*1.e+6 + (j+jadd)*1.e+3 + k + x_add
+               coarse_data(i,j,k) = (i+iadd)*1.e+6 + (j+jadd)*1.e+3 + k + x_add
              enddo
           enddo
        enddo
@@ -132,7 +132,7 @@ subroutine fill_coarse_data_r4(data, rotate, iadd, jadd, is_c, ie_c, js_c, je_c,
        do k = 1, nz
           do j = js_c, je_c+jshift
              do i = is_c, ie_c+ishift
-                data(i,j,k) = sign1*((nx-j+1+iadd+jshift)*1.e+6 + (i+jadd)*1.e+3 + k + y_add)
+               coarse_data(i,j,k) = sign1*((nx-j+1+iadd+jshift)*1.e+6 + (i+jadd)*1.e+3 + k + y_add)
              enddo
           enddo
        enddo
@@ -141,7 +141,7 @@ subroutine fill_coarse_data_r4(data, rotate, iadd, jadd, is_c, ie_c, js_c, je_c,
        do k = 1, nz
           do j = js_c, je_c+jshift
              do i = is_c, ie_c+ishift
-                data(i,j,k) = sign2*((j+iadd)*1.e+6 + (ny-i+1+jadd+ishift)*1.e+3 + k + y_add)
+               coarse_data(i,j,k) = sign2*((j+iadd)*1.e+6 + (ny-i+1+jadd+ishift)*1.e+3 + k + y_add)
              enddo
           enddo
        enddo
@@ -155,7 +155,7 @@ subroutine fill_coarse_data_r4(data, rotate, iadd, jadd, is_c, ie_c, js_c, je_c,
           i = ie_c+ishift
           do k = 1, nz
              do j = js_c, je_c+jshift
-                data(i,j,k) = i*1.e+6 + (j+jadd)*1.e+3 + k + x_add
+               coarse_data(i,j,k) = i*1.e+6 + (j+jadd)*1.e+3 + k + x_add
              enddo
           enddo
        endif
@@ -167,7 +167,7 @@ subroutine fill_coarse_data_r4(data, rotate, iadd, jadd, is_c, ie_c, js_c, je_c,
           j = je_c+jshift
           do k = 1, nz
              do j = js_c, je_c+jshift
-                data(i,j,k) = (i+iadd)*1.e+6 + j*1.e+3 + k + x_add
+               coarse_data(i,j,k) = (i+iadd)*1.e+6 + j*1.e+3 + k + x_add
              enddo
           enddo
        endif

--- a/test_fms/mpp/test_mpp_domains.F90
+++ b/test_fms/mpp/test_mpp_domains.F90
@@ -3678,63 +3678,63 @@ end subroutine test_halosize_update
   end subroutine test_unstruct_update
   !#################################################################################
 
-  subroutine fill_halo_zero(data, whalo, ehalo, shalo, nhalo, xshift, yshift, isc, iec, jsc, jec, isd, ied, jsd, jed)
+  subroutine fill_halo_zero(halo_data, whalo, ehalo, shalo, nhalo, xshift, yshift, isc, iec, jsc, jec, isd, ied, jsd, jed)
     integer,                         intent(in) :: isc, iec, jsc, jec, isd, ied, jsd, jed
     integer,                         intent(in) :: whalo, ehalo, shalo, nhalo, xshift, yshift
-    real, dimension(isd:,jsd:,:), intent(inout) :: data
+    real, dimension(isd:,jsd:,:), intent(inout) :: halo_data
 
     if(whalo >=0) then
-       data(iec+ehalo+1+xshift:ied+xshift,jsd:jed+yshift,:) = 0
-       data(isd:isc-whalo-1,jsd:jed+yshift,:) = 0
+       halo_data(iec+ehalo+1+xshift:ied+xshift,jsd:jed+yshift,:) = 0
+       halo_data(isd:isc-whalo-1,jsd:jed+yshift,:) = 0
     else
-       data(iec+1+xshift:iec-ehalo+xshift,jsc+shalo:jec-nhalo+yshift,:) = 0
-       data(isc+whalo:isc-1,jsc+shalo:jec-nhalo+yshift,:) = 0
+       halo_data(iec+1+xshift:iec-ehalo+xshift,jsc+shalo:jec-nhalo+yshift,:) = 0
+       halo_data(isc+whalo:isc-1,jsc+shalo:jec-nhalo+yshift,:) = 0
     end if
 
     if(shalo>=0) then
-       data(isd:ied+xshift, jec+nhalo+1+yshift:jed+yshift,:) = 0
-       data(isd:ied+xshift, jsd:jsc-shalo-1,:) = 0
+       halo_data(isd:ied+xshift, jec+nhalo+1+yshift:jed+yshift,:) = 0
+       halo_data(isd:ied+xshift, jsd:jsc-shalo-1,:) = 0
     else
-       data(isc+whalo:iec-ehalo+xshift,jec+1+yshift:jec-nhalo+yshift,:) = 0
-       data(isc+whalo:iec-ehalo+xshift,jsc+shalo:jsc-1,:) = 0
+       halo_data(isc+whalo:iec-ehalo+xshift,jec+1+yshift:jec-nhalo+yshift,:) = 0
+       halo_data(isc+whalo:iec-ehalo+xshift,jsc+shalo:jsc-1,:) = 0
     end if
 
   end subroutine fill_halo_zero
 
   !##############################################################################
   ! this routine fill the halo points for the regular mosaic.
-  subroutine fill_regular_mosaic_halo(data, data_all, te, tse, ts, tsw, tw, tnw, tn, tne)
-    real, dimension(1-whalo:,1-shalo:,:), intent(inout) :: data
+  subroutine fill_regular_mosaic_halo(halo_data, data_all, te, tse, ts, tsw, tw, tnw, tn, tne)
+    real, dimension(1-whalo:,1-shalo:,:), intent(inout) :: halo_data
     real, dimension(:,:,:,:),             intent(in)    :: data_all
     integer,                              intent(in)    :: te, tse, ts, tsw, tw, tnw, tn, tne
 
-       data(nx+1:nx+ehalo, 1:ny,          :) = data_all(1:ehalo,       1:ny,          :, te) ! east
-       data(1:nx,          1-shalo:0,     :) = data_all(1:nx,          ny-shalo+1:ny, :, ts) ! south
-       data(1-whalo:0,     1:ny,          :) = data_all(nx-whalo+1:nx, 1:ny,          :, tw) ! west
-       data(1:nx,          ny+1:ny+nhalo, :) = data_all(1:nx,          1:nhalo,       :, tn) ! north
-       data(nx+1:nx+ehalo, 1-shalo:0,     :) = data_all(1:ehalo,       ny-shalo+1:ny, :,tse) ! southeast
-       data(1-whalo:0,     1-shalo:0,     :) = data_all(nx-whalo+1:nx, ny-shalo+1:ny, :,tsw) ! southwest
-       data(nx+1:nx+ehalo, ny+1:ny+nhalo, :) = data_all(1:ehalo,       1:nhalo,       :,tnw) ! northeast
-       data(1-whalo:0,     ny+1:ny+nhalo, :) = data_all(nx-whalo+1:nx, 1:nhalo,       :,tne) ! northwest
+       halo_data(nx+1:nx+ehalo, 1:ny,          :) = data_all(1:ehalo,       1:ny,          :, te) ! east
+       halo_data(1:nx,          1-shalo:0,     :) = data_all(1:nx,          ny-shalo+1:ny, :, ts) ! south
+       halo_data(1-whalo:0,     1:ny,          :) = data_all(nx-whalo+1:nx, 1:ny,          :, tw) ! west
+       halo_data(1:nx,          ny+1:ny+nhalo, :) = data_all(1:nx,          1:nhalo,       :, tn) ! north
+       halo_data(nx+1:nx+ehalo, 1-shalo:0,     :) = data_all(1:ehalo,       ny-shalo+1:ny, :,tse) ! southeast
+       halo_data(1-whalo:0,     1-shalo:0,     :) = data_all(nx-whalo+1:nx, ny-shalo+1:ny, :,tsw) ! southwest
+       halo_data(nx+1:nx+ehalo, ny+1:ny+nhalo, :) = data_all(1:ehalo,       1:nhalo,       :,tnw) ! northeast
+       halo_data(1-whalo:0,     ny+1:ny+nhalo, :) = data_all(nx-whalo+1:nx, 1:nhalo,       :,tne) ! northwest
 
 
 
   end subroutine fill_regular_mosaic_halo
 
-  subroutine fill_folded_north_halo(data, ioff, joff, ishift, jshift, sign)
-    class(*), dimension(1-whalo:,1-shalo:,:), intent(inout) :: data
+  subroutine fill_folded_north_halo(halo_data, ioff, joff, ishift, jshift, sign)
+    class(*), dimension(1-whalo:,1-shalo:,:), intent(inout) :: halo_data
     integer,                              intent(in   ) :: ioff, joff, ishift, jshift, sign
 
-    select type(data)
+    select type(halo_data)
       type is (real(r4_kind))
-        call fill_folded_north_halo_r4(data, ioff, joff, ishift, jshift, sign)
+        call fill_folded_north_halo_r4(halo_data, ioff, joff, ishift, jshift, sign)
       type is (real(r8_kind))
-        call fill_folded_north_halo_r8(data, ioff, joff, ishift, jshift, sign)
+        call fill_folded_north_halo_r8(halo_data, ioff, joff, ishift, jshift, sign)
     end select
   end subroutine
   !################################################################################
-  subroutine fill_folded_north_halo_r4(data, ioff, joff, ishift, jshift, sign)
-    real(r4_kind), dimension(1-whalo:,1-shalo:,:), intent(inout) :: data
+  subroutine fill_folded_north_halo_r4(halo_data, ioff, joff, ishift, jshift, sign)
+    real(r4_kind), dimension(1-whalo:,1-shalo:,:), intent(inout) :: halo_data
     integer,                              intent(in   ) :: ioff, joff, ishift, jshift, sign
     integer  :: nxp, nyp, m1, m2
 
@@ -3743,17 +3743,19 @@ end subroutine test_halosize_update
     m1 = ishift - ioff
     m2 = 2*ishift - ioff
 
-    data(1-whalo:0,                  1:nyp,:) =      data(nx-whalo+1:nx,        1:ny+jshift,:) ! west
-    data(nx+1:nx+ehalo+ishift,       1:nyp,:) =      data(1:ehalo+ishift,       1:ny+jshift,:) ! east
-    if(m1 .GE. 1-whalo) data(1-whalo:m1,  nyp+1:nyp+nhalo,:) = sign*data(whalo+m2:1+ishift:-1, &
+    halo_data(1-whalo:0,                  1:nyp,:) =      halo_data(nx-whalo+1:nx,        1:ny+jshift,:) ! west
+    halo_data(nx+1:nx+ehalo+ishift,       1:nyp,:) =      halo_data(1:ehalo+ishift,       1:ny+jshift,:) ! east
+    if(m1 .GE. 1-whalo) halo_data(1-whalo:m1,  nyp+1:nyp+nhalo,:) = sign*halo_data(whalo+m2:1+ishift:-1, &
       &  nyp-joff:nyp-nhalo-joff+1:-1,:)
-    data(m1+1:nx+m2,       nyp+1:nyp+nhalo,:) = sign*data(nx+ishift:1:-1,       nyp-joff:nyp-nhalo-joff+1:-1,:)
-    data(nx+m2+1:nxp+ehalo,nyp+1:nyp+nhalo,:) = sign*data(nx:nx-ehalo+m1+1:-1,  nyp-joff:nyp-nhalo-joff+1:-1,:)
+    halo_data(m1+1:nx+m2,       nyp+1:nyp+nhalo,:) = &
+      sign*halo_data(nx+ishift:1:-1,       nyp-joff:nyp-nhalo-joff+1:-1,:)
+    halo_data(nx+m2+1:nxp+ehalo,nyp+1:nyp+nhalo,:) = &
+      sign*halo_data(nx:nx-ehalo+m1+1:-1,  nyp-joff:nyp-nhalo-joff+1:-1,:)
 
   end subroutine fill_folded_north_halo_r4
   ! r8 version needed for mixed mode
-  subroutine fill_folded_north_halo_r8(data, ioff, joff, ishift, jshift, sign)
-    real(r8_kind), dimension(1-whalo:,1-shalo:,:), intent(inout) :: data
+  subroutine fill_folded_north_halo_r8(halo_data, ioff, joff, ishift, jshift, sign)
+    real(r8_kind), dimension(1-whalo:,1-shalo:,:), intent(inout) :: halo_data
     integer,                              intent(in   ) :: ioff, joff, ishift, jshift, sign
     integer  :: nxp, nyp, m1, m2
 
@@ -3762,18 +3764,20 @@ end subroutine test_halosize_update
     m1 = ishift - ioff
     m2 = 2*ishift - ioff
 
-    data(1-whalo:0,                  1:nyp,:) =      data(nx-whalo+1:nx,        1:ny+jshift,:) ! west
-    data(nx+1:nx+ehalo+ishift,       1:nyp,:) =      data(1:ehalo+ishift,       1:ny+jshift,:) ! east
+    halo_data(1-whalo:0,                  1:nyp,:) =      halo_data(nx-whalo+1:nx,        1:ny+jshift,:) ! west
+    halo_data(nx+1:nx+ehalo+ishift,       1:nyp,:) =      halo_data(1:ehalo+ishift,       1:ny+jshift,:) ! east
     if(m1 .GE. 1-whalo) &
-      data(1-whalo:m1,  nyp+1:nyp+nhalo,:) = sign*data(whalo+m2:1+ishift:-1, nyp-joff:nyp-nhalo-joff+1:-1,:)
-    data(m1+1:nx+m2,       nyp+1:nyp+nhalo,:) = sign*data(nx+ishift:1:-1,       nyp-joff:nyp-nhalo-joff+1:-1,:)
-    data(nx+m2+1:nxp+ehalo,nyp+1:nyp+nhalo,:) = sign*data(nx:nx-ehalo+m1+1:-1,  nyp-joff:nyp-nhalo-joff+1:-1,:)
+      halo_data(1-whalo:m1,  nyp+1:nyp+nhalo,:) = sign*halo_data(whalo+m2:1+ishift:-1, nyp-joff:nyp-nhalo-joff+1:-1,:)
+    halo_data(m1+1:nx+m2,       nyp+1:nyp+nhalo,:) = &
+      sign*halo_data(nx+ishift:1:-1,       nyp-joff:nyp-nhalo-joff+1:-1,:)
+    halo_data(nx+m2+1:nxp+ehalo,nyp+1:nyp+nhalo,:) = &
+      sign*halo_data(nx:nx-ehalo+m1+1:-1,  nyp-joff:nyp-nhalo-joff+1:-1,:)
 
   end subroutine fill_folded_north_halo_r8
 
   !################################################################################
-  subroutine fill_folded_south_halo(data, ioff, joff, ishift, jshift, sign)
-    real, dimension(1-whalo:,1-shalo:,:), intent(inout) :: data
+  subroutine fill_folded_south_halo(halo_data, ioff, joff, ishift, jshift, sign)
+    real, dimension(1-whalo:,1-shalo:,:), intent(inout) :: halo_data
     integer,                              intent(in   ) :: ioff, joff, ishift, jshift, sign
     integer  :: nxp, nyp, m1, m2
 
@@ -3783,17 +3787,18 @@ end subroutine test_halosize_update
     m2 = 2*ishift - ioff
 
 
-    data(1-whalo:0,                  1:nyp,:) =      data(nx-whalo+1:nx,        1:nyp,:) ! west
-    data(nx+1:nx+ehalo+ishift,       1:nyp,:) =      data(1:ehalo+ishift,       1:nyp,:) ! east
-    if(m1 .GE. 1-whalo)data(1-whalo:m1, 1-shalo:0,:) = sign*data(whalo+m2:1+ishift:-1, shalo+jshift:1+jshift:-1,:)
-    data(m1+1:nx+m2,       1-shalo:0,:) = sign*data(nxp:1:-1,             shalo+jshift:1+jshift:-1,:)
-    data(nx+m2+1:nxp+ehalo,1-shalo:0,:) = sign*data(nx:nx-ehalo+m1+1:-1,  shalo+jshift:1+jshift:-1,:)
+    halo_data(1-whalo:0,                  1:nyp,:) =      halo_data(nx-whalo+1:nx,        1:nyp,:) ! west
+    halo_data(nx+1:nx+ehalo+ishift,       1:nyp,:) =      halo_data(1:ehalo+ishift,       1:nyp,:) ! east
+    if(m1 .GE. 1-whalo)halo_data(1-whalo:m1, 1-shalo:0,:) = &
+      sign*halo_data(whalo+m2:1+ishift:-1, shalo+jshift:1+jshift:-1,:)
+    halo_data(m1+1:nx+m2,       1-shalo:0,:) = sign*halo_data(nxp:1:-1,             shalo+jshift:1+jshift:-1,:)
+    halo_data(nx+m2+1:nxp+ehalo,1-shalo:0,:) = sign*halo_data(nx:nx-ehalo+m1+1:-1,  shalo+jshift:1+jshift:-1,:)
 
   end subroutine fill_folded_south_halo
 
   !################################################################################
-  subroutine fill_folded_west_halo(data, ioff, joff, ishift, jshift, sign)
-    real, dimension(1-whalo:,1-shalo:,:), intent(inout) :: data
+  subroutine fill_folded_west_halo(halo_data, ioff, joff, ishift, jshift, sign)
+    real, dimension(1-whalo:,1-shalo:,:), intent(inout) :: halo_data
     integer,                              intent(in   ) :: ioff, joff, ishift, jshift, sign
     integer  :: nxp, nyp, m1, m2
 
@@ -3802,17 +3807,18 @@ end subroutine test_halosize_update
     m1 = jshift - joff
     m2 = 2*jshift - joff
 
-    data(1:nxp, 1-shalo:0, :)      = data(1:nxp, ny-shalo+1:ny, :) ! south
-    data(1:nxp, ny+1:nyp+nhalo, :) = data(1:nxp, 1:nhalo+jshift,:) ! north
-    if(m1 .GE. 1-shalo) data(1-whalo:0, 1-shalo:m1, :) = sign*data(whalo+ishift:1+ishift:-1, shalo+m2:1+jshift:-1,:)
-    data(1-whalo:0, m1+1:ny+m2, :) = sign*data(whalo+ishift:1+ishift:-1, nyp:1:-1, :)
-    data(1-whalo:0, ny+m2+1:nyp+nhalo,:) = sign*data(whalo+ishift:1+ishift:-1, ny:ny-nhalo+m1+1:-1,:)
+    halo_data(1:nxp, 1-shalo:0, :)      = halo_data(1:nxp, ny-shalo+1:ny, :) ! south
+    halo_data(1:nxp, ny+1:nyp+nhalo, :) = halo_data(1:nxp, 1:nhalo+jshift,:) ! north
+    if(m1 .GE. 1-shalo) halo_data(1-whalo:0, 1-shalo:m1, :) = &
+      sign*halo_data(whalo+ishift:1+ishift:-1, shalo+m2:1+jshift:-1,:)
+    halo_data(1-whalo:0, m1+1:ny+m2, :) = sign*halo_data(whalo+ishift:1+ishift:-1, nyp:1:-1, :)
+    halo_data(1-whalo:0, ny+m2+1:nyp+nhalo,:) = sign*halo_data(whalo+ishift:1+ishift:-1, ny:ny-nhalo+m1+1:-1,:)
 
   end subroutine fill_folded_west_halo
 
   !################################################################################
-  subroutine fill_folded_east_halo(data, ioff, joff, ishift, jshift, sign)
-    real, dimension(1-whalo:,1-shalo:,:), intent(inout) :: data
+  subroutine fill_folded_east_halo(halo_data, ioff, joff, ishift, jshift, sign)
+    real, dimension(1-whalo:,1-shalo:,:), intent(inout) :: halo_data
     integer,                              intent(in   ) :: ioff, joff, ishift, jshift, sign
     integer  :: nxp, nyp, m1, m2
 
@@ -3821,12 +3827,13 @@ end subroutine test_halosize_update
     m1 = jshift - joff
     m2 = 2*jshift - joff
 
-    data(1:nxp, 1-shalo:0, :)      = data(1:nxp, ny-shalo+1:ny, :) ! south
-    data(1:nxp, ny+1:nyp+nhalo, :) = data(1:nxp, 1:nhalo+jshift,:) ! north
-    if(m1 .GE. 1-shalo) data(nxp+1:nxp+ehalo, 1-shalo:m1, :) = sign*data(nxp-ioff:nxp-ehalo-ioff+1:-1, &
+    halo_data(1:nxp, 1-shalo:0, :)      = halo_data(1:nxp, ny-shalo+1:ny, :) ! south
+    halo_data(1:nxp, ny+1:nyp+nhalo, :) = halo_data(1:nxp, 1:nhalo+jshift,:) ! north
+    if(m1 .GE. 1-shalo) halo_data(nxp+1:nxp+ehalo, 1-shalo:m1, :) = sign*halo_data(nxp-ioff:nxp-ehalo-ioff+1:-1, &
       &  shalo+m2:1+jshift:-1,:)
-    data(nxp+1:nxp+ehalo, m1+1:ny+m2, :) = sign*data(nxp-ioff:nxp-ehalo-ioff+1:-1, nyp:1:-1, :)
-    data(nxp+1:nxp+ehalo, ny+m2+1:nyp+nhalo,:) = sign*data(nxp-ioff:nxp-ehalo-ioff+1:-1, ny:ny-nhalo+m1+1:-1,:)
+    halo_data(nxp+1:nxp+ehalo, m1+1:ny+m2, :) = sign*halo_data(nxp-ioff:nxp-ehalo-ioff+1:-1, nyp:1:-1, :)
+    halo_data(nxp+1:nxp+ehalo, ny+m2+1:nyp+nhalo,:) = &
+      sign*halo_data(nxp-ioff:nxp-ehalo-ioff+1:-1, ny:ny-nhalo+m1+1:-1,:)
 
   end subroutine fill_folded_east_halo
 
@@ -4081,8 +4088,8 @@ end subroutine test_halosize_update
   !##############################################################################
   ! this routine fill the halo points for the cubic grid. ioff and joff is used to distinguish
   ! T, C, E, or N-cell
-  subroutine fill_cubic_grid_halo(data, data1_all, data2_all, tile, ioff, joff, sign1, sign2)
-    real, dimension(1-whalo:,1-shalo:,:), intent(inout) :: data
+  subroutine fill_cubic_grid_halo(halo_data, data1_all, data2_all, tile, ioff, joff, sign1, sign2)
+    real, dimension(1-whalo:,1-shalo:,:), intent(inout) :: halo_data
     real, dimension(:,:,:,:),             intent(in)    :: data1_all, data2_all
     integer,                              intent(in)    :: tile, ioff, joff, sign1, sign2
     integer                                             :: lw, le, ls, ln
@@ -4092,26 +4099,26 @@ end subroutine test_halosize_update
        if(le > 6 ) le = le - 6
        if(ls < 1 ) ls = ls + 6
        if(ln > 6 ) ln = ln - 6
-       data(1-whalo:0, 1:ny+joff, :) = data1_all(nx-whalo+1:nx, 1:ny+joff, :, lw) ! west
+       halo_data(1-whalo:0, 1:ny+joff, :) = data1_all(nx-whalo+1:nx, 1:ny+joff, :, lw) ! west
        do i = 1, ehalo
-          data(nx+i+ioff, 1:ny+joff, :)    = sign1*data2_all(nx+joff:1:-1, i+ioff, :, le) ! east
+          halo_data(nx+i+ioff, 1:ny+joff, :)    = sign1*data2_all(nx+joff:1:-1, i+ioff, :, le) ! east
        end do
        do i = 1, shalo
-          data(1:nx+ioff, 1-i, :)     = sign2*data2_all(nx-i+1, ny+ioff:1:-1, :, ls) ! south
+          halo_data(1:nx+ioff, 1-i, :)     = sign2*data2_all(nx-i+1, ny+ioff:1:-1, :, ls) ! south
        end do
-       data(1:nx+ioff, ny+1+joff:ny+nhalo+joff, :) = data1_all(1:nx+ioff, 1+joff:nhalo+joff, :, ln) ! north
+       halo_data(1:nx+ioff, ny+1+joff:ny+nhalo+joff, :) = data1_all(1:nx+ioff, 1+joff:nhalo+joff, :, ln) ! north
     else ! tile 1, 3, 5
        lw = tile - 2; le = tile + 1; ls = tile - 1; ln = tile + 2
        if(lw < 1 ) lw = lw + 6
        if(ls < 1 ) ls = ls + 6
        if(ln > 6 ) ln = ln - 6
        do i = 1, whalo
-          data(1-i, 1:ny+joff, :)     = sign1*data2_all(nx+joff:1:-1, ny-i+1, :, lw) ! west
+          halo_data(1-i, 1:ny+joff, :)     = sign1*data2_all(nx+joff:1:-1, ny-i+1, :, lw) ! west
        end do
-       data(nx+1+ioff:nx+ehalo+ioff, 1:ny+joff, :) = data1_all(1+ioff:ehalo+ioff, 1:ny+joff, :, le) ! east
-       data(1:nx+ioff, 1-shalo:0, :)     = data1_all(1:nx+ioff, ny-shalo+1:ny, :, ls) ! south
+       halo_data(nx+1+ioff:nx+ehalo+ioff, 1:ny+joff, :) = data1_all(1+ioff:ehalo+ioff, 1:ny+joff, :, le) ! east
+       halo_data(1:nx+ioff, 1-shalo:0, :)     = data1_all(1:nx+ioff, ny-shalo+1:ny, :, ls) ! south
        do i = 1, nhalo
-          data(1:nx+ioff, ny+i+joff, :)    = sign2*data2_all(i+joff, ny+ioff:1:-1, :, ln) ! north
+          halo_data(1:nx+ioff, ny+i+joff, :)    = sign2*data2_all(i+joff, ny+ioff:1:-1, :, ln) ! north
        end do
     end if
 
@@ -4456,8 +4463,8 @@ end subroutine test_halosize_update
 
   end subroutine test_nonuniform_mosaic
 
-  subroutine fill_five_tile_halo(data, data_all, tile, ioff, joff)
-    real, dimension(1-whalo:,1-shalo:,:), intent(inout) :: data
+  subroutine fill_five_tile_halo(halo_data, data_all, tile, ioff, joff)
+    real, dimension(1-whalo:,1-shalo:,:), intent(inout) :: halo_data
     real, dimension(:,:,:,:),             intent(in)    :: data_all
     integer,                              intent(in)    :: tile, ioff, joff
     integer                                             :: nxm, nym
@@ -4466,57 +4473,58 @@ end subroutine test_halosize_update
 
     select case(tile)
     case(1)
-       data(nxm+1+ioff:nxm+ehalo+ioff, 1:ny,:) = data_all(1+ioff:ehalo+ioff, 1:ny,:,2) ! east
-       data(nxm+1+ioff:nxm+ehalo+ioff, ny+1:nym+joff,:) = data_all(1+ioff:ehalo+ioff, 1:ny+joff,:,4) ! east
-       data(1-whalo:0, 1:ny,:) = data_all(nx-whalo+1:nx, 1:ny,:,3) ! west
-       data(1-whalo:0, ny+1:nym+joff,:) = data_all(nx-whalo+1:nx, 1:ny+joff,:,5) ! west
-       data(1:nxm+ioff, 1-shalo:0,:) = data_all(1:nxm+ioff, nym-shalo+1:nym,:,1) ! south
-       data(1:nxm+ioff, nym+1+joff:nym+nhalo+joff,:) = data_all(1:nxm+ioff, 1+joff:nhalo+joff,:,1) ! north
-       data(nxm+1+ioff:nxm+ehalo+ioff, 1-shalo:0,:) = data_all(1+ioff:ehalo+ioff, ny-shalo+1:ny,:,4) ! southeast
-       data(1-whalo:0, 1-shalo:0,:) = data_all(nx-whalo+1:nx, ny-shalo+1:ny,:,5) ! southwest
-       data(nxm+1+ioff:nxm+ehalo+ioff,nym+1+joff:nym+nhalo+joff,:) = &
+       halo_data(nxm+1+ioff:nxm+ehalo+ioff, 1:ny,:) = data_all(1+ioff:ehalo+ioff, 1:ny,:,2) ! east
+       halo_data(nxm+1+ioff:nxm+ehalo+ioff, ny+1:nym+joff,:) = data_all(1+ioff:ehalo+ioff, 1:ny+joff,:,4) ! east
+       halo_data(1-whalo:0, 1:ny,:) = data_all(nx-whalo+1:nx, 1:ny,:,3) ! west
+       halo_data(1-whalo:0, ny+1:nym+joff,:) = data_all(nx-whalo+1:nx, 1:ny+joff,:,5) ! west
+       halo_data(1:nxm+ioff, 1-shalo:0,:) = data_all(1:nxm+ioff, nym-shalo+1:nym,:,1) ! south
+       halo_data(1:nxm+ioff, nym+1+joff:nym+nhalo+joff,:) = data_all(1:nxm+ioff, 1+joff:nhalo+joff,:,1) ! north
+       halo_data(nxm+1+ioff:nxm+ehalo+ioff, 1-shalo:0,:) = data_all(1+ioff:ehalo+ioff, ny-shalo+1:ny,:,4) ! southeast
+       halo_data(1-whalo:0, 1-shalo:0,:) = data_all(nx-whalo+1:nx, ny-shalo+1:ny,:,5) ! southwest
+       halo_data(nxm+1+ioff:nxm+ehalo+ioff,nym+1+joff:nym+nhalo+joff,:) = &
                                                   & data_all(1+ioff:ehalo+ioff, 1+joff:nhalo+joff,:,2) ! northeast
-       data(1-whalo:0, nym+1+joff:nym+nhalo+joff,:) = data_all(nx-whalo+1:nx, 1+joff:nhalo+joff,:,3) ! northwest
+       halo_data(1-whalo:0, nym+1+joff:nym+nhalo+joff,:) = data_all(nx-whalo+1:nx, 1+joff:nhalo+joff,:,3) ! northwest
     case(2)
-       data(nx+1+ioff:nx+ehalo+ioff, 1:ny+joff,:) = data_all(1+ioff:ehalo+ioff, 1:ny+joff,:,3) ! east
-       data(1-whalo:0, 1:ny+joff,:) = data_all(nxm-whalo+1:nxm, 1:ny+joff,:,1) ! west
-       data(1:nx+ioff, 1-shalo:0,:) = data_all(1:nx+ioff, ny-shalo+1:ny,:,4) ! south
-       data(1:nx+ioff, ny+1+joff:ny+nhalo+joff,:) = data_all(1:nx+ioff, 1+joff:nhalo+joff,:,4) ! north
-       data(nx+1+ioff:nx+ehalo+ioff, 1-shalo:0,:) = data_all(1+ioff:ehalo+ioff, ny-shalo+1:ny,:,5) ! southeast
-       data(1-whalo:0, 1-shalo:0,:) = data_all(nxm-whalo+1:nxm, nym-shalo+1:nym,:,1) ! southwest
-       data(nx+1+ioff:nx+ehalo+ioff,ny+1+joff:ny+nhalo+joff,:) = &
-                                                  & data_all(1+ioff:ehalo+ioff,      1+joff:nhalo+joff,:,5) ! northeast
-       data(1-whalo:0, ny+1+joff:ny+nhalo+joff,:) = data_all(nxm-whalo+1:nxm, ny+1+joff:ny+nhalo+joff,:,1) ! northwest
+       halo_data(nx+1+ioff:nx+ehalo+ioff, 1:ny+joff,:) = data_all(1+ioff:ehalo+ioff, 1:ny+joff,:,3) ! east
+       halo_data(1-whalo:0, 1:ny+joff,:) = data_all(nxm-whalo+1:nxm, 1:ny+joff,:,1) ! west
+       halo_data(1:nx+ioff, 1-shalo:0,:) = data_all(1:nx+ioff, ny-shalo+1:ny,:,4) ! south
+       halo_data(1:nx+ioff, ny+1+joff:ny+nhalo+joff,:) = data_all(1:nx+ioff, 1+joff:nhalo+joff,:,4) ! north
+       halo_data(nx+1+ioff:nx+ehalo+ioff, 1-shalo:0,:) = data_all(1+ioff:ehalo+ioff, ny-shalo+1:ny,:,5) ! southeast
+       halo_data(1-whalo:0, 1-shalo:0,:) = data_all(nxm-whalo+1:nxm, nym-shalo+1:nym,:,1) ! southwest
+       halo_data(nx+1+ioff:nx+ehalo+ioff,ny+1+joff:ny+nhalo+joff,:) = &
+                                                  & data_all(1+ioff:ehalo+ioff,   1+joff:nhalo+joff,:,5) ! northeast
+       halo_data(1-whalo:0, ny+1+joff:ny+nhalo+joff,:) = &
+         data_all(nxm-whalo+1:nxm, ny+1+joff:ny+nhalo+joff,:,1) ! northwest
     case(3)
-       data(nx+1+ioff:nx+ehalo+ioff, 1:ny+joff,:) = data_all(1+ioff:ehalo+ioff, 1:ny+joff,:,1) ! east
-       data(1-whalo:0, 1:ny+joff,:) = data_all(nx-whalo+1:nx, 1:ny+joff,:,2) ! west
-       data(1:nx+ioff, 1-shalo:0,:) = data_all(1:nx+ioff, ny-shalo+1:ny,:,5) ! south
-       data(1:nx+ioff, ny+1+joff:ny+nhalo+joff,:) = data_all(1:nx+ioff, 1+joff:nhalo+joff,:,5) ! north
-       data(nx+1+ioff:nx+ehalo+ioff, 1-shalo:0,:) = data_all(1+ioff:ehalo+ioff, nym-shalo+1:nym,:,1) ! southeast
-       data(1-whalo:0, 1-shalo:0,:) = data_all(nx-whalo+1:nx, ny-shalo+1:ny,:,4) ! southwest
-       data(nx+1+ioff:nx+ehalo+ioff,ny+1+joff:ny+nhalo+joff,:) = &
-                                                  & data_all(1+ioff:ehalo+ioff,ny+1+joff:ny+nhalo+joff,:,1) ! northeast
-       data(1-whalo:0, ny+1+joff:ny+nhalo+joff,:) = data_all(nx-whalo+1:nx, 1+joff:nhalo+joff,:,4) ! northwest
+       halo_data(nx+1+ioff:nx+ehalo+ioff, 1:ny+joff,:) = data_all(1+ioff:ehalo+ioff, 1:ny+joff,:,1) ! east
+       halo_data(1-whalo:0, 1:ny+joff,:) = data_all(nx-whalo+1:nx, 1:ny+joff,:,2) ! west
+       halo_data(1:nx+ioff, 1-shalo:0,:) = data_all(1:nx+ioff, ny-shalo+1:ny,:,5) ! south
+       halo_data(1:nx+ioff, ny+1+joff:ny+nhalo+joff,:) = data_all(1:nx+ioff, 1+joff:nhalo+joff,:,5) ! north
+       halo_data(nx+1+ioff:nx+ehalo+ioff, 1-shalo:0,:) = data_all(1+ioff:ehalo+ioff, nym-shalo+1:nym,:,1) ! southeast
+       halo_data(1-whalo:0, 1-shalo:0,:) = data_all(nx-whalo+1:nx, ny-shalo+1:ny,:,4) ! southwest
+       halo_data(nx+1+ioff:nx+ehalo+ioff,ny+1+joff:ny+nhalo+joff,:) = &
+                                                & data_all(1+ioff:ehalo+ioff,ny+1+joff:ny+nhalo+joff,:,1) ! northeast
+       halo_data(1-whalo:0, ny+1+joff:ny+nhalo+joff,:) = data_all(nx-whalo+1:nx, 1+joff:nhalo+joff,:,4) ! northwest
     case(4)
-       data(nx+1+ioff:nx+ehalo+ioff, 1:ny+joff,:) = data_all(1+ioff:ehalo+ioff, 1:ny+joff,:,5) ! east
-       data(1-whalo:0, 1:ny+joff,:) = data_all(nxm-whalo+1:nxm, ny+1:2*ny+joff,:,1) ! west
-       data(1:nx+ioff, 1-shalo:0,:) = data_all(1:nx+ioff, ny-shalo+1:ny,:,2) ! south
-       data(1:nx+ioff, ny+1+joff:ny+nhalo+joff,:) = data_all(1:nx+ioff, 1+joff:nhalo+joff,:,2) ! north
-       data(nx+1+ioff:nx+ehalo+ioff, 1-shalo:0,:) = data_all(1+ioff:ehalo+ioff, ny-shalo+1:ny,:,3) ! southeast
-       data(1-whalo:0, 1-shalo:0,:) = data_all(nxm-whalo+1:nxm, ny-shalo+1:ny,:,1) ! southwest
-       data(nx+1+ioff:nx+ehalo+ioff,ny+1+joff:ny+nhalo+joff,:) = &
+       halo_data(nx+1+ioff:nx+ehalo+ioff, 1:ny+joff,:) = data_all(1+ioff:ehalo+ioff, 1:ny+joff,:,5) ! east
+       halo_data(1-whalo:0, 1:ny+joff,:) = data_all(nxm-whalo+1:nxm, ny+1:2*ny+joff,:,1) ! west
+       halo_data(1:nx+ioff, 1-shalo:0,:) = data_all(1:nx+ioff, ny-shalo+1:ny,:,2) ! south
+       halo_data(1:nx+ioff, ny+1+joff:ny+nhalo+joff,:) = data_all(1:nx+ioff, 1+joff:nhalo+joff,:,2) ! north
+       halo_data(nx+1+ioff:nx+ehalo+ioff, 1-shalo:0,:) = data_all(1+ioff:ehalo+ioff, ny-shalo+1:ny,:,3) ! southeast
+       halo_data(1-whalo:0, 1-shalo:0,:) = data_all(nxm-whalo+1:nxm, ny-shalo+1:ny,:,1) ! southwest
+       halo_data(nx+1+ioff:nx+ehalo+ioff,ny+1+joff:ny+nhalo+joff,:) = &
                                                   & data_all(1+ioff:ehalo+ioff,1+joff:nhalo+joff,:,3) ! northeast
-       data(1-whalo:0, ny+1+joff:ny+nhalo+joff,:) = data_all(nxm-whalo+1:nxm, 1+joff:nhalo+joff,:,1) ! northwest
+       halo_data(1-whalo:0, ny+1+joff:ny+nhalo+joff,:) = data_all(nxm-whalo+1:nxm, 1+joff:nhalo+joff,:,1) ! northwest
     case(5)
-       data(nx+1+ioff:nx+ehalo+ioff, 1: ny+joff,:) = data_all(1+ioff:ehalo+ioff, ny+1:2*ny+joff,:,1) ! east
-       data(1-whalo:0, 1:ny+joff,:) = data_all(nx-whalo+1:nx, 1:ny+joff,:,4) ! west
-       data(1:nx+ioff, 1-shalo:0,:) = data_all(1:nx+ioff, ny-shalo+1:ny,:,3) ! south
-       data(1:nx+ioff, ny+1+joff:ny+nhalo+joff,:) = data_all(1:nx+ioff, 1+joff:nhalo+joff,:,3) ! north
-       data(nx+1+ioff:nx+ehalo+ioff, 1-shalo:0,:) = data_all(1+ioff:ehalo+ioff, ny-shalo+1:ny,:,1) ! southeast
-       data(1-whalo:0, 1-shalo:0,:) = data_all(nx-whalo+1:nx, ny-shalo+1:ny,:,2) ! southwest
-       data(nx+1+ioff:nx+ehalo+ioff,ny+1+joff:ny+nhalo+joff,:) = &
+       halo_data(nx+1+ioff:nx+ehalo+ioff, 1: ny+joff,:) = data_all(1+ioff:ehalo+ioff, ny+1:2*ny+joff,:,1) ! east
+       halo_data(1-whalo:0, 1:ny+joff,:) = data_all(nx-whalo+1:nx, 1:ny+joff,:,4) ! west
+       halo_data(1:nx+ioff, 1-shalo:0,:) = data_all(1:nx+ioff, ny-shalo+1:ny,:,3) ! south
+       halo_data(1:nx+ioff, ny+1+joff:ny+nhalo+joff,:) = data_all(1:nx+ioff, 1+joff:nhalo+joff,:,3) ! north
+       halo_data(nx+1+ioff:nx+ehalo+ioff, 1-shalo:0,:) = data_all(1+ioff:ehalo+ioff, ny-shalo+1:ny,:,1) ! southeast
+       halo_data(1-whalo:0, 1-shalo:0,:) = data_all(nx-whalo+1:nx, ny-shalo+1:ny,:,2) ! southwest
+       halo_data(nx+1+ioff:nx+ehalo+ioff,ny+1+joff:ny+nhalo+joff,:) = &
                                                   & data_all(1+ioff:ehalo+ioff,1+joff:nhalo+joff,:,1) ! northeast
-       data(1-whalo:0, ny+1+joff:ny+nhalo+joff,:) = data_all(nx-whalo+1:nx, 1+joff:nhalo+joff,:,2) ! northwest
+       halo_data(1-whalo:0, ny+1+joff:ny+nhalo+joff,:) = data_all(nx-whalo+1:nx, 1+joff:nhalo+joff,:,2) ! northwest
     end select
 
   end subroutine fill_five_tile_halo
@@ -5294,29 +5302,30 @@ end subroutine test_halosize_update
   end subroutine test_get_boundary
 
   !#######################################################################################
-  subroutine fill_regular_refinement_halo( data, data_all, ni, nj, tm, te, tse, ts, tsw, tw, tnw, tn, tne, ioff, joff )
-    real, dimension(1-whalo:,1-shalo:,:), intent(inout) :: data
+  subroutine fill_regular_refinement_halo( halo_data, data_all, ni, nj, tm, te, tse, ts, &
+                                          tsw, tw, tnw, tn, tne, ioff, joff )
+    real, dimension(1-whalo:,1-shalo:,:), intent(inout) :: halo_data
     real, dimension(:,:,:,:),             intent(in)    :: data_all
     integer, dimension(:),                intent(in)    :: ni, nj
     integer,                              intent(in)    :: tm, te, tse, ts, tsw, tw, tnw, tn, tne
     integer,                              intent(in)    :: ioff, joff
 
 
-    if(te>0) data    (ni(tm)+1+ioff:ni(tm)+ehalo+ioff, 1:nj(tm)+joff,                   :) = &
+    if(te>0) halo_data    (ni(tm)+1+ioff:ni(tm)+ehalo+ioff, 1:nj(tm)+joff,                   :) = &
              data_all(1+ioff:ehalo+ioff,               1:nj(te)+joff,                   :,te)  ! east
-    if(ts>0) data    (1:ni(tm)+ioff,                   1-shalo:0,                       :) = &
+    if(ts>0) halo_data    (1:ni(tm)+ioff,                   1-shalo:0,                       :) = &
              data_all(1:ni(ts)+ioff,                   nj(ts)-shalo+1:nj(ts),           :,ts)  ! south
-    if(tw>0) data    (1-whalo:0,                       1:nj(tm)+joff,                   :) = &
+    if(tw>0) halo_data    (1-whalo:0,                       1:nj(tm)+joff,                   :) = &
              data_all(ni(tw)-whalo+1:ni(tw),           1:nj(tw)+joff,                   :,tw)  ! west
-    if(tn>0) data    (1:ni(tm)+ioff,                   nj(tm)+1+joff:nj(tm)+nhalo+joff, :) = &
+    if(tn>0) halo_data    (1:ni(tm)+ioff,                   nj(tm)+1+joff:nj(tm)+nhalo+joff, :) = &
              data_all(1:ni(tn)+ioff,                   1+joff:nhalo+joff,               :,tn)  ! north
-    if(tse>0)data    (ni(tm)+1+ioff:ni(tm)+ehalo+ioff, 1-shalo:0,                       :) = &
+    if(tse>0)halo_data    (ni(tm)+1+ioff:ni(tm)+ehalo+ioff, 1-shalo:0,                       :) = &
              data_all(1+ioff:ehalo+ioff,               nj(tse)-shalo+1:nj(tse),         :,tse) ! southeast
-    if(tsw>0)data    (1-whalo:0,                       1-shalo:0,                       :) = &
+    if(tsw>0)halo_data    (1-whalo:0,                       1-shalo:0,                       :) = &
              data_all(ni(tsw)-whalo+1:ni(tsw),         nj(tsw)-shalo+1:nj(tsw),         :,tsw) ! southwest
-    if(tne>0)data    (ni(tm)+1+ioff:ni(tm)+ehalo+ioff, nj(tm)+1+joff:nj(tm)+nhalo+joff, :) = &
+    if(tne>0)halo_data    (ni(tm)+1+ioff:ni(tm)+ehalo+ioff, nj(tm)+1+joff:nj(tm)+nhalo+joff, :) = &
              data_all(1+ioff:ehalo+ioff,               1+joff:nhalo+joff,               :,tnw) ! northeast
-    if(tnw>0)data    (1-whalo:0,                       nj(tm)+1+joff:nj(tm)+nhalo+joff, :) = &
+    if(tnw>0)halo_data    (1-whalo:0,                       nj(tm)+1+joff:nj(tm)+nhalo+joff, :) = &
              data_all(ni(tnw)-whalo+1:ni(tnw),         1+joff:nhalo+joff,               :,tne) ! northwest
 
   end subroutine fill_regular_refinement_halo
@@ -5324,8 +5333,8 @@ end subroutine test_halosize_update
   !##############################################################################
   ! this routine fill the halo points for the refined cubic grid. ioff and joff is used to distinguish
   ! T, C, E, or N-cell
-  subroutine fill_cubicgrid_refined_halo(data, data1_all, data2_all, ni, nj, tile, ioff, joff, sign1, sign2)
-    real, dimension(1-whalo:,1-shalo:,:), intent(inout) :: data
+  subroutine fill_cubicgrid_refined_halo(halo_data, data1_all, data2_all, ni, nj, tile, ioff, joff, sign1, sign2)
+    real, dimension(1-whalo:,1-shalo:,:), intent(inout) :: halo_data
     real, dimension(:,:,:,:),             intent(in)    :: data1_all, data2_all
     integer, dimension(:),                intent(in)    :: ni, nj
     integer,                              intent(in)    :: tile, ioff, joff, sign1, sign2
@@ -5337,20 +5346,20 @@ end subroutine test_halosize_update
        if(ls < 1 ) ls = ls + 6
        if(ln > 6 ) ln = ln - 6
        if( nj(tile) == nj(lw) ) then
-          data(1-whalo:0, 1:nj(tile)+joff, :) = data1_all(ni(lw)-whalo+1:ni(lw), 1:nj(lw)+joff, :, lw) ! west
+          halo_data(1-whalo:0, 1:nj(tile)+joff, :) = data1_all(ni(lw)-whalo+1:ni(lw), 1:nj(lw)+joff, :, lw) ! west
        end if
        if( nj(tile) == ni(le) ) then
           do i = 1, ehalo
-             data(ni(tile)+i+ioff, 1:nj(tile)+joff, :)    = sign1*data2_all(ni(le)+joff:1:-1, i+ioff, :, le) ! east
+             halo_data(ni(tile)+i+ioff, 1:nj(tile)+joff, :) = sign1*data2_all(ni(le)+joff:1:-1, i+ioff, :, le) ! east
           end do
        end if
        if(ni(tile) == nj(ls) ) then
           do i = 1, shalo
-             data(1:ni(tile)+ioff, 1-i, :)     = sign2*data2_all(ni(ls)-i+1, nj(ls)+ioff:1:-1, :, ls) ! south
+             halo_data(1:ni(tile)+ioff, 1-i, :)     = sign2*data2_all(ni(ls)-i+1, nj(ls)+ioff:1:-1, :, ls) ! south
           end do
        end if
        if(ni(tile) == ni(ln) ) then
-          data(1:ni(tile)+ioff, nj(tile)+1+joff:nj(tile)+nhalo+joff, :) = &
+          halo_data(1:ni(tile)+ioff, nj(tile)+1+joff:nj(tile)+nhalo+joff, :) = &
                                                   & data1_all(1:ni(ln)+ioff, 1+joff:nhalo+joff, :, ln) ! north
        end if
     else ! tile 1, 3, 5
@@ -5360,34 +5369,34 @@ end subroutine test_halosize_update
        if(ln > 6 ) ln = ln - 6
        if(nj(tile) == ni(lw) ) then
           do i = 1, whalo
-             data(1-i, 1:nj(tile)+joff, :)     = sign1*data2_all(ni(lw)+joff:1:-1, nj(lw)-i+1, :, lw) ! west
+            halo_data(1-i, 1:nj(tile)+joff, :)     = sign1*data2_all(ni(lw)+joff:1:-1, nj(lw)-i+1, :, lw) ! west
           end do
        end if
        if(nj(tile) == nj(le) ) then
-          data(ni(tile)+1+ioff:ni(tile)+ehalo+ioff, 1:nj(tile)+joff, :) = &
+          halo_data(ni(tile)+1+ioff:ni(tile)+ehalo+ioff, 1:nj(tile)+joff, :) = &
                                                   & data1_all(1+ioff:ehalo+ioff, 1:nj(le)+joff, :, le) ! east
        end if
        if(ni(tile) == ni(ls) ) then
-          data(1:ni(tile)+ioff, 1-shalo:0, :)     = data1_all(1:ni(ls)+ioff, nj(ls)-shalo+1:nj(ls), :, ls) ! south
+          halo_data(1:ni(tile)+ioff, 1-shalo:0, :)     = data1_all(1:ni(ls)+ioff, nj(ls)-shalo+1:nj(ls), :, ls) ! south
        end if
        if(ni(tile) == nj(ln) ) then
           do i = 1, nhalo
-             data(1:ni(tile)+ioff, nj(tile)+i+joff, :)    = sign2*data2_all(i+joff, nj(ln)+ioff:1:-1, :, ln) ! north
+             halo_data(1:ni(tile)+ioff, nj(tile)+i+joff, :)    = sign2*data2_all(i+joff, nj(ln)+ioff:1:-1, :, ln) ! north
           end do
        end if
     end if
 
   end subroutine fill_cubicgrid_refined_halo
 
-  subroutine set_corner_zero( data, isd, ied, jsd, jed, isc, iec, jsc, jec )
+  subroutine set_corner_zero( corner_data, isd, ied, jsd, jed, isc, iec, jsc, jec )
      integer,                               intent(in) :: isd, ied, jsd, jed
      integer,                               intent(in) :: isc, iec, jsc, jec
-     real, dimension(isd:,jsd:,:), intent(inout) :: data
+     real, dimension(isd:,jsd:,:), intent(inout) :: corner_data
 
-    data (isd  :isc-1, jsd  :jsc-1,:) = 0
-    data (isd  :isc-1, jec+1:jed,  :) = 0
-    data (iec+1:ied  , jsd  :jsc-1,:) = 0
-    data (iec+1:ied  , jec+1:jed,  :) = 0
+    corner_data (isd  :isc-1, jsd  :jsc-1,:) = 0
+    corner_data (isd  :isc-1, jec+1:jed,  :) = 0
+    corner_data (iec+1:ied  , jsd  :jsc-1,:) = 0
+    corner_data (iec+1:ied  , jec+1:jed,  :) = 0
 
 
   end subroutine set_corner_zero

--- a/test_fms/mpp/test_mpp_domains.F90
+++ b/test_fms/mpp/test_mpp_domains.F90
@@ -3678,7 +3678,8 @@ end subroutine test_halosize_update
   end subroutine test_unstruct_update
   !#################################################################################
 
-  subroutine fill_halo_zero(halo_data, whalo, ehalo, shalo, nhalo, xshift, yshift, isc, iec, jsc, jec, isd, ied, jsd, jed)
+  subroutine fill_halo_zero(halo_data, whalo, ehalo, shalo, nhalo, xshift, yshift, &
+                            isc, iec, jsc, jec, isd, ied, jsd, jed)
     integer,                         intent(in) :: isc, iec, jsc, jec, isd, ied, jsd, jed
     integer,                         intent(in) :: whalo, ehalo, shalo, nhalo, xshift, yshift
     real, dimension(isd:,jsd:,:), intent(inout) :: halo_data
@@ -5377,11 +5378,11 @@ end subroutine test_halosize_update
                                                   & data1_all(1+ioff:ehalo+ioff, 1:nj(le)+joff, :, le) ! east
        end if
        if(ni(tile) == ni(ls) ) then
-          halo_data(1:ni(tile)+ioff, 1-shalo:0, :)     = data1_all(1:ni(ls)+ioff, nj(ls)-shalo+1:nj(ls), :, ls) ! south
+          halo_data(1:ni(tile)+ioff, 1-shalo:0, :)    = data1_all(1:ni(ls)+ioff, nj(ls)-shalo+1:nj(ls), :, ls) ! south
        end if
        if(ni(tile) == nj(ln) ) then
           do i = 1, nhalo
-             halo_data(1:ni(tile)+ioff, nj(tile)+i+joff, :)    = sign2*data2_all(i+joff, nj(ln)+ioff:1:-1, :, ln) ! north
+             halo_data(1:ni(tile)+ioff, nj(tile)+i+joff, :) = sign2*data2_all(i+joff, nj(ln)+ioff:1:-1, :, ln) ! north
           end do
        end if
     end if

--- a/test_fms/mpp/test_mpp_gatscat.F90
+++ b/test_fms/mpp/test_mpp_gatscat.F90
@@ -121,7 +121,7 @@ contains
 
     integer :: pelist(npes)
     integer :: i,j,k
-    real(kind=r4_kind), allocatable, dimension(:,:)  ::  data     !!Data to be scattered
+    real(kind=r4_kind), allocatable, dimension(:,:)  ::  scatter_data     !!Data to be scattered
     real(kind=r4_kind), allocatable, dimension(:,:)  ::  segment
     integer :: DS, SS  !!Source data size and segment size
     integer :: iz, jz  !!The zeroth element to be scattered is at pos data(is+iz, js+jz)
@@ -130,7 +130,7 @@ contains
 
     DS = 7 !! DS should be less than 10 for the tests below to make sense.
     SS = 6
-    allocate(data(DS, DS))
+    allocate(scatter_data(DS, DS))
     allocate(segment(SS, SS))
 
     !!The full PE list [0, ...,npes-1]
@@ -139,7 +139,7 @@ contains
     enddo
 
     !!Initialize all data on all PEs
-    data = -1
+    scatter_data = -1
     segment = -2.0
     !! Re-initialize data  on the root PE only.
     !! Data is such that we can calculate what it should be with a Formula
@@ -147,7 +147,7 @@ contains
     if (pe == root) then
        do i = 1,DS
           do j = 1,DS
-             data(i,j) = i*10 + j
+             scatter_data(i,j) = i*10 + j
           enddo
        enddo
        !! And re-initalize segment on the root pe.
@@ -170,9 +170,9 @@ contains
     js = 2
     je = 3
     if(pe .eq. root) then
-       call mpp_scatter(is, ie, js, je, pelist(1:npes-1), segment, data, .true., iz, jz)
+       call mpp_scatter(is, ie, js, je, pelist(1:npes-1), segment, scatter_data, .true., iz, jz)
     else
-       call mpp_scatter(is, ie, js, je, pelist(1:npes -1), segment, data, .false., iz, jz)
+       call mpp_scatter(is, ie, js, je, pelist(1:npes -1), segment, scatter_data, .false., iz, jz)
     endif
 
     call mpp_sync() !
@@ -227,7 +227,7 @@ end subroutine test_scatter_2D_R4
 
     integer :: pelist(npes)
     integer :: i,j,k
-    real(kind=r8_kind), allocatable, dimension(:,:)  ::  data     !!Data to be scattered
+    real(kind=r8_kind), allocatable, dimension(:,:)  ::  scatter_data     !!Data to be scattered
     real(kind=r8_kind), allocatable, dimension(:,:)  ::  segment
     integer :: DS, SS  !!Source data size and segment size
     integer :: iz, jz  !!The zeroth element to be scattered is at pos data(is+iz, js+jz)
@@ -237,7 +237,7 @@ end subroutine test_scatter_2D_R4
 
     DS = 7 !! DS should be less than 10 for the tests below to make sense.
     SS = 6
-    allocate(data(DS, DS))
+    allocate(scatter_data(DS, DS))
     allocate(segment(SS, SS))
 
     !!The full PE list [0, ...,npes-1]
@@ -246,7 +246,7 @@ end subroutine test_scatter_2D_R4
     enddo
 
     !!Initialize all data on all PEs
-    data = -1
+    scatter_data = -1
     segment = -2.0
     !! Re-initialize data  on the root PE only.
     !! Data is such that we can calculate what it should be with a Formula
@@ -254,7 +254,7 @@ end subroutine test_scatter_2D_R4
     if (pe == root) then
        do i = 1,DS
           do j = 1,DS
-             data(i,j) = i*10 + j
+             scatter_data(i,j) = i*10 + j
           enddo
        enddo
        !! And re-initalize segment on the root pe.
@@ -277,9 +277,9 @@ end subroutine test_scatter_2D_R4
     js = 2
     je = 3
     if(pe .eq. root) then
-       call mpp_scatter(is, ie, js, je, pelist(1:npes-1), segment, data, .true., iz, jz)
+       call mpp_scatter(is, ie, js, je, pelist(1:npes-1), segment, scatter_data, .true., iz, jz)
     else
-       call mpp_scatter(is, ie, js, je, pelist(1:npes -1), segment, data, .false., iz, jz)
+       call mpp_scatter(is, ie, js, je, pelist(1:npes -1), segment, scatter_data, .false., iz, jz)
     endif
 
     call mpp_sync()
@@ -334,7 +334,7 @@ end subroutine test_scatter_2D_R8
 
     integer :: pelist(npes)
     integer :: i,j,k
-    real(kind=r4_kind), allocatable, dimension(:,:,:)  ::  data     !!Data to be scattered
+    real(kind=r4_kind), allocatable, dimension(:,:,:)  ::  scatter_data     !!Data to be scattered
     real(kind=r4_kind), allocatable, dimension(:,:,:)  ::  segment
     integer :: DS, SS  !!Source data size and segment size
     integer :: iz, jz  !!The zeroth element to be scattered is at pos data(is+iz, js+jz)
@@ -346,7 +346,7 @@ end subroutine test_scatter_2D_R8
     NZ = 11 !! Depth of the square tube to be scattered.
     DS = 6 !! DS should be less than 10 for the tests below to make sense.
     SS = 5 !! Can be different that DS, but see retrictions.
-    allocate(data(DS, DS, NZ))
+    allocate(scatter_data(DS, DS, NZ))
     allocate(segment(SS, SS, NZ))
 
     !!The full PE list is [0, ...,npes-1]
@@ -355,7 +355,7 @@ end subroutine test_scatter_2D_R8
     enddo
 
     !!Initialize all data on all PEs
-    data = -1
+    scatter_data = -1
     segment = -2.0
     !! Re-initialize data  on the root PE only.
     !! Data is such that we can calculate what it should be with a Formula
@@ -364,7 +364,7 @@ end subroutine test_scatter_2D_R8
        do i = 1,DS
           do j = 1,DS
              do k = 1,NZ
-             data(i,j, k) = k*100 + j*10 + i
+             scatter_data(i,j, k) = k*100 + j*10 + i
           enddo
        enddo
        enddo
@@ -372,7 +372,7 @@ end subroutine test_scatter_2D_R8
        do i = 1,SS
           do j = 1,SS
              do k = 1,NZ
-             segment(i,j, k) = data(i,j, k)
+             segment(i,j, k) = scatter_data(i,j, k)
           enddo
        enddo
        enddo
@@ -390,9 +390,9 @@ end subroutine test_scatter_2D_R8
     js = 2
     je = 3
     if(pe .eq. root) then
-       call mpp_scatter(is, ie, js, je, NZ, pelist(1:npes-1), segment, data, .true., iz, jz)
+       call mpp_scatter(is, ie, js, je, NZ, pelist(1:npes-1), segment, scatter_data, .true., iz, jz)
     else
-       call mpp_scatter(is, ie, js, je, NZ, pelist(1:npes -1), segment, data, .false., iz, jz)
+       call mpp_scatter(is, ie, js, je, NZ, pelist(1:npes -1), segment, scatter_data, .false., iz, jz)
     endif
 
     call mpp_sync()
@@ -464,7 +464,7 @@ end subroutine test_scatter_2D_R8
 
     integer :: pelist(npes)
     integer :: i,j,k
-    real(kind=r8_kind), allocatable, dimension(:,:,:)  ::  data     !!Data to be scattered
+    real(kind=r8_kind), allocatable, dimension(:,:,:)  ::  scatter_data     !!Data to be scattered
     real(kind=r8_kind), allocatable, dimension(:,:,:)  ::  segment
     integer :: DS, SS  !!Source data size and segment size
     integer :: iz, jz  !!The zeroth element to be scattered is at pos data(is+iz, js+jz)
@@ -476,7 +476,7 @@ end subroutine test_scatter_2D_R8
     NZ = 11 !! Depth of the square tube to be scattered.
     DS = 6 !! DS should be less than 10 for the tests below to make sense.
     SS = 5 !! Can be different that DS, but see retrictions.
-    allocate(data(DS, DS, NZ))
+    allocate(scatter_data(DS, DS, NZ))
     allocate(segment(SS, SS, NZ))
 
     !!The full PE list is [0, ...,npes-1]
@@ -485,7 +485,7 @@ end subroutine test_scatter_2D_R8
     enddo
 
     !!Initialize all data on all PEs
-    data = -1
+    scatter_data = -1
     segment = -2.0
     !! Re-initialize data  on the root PE only.
     !! Data is such that we can calculate what it should be with a Formula
@@ -494,7 +494,7 @@ end subroutine test_scatter_2D_R8
        do i = 1,DS
           do j = 1,DS
              do k = 1,NZ
-             data(i,j, k) = k*100 + j*10 + i
+             scatter_data(i,j, k) = k*100 + j*10 + i
           enddo
        enddo
        enddo
@@ -502,7 +502,7 @@ end subroutine test_scatter_2D_R8
        do i = 1,SS
           do j = 1,SS
              do k = 1,NZ
-             segment(i,j, k) = data(i,j, k)
+             segment(i,j, k) = scatter_data(i,j, k)
           enddo
        enddo
        enddo
@@ -520,9 +520,9 @@ end subroutine test_scatter_2D_R8
     js = 2
     je = 3
     if(pe .eq. root) then
-       call mpp_scatter(is, ie, js, je, NZ, pelist(1:npes-1), segment, data, .true., iz, jz)
+       call mpp_scatter(is, ie, js, je, NZ, pelist(1:npes-1), segment, scatter_data, .true., iz, jz)
     else
-       call mpp_scatter(is, ie, js, je, NZ, pelist(1:npes -1), segment, data, .false., iz, jz)
+       call mpp_scatter(is, ie, js, je, NZ, pelist(1:npes -1), segment, scatter_data, .false., iz, jz)
     endif
 
     call mpp_sync()
@@ -787,7 +787,7 @@ subroutine test_gather2DV(npes,pe,root,out_unit)
      integer :: pelist(npes),rsize(npes)
      integer :: pelist2(npes),rsize2(npes)
      integer :: i,j,k,l,nz,ssize,nelems
-     real,allocatable,dimension(:,:) :: data, cdata, sbuff,rbuff
+     real,allocatable,dimension(:,:) :: gather_data, cdata, sbuff,rbuff
      real,allocatable :: ref(:,:)
      integer, parameter :: KSIZE=10
 
@@ -805,9 +805,9 @@ subroutine test_gather2DV(npes,pe,root,out_unit)
      write(out_unit,*)
 
      ssize = pe+1
-     allocate(data(ssize,KSIZE))
+     allocate(gather_data(ssize,KSIZE))
      do k=1,KSIZE; do i=1,ssize
-       data(i,k) = 10000.0*k + pe + 0.0001*i
+       gather_data(i,k) = 10000.0*k + pe + 0.0001*i
      enddo; enddo
      do i=1,npes
        pelist(i) = i-1
@@ -834,7 +834,7 @@ subroutine test_gather2DV(npes,pe,root,out_unit)
      ! and a clear, concise unpack
      do j=1,ssize
        do i=1,nz
-         sbuff(i,j) = data(j,i)
+         sbuff(i,j) = gather_data(j,i)
      enddo; enddo
 
   !  Note that the gatherV implied here is asymmetric; only root needs to know the vector of recv size
@@ -892,7 +892,7 @@ subroutine test_gather2DV(npes,pe,root,out_unit)
      endif
      call mpp_sync()
      write(out_unit,*) "Test gather2DV with reversed pelist successful"
-     deallocate(data,sbuff,rbuff,cdata,ref)
+     deallocate(gather_data,sbuff,rbuff,cdata,ref)
   end subroutine test_gather2DV
 
 end program test_mpp_gatscat

--- a/test_fms/mpp/test_mpp_sendrecv.F90
+++ b/test_fms/mpp/test_mpp_sendrecv.F90
@@ -119,11 +119,11 @@ contains
 
     integer :: pelist(npes)
     integer :: i,j, p
-    real(kind=r4_kind), allocatable, dimension(:,:)  ::  data     !!Data to be sendrecved
+    real(kind=r4_kind), allocatable, dimension(:,:)  ::  sendrecv_data     !!Data to be sendrecved
     integer :: DS
 
     DS = 9
-    allocate(data(DS, DS))
+    allocate(sendrecv_data (DS, DS))
 
     !!The full PE list [0, ...,npes-1]
     do i=0,npes-1
@@ -131,14 +131,14 @@ contains
     enddo
 
     !!Initialize all data on all PEs
-    data = -1.0
+    sendrecv_data = -1.0
     !! Re-initialize data on the root PE only.
     !! Data is such that we can calculate what it should be with a Formula
     !! using the indecies. E.g.. data(3,4) is 34.000, etc.
     if (pe == root) then
        do i = 1,DS
           do j = 1,DS
-             data(i,j) = i*10.0 + j*1.0
+             sendrecv_data(i,j) = i*10.0 + j*1.0
           enddo
        enddo
     endif
@@ -147,10 +147,10 @@ contains
     !! And receive from all other pes
     if ( pe == root ) then
        do p = 1,npes-1
-          call mpp_send( data, DS* DS, p )
+          call mpp_send( sendrecv_data, DS* DS, p )
        end do
     else
-       call mpp_recv( data, DS * DS, 0 )
+       call mpp_recv( sendrecv_data, DS * DS, 0 )
     end if
 
     call mpp_sync() ! Needed ?
@@ -159,7 +159,7 @@ contains
     if(ANY(pe == pelist(1:npes-1))) then
        do j = 1, DS
           do i = 1, DS
-             if (data(i,j) /= ( i*10.0 + j*1.0)) then
+             if (sendrecv_data(i,j) /= ( i*10.0 + j*1.0)) then
                 call mpp_error(FATAL, "Test sendrecv 2D R4 failed - basic copy area.")
              endif
           enddo
@@ -177,11 +177,11 @@ contains
 
     integer :: pelist(npes)
     integer :: i,j, p
-    real(kind=r8_kind), allocatable, dimension(:,:)  ::  data     !!Data to be sendrecved
+    real(kind=r8_kind), allocatable, dimension(:,:)  ::  sendrecv_data     !!Data to be sendrecved
     integer :: DS
 
     DS = 9
-    allocate(data(DS, DS))
+    allocate(sendrecv_data(DS, DS))
 
     !!The full PE list [0, ...,npes-1]
     do i=0,npes-1
@@ -189,14 +189,14 @@ contains
     enddo
 
     !!Initialize all data on all PEs
-    data = -1.0
+    sendrecv_data = -1.0
     !! Re-initialize data on the root PE only.
     !! Data is such that we can calculate what it should be with a Formula
     !! using the indecies. E.g.. data(3,4) is 34.000, etc.
     if (pe == root) then
        do i = 1,DS
           do j = 1,DS
-             data(i,j) = i*10.0 + j*1.0
+             sendrecv_data(i,j) = i*10.0 + j*1.0
           enddo
        enddo
     endif
@@ -205,10 +205,10 @@ contains
     !! And receive from all other pes
     if ( pe == root ) then
        do p = 1,npes-1
-          call mpp_send( data, DS* DS, p )
+          call mpp_send( sendrecv_data, DS* DS, p )
        end do
     else
-       call mpp_recv( data, DS * DS, 0 )
+       call mpp_recv( sendrecv_data, DS * DS, 0 )
     end if
 
     call mpp_sync() ! Needed ?
@@ -218,7 +218,7 @@ contains
     if(ANY(pe == pelist(1:npes-1))) then
        do j = 1, DS
           do i = 1, DS
-             if (data(i,j) /= ( i*10.0 + j*1.0)) then
+             if (sendrecv_data(i,j) /= ( i*10.0 + j*1.0)) then
                 call mpp_error(FATAL, "Test sendrecv 2D R8 failed - basic copy area.")
              endif
           enddo
@@ -236,7 +236,7 @@ contains
 
     integer :: pelist(npes)
     integer :: i,j,k, p
-    real(kind=r4_kind), allocatable, dimension(:,:,:)  ::  data     !!Data to be sendrecved
+    real(kind=r4_kind), allocatable, dimension(:,:,:)  ::  sendrecv_data     !!Data to be sendrecved
     integer :: DS
     integer :: iz, jz  !!The zeroth element to be sendrecved is at pos data(is+iz, js+jz)
     integer :: is, ie, js, je !!The amount of data to be sendrecved is (ie - is)*(je - js)
@@ -245,7 +245,7 @@ contains
 
     NZ = 9 !! Depth of the square tube to be sendrecved.
     DS = 8 !! DS should be less than 10 for the tests below to make sense.
-    allocate(data(DS, DS, NZ))
+    allocate(sendrecv_data(DS, DS, NZ))
 
     !!The full PE list is [0, ...,npes-1]
     do i=0,npes-1
@@ -253,7 +253,7 @@ contains
     enddo
 
     !!Initialize all data on all PEs
-    data = -1.0
+    sendrecv_data = -1.0
     !! Re-initialize data  on the root PE only.
     !! Data is such that we can calculate what it should be with a Formula
     !! using the indecies. E.g.. data(3,4,5) is 543.000, etc.
@@ -261,7 +261,7 @@ contains
        do i = 1,DS
           do j = 1,DS
              do k = 1,NZ
-                data(i,j, k) = k*100.0 + j*10.0 + i*1.0
+                sendrecv_data(i,j, k) = k*100.0 + j*10.0 + i*1.0
              enddo
           enddo
        enddo
@@ -272,10 +272,10 @@ contains
     !! And receive from all other pes
     if ( pe == root ) then
        do p = 1,npes-1
-          call mpp_send( data, DS* DS* NZ, p )
+          call mpp_send( sendrecv_data, DS* DS* NZ, p )
        end do
     else
-       call mpp_recv( data, DS * DS * NZ, 0 )
+       call mpp_recv( sendrecv_data, DS * DS * NZ, 0 )
     end if
 
     call mpp_sync() ! Needed ?
@@ -286,7 +286,7 @@ contains
        do k = 1,  NZ
           do j = 1, DS
              do i = 1, DS
-                if (data(i,j, k) /= ( k*100.0 + j*10.0 + i*1.0 )) then
+                if (sendrecv_data(i,j, k) /= ( k*100.0 + j*10.0 + i*1.0 )) then
                    call mpp_error(FATAL, "Test sendrecv 3D R4 failed - basic copy area.")
                 endif
              enddo
@@ -307,7 +307,7 @@ contains
 
     integer :: pelist(npes)
     integer :: i,j,k, p
-    real(kind=r8_kind), allocatable, dimension(:,:,:)  ::  data     !!Data to be sendrecved
+    real(kind=r8_kind), allocatable, dimension(:,:,:)  ::  sendrecv_data     !!Data to be sendrecved
     integer :: DS
     integer :: iz, jz  !!The zeroth element to be sendrecved is at pos data(is+iz, js+jz)
     integer :: is, ie, js, je !!The amount of data to be sendrecved is (ie - is)*(je - js)
@@ -316,7 +316,7 @@ contains
 
     NZ = 9 !! Depth of the square tube to be sendrecved.
     DS = 8 !! DS should be less than 10 for the tests below to make sense.
-    allocate(data(DS, DS, NZ))
+    allocate(sendrecv_data(DS, DS, NZ))
 
     !!The full PE list is [0, ...,npes-1]
     do i=0,npes-1
@@ -324,7 +324,7 @@ contains
     enddo
 
     !!Initialize all data on all PEs
-    data = -1.0
+    sendrecv_data = -1.0
     !! Re-initialize data  on the root PE only.
     !! Data is such that we can calculate what it should be with a Formula
     !! using the indecies. E.g.. data(3,4,5) is 543.000, etc.
@@ -332,7 +332,7 @@ contains
        do i = 1,DS
           do j = 1,DS
              do k = 1,NZ
-                data(i,j, k) = k*100.0 + j*10.0 + i*1.0
+                sendrecv_data(i,j, k) = k*100.0 + j*10.0 + i*1.0
              enddo
           enddo
        enddo
@@ -343,10 +343,10 @@ contains
     !! And receive from all other pes
     if ( pe == root ) then
        do p = 1,npes-1
-          call mpp_send( data, DS* DS* NZ, p )
+          call mpp_send( sendrecv_data, DS* DS* NZ, p )
        end do
     else
-       call mpp_recv( data, DS * DS * NZ, 0 )
+       call mpp_recv( sendrecv_data, DS * DS * NZ, 0 )
     end if
 
     call mpp_sync() ! Needed ?
@@ -357,7 +357,7 @@ contains
        do k = 1,  NZ
           do j = 1, DS
              do i = 1, DS
-                if (data(i,j, k) /= ( k*100.0 + j*10.0 + i*1.0 )) then
+                if (sendrecv_data(i,j, k) /= ( k*100.0 + j*10.0 + i*1.0 )) then
                    call mpp_error(FATAL, "Test sendrecv 3D R8 failed - basic copy area.")
                 endif
              enddo
@@ -377,11 +377,11 @@ contains
 
     integer :: pelist(npes)
     integer(kind=i4_kind) :: i,j
-    integer(kind=i4_kind), allocatable, dimension(:,:)  ::  data     !!Data to be sendrecved
+    integer(kind=i4_kind), allocatable, dimension(:,:)  ::  sendrecv_data     !!Data to be sendrecved
     integer :: DS, p
 
     DS = 9
-    allocate(data(DS, DS))
+    allocate(sendrecv_data(DS, DS))
 
     !!The full PE list [0, ...,npes-1]
     do i=0,npes-1
@@ -389,14 +389,14 @@ contains
     enddo
 
     !!Initialize all data on all PEs
-    data = -1
+    sendrecv_data = -1
     !! Re-initialize data on the root PE only.
     !! Data is such that we can calculate what it should be with a Formula
     !! using the indecies. E.g.. data(3,4) is 34.000, etc.
     if (pe == root) then
        do i = 1,DS
           do j = 1,DS
-             data(i,j) = i*10 + j
+             sendrecv_data(i,j) = i*10 + j
           enddo
        enddo
     endif
@@ -405,10 +405,10 @@ contains
     !! And receive from all other pes
     if ( pe == root ) then
        do p = 1,npes-1
-          call mpp_send( data, DS* DS, p )
+          call mpp_send( sendrecv_data, DS* DS, p )
        end do
     else
-       call mpp_recv( data, DS * DS, 0 )
+       call mpp_recv( sendrecv_data, DS * DS, 0 )
     end if
 
     call mpp_sync() ! Needed ?
@@ -417,7 +417,7 @@ contains
     if(ANY(pe == pelist(1:npes-1))) then
        do j = 1, DS
           do i = 1, DS
-             if (data(i,j) /= ( i * 10 + j  )) then
+             if (sendrecv_data(i,j) /= ( i * 10 + j  )) then
                 call mpp_error(FATAL, "Test sendrecv 2D I4 failed - basic copy area.")
              endif
           enddo
@@ -435,11 +435,11 @@ contains
 
     integer :: pelist(npes)
     integer(kind=i8_kind) :: i,j
-    integer(kind=i8_kind), allocatable, dimension(:,:)  ::  data     !!Data to be sendrecved
+    integer(kind=i8_kind), allocatable, dimension(:,:)  ::  sendrecv_data     !!Data to be sendrecved
     integer :: DS, p
 
     DS = 9
-    allocate(data(DS, DS))
+    allocate(sendrecv_data(DS, DS))
 
     !!The full PE list [0, ...,npes-1]
     do i=0,npes-1
@@ -447,14 +447,14 @@ contains
     enddo
 
     !!Initialize all data on all PEs
-    data = -1
+    sendrecv_data = -1
     !! Re-initialize data on the root PE only.
     !! Data is such that we can calculate what it should be with a Formula
     !! using the indecies. E.g.. data(3,4) is 34.000, etc.
     if (pe == root) then
        do i = 1,DS
           do j = 1,DS
-             data(i,j) = i*10 + j
+             sendrecv_data(i,j) = i*10 + j
           enddo
        enddo
     endif
@@ -463,10 +463,10 @@ contains
     !! And receive from all other pes
     if ( pe == root ) then
        do p = 1,npes-1
-          call mpp_send( data, DS* DS, p )
+          call mpp_send( sendrecv_data, DS* DS, p )
        end do
     else
-       call mpp_recv( data, DS * DS, 0 )
+       call mpp_recv( sendrecv_data, DS * DS, 0 )
     end if
 
     call mpp_sync() ! Needed ?
@@ -475,7 +475,7 @@ contains
     if(ANY(pe == pelist(1:npes-1))) then
        do j = 1, DS
           do i = 1, DS
-             if (data(i,j) /= ( i * 10 + j  )) then
+             if (sendrecv_data(i,j) /= ( i * 10 + j  )) then
                 call mpp_error(FATAL, "Test sendrecv 2D I8 failed - basic copy area.")
              endif
           enddo
@@ -493,7 +493,7 @@ contains
 
     integer :: pelist(npes)
     integer(kind=i4_kind) :: i,j,k
-    integer(kind=i4_kind), allocatable, dimension(:,:,:)  ::  data     !!Data to be sendrecved
+    integer(kind=i4_kind), allocatable, dimension(:,:,:)  ::  sendrecv_data     !!Data to be sendrecved
     integer :: DS
     integer :: iz, jz  !!The zeroth element to be sendrecved is at pos data(is+iz, js+jz)
     integer :: is, ie, js, je !!The amount of data to be sendrecved is (ie - is)*(je - js)
@@ -502,7 +502,7 @@ contains
 
     NZ = 9 !! Depth of the square tube to be sendrecved.
     DS = 8 !! DS should be less than 10 for the tests below to make sense.
-    allocate(data(DS, DS, NZ))
+    allocate(sendrecv_data(DS, DS, NZ))
 
     !!The full PE list is [0, ...,npes-1]
     do i=0,npes-1
@@ -510,7 +510,7 @@ contains
     enddo
 
     !!Initialize all data on all PEs
-    data = -1
+    sendrecv_data = -1
     !! Re-initialize data  on the root PE only.
     !! Data is such that we can calculate what it should be with a Formula
     !! using the indecies. E.g.. data(3,4,5) is 543.000, etc.
@@ -518,7 +518,7 @@ contains
        do i = 1,DS
           do j = 1,DS
              do k = 1,NZ
-                data(i,j, k) = k*100 + j*10 + i
+                sendrecv_data(i,j, k) = k*100 + j*10 + i
              enddo
           enddo
        enddo
@@ -529,10 +529,10 @@ contains
     !! And receive from all other pes
     if ( pe == root ) then
        do p = 1,npes-1
-          call mpp_send( data, DS* DS* NZ, p )
+          call mpp_send( sendrecv_data, DS* DS* NZ, p )
        end do
     else
-       call mpp_recv( data, DS * DS * NZ, 0 )
+       call mpp_recv( sendrecv_data, DS * DS * NZ, 0 )
     end if
 
     call mpp_sync() ! Needed ?
@@ -543,7 +543,7 @@ contains
        do k = 1,  NZ
           do j = 1, DS
              do i = 1, DS
-                if (data(i,j, k) /= ( k * 100 + j*10 + i )) then
+                if (sendrecv_data(i,j, k) /= ( k * 100 + j*10 + i )) then
                    call mpp_error(FATAL, "Test sendrecv 3D I4 failed - basic copy area.")
                 endif
              enddo
@@ -563,7 +563,7 @@ contains
 
     integer :: pelist(npes)
     integer(kind=i8_kind) :: i,j,k
-    integer(kind=i8_kind), allocatable, dimension(:,:,:)  ::  data     !!Data to be sendrecved
+    integer(kind=i8_kind), allocatable, dimension(:,:,:)  ::  sendrecv_data     !!Data to be sendrecved
     integer :: DS
     integer :: iz, jz  !!The zeroth element to be sendrecved is at pos data(is+iz, js+jz)
     integer :: is, ie, js, je !!The amount of data to be sendrecved is (ie - is)*(je - js)
@@ -572,7 +572,7 @@ contains
 
     NZ = 9 !! Depth of the square tube to be sendrecved.
     DS = 8 !! DS should be less than 10 for the tests below to make sense.
-    allocate(data(DS, DS, NZ))
+    allocate(sendrecv_data(DS, DS, NZ))
 
     !!The full PE list is [0, ...,npes-1]
     do i=0,npes-1
@@ -580,7 +580,7 @@ contains
     enddo
 
     !!Initialize all data on all PEs
-    data = -1
+    sendrecv_data = -1
     !! Re-initialize data  on the root PE only.
     !! Data is such that we can calculate what it should be with a Formula
     !! using the indecies. E.g.. data(3,4,5) is 543.000, etc.
@@ -588,7 +588,7 @@ contains
        do i = 1,DS
           do j = 1,DS
              do k = 1,NZ
-                data(i,j, k) = k*100 + j*10 + i
+                sendrecv_data(i,j, k) = k*100 + j*10 + i
              enddo
           enddo
        enddo
@@ -599,10 +599,10 @@ contains
     !! And receive from all other pes
     if ( pe == root ) then
        do p = 1,npes-1
-          call mpp_send( data, DS* DS* NZ, p )
+          call mpp_send( sendrecv_data, DS* DS* NZ, p )
        end do
     else
-       call mpp_recv( data, DS * DS * NZ, 0 )
+       call mpp_recv( sendrecv_data, DS * DS * NZ, 0 )
     end if
 
     call mpp_sync() ! Needed ?
@@ -613,7 +613,7 @@ contains
        do k = 1,  NZ
           do j = 1, DS
              do i = 1, DS
-                if (data(i,j, k) /= ( k * 100 + j*10 + i )) then
+                if (sendrecv_data(i,j, k) /= ( k * 100 + j*10 + i )) then
                    call mpp_error(FATAL, "Test sendrecv 3D I8 failed - basic copy area.")
                 endif
              enddo

--- a/test_fms/sat_vapor_pres/test_sat_vapor_pres.F90
+++ b/test_fms/sat_vapor_pres/test_sat_vapor_pres.F90
@@ -52,8 +52,8 @@ integer, parameter :: ESRES=10  !> taken from sat_vapor_pres_mod
 real(r8_kind), dimension(:), allocatable :: TABLE, DTABLE, TABLE2, DTABLE2, TABLE3, DTABLE3
 integer :: io, N
 
-integer, parameter :: nml_unit_var=100
-character(100) :: nml_file
+integer :: nml_unit_var
+character(*), parameter :: nml_file = 'test_sat_vapor_pres.nml'
 logical :: test1, test2, test3, test4, test5
 NAMELIST / test_sat_vapor_pres_nml/ test1, test2, test3, test4, test5
 
@@ -64,8 +64,7 @@ call fms_init()
 call sat_vapor_pres_init()  !> compute tables to be used for testing
 call compute_tables()       !> compute tables to generate answers/reference values
 
-nml_file='test_sat_vapor_pres.nml'
-open(unit=nml_unit_var, file=trim(nml_file), action='read')
+open(newunit=nml_unit_var, file=nml_file, action='read')
 read(unit=nml_unit_var, nml=test_sat_vapor_pres_nml,iostat=io)
 close(nml_unit_var)
 


### PR DESCRIPTION
**Description**
`data` was introduced as a "data statement" in fortran 77. It can be used to declare/assign values to variables.
In FMS, the instance of `data` being used as a variable name happens often. This PR suggests changes to these variable names, and does not include any directories/modules that are either no longer used and/or deprecated (i.e. axis_utils, mpp_io, fms_io, etc). 


Fixes # 1328

**How Has This Been Tested?**
autotools with gcc/13.1.0, netcdf/4.9.2, mpich/4.1.2,  hdf5/1.14.1-2, libyaml/0.2.5

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

