### PR TITLE
revert argument changes for xgrid

### DIFF
--- a/exchange/xgrid.F90
+++ b/exchange/xgrid.F90
@@ -1457,18 +1457,18 @@ end subroutine get_grid_version2
 
 !#######################################################################
 !> @brief Read the area elements from NetCDF file
-subroutine get_area_elements_fms2_io(fileobj, name, get_area_data)
+subroutine get_area_elements_fms2_io(fileobj, name, data)
   type(FmsNetcdfDomainFile_t), intent(in) :: fileobj
   character(len=*), intent(in)            :: name
-  real(r8_kind), intent(out)              :: get_area_data(:,:)
+  real(r8_kind), intent(out)              :: data(:,:)
 
   if(variable_exists(fileobj, name)) then
-     call read_data(fileobj, name, get_area_data)
+     call read_data(fileobj, name, data)
   else
      call error_mesg('xgrid_mod', 'no field named '//trim(name)//' in grid file '//trim(fileobj%path)// &
                      ' Will set data to negative values...', NOTE)
      ! area elements no present in grid_spec file, set to negative values....
-     get_area_data = -1.0_r8_kind
+     data = -1.0_r8_kind
   endif
 
 end subroutine get_area_elements_fms2_io
@@ -4418,7 +4418,7 @@ end subroutine get_index_range
 !!   first grid, which typically is on the atmos side.
 !!   note that "from" and "to" are optional, the stocks will be subtracted, resp. added, only
 !!   if these are present.
-subroutine stock_move_3d(from, to, grid_index, stock_data3d, xmap, &
+subroutine stock_move_3d(from, to, grid_index, data, xmap, &
      & delta_t, from_side, to_side, radius, verbose, ier)
 
   ! this version takes rank 3 data, it can be used to compute the flux on anything but the
@@ -4431,7 +4431,7 @@ subroutine stock_move_3d(from, to, grid_index, stock_data3d, xmap, &
 
   type(stock_type), intent(inout), optional :: from, to
   integer,          intent(in)              :: grid_index        !< grid index
-  real(r8_kind),    intent(in)              :: stock_data3d(:,:,:)  !< data array is 3d
+  real(r8_kind),    intent(in)              :: data(:,:,:)  !< data array is 3d
   type(xmap_type),  intent(in)              :: xmap
   real(r8_kind),    intent(in)              :: delta_t
   integer,          intent(in)              :: from_side !< ISTOCK_TOP, ISTOCK_BOTTOM, or ISTOCK_SIDE
@@ -4455,7 +4455,7 @@ subroutine stock_move_3d(from, to, grid_index, stock_data3d, xmap, &
   endif
 
      from_dq = delta_t * 4.0_r8_kind * PI * radius**2 * sum( sum(xmap%grids(grid_index)%area * &
-          & sum(xmap%grids(grid_index)%frac_area * stock_data3d, DIM=3), DIM=1))
+          & sum(xmap%grids(grid_index)%frac_area * data, DIM=3), DIM=1))
      to_dq = from_dq
 
   ! update only if argument is present.
@@ -4478,7 +4478,7 @@ end subroutine stock_move_3d
 !> @brief this version takes rank 2 data, it can be used to compute the flux on the atmos side
 !!   note that "from" and "to" are optional, the stocks will be subtracted, resp. added, only
 !!   if these are present.
-subroutine stock_move_2d(from, to, grid_index, stock_data2d, xmap, &
+subroutine stock_move_2d(from, to, grid_index, data, xmap, &
      & delta_t, from_side, to_side, radius, verbose, ier)
 
   ! this version takes rank 2 data, it can be used to compute the flux on the atmos side
@@ -4490,7 +4490,7 @@ subroutine stock_move_2d(from, to, grid_index, stock_data2d, xmap, &
 
   type(stock_type),  intent(inout), optional :: from, to
   integer, optional, intent(in)              :: grid_index
-  real(r8_kind),     intent(in)              :: stock_data2d(:,:)    !< data array is 2d
+  real(r8_kind),     intent(in)              :: data(:,:)    !< data array is 2d
   type(xmap_type),   intent(in)              :: xmap
   real(r8_kind),     intent(in)              :: delta_t
   integer,           intent(in)              :: from_side !< ISTOCK_TOP, ISTOCK_BOTTOM, or ISTOCK_SIDE
@@ -4511,7 +4511,7 @@ subroutine stock_move_2d(from, to, grid_index, stock_data2d, xmap, &
   if( .not. present(grid_index) .or. grid_index==1 ) then
 
      ! only makes sense if grid_index == 1
-     from_dq = delta_t * 4.0_r8_kind*PI*radius**2 * sum(sum(xmap%grids(1)%area * stock_data2d, DIM=1))
+     from_dq = delta_t * 4.0_r8_kind*PI*radius**2 * sum(sum(xmap%grids(1)%area * data, DIM=1))
      to_dq = from_dq
 
   else
@@ -4604,13 +4604,13 @@ end subroutine stock_move_ug_3d
 
 !#######################################################################
 !> @brief surface/time integral of a 2d array
-subroutine stock_integrate_2d(integrate_data2d, xmap, delta_t, radius, res, ier)
+subroutine stock_integrate_2d(data, xmap, delta_t, radius, res, ier)
 
   ! surface/time integral of a 2d array
 
   use mpp_mod, only : mpp_sum
 
-  real(r8_kind),   intent(in)   :: integrate_data2d(:,:)    !< data array is 2d
+  real(r8_kind),   intent(in)   :: data(:,:)    !< data array is 2d
   type(xmap_type), intent(in)   :: xmap
   real(r8_kind),   intent(in)   :: delta_t
   real(r8_kind),   intent(in)   :: radius       !< earth radius
@@ -4625,7 +4625,7 @@ subroutine stock_integrate_2d(integrate_data2d, xmap, delta_t, radius, res, ier)
      return
   endif
 
-  res = delta_t * 4.0_r8_kind * PI * radius**2 * sum(sum(xmap%grids(1)%area * integrate_data2d, DIM=1))
+  res = delta_t * 4.0_r8_kind * PI * radius**2 * sum(sum(xmap%grids(1)%area * data, DIM=1))
 
 end subroutine stock_integrate_2d
 !#######################################################################


### PR DESCRIPTION
**Description**
The data argument was changed as part of #1355, but this broke some of the coupler code (and likely other components). This reverts the xgrid changes to arguments.

**How Has This Been Tested?**
make check on amd, ci

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

