### PR TITLE
Add tile number to the filename for subregional files

### DIFF
--- a/diag_manager/diag_output.F90
+++ b/diag_manager/diag_output.F90
@@ -111,6 +111,8 @@ CONTAINS
     integer, allocatable, dimension(:) :: current_pelist
     integer :: mype  !< The pe you are on
     character(len=9) :: mype_string !< a string to store the pe
+    character(len=128) :: tmp_filename      !< Temp variable to store the file_name
+
     !---- initialize mpp_io ----
     IF ( .NOT.module_is_initialized ) THEN
        module_is_initialized = .TRUE.
@@ -135,8 +137,11 @@ CONTAINS
        fileob => fileobjND
        mype = mpp_pe()
        write(mype_string,'(I0.4)') mype
+       call get_mosaic_tile_file(file_name, tmp_filename, .true., domain)
+       tmp_filename = trim(tmp_filename)//"."//trim(mype_string)
+
         if (.not.check_if_open(fileob)) then
-               call open_check(open_file(fileobjND, trim(file_name)//".nc."//trim(mype_string), "overwrite", &
+               call open_check(open_file(fileobjND, trim(tmp_filename), "overwrite", &
                             is_restart=.false.))
                !< For regional subaxis add the NumFilesInSet attribute, which is added by fms2_io for (other)
                !< domains with sufficient decomposition info. Note mppnccombine will work with an entry of zero.

--- a/diag_manager/diag_output.F90
+++ b/diag_manager/diag_output.F90
@@ -111,7 +111,8 @@ CONTAINS
     integer, allocatable, dimension(:) :: current_pelist
     integer :: mype  !< The pe you are on
     character(len=9) :: mype_string !< a string to store the pe
-    character(len=128) :: tmp_filename      !< Temp variable to store the file_name
+    character(len=128) :: filename_tile !< Filename with the tile number included
+                                        !! It is needed for subregional diagnostics
 
     !---- initialize mpp_io ----
     IF ( .NOT.module_is_initialized ) THEN
@@ -137,11 +138,13 @@ CONTAINS
        fileob => fileobjND
        mype = mpp_pe()
        write(mype_string,'(I0.4)') mype
-       call get_mosaic_tile_file(file_name, tmp_filename, .true., domain)
-       tmp_filename = trim(tmp_filename)//"."//trim(mype_string)
+       !! Add the tile number to the subregional file
+       !! This is needed for the combiner to work correctly
+       call get_mosaic_tile_file(file_name, filename_tile, .true., domain)
+       filename_tile = trim(filename_tile)//"."//trim(mype_string)
 
         if (.not.check_if_open(fileob)) then
-               call open_check(open_file(fileobjND, trim(tmp_filename), "overwrite", &
+               call open_check(open_file(fileobjND, trim(filename_tile), "overwrite", &
                             is_restart=.false.))
                !< For regional subaxis add the NumFilesInSet attribute, which is added by fms2_io for (other)
                !< domains with sufficient decomposition info. Note mppnccombine will work with an entry of zero.


### PR DESCRIPTION
**Description**
Add tile number to the filename for subregional files

Fixes #1008 

**How Has This Been Tested?**
This was tested with an AM4.2 amip run
and this table:
```
ESM4_amip_D1_am4p2_proto7b_isop_whiteCapsAlbedo_salt_nudge_ch4_2d_adj_vmr_high_terpene_SIS2
1870 1 1 0 0 0

"US_aircraft",1,"hours",1,"days","time"
"dynamics", "H2", "H2", "US_aircraft", "all", .true., "232.50,292.50,25.00,50.00,239.00,1000.00", 2
```

Before this update tile was not added to the filename and now it is. This update is needed in order for the combiner to work correctly.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

