### PR TITLE
Fix the `start_time` functionality in the diag_table

### DIFF
--- a/diag_manager/diag_manager.F90
+++ b/diag_manager/diag_manager.F90
@@ -218,7 +218,8 @@ use platform_mod
        & check_out_of_bounds, check_bounds_are_exact_dynamic, check_bounds_are_exact_static,&
        & diag_time_inc, find_input_field, init_input_field, init_output_field,&
        & diag_data_out, write_static, get_date_dif, get_subfield_vert_size, sync_file_times,&
-       & prepend_attribute, attribute_init, diag_util_init, field_log_separator
+       & prepend_attribute, attribute_init, diag_util_init, field_log_separator, &
+       & get_file_start_time
   USE diag_data_mod, ONLY: max_files, CMOR_MISSING_VALUE, DIAG_OTHER, DIAG_OCEAN, DIAG_ALL, EVERY_TIME,&
        & END_OF_RUN, DIAG_SECONDS, DIAG_MINUTES, DIAG_HOURS, DIAG_DAYS, DIAG_MONTHS, DIAG_YEARS, num_files,&
        & max_input_fields, max_output_fields, num_output_fields, EMPTY, FILL_VALUE, null_axis_id,&
@@ -444,6 +445,7 @@ CONTAINS
     INTEGER :: stdout_unit
     LOGICAL :: mask_variant1, verbose1
     CHARACTER(len=128) :: msg
+    TYPE(time_type) :: init_time2
 
     ! get stdout unit number
     stdout_unit = stdout()
@@ -559,7 +561,6 @@ CONTAINS
           ind = input_fields(field)%output_fields(j)
           output_fields(ind)%static = .FALSE.
           ! Set up times in output_fields
-          output_fields(ind)%last_output = init_time
           ! Get output frequency from for the appropriate output file
           file_num = output_fields(ind)%output_file
           IF ( file_num == max_files ) CYCLE
@@ -578,8 +579,10 @@ CONTAINS
           END IF
 
           freq = files(file_num)%output_freq
+          call get_file_start_time(file_num, init_time2)
           output_units = files(file_num)%output_units
-          output_fields(ind)%next_output = diag_time_inc(init_time, freq, output_units, err_msg=msg)
+          output_fields(ind)%last_output = init_time2
+          output_fields(ind)%next_output = diag_time_inc(init_time2, freq, output_units, err_msg=msg)
           IF ( msg /= '' ) THEN
              IF ( fms_error_handler('diag_manager_mod::register_diag_field',&
                   & ' file='//TRIM(files(file_num)%name)//': '//TRIM(msg),err_msg)) RETURN

--- a/diag_manager/diag_manager.F90
+++ b/diag_manager/diag_manager.F90
@@ -445,7 +445,7 @@ CONTAINS
     INTEGER :: stdout_unit
     LOGICAL :: mask_variant1, verbose1
     CHARACTER(len=128) :: msg
-    TYPE(time_type) :: init_time2
+    TYPE(time_type) :: diag_file_init_time !< The intial time of the diag_file
 
     ! get stdout unit number
     stdout_unit = stdout()
@@ -579,10 +579,10 @@ CONTAINS
           END IF
 
           freq = files(file_num)%output_freq
-          call get_file_start_time(file_num, init_time2)
+          diag_file_init_time = get_file_start_time(file_num)
           output_units = files(file_num)%output_units
-          output_fields(ind)%last_output = init_time2
-          output_fields(ind)%next_output = diag_time_inc(init_time2, freq, output_units, err_msg=msg)
+          output_fields(ind)%last_output = diag_file_init_time
+          output_fields(ind)%next_output = diag_time_inc(diag_file_init_time, freq, output_units, err_msg=msg)
           IF ( msg /= '' ) THEN
              IF ( fms_error_handler('diag_manager_mod::register_diag_field',&
                   & ' file='//TRIM(files(file_num)%name)//': '//TRIM(msg),err_msg)) RETURN

--- a/diag_manager/diag_manager.F90
+++ b/diag_manager/diag_manager.F90
@@ -1917,7 +1917,6 @@ CONTAINS
        if (present(time)) then
          !! If the last_output is greater than the time passed in, it is not time to start averaging the data
          if (output_fields(out_num)%last_output > time) CYCLE
-         endif
        endif
 
        IF ( .NOT.output_fields(out_num)%static .AND. .NOT.need_compute .AND. debug_diag_manager ) THEN

--- a/diag_manager/diag_manager.F90
+++ b/diag_manager/diag_manager.F90
@@ -1914,6 +1914,12 @@ CONTAINS
           ! Finished output of previously buffered data, now deal with buffering new data
        END IF
 
+       if (present(time)) then
+         !! If the last_output is greater than the time passed in, it is not time to start averaging the data
+         if (output_fields(out_num)%last_output > time) CYCLE
+         endif
+       endif
+
        IF ( .NOT.output_fields(out_num)%static .AND. .NOT.need_compute .AND. debug_diag_manager ) THEN
           CALL check_bounds_are_exact_dynamic(out_num, diag_field_id, Time, err_msg=err_msg_local)
           IF ( err_msg_local /= '' ) THEN

--- a/diag_manager/diag_util.F90
+++ b/diag_manager/diag_util.F90
@@ -84,7 +84,7 @@ use,intrinsic :: iso_c_binding, only: c_double,c_float,c_int64_t, &
        & prepend_attribute, attribute_init, diag_util_init,&
        & update_bounds, check_out_of_bounds, check_bounds_are_exact_dynamic, check_bounds_are_exact_static,&
        & fms_diag_check_out_of_bounds, &
-       & fms_diag_check_bounds_are_exact_dynamic, fms_diag_check_bounds_are_exact_static
+       & fms_diag_check_bounds_are_exact_dynamic, fms_diag_check_bounds_are_exact_static, get_file_start_time
 
 
   !> @brief Prepend a value to a string attribute in the output field or output file.
@@ -2753,6 +2753,12 @@ END SUBROUTINE check_bounds_are_exact_dynamic
     END IF
   END SUBROUTINE prepend_attribute_file
 
+  subroutine get_file_start_time(file_num, start_time)
+   integer, intent(in) :: file_num
+   TYPE(time_type), intent(out) :: start_time
+
+   start_time = files(file_num)%start_time
+  end subroutine
 END MODULE diag_util_mod
 !> @}
 ! close documentation grouping

--- a/diag_manager/diag_util.F90
+++ b/diag_manager/diag_util.F90
@@ -2753,12 +2753,16 @@ END SUBROUTINE check_bounds_are_exact_dynamic
     END IF
   END SUBROUTINE prepend_attribute_file
 
-  subroutine get_file_start_time(file_num, start_time)
-   integer, intent(in) :: file_num
-   TYPE(time_type), intent(out) :: start_time
+  !> @brief Get the a diag_file's start_time as it is defined in the diag_table
+  !! @return the start_time for the file
+  function get_file_start_time(file_num) &
+   result (start_time)
+   integer,         intent(in)  :: file_num   !< File number of the file to get the start_time from
+
+   TYPE(time_type) :: start_time !< The start_time to return
 
    start_time = files(file_num)%start_time
-  end subroutine
+  end function get_file_start_time
 END MODULE diag_util_mod
 !> @}
 ! close documentation grouping


### PR DESCRIPTION
**Description**
Fix the `start_time` functionality in the diag_table

Fixes #1379 

**How Has This Been Tested?**
CI
Ran the C96L65 AM5 experiments

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

