### PR TITLE
Modern diag manager: Input buffer obj

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,6 +134,7 @@ list(APPEND fms_fortran_src_files
   diag_manager/fms_diag_dlinked_list.F90
   diag_manager/fms_diag_object_container.F90
   diag_manager/fms_diag_output_buffer.F90
+  diag_manager/fms_diag_input_buffer.F90
   diag_manager/fms_diag_time_reduction.F90
   diag_manager/fms_diag_outfield.F90
   diag_manager/fms_diag_elem_weight_procs.F90

--- a/diag_manager/Makefile.am
+++ b/diag_manager/Makefile.am
@@ -47,6 +47,7 @@ libdiag_manager_la_SOURCES = \
   fms_diag_object_container.F90 \
   fms_diag_dlinked_list.F90 \
   fms_diag_output_buffer.F90 \
+  fms_diag_input_buffer.F90 \
   fms_diag_time_reduction.F90 \
   fms_diag_outfield.F90 \
   fms_diag_elem_weight_procs.F90 \
@@ -72,9 +73,11 @@ fms_diag_object_mod.$(FC_MODEXT): diag_data_mod.$(FC_MODEXT) fms_diag_file_objec
                                   fms_diag_time_utils_mod.$(FC_MODEXT) \
                                   fms_diag_output_buffer_mod.$(FC_MODEXT) \
                                   fms_diag_reduction_methods_mod.$(FC_MODEXT) \
-                                  fms_diag_bbox_mod.$(FC_MODEXT)
+                                  fms_diag_bbox_mod.$(FC_MODEXT) \
+                                  fms_diag_input_buffer_mod.$(FC_MODEXT)
+fms_diag_input_buffer_mod.$(FC_MODEXT): fms_diag_axis_object_mod.$(FC_MODEXT)
 fms_diag_field_object_mod.$(FC_MODEXT): diag_data_mod.$(FC_MODEXT) fms_diag_yaml_mod.$(FC_MODEXT) fms_diag_time_utils_mod.$(FC_MODEXT) \
-                                        fms_diag_axis_object_mod.$(FC_MODEXT)
+                                        fms_diag_axis_object_mod.$(FC_MODEXT) fms_diag_input_buffer_mod.$(FC_MODEXT)
 fms_diag_file_object_mod.$(FC_MODEXT): diag_data_mod.$(FC_MODEXT) fms_diag_yaml_mod.$(FC_MODEXT) fms_diag_field_object_mod.$(FC_MODEXT) fms_diag_time_utils_mod.$(FC_MODEXT) \
                                        fms_diag_axis_object_mod.$(FC_MODEXT) fms_diag_output_buffer_mod.$(FC_MODEXT)
 fms_diag_object_container_mod.$(FC_MODEXT): fms_diag_object_mod.$(FC_MODEXT) fms_diag_dlinked_list_mod.$(FC_MODEXT) fms_diag_time_utils_mod.$(FC_MODEXT)
@@ -115,6 +118,7 @@ MODFILES = \
   fms_diag_dlinked_list_mod.$(FC_MODEXT) \
   fms_diag_object_container_mod.$(FC_MODEXT) \
   fms_diag_output_buffer_mod.$(FC_MODEXT) \
+  fms_diag_input_buffer_mod.$(FC_MODEXT) \
   diag_manager_mod.$(FC_MODEXT) \
   fms_diag_time_reduction_mod.$(FC_MODEXT) \
   fms_diag_outfield_mod.$(FC_MODEXT) \

--- a/diag_manager/fms_diag_bbox.F90
+++ b/diag_manager/fms_diag_bbox.F90
@@ -353,6 +353,10 @@ end function determine_if_block_is_in_region
       this%jmax = UBOUND(array,2)
       this%kmin = LBOUND(array,3)
       this%kmax = UBOUND(array,3)
+
+      this%has_halos = .false.
+      this%nhalo_I = 0
+      this%nhalo_J = 0
    END SUBROUTINE  reset_bounds_from_array_4D
 
    !> @brief Reset the instance bounding box with the bounds determined from the

--- a/diag_manager/fms_diag_field_object.F90
+++ b/diag_manager/fms_diag_field_object.F90
@@ -126,6 +126,7 @@ type fmsDiagField_type
      procedure :: has_volume
      procedure :: has_missing_value
      procedure :: has_data_RANGE
+     procedure :: has_input_data_buffer
 ! Get functions
      procedure :: get_attributes
      procedure :: get_static
@@ -1418,6 +1419,14 @@ pure logical function has_data_RANGE (this)
   class (fmsDiagField_type), intent(in) :: this !< diag object
   has_data_RANGE = allocated(this%data_RANGE)
 end function has_data_RANGE
+
+!> @brief Checks if obj%input_data_buffer is allocated
+!! @return true if obj%input_data_buffer is allocated
+pure logical function has_input_data_buffer (this)
+  class (fmsDiagField_type), intent(in) :: this !< diag object
+  has_input_data_buffer = allocated(this%input_data_buffer)
+end function has_input_data_buffer
+
 !> @brief Add a attribute to the diag_obj using the diag_field_id
 subroutine diag_field_add_attribute(this, att_name, att_value)
   class (fmsDiagField_type), intent (inout) :: this !< The field object

--- a/diag_manager/fms_diag_file_object.F90
+++ b/diag_manager/fms_diag_file_object.F90
@@ -67,10 +67,7 @@ type :: fmsDiagFile_type
   TYPE(time_type) :: next_output      !< Time of the next write
   TYPE(time_type) :: next_next_output !< Time of the next next write
   TYPE(time_type) :: no_more_data     !< Time to stop receiving data for this file
-  logical         :: done_writing_data!< Set to .True. if finished writing data
-                                      !! This is be initialized to .false. and set to true for
-                                      !! static files after the first write and for
-                                      !! files that are using the file_duration functionality
+  logical         :: done_writing_data!< .True. if finished writing data
 
   !< This will be used when using the new_file_freq keys in the diag_table.yaml
   TYPE(time_type) :: next_close       !< Time to close the file

--- a/diag_manager/fms_diag_input_buffer.F90
+++ b/diag_manager/fms_diag_input_buffer.F90
@@ -1,0 +1,206 @@
+!***********************************************************************
+!*                   GNU Lesser General Public License
+!*
+!* This file is part of the GFDL Flexible Modeling System (FMS).
+!*
+!* FMS is free software: you can redistribute it and/or modify it under
+!* the terms of the GNU Lesser General Public License as published by
+!* the Free Software Foundation, either version 3 of the License, or (at
+!* your option) any later version.
+!*
+!* FMS is distributed in the hope that it will be useful, but WITHOUT
+!* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+!* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+!* for more details.
+!*
+!* You should have received a copy of the GNU Lesser General Public
+!* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
+!***********************************************************************
+!> @defgroup fms_diag_input_buffer_mod fms_diag_input_buffer_mod
+!> @ingroup diag_manager
+!! @brief
+!> @addtogroup fms_diag_input_buffer_mod
+!> @{
+module fms_diag_input_buffer_mod
+#ifdef use_yaml
+  use platform_mod,             only: r8_kind, r4_kind, i4_kind, i8_kind
+  use fms_diag_axis_object_mod, only: fmsDiagAxisContainer_type, fmsDiagFullAxis_type
+  implicit NONE
+  private
+
+  !> @brief Type to hold the information needed for the input buffer
+  !! This is used when set_math_needs_to_be_done = .true. (i.e calling send_data
+  !! from an openmp region with multiple threads)
+  type fmsDiagInputBuffer_t
+    logical                        :: initialized     !< .True. if the input buffer has been initialized
+    class(*),          allocatable :: buffer(:,:,:,:) !< Input data passed in send_data
+    logical,           allocatable :: mask(:,:,:,:)   !< Mask passed in send_data
+    real(kind=r8_kind)             :: weight          !< Weight passed in send_data
+
+    contains
+    procedure :: get_buffer
+    procedure :: get_mask
+    procedure :: get_weight
+    procedure :: init => init_input_buffer_object
+    procedure :: set_input_buffer_object
+    procedure :: is_initialized
+  end type fmsDiagInputBuffer_t
+
+  public :: fmsDiagInputBuffer_t
+
+  contains
+
+  !> @brief Get the buffer from the input buffer object
+  !! @return a pointer to the buffer
+  function get_buffer(this) &
+    result(buffer)
+    class(fmsDiagInputBuffer_t), target, intent(in) :: this !< input buffer object
+    class(*), pointer :: buffer(:,:,:,:)
+
+    buffer => this%buffer
+  end function get_buffer
+
+  !> @brief Get the mask from the input buffer object
+  !! @return a pointer to the mask
+  function get_mask(this) &
+    result(mask)
+    class(fmsDiagInputBuffer_t), target, intent(in) :: this !< input buffer object
+    logical, pointer :: mask(:,:,:,:)
+
+    mask => this%mask
+  end function get_mask
+
+  !> @brief Get the weight from the input buffer object
+  !! @return a pointer to the weight
+  function get_weight(this) &
+    result(weight)
+    class(fmsDiagInputBuffer_t), target, intent(in) :: this !< input buffer object
+    real(kind=r8_kind), pointer :: weight
+
+    weight => this%weight
+  end function get_weight
+
+  !> @brief Initiliazes an input data buffer
+  !! @return Error message if something went wrong
+  function init_input_buffer_object(this, input_data, axis_ids, diag_axis) &
+    result(err_msg)
+    class(fmsDiagInputBuffer_t),         intent(out)   :: this                !< input buffer object
+    class(*),                            intent(in)    :: input_data(:,:,:,:) !< input data
+    integer, target,                     intent(in)    :: axis_ids(:)         !< axis ids for the field
+    class(fmsDiagAxisContainer_type),    intent(in)    :: diag_axis(:)        !< Array of diag_axis
+    character(len=128) :: err_msg
+
+    integer            :: naxes         !< The number of axes in the field
+    integer, parameter :: ndims = 4     !< Number of dimensions
+    integer            :: length(ndims) !< The length of an axis
+    integer            :: a             !< For looping through axes
+    integer, pointer   :: axis_id       !< The axis ID
+
+    err_msg = ""
+
+    !! Use the axis to get the size
+    !> Initialize the axis lengths to 1.  Any dimension that does not have an axis will have a length
+    !! of 1.
+    length = 1
+    naxes = size(axis_ids)
+    axis_loop: do a = 1,naxes
+      axis_id => axis_ids(a)
+      select type (axis => diag_axis(axis_id)%axis)
+      type is (fmsDiagFullAxis_type)
+        length(a) = axis%axis_length()
+      end select
+    enddo axis_loop
+
+    allocate(this%mask(length(1), length(2), length(3), length(4)))
+    select type (input_data)
+    type is (real(r4_kind))
+      allocate(real(kind=r4_kind) :: this%buffer(length(1), length(2), length(3), length(4)))
+    type is (real(r8_kind))
+      allocate(real(kind=r8_kind) :: this%buffer(length(1), length(2), length(3), length(4)))
+    type is (integer(i4_kind))
+      allocate(integer(kind=i4_kind) :: this%buffer(length(1), length(2), length(3), length(4)))
+    type is (integer(i8_kind))
+      allocate(integer(kind=i4_kind) :: this%buffer(length(1), length(2), length(3), length(4)))
+    class default
+      err_msg = "The data input is not one of the supported types."&
+        "Only r4, r8, i4, and i8 types are supported."
+    end select
+
+    this%weight = 1.0_r8_kind
+    this%initialized = .true.
+  end function init_input_buffer_object
+
+  !> @brief Sets the members of the input buffer object
+  !! @return Error message if something went wrong
+  function set_input_buffer_object(this, input_data, weight, mask, is, js, ks, ie, je, ke) &
+    result(err_msg)
+
+    class(fmsDiagInputBuffer_t), intent(inout) :: this                !< input buffer object
+    class(*),                    intent(in)    :: input_data(:,:,:,:) !< Field data
+    real(kind=r8_kind),          intent(in)    :: weight              !< Weight for the field
+    logical,                     intent(in)    :: mask(:,:,:,:)       !< Mask for the field
+    integer,                     intent(in)    :: is, js, ks          !< Starting index for each of the dimension
+    integer,                     intent(in)    :: ie, je, ke          !< Ending index for each of the dimensions
+
+    character(len=128) :: err_msg
+    err_msg = ""
+
+    if (.not. this%initialized) then
+      err_msg = "The data buffer was never initiliazed. This shouldn't happen."
+      return
+    endif
+
+    this%mask(is:ie, js:je, ks:ke, :) = mask
+    this%weight = weight
+
+    select type (input_data)
+    type is (real(kind=r4_kind))
+      select type (db => this%buffer)
+      type is (real(kind=r4_kind))
+        db(is:ie, js:je, ks:ke, :) = input_data
+      class default
+        err_msg = "The data buffer was not allocated to the correct type (r4_kind). This shouldn't happen"
+        return
+      end select
+    type is (real(kind=r8_kind))
+      select type (db => this%buffer)
+      type is (real(kind=r8_kind))
+        db(is:ie, js:je, ks:ke, :) = input_data
+      class default
+        err_msg = "The data buffer was not allocated to the correct type (r8_kind). This shouldn't happen"
+        return
+      end select
+    type is (integer(kind=i4_kind))
+      select type (db => this%buffer)
+      type is (integer(kind=i4_kind))
+        db(is:ie, js:je, ks:ke, :) = input_data
+      class default
+        err_msg = "The data buffer was not allocated to the correct type (i4_kind). This shouldn't happen"
+        return
+      end select
+    type is (integer(kind=i8_kind))
+      select type (db => this%buffer)
+      type is (integer(kind=i8_kind))
+        db(is:ie, js:je, ks:ke, :) = input_data
+      class default
+        err_msg = "The data buffer was not allocated to the correct type (i8_kind). This shouldn't happen"
+        return
+      end select
+    end select
+  end function set_input_buffer_object
+
+  !> @brief Determine if an input buffer is initialized
+  !! @return .true. if the input buffer is initialized
+  pure logical function is_initialized(this)
+    class(fmsDiagInputBuffer_t), intent(in) :: this !< input buffer object
+
+    is_initialized = .false.
+    if (this%initialized) then
+      is_initialized = .true.
+    else
+      if (allocated(this%buffer)) is_initialized = .true.
+    endif
+  end function is_initialized
+#endif
+end module fms_diag_input_buffer_mod
+!> @}

--- a/test_fms/diag_manager/test_reduction_methods.F90
+++ b/test_fms/diag_manager/test_reduction_methods.F90
@@ -228,6 +228,16 @@ program test_reduction_methods
           mask=dlmask(:,:,:,1))
       end select
     case (test_openmp)
