### PR TITLE
ci: cancel runs if newer commit available and update checkout action

### DIFF
--- a/.github/workflows/github_autotools_gnu.yml
+++ b/.github/workflows/github_autotools_gnu.yml
@@ -27,7 +27,7 @@ jobs:
         SKIP_TESTS: "test_yaml_parser.5" # temporary till fixes are in
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Prepare GNU autoconf for build
       run: autoreconf -if
     - name: Configure the build

--- a/.github/workflows/github_autotools_gnu.yml
+++ b/.github/workflows/github_autotools_gnu.yml
@@ -4,6 +4,11 @@ name: Build libFMS test with autotools
 
 on: [push, pull_request]
 
+# cancel running jobs if theres a newer push
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/github_autotools_intel.yml
+++ b/.github/workflows/github_autotools_intel.yml
@@ -53,7 +53,7 @@ jobs:
         ./configure --prefix=/libs
         make -j install && cd
     - name: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Configure
       run: autoreconf -if ./configure.ac && ./configure --with-yaml
     - name: Compile

--- a/.github/workflows/github_autotools_intel.yml
+++ b/.github/workflows/github_autotools_intel.yml
@@ -1,4 +1,10 @@
 on: pull_request
+
+# cancel running jobs if theres a newer push
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   intel-autotools:
     runs-on: ubuntu-latest

--- a/.github/workflows/github_cmake_gnu.yml
+++ b/.github/workflows/github_cmake_gnu.yml
@@ -2,6 +2,11 @@ name: Build libFMS with cmake
 
 on: [push, pull_request]
 
+# cancel running jobs if theres a newer push
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/github_cmake_gnu.yml
+++ b/.github/workflows/github_cmake_gnu.yml
@@ -21,7 +21,7 @@ jobs:
         CMAKE_FLAGS: "${{ matrix.omp-flags }} ${{ matrix.io-flag  }} ${{ matrix.libyaml-flag }} -D64BIT=on"
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Generate makefiles with CMake
       run: cmake $CMAKE_FLAGS .
     - name: Build the library

--- a/.github/workflows/github_coupler_gnu.yml
+++ b/.github/workflows/github_coupler_gnu.yml
@@ -22,11 +22,11 @@ jobs:
         LDFLAGS: '-L/opt/view/lib'
     steps:
     - name: Checkout FMS
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         path: FMS
     - name: Checkout FMScoupler
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         repository: 'NOAA-GFDL/FMScoupler'
         path: FMScoupler

--- a/.github/workflows/github_coupler_gnu.yml
+++ b/.github/workflows/github_coupler_gnu.yml
@@ -1,6 +1,11 @@
 name: Test coupler build
 on: [pull_request]
 
+# cancel running jobs if theres a newer push
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   coupler-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/github_doc_site.yml
+++ b/.github/workflows/github_doc_site.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup repo
         run: | # do autotool's job for substitutes since we don't need a full build environement
           mkdir gen_docs

--- a/.github/workflows/github_linter.yml
+++ b/.github/workflows/github_linter.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Run Lint
         uses: NOAA-GFDL/simple_lint@f5aa1fe976bd4c231db0536ba00cbfdc26708253
         with:

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -7,7 +7,7 @@ jobs:
   add-dev-to-version:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Append version with dev
       run: sed -i '/20[0-9][0-9]\.[0-9][0-9]/ s/]/-dev]/' configure.ac
     - name: Create pull request


### PR DESCRIPTION
**Description**
This adds the same setting Lauren added to the FV3 parallelworks CI. It'll cancel a run in progress if a newer commit is available.

This should help with storage usage and we should have quicker checks with PR's as well since it won't be wasting time on the older commits.

also updates all our checkout actions versions to the newest since the old one was deprecated.

**How Has This Been Tested?**
ci

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

