### PR TITLE
Update CMakeLists.txt - append extra flags for gnu 10+ with mpich

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -349,7 +349,7 @@ foreach(kind ${kinds})
   if ( CMAKE_Fortran_COMPILER_VERSION MATCHES "1[0-9]\.[0-9]*\.[0-9]*" AND CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
     if(MPI_C_COMPILER MATCHES ".*mpich.*" )
       message(STATUS "Adding -fallow-argument-mismatch flag to compile with GCC >=10 and MPICH")
-      set_target_properties(${libTgt}_f PROPERTIES COMPILE_FLAGS "-fallow-argument-mismatch -w")
+      target_compile_options(${libTgt}_f PRIVATE "-fallow-argument-mismatch;-w")
     endif()
   endif()
 


### PR DESCRIPTION
**Description**
This PR fixes https://github.com/NOAA-GFDL/FMS/issues/1417. Instead of overwriting the compile flags for the Fortran targets, it appends the compatibility flags for gnu 10 with mpich to the existing flags. The syntax I used is available since cmake 2.8.12.

Resolves https://github.com/NOAA-GFDL/FMS/issues/1417

**How Has This Been Tested?**
Tested on Derecho with gcc@12.2.0 and cray-mpich@8.1.25.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] My changes generate no new warnings
- [ ] ~~Any dependent changes have been merged and published in downstream modules~~
- [ ] ~~New check tests, if applicable, are included~~
- [ ] `make distcheck` passes (not run)

