### PR TITLE
allow for arguments in test_fms mpi_launcher override

### DIFF
--- a/test_fms/test-lib.sh.in
+++ b/test_fms/test-lib.sh.in
@@ -96,8 +96,10 @@ mpirun () {
 # Set the name of the mpi launcher for use in test scripts.
   local mpi_launcher='@MPI_LAUNCHER@'
   local oversubscribe='@OVERSUBSCRIBE@'
+  # need to strip off any args that may be included with MPI_LAUNCHER arg for check below to work
+  local mpi_cmd="`echo $mpi_launcher | awk '{print $1;}'`"
   # Check if running with MPI: if so, the mpi_launcher will point to a command
-  command -v "$mpi_launcher" 2>&1 > /dev/null
+  command -v "$mpi_cmd" 2>&1 > /dev/null
   if test $? -eq 0
   then
     # use `command` to keep from reusing this function


### PR DESCRIPTION
**Description**
Fixes an issue with one of the shell testing functions. If including arguments in the mpi launcher override it would cause the launcher to just not be used because it would fail the `command -v` check.

**How Has This Been Tested?**
This came up while running on parallelworks and was tested there

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

