### PR TITLE
add allocatable and pure macros back into fms_platform.h

### DIFF
--- a/include/fms_platform.h
+++ b/include/fms_platform.h
@@ -46,6 +46,28 @@ use,intrinsic :: iso_c_binding, only: c_double,c_float,c_int64_t, &
 !DEC$ MESSAGE:'Using 8-byte addressing'
 #endif
 
+!Control "pure" functions.
+#ifdef NO_F95
+#define _PURE
+!DEC$ MESSAGE:'Not using pure routines.'
+#else
+#define _PURE pure
+!DEC$ MESSAGE:'Using pure routines.'
+#endif
+
+!Control array members of derived types.
+#ifdef NO_F2000
+#define _ALLOCATABLE pointer
+#define _NULL =>null()
+#define _ALLOCATED associated
+!DEC$ MESSAGE:'Using pointer derived type array members.'
+#else
+#define _ALLOCATABLE allocatable
+#define _NULL
+#define _ALLOCATED allocated
+!DEC$ MESSAGE:'Using allocatable derived type array members.'
+#endif
+
 !Control use of cray pointers within mpp_peset
 !Other cray pointer usage in mpp routines is compiled regardless
 #ifdef NO_CRAY_POINTERS


### PR DESCRIPTION
**Description**
adds back in the macros for allocatables/pointers

**How Has This Been Tested?**
CI

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passe

