### PR TITLE
fix diag_send_complete loops and add get_file_ids

### DIFF
--- a/diag_manager/fms_diag_field_object.F90
+++ b/diag_manager/fms_diag_field_object.F90
@@ -164,6 +164,7 @@ type fmsDiagField_type
      procedure :: get_math_needs_to_be_done
      procedure :: add_area_volume
      procedure :: append_time_cell_methods
+     procedure :: get_file_ids
 end type fmsDiagField_type
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! variables !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 type(fmsDiagField_type) :: null_ob
@@ -1638,6 +1639,13 @@ result(compute_domain)
     end select
   enddo axis_loop
 end function get_starting_compute_domain
+
+!> Get list of field ids
+pure function get_file_ids(this)
+  class(fmsDiagField_type), intent(in) :: this
+  integer, allocatable :: get_file_ids(:) !< Ids of the FMS_diag_files the variable
+  get_file_ids = this%file_ids
+end function
 
 #endif
 end module fms_diag_field_object_mod

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -667,38 +667,26 @@ CALL MPP_ERROR(FATAL,"You can not use the modern diag manager without compiling 
     file_ids = diag_field%get_file_ids()
     math = diag_field%get_math_needs_to_be_done()
     ! if doing math loop through each file for given field
-    if (size(file_ids) .ge. 1 .and. math) then
-      file_loop: do ifile = 1, size(file_ids)
-        diag_file => this%FMS_diag_files(ifile)
-        ! if the file is not allocated go away
-        if(.not. allocated(diag_file%FMS_diag_file)) then
-          if(DEBUG_SC) call mpp_error(NOTE, "file id:"//string(ifile)//" not allocated for field:"//diag_field%get_varname())
-          cycle
-        endif
-        ! If the field is not registered go away
-        if (.not. diag_file%FMS_diag_file%is_field_registered(ifield)) then 
-          if(DEBUG_SC) call mpp_error(NOTE, "file id:"//string(ifile)//" not registered for field:"//diag_field%get_varname())
-          cycle
-        endif
-        ! Check if buffer alloc'd
-        has_input_buff: if (diag_field%has_input_data_buffer()) then
-          input_data_buffer => diag_field%get_data_buffer()
-          ! reset bounds, allocate output buffer, and update it with reduction
-          call bounds%reset_bounds_from_array_4D(input_data_buffer)
-          call this%allocate_diag_field_output_buffers(input_data_buffer, ifield)
-          error_string = this%fms_diag_do_reduction(input_data_buffer, ifield, &
+    doing_math: if (size(file_ids) .ge. 1 .and. math) then
+      ! Check if buffer alloc'd
+      has_input_buff: if (diag_field%has_input_data_buffer()) then
+        input_data_buffer => diag_field%get_data_buffer()
+        ! reset bounds, allocate output buffer, and update it with reduction
+        call bounds%reset_bounds_from_array_4D(input_data_buffer)
+        call this%allocate_diag_field_output_buffers(input_data_buffer, ifield)
+        error_string = this%fms_diag_do_reduction(input_data_buffer, ifield, &
                               diag_field%get_mask(), diag_field%get_weight(), &
                               bounds, .False., Time=this%current_model_time)
-          if (trim(error_string) .ne. "") call mpp_error(FATAL, "Field:"//trim(diag_field%get_varname()//&
-                                                         " -"//trim(error_string)))
-        endif has_input_buff 
-
-    enddo file_loop
-  endif
-  !> Clean up, clean up, everybody do your share
-  if (allocated(file_ids)) deallocate(file_ids)
-  if (associated(diag_field)) nullify(diag_field)
-enddo field_loop
+        if (trim(error_string) .ne. "") call mpp_error(FATAL, "Field:"//trim(diag_field%get_varname()//&
+                                                       " -"//trim(error_string)))
+      else
+        call mpp_error(FATAL, "diag_send_complete:: no input buffer allocated for field"//diag_field%get_longname())
+      endif has_input_buff
+    endif doing_math
+    !> Clean up, clean up, everybody do your share
+    if (allocated(file_ids)) deallocate(file_ids)
+    if (associated(diag_field)) nullify(diag_field)
+  enddo field_loop
 
 call this%fms_diag_do_io()
 #endif

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -46,6 +46,7 @@ USE fms_diag_bbox_mod, ONLY: fmsDiagIbounds_type, determine_if_block_is_in_regio
 use omp_lib
 #endif
 use mpp_domains_mod, only: domain1d, domain2d, domainUG, null_domain2d
+use fms_string_utils_mod, only: string
 use platform_mod
 implicit none
 private
@@ -648,43 +649,58 @@ CALL MPP_ERROR(FATAL,"You can not use the modern diag manager without compiling 
   class(*), pointer :: input_data_buffer(:,:,:,:)
   character(len=128) :: error_string
   type(fmsDiagIbounds_type) :: bounds
+  integer, dimension(:), allocatable :: file_ids !< Array of file IDs for a field
+  logical, parameter :: DEBUG_SC = .true. !< turn on output for debugging
 
   !< Update the current model time by adding the time_step
   this%current_model_time = this%current_model_time + time_step
 
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   !! In the future, this may be parallelized for offloading
-  file_loop: do ifile = 1, size(this%FMS_diag_files)
-    diag_file => this%FMS_diag_files(ifile)
-    field_outer_if: if (size(diag_file%FMS_diag_file%get_field_ids()) .ge. 1) then
-      allocate (file_field_ids(size(diag_file%FMS_diag_file%get_field_ids() )))
-      file_field_ids = diag_file%FMS_diag_file%get_field_ids()
-      field_loop: do ifield = 1, size(file_field_ids)
+  ! loop through each field
+  field_loop: do ifield = 1, size(this%FMS_diag_fields)
+    diag_field => this%FMS_diag_fields(ifield)
+    if(.not. diag_field%is_registered()) cycle
+    if(DEBUG_SC) call mpp_error(NOTE, "fms_diag_send_complete:: var: "//diag_field%get_varname())
+    ! get files the field is in
+    allocate (file_ids(size(diag_field%get_file_ids() )))
+    file_ids = diag_field%get_file_ids()
+    math = diag_field%get_math_needs_to_be_done()
+    ! if doing math loop through each file for given field
+    if (size(file_ids) .ge. 1 .and. math) then
+      file_loop: do ifile = 1, size(file_ids)
+        diag_file => this%FMS_diag_files(ifile)
+        ! if the file is not allocated go away
+        if(.not. allocated(diag_file%FMS_diag_file)) then
+          if(DEBUG_SC) call mpp_error(NOTE, "file id:"//string(ifile)//" not allocated for field:"//diag_field%get_varname())
+          cycle
+        endif
         ! If the field is not registered go away
-        if (.not. diag_file%FMS_diag_file%is_field_registered(ifield)) cycle
-
-        diag_field => this%FMS_diag_fields(file_field_ids(ifield))
-        !> Check if math needs to be done
-        math = diag_field%get_math_needs_to_be_done()
-        calling_math: if (math) then
+        if (.not. diag_file%FMS_diag_file%is_field_registered(ifield)) then 
+          if(DEBUG_SC) call mpp_error(NOTE, "file id:"//string(ifile)//" not registered for field:"//diag_field%get_varname())
+          cycle
+        endif
+        ! Check if buffer alloc'd
+        has_input_buff: if (diag_field%has_input_data_buffer()) then
           input_data_buffer => diag_field%get_data_buffer()
+          ! reset bounds, allocate output buffer, and update it with reduction
           call bounds%reset_bounds_from_array_4D(input_data_buffer)
-          call this%allocate_diag_field_output_buffers(input_data_buffer, file_field_ids(ifield))
-          error_string = this%fms_diag_do_reduction(input_data_buffer, file_field_ids(ifield), &
-            diag_field%get_mask(), diag_field%get_weight(), &
-            bounds, .False., Time=this%current_model_time)
+          call this%allocate_diag_field_output_buffers(input_data_buffer, ifield)
+          error_string = this%fms_diag_do_reduction(input_data_buffer, ifield, &
+                              diag_field%get_mask(), diag_field%get_weight(), &
+                              bounds, .False., Time=this%current_model_time)
           if (trim(error_string) .ne. "") call mpp_error(FATAL, "Field:"//trim(diag_field%get_varname()//&
-            " -"//trim(error_string)))
-        endif calling_math
-        !> Clean up, clean up, everybody everywhere
-        if (associated(diag_field)) nullify(diag_field)
-      enddo field_loop
-      !> Clean up, clean up, everybody do your share
-      if (allocated(file_field_ids)) deallocate(file_field_ids)
-    endif field_outer_if
-  enddo file_loop
+                                                         " -"//trim(error_string)))
+        endif has_input_buff 
 
-  call this%fms_diag_do_io()
+    enddo file_loop
+  endif
+  !> Clean up, clean up, everybody do your share
+  if (allocated(file_ids)) deallocate(file_ids)
+  if (associated(diag_field)) nullify(diag_field)
+enddo field_loop
+
+call this%fms_diag_do_io()
 #endif
 
 end subroutine fms_diag_send_complete


### PR DESCRIPTION
**Description**
moves the loops around in diag_send_complete so that it goes through the fields, and then the files the field is in.

I've had this as part of the average updates but figured it would better to put it in separately.

Fixes # (issue)

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes. Please also note
any relevant details for your test configuration (e.g. compiler, OS).  Include
enough information so someone can reproduce your tests.

**Checklist:**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] `make distcheck` passes