+      select case(mask_case)
+      case (no_mask)
+        used=send_data(id_var1, cdata(:, 1, 1, 1), time)
+      case (logical_mask)
+        used=send_data(id_var1, cdata(:, 1, 1, 1), time, &
+            mask=clmask(:, 1, 1, 1))
+      case (real_mask)
+        used=send_data(id_var1, cdata(:, 1, 1, 1), time, &
+            rmask=crmask(:, 1, 1, 1))
+      end select
 !$OMP parallel do default(shared) private(iblock, isw, iew, jsw, jew, is1, ie1, js1, je1)
       do iblock=1, 4
         isw = my_block%ibs(iblock)
@@ -243,19 +253,14 @@ program test_reduction_methods
 
         select case (mask_case)
         case (no_mask)
-          used=send_data(id_var1, cdata(is1:ie1, 1, 1, 1), time, is_in=is1, ie_in=ie1)
           used=send_data(id_var2, cdata(is1:ie1, js1:je1, 1, 1), time, is_in=is1, js_in=js1)
           used=send_data(id_var3, cdata(is1:ie1, js1:je1, :, 1), time, is_in=is1, js_in=js1)
         case (real_mask)
-          used=send_data(id_var1, cdata(is1:ie1, 1, 1, 1), time, is_in=is1, ie_in=ie1, &
-            rmask=crmask(is1:ie1, 1, 1, 1))
           used=send_data(id_var2, cdata(is1:ie1, js1:je1, 1, 1), time, is_in=is1, js_in=js1, &
             rmask=crmask(is1:ie1, js1:je1, 1, 1))
           used=send_data(id_var3, cdata(is1:ie1, js1:je1, :, 1), time, is_in=is1, js_in=js1, &
             rmask=crmask(is1:ie1, js1:je1, :, 1))
         case (logical_mask)
