### PR TITLE
Field manager namelist

### DIFF
--- a/field_manager/field_manager.F90
+++ b/field_manager/field_manager.F90
@@ -466,6 +466,8 @@ type, private :: field_mgr_type
   type(method_type), dimension(:), allocatable        :: methods !< methods associated with this field name
 end type field_mgr_type
 
+!TODO These two types: field_names_type and field_names_type_short
+!! will no longer be needed when the legacy field table is not used
 !> @brief Private type for internal use
 !> @ingroup field_manager_mod
 type, private :: field_names_type

--- a/field_manager/field_manager.F90
+++ b/field_manager/field_manager.F90
@@ -155,10 +155,12 @@
 !> @addtogroup field_manager_mod
 !> @{
 module field_manager_mod
+!TODO this variable can be removed when the legacy table is no longer used
 #ifndef MAXFIELDS_
 #define MAXFIELDS_ 250
 #endif
 
+!TODO this variable can be removed when the legacy table is not longer used
 #ifndef MAXFIELDMETHODS_
 #define MAXFIELDMETHODS_ 250
 #endif
@@ -436,10 +438,12 @@ character(len=35), parameter :: warn_header       = '==>Warning from '//trim(mod
 character(len=32), parameter :: note_header       = '==>Note from '//trim(module_name)//': '
 character(len=1),  parameter :: comma             = ","
 character(len=1),  parameter :: list_sep          = '/'
+!TODO these variable can be removed when the legacy table is no longer used
 character(len=1),  parameter :: comment           = '#'
 character(len=1),  parameter :: dquote            = '"'
 character(len=1),  parameter :: equal             = '='
 character(len=1),  parameter :: squote            = "'"
+!
 integer,           parameter :: null_type         = 0
 integer,           parameter :: integer_type      = 1
 integer,           parameter :: list_type         = 2
@@ -448,8 +452,10 @@ integer,           parameter :: real_type         = 4
 integer,           parameter :: string_type       = 5
 integer,           parameter :: num_types         = 5
 integer,           parameter :: array_increment   = 10
+!TODO these variable can be removed when the legacy table is no longer used
 integer,           parameter :: MAX_FIELDS        = MAXFIELDS_
 integer,           parameter :: MAX_FIELD_METHODS = MAXFIELDMETHODS_
+!
 
 !> @brief Private type for internal use
 !> @ingroup field_manager_mod

--- a/field_manager/include/field_manager.inc
+++ b/field_manager/include/field_manager.inc
@@ -57,7 +57,7 @@ integer, parameter :: lkind=FMS_FM_KIND_
 out_unit = stdout()
 !        Initialize the field manager if needed
 if (.not. module_is_initialized) then
-  call initialize
+  call initialize_module_variables
 endif
 !        Must supply a field field name
 if (name .eq. ' ') then
@@ -126,7 +126,7 @@ integer                          :: out_unit
 out_unit = stdout()
 !        Initialize the field manager if needed
 if (.not. module_is_initialized) then
-  call initialize
+  call initialize_module_variables
 endif
 !        Must supply a field name
 if (name .eq. ' ') then

--- a/test_fms/field_manager/Makefile.am
+++ b/test_fms/field_manager/Makefile.am
@@ -29,17 +29,25 @@ AM_CPPFLAGS = -I$(MODDIR)
 LDADD = $(top_builddir)/libFMS/libFMS.la
 
 # Build this test program.
-check_PROGRAMS = test_field_manager_r4 test_field_manager_r8
+check_PROGRAMS = test_field_manager_r4 test_field_manager_r8 test_field_table_read
 
 # This is the source code for the test.
 test_field_manager_r4_SOURCES = test_field_manager.F90
 test_field_manager_r8_SOURCES = test_field_manager.F90
+test_field_table_read_SOURCES = test_field_table_read.F90
 
 test_field_manager_r4_CPPFLAGS=-DTEST_FM_KIND_=4 -I$(MODDIR)
 test_field_manager_r8_CPPFLAGS=-DTEST_FM_KIND_=8 -I$(MODDIR)
 
+if SKIP_PARSER_TESTS
+skipflag="skip"
+else
+skipflag=""
+endif
+
 TEST_EXTENSIONS = .sh
 SH_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) $(abs_top_srcdir)/test_fms/tap-driver.sh
