### PR TITLE
mixed precision remove cp fileobj  in interpolator_tye_eq

### DIFF
--- a/interpolator/interpolator.F90
+++ b/interpolator/interpolator.F90
@@ -444,7 +444,6 @@ type(interpolate_type), intent(inout) :: Out
      Out%je = In%je
      Out%vertical_indices = In%vertical_indices
      Out%climatological_year = In%climatological_year
-     Out%fileobj = In%fileobj
      if (allocated(In%has_level    )) Out%has_level     =  In%has_level
      if (allocated(In%field_name   )) Out%field_name    =  In%field_name
      if (allocated(In%time_init    )) Out%time_init     =  In%time_init

--- a/test_fms/interpolator/test_interpolator2.F90
+++ b/test_fms/interpolator/test_interpolator2.F90
@@ -87,6 +87,9 @@ program test_interpolator2
   call test_interpolator(o3)
 
   !> test interpolate_type_eq
+  !! This test has been commented out and will be included
+  !! in the testing suite once fileobj cp is added into
+  !! test_interpolate_type_eq
   !write(*,*) '===== test_interpolate_type_eq ====='
   !call test_interpolate_type_eq()
 

--- a/test_fms/interpolator/test_interpolator2.F90
+++ b/test_fms/interpolator/test_interpolator2.F90
@@ -87,8 +87,8 @@ program test_interpolator2
   call test_interpolator(o3)
 
   !> test interpolate_type_eq
-  write(*,*) '===== test_interpolate_type_eq ====='
-  call test_interpolate_type_eq()
+  !write(*,*) '===== test_interpolate_type_eq ====='
+  !call test_interpolate_type_eq()
 
   !> test query_interpolator
   write(*,*) '===== test_query_interpolator ====='


### PR DESCRIPTION
The cp fileobj correction is not in main yet and has been accidentally introduced in the mixedmode branch.
This cp fileobj will be added to mixedmode once the change is approved in main.