-          used=send_data(id_var1, cdata(is1:ie1, 1, 1, 1), time, is_in=is1, ie_in=ie1, &
-            mask=clmask(is1:ie1, 1, 1, 1))
           used=send_data(id_var2, cdata(is1:ie1, js1:je1, 1, 1), time, is_in=is1, js_in=js1, &
             mask=clmask(is1:ie1, js1:je1, 1, 1))
           used=send_data(id_var3, cdata(is1:ie1, js1:je1, :, 1), time, is_in=is1, js_in=js1, &
@@ -263,7 +268,6 @@ program test_reduction_methods
         end select
       enddo
     end select
-
     call diag_send_complete(Time_step)
   enddo
 

--- a/test_fms/diag_manager/test_time_none.sh
+++ b/test_fms/diag_manager/test_time_none.sh
@@ -109,8 +109,7 @@ test_expect_success "Checking answers for the "none" reduction method, real mask
   mpirun -n 1 ../check_time_none
 '
 
-TODO this needs to be set back to 2, once the set_math_needs_to_be_done=.true. portion of the code is implemented
-export OMP_NUM_THREADS=1
+export OMP_NUM_THREADS=2
 my_test_count=`expr $my_test_count + 1`
 printf "&diag_manager_nml \n use_modern_diag=.true. \n / \n&test_reduction_methods_nml \n test_case = 1 \n \n/" | cat > input.nml
 test_expect_success "Running diag_manager with "none" reduction method with openmp (test $my_test_count)" '


### PR DESCRIPTION
**Description**

- Sets up an input buffer object to store the data when running with multiple threads
- Sets up the math in diag_send_complete
- The `time_none` unit tests were updated to run with multiple threads

Fixes # (issue)

**How Has This Been Tested?**
CI

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