+TESTS_ENVIRONMENT= parser_skip=${skipflag}
 
 # Run the test program.
 TESTS = test_field_manager2.sh

--- a/test_fms/field_manager/test_field_manager2.sh
+++ b/test_fms/field_manager/test_field_manager2.sh
@@ -27,7 +27,9 @@
 # Set common test settings.
 . ../test-lib.sh
 
-# Copy files for test.
+rm -rf input.nml field_table field_table.yaml
+# Field manager with the legacy table (not setting namelist)
+touch input.nml
 cat <<_EOF > field_table
 # Simplified field table to run the field table unit tests
  "TRACER", "ocean_mod", "biotic1"
@@ -43,6 +45,17 @@ cat <<_EOF > field_table
            "longname",     "specific humidity"
             "units",        "kg/kg" /
 _EOF
+test_expect_success "field table read with the default settings" 'mpirun -n 1 ./test_field_table_read'
+
+cat <<_EOF > input.nml
+&field_manager_nml
+  use_field_table_yaml = .false.
+/
+_EOF
+test_expect_success "field table read with use_field_table.yaml = .false." 'mpirun -n 1 ./test_field_table_read'
+
+test_expect_success "field manager functional r4 with legacy table" 'mpirun -n 2 ./test_field_manager_r4'
+test_expect_success "field manager functional r8 with legacy table" 'mpirun -n 2 ./test_field_manager_r8'
 
 cat <<_EOF > field_table.yaml
 field_table:
@@ -73,11 +86,26 @@ field_table:
 _EOF
 
 cat <<_EOF > input.nml
-&test_field_manager
+&field_manager_nml
+  use_field_table_yaml = .false.
+/
+_EOF
+test_expect_failure "field table read with use_field_table.yaml = .false. both version of the table present" 'mpirun -n 1 ./test_field_table_read'
+
+rm -rf field_table
+
+cat <<_EOF > input.nml
+&field_manager_nml
+  use_field_table_yaml = .true.
 /
 _EOF
 
-test_expect_success "field manager functional r4" 'mpirun -n 2 ./test_field_manager_r4'
-test_expect_success "field manager functional r8" 'mpirun -n 2 ./test_field_manager_r8'
+if [ ! -z $parser_skip ]; then
+  test_expect_failure "field table read with use_field_table.yaml = .true. but not compiling with yaml" 'mpirun -n 1 ./test_field_table_read'
+else
+  test_expect_success "field table read with use_field_table.yaml = .true." 'mpirun -n 1 ./test_field_table_read'
+  test_expect_success "field manager functional r4 with yaml table" 'mpirun -n 2 ./test_field_manager_r4'
+  test_expect_success "field manager functional r8 with yaml table" 'mpirun -n 2 ./test_field_manager_r8'
+fi
 
 test_done

--- a/test_fms/field_manager/test_field_table_read.F90
+++ b/test_fms/field_manager/test_field_table_read.F90
@@ -1,0 +1,50 @@
+!***********************************************************************
+!*                   GNU Lesser General Public License
+!*
+!* This file is part of the GFDL Flexible Modeling System (FMS).
+!*
+!* FMS is free software: you can redistribute it and/or modify it under
+!* the terms of the GNU Lesser General Public License as published by
+!* the Free Software Foundation, either version 3 of the License, or (at
+!* your option) any later version.
+!*
+!* FMS is distributed in the hope that it will be useful, but WITHOUT
+!* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+!* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+!* for more details.
+!*
+!* You should have received a copy of the GNU Lesser General Public
+!* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
+!***********************************************************************
+
+!********************* Sample field table required: *********************
+! "TRACER", "ocean_mod", "biotic1"
+!           "diff_horiz", "linear", "slope=ok"
+!           "longname", "biotic one" /
+! "TRACER", "ocean_mod", "age_ctl" /
+! "TRACER", "atmos_mod","radon"
+!           "longname","radon-222"
+!           "units","VMR*1E21"
+!           "profile_type","fixed","surface_value=0.0E+00"
+!           "convection","all"/
+! "TRACER", "land_mod", "sphum"
+!           "longname",     "specific humidity"
+!            "units",        "kg/kg" /
+!***********************************************************************
+
+program test_field_table_read
+
+use field_manager_mod, only: field_manager_init
+use fms_mod,           only: fms_init, fms_end
+use mpp_mod, only : mpp_pe, mpp_root_pe, mpp_error, NOTE, FATAL
+
+implicit none
+
+integer :: nfields
+
+call fms_init
+call field_manager_init(nfields)
+if (nfields .ne. 4) &
+  call mpp_error(FATAL, "The number fields is not the epected result")
+call fms_end
+end program test_field_table_read

--- a/test_fms/field_manager/test_field_table_read.F90
+++ b/test_fms/field_manager/test_field_table_read.F90
@@ -45,6 +45,6 @@ integer :: nfields
 call fms_init
 call field_manager_init(nfields)
 if (nfields .ne. 4) &
-  call mpp_error(FATAL, "The number fields is not the epected result")
+  call mpp_error(FATAL, "test_field_table_read:: The number fields returned is not the expected result")
 call fms_end
 end program test_field_table_read

--- a/test_fms/tracer_manager/Makefile.am
+++ b/test_fms/tracer_manager/Makefile.am
@@ -38,8 +38,15 @@ test_tracer_manager_r8_SOURCES = test_tracer_manager.F90
 test_tracer_manager_r4_CPPFLAGS=-DTEST_TM_KIND_=4 -I$(MODDIR)
 test_tracer_manager_r8_CPPFLAGS=-DTEST_TM_KIND_=8 -I$(MODDIR)
 
+if SKIP_PARSER_TESTS
+skipflag="skip"
+else
+skipflag=""
+endif
+
 TEST_EXTENSIONS = .sh
 SH_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) $(abs_top_srcdir)/test_fms/tap-driver.sh
+TESTS_ENVIRONMENT= parser_skip=${skipflag}
 
 # Run the test program.
 TESTS = test_tracer_manager2.sh

--- a/test_fms/tracer_manager/test_tracer_manager2.sh
+++ b/test_fms/tracer_manager/test_tracer_manager2.sh
@@ -27,6 +27,9 @@
 # Set common test settings.
 . ../test-lib.sh
 
+rm -rf input.nml field_table field_table.yaml
+touch input.nml
+
 # Copy files for test.
 cat <<_EOF > field_table
 # Simplified field table to run the field table unit tests
@@ -50,6 +53,17 @@ cat <<_EOF > field_table
  "TRACER", "land_mod", "sphum"
            "longname",     "specific humidity"
             "units",        "kg/kg" /
+_EOF
+
+test_expect_success "tracer_manager r4 with the legacy field table" 'mpirun -n 2 ./test_tracer_manager_r4'
+test_expect_success "tracer_manager r8 with the legacy field table" 'mpirun -n 2 ./test_tracer_manager_r8'
+
+if [ -z $parser_skip ]; then
+rm -rf field_table
+cat <<_EOF > input.nml
+&field_manager_nml
+  use_field_table_yaml = .true.
+/
 _EOF
 
 cat <<_EOF > field_table.yaml
@@ -98,12 +112,8 @@ field_table:
       units: kg/kg
 _EOF
 
-cat <<_EOF > input.nml
-&test_tracer_manager
-/
-_EOF
-
-test_expect_success "tracer_manager r4" 'mpirun -n 2 ./test_tracer_manager_r4'
-test_expect_success "tracer_manager r8" 'mpirun -n 2 ./test_tracer_manager_r8'
+test_expect_success "tracer_manager r4 with the yaml field table" 'mpirun -n 2 ./test_tracer_manager_r4'
+test_expect_success "tracer_manager r8 with the yaml field table" 'mpirun -n 2 ./test_tracer_manager_r8'
+fi
 
 test_done


### PR DESCRIPTION
**Description**
Adds a namelist to specify whether or not use the yaml tables (`use_field_table_yaml`)
The code crashes if `use_field_table_yaml = . true.` and are not compiling with yaml.
The code crashes if both versions of the tables are present
Adds units test to test all the options

Fixes #1313 

**How Has This Been Tested?**
CI

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

