### PR TITLE
Keyword name

### DIFF
--- a/axis_utils/axis_utils2.F90
+++ b/axis_utils/axis_utils2.F90
@@ -113,7 +113,7 @@ contains
     character(len=16), dimension(3) :: lon_units, lat_units
     character(len=8) , dimension(4) :: z_units
     character(len=3) , dimension(6) :: t_units
-    character(len=32) :: name
+    character(len=32) :: axis_name
     integer :: i
 
     lon_names = (/'lon','x  '/)
@@ -141,34 +141,34 @@ contains
     endif
 
     if (cart /= 'X' .and. cart /= 'Y' .and. cart /= 'Z' .and. cart /= 'T') then
-       name = lowercase(axisname)
+       axis_name = lowercase(axisname)
        do i=1,size(lon_names(:))
-          if (trim(name(1:3)) == trim(lon_names(i))) cart = 'X'
+          if (trim(axis_name(1:3)) == trim(lon_names(i))) cart = 'X'
        enddo
        do i=1,size(lat_names(:))
-          if (trim(name(1:3)) == trim(lat_names(i))) cart = 'Y'
+          if (trim(axis_name(1:3)) == trim(lat_names(i))) cart = 'Y'
        enddo
        do i=1,size(z_names(:))
-          if (trim(name) == trim(z_names(i))) cart = 'Z'
+          if (trim(axis_name) == trim(z_names(i))) cart = 'Z'
        enddo
        do i=1,size(t_names(:))
-          if (trim(name) == t_names(i)) cart = 'T'
+          if (trim(axis_name) == t_names(i)) cart = 'T'
        enddo
     end if
 
     if (cart /= 'X' .and. cart /= 'Y' .and. cart /= 'Z' .and. cart /= 'T') then
-       name = lowercase(axisname)
+       axis_name = lowercase(axisname)
        do i=1,size(lon_units(:))
-          if (trim(name) == trim(lon_units(i))) cart = 'X'
+          if (trim(axis_name) == trim(lon_units(i))) cart = 'X'
        enddo
        do i=1,size(lat_units(:))
-          if (trim(name) == trim(lat_units(i))) cart = 'Y'
+          if (trim(axis_name) == trim(lat_units(i))) cart = 'Y'
        enddo
        do i=1,size(z_units(:))
-          if (trim(name) == trim(z_units(i))) cart = 'Z'
+          if (trim(axis_name) == trim(z_units(i))) cart = 'Z'
        enddo
        do i=1,size(t_units(:))
-          if (name(1:3) == trim(t_units(i))) cart = 'T'
+          if (axis_name(1:3) == trim(t_units(i))) cart = 'T'
        enddo
     end if
   end subroutine get_axis_cart

--- a/axis_utils/include/axis_utils2.inc
+++ b/axis_utils/include/axis_utils2.inc
@@ -26,10 +26,10 @@
 !> @{
 
   !> get axis edge data from a given file
-  subroutine AXIS_EDGES_(fileobj, name, edge_data, reproduce_null_char_bug_flag)
+  subroutine AXIS_EDGES_(fileobj, axis_name, edge_data, reproduce_null_char_bug_flag)
 
   class(FmsNetcdfFile_t), intent(in)            :: fileobj  !< File object to read from
-  character(len=*), intent(in)                  :: name  !< Name of a given axis
+  character(len=*), intent(in)                  :: axis_name  !< Name of a given axis
   real(FMS_AU_KIND_), dimension(:), intent(out) :: edge_data  !< Returned edge data from given axis name
   logical, intent(in), optional                 :: reproduce_null_char_bug_flag  !< Flag indicating to reproduce
                                      !! the mpp_io bug where the null characters were not removed
@@ -47,10 +47,10 @@
                                               !! the null characters were not removed after reading a string attribute
   integer, parameter                                   :: lkind = FMS_AU_KIND_
 
-  ndims = get_variable_num_dimensions(fileobj, name)
+  ndims = get_variable_num_dimensions(fileobj, axis_name)
   allocate(dim_sizes(ndims))
 
-  call get_variable_size(fileobj, name, dim_sizes)
+  call get_variable_size(fileobj, axis_name, dim_sizes)
 
   n = dim_sizes(1)
   if (size(edge_data) .ne. n+1) then
@@ -62,9 +62,9 @@
   if (present(reproduce_null_char_bug_flag)) reproduce_null_char_bug = reproduce_null_char_bug_flag
 
   buffer = ""
-  if (variable_att_exists(fileobj, name, "edges")) then
+  if (variable_att_exists(fileobj, axis_name, "edges")) then
    !! If the reproduce_null_char_bug flag is turned on fms2io will not remove the null character
-    call get_variable_attribute(fileobj, name, "edges", buffer(1:128), &
+    call get_variable_attribute(fileobj, axis_name, "edges", buffer(1:128), &
         reproduce_null_char_bug_flag=reproduce_null_char_bug)
 
    !! Check for a null character here, if it exists *_bnds will be calculated instead of read in
@@ -73,9 +73,9 @@
         i = index(buffer, char(0))
         if (i > 0) buffer = ""
     endif
-  elseif (variable_att_exists(fileobj, name, "bounds")) then
+  elseif (variable_att_exists(fileobj, axis_name, "bounds")) then
    !! If the reproduce_null_char_bug flag is turned on fms2io will not remove the null character
-    call get_variable_attribute(fileobj, name, "bounds", buffer(1:128), &
+    call get_variable_attribute(fileobj, axis_name, "bounds", buffer(1:128), &
         reproduce_null_char_bug_flag=reproduce_null_char_bug)
 
     !! Check for a null character here, if it exists *_bnds will be calculated instead of read in
@@ -116,7 +116,7 @@
   else
       allocate(r_var(n))
 
-      call read_data(fileobj, name, r_var)
+      call read_data(fileobj, axis_name, r_var)
 
       do i = 2, n
          edge_data(i) = r_var(i-1) + 0.5_lkind*(r_var(i) - r_var(i-1))

--- a/coupler/coupler_types.F90
+++ b/coupler/coupler_types.F90
@@ -78,7 +78,7 @@ module coupler_types_mod
   !> Coupler data for 3D values
   !> @ingroup coupler_types_mod
   type, public :: coupler_3d_real8_values_type
-    character(len=48)       :: name = ' '  !< The diagnostic name for this array
+    character(len=48)       :: diag_name = ' '  !< The diagnostic name for this array
     logical                 :: mean = .true. !< mean
     logical                 :: override = .false. !< override
     integer                 :: id_diag = 0 !< The diagnostic id for this array
@@ -96,7 +96,7 @@ module coupler_types_mod
   !> Coupler data for 3D fields
   !> @ingroup coupler_types_mod
   type, public :: coupler_3d_real8_field_type
-    character(len=48)                 :: name = ' ' !< name
+    character(len=48)                 :: field_name = ' ' !< name
     integer                           :: num_fields = 0 !< num_fields
     type(coupler_3d_real8_values_type), pointer, dimension(:) :: field => NULL() !< field
     character(len=128)                :: flux_type = ' ' !< flux_type
@@ -121,7 +121,7 @@ module coupler_types_mod
   !> Coupler data for 3D values
   !> @ingroup coupler_types_mod
   type, public :: coupler_3d_real4_values_type
-    character(len=48)       :: name = ' '  !< The diagnostic name for this array
+    character(len=48)       :: diag_name = ' '  !< The diagnostic name for this array
     logical                 :: mean = .true. !< mean
     logical                 :: override = .false. !< override
     integer                 :: id_diag = 0 !< The diagnostic id for this array
@@ -139,7 +139,7 @@ module coupler_types_mod
   !> Coupler data for 3D fields
   !> @ingroup coupler_types_mod
   type, public :: coupler_3d_real4_field_type
-    character(len=48)                 :: name = ' ' !< name
+    character(len=48)                 :: field_name = ' ' !< name
     integer                           :: num_fields = 0 !< num_fields
     type(coupler_3d_real4_values_type), pointer, dimension(:) :: field => NULL() !< field
     character(len=128)                :: flux_type = ' ' !< flux_type
@@ -181,7 +181,7 @@ module coupler_types_mod
   !> Coupler data for 2D values
   !> @ingroup coupler_types_mod
   type, public    :: coupler_2d_real8_values_type
-    character(len=48)       :: name = ' '  !< The diagnostic name for this array
+    character(len=48)       :: diag_name = ' '  !< The diagnostic name for this array
     real(r8_kind), pointer, contiguous, dimension(:,:) :: values => NULL() !< The pointer to the
                                            !! array of values for this field; this
                                            !! should be changed to allocatable
@@ -199,7 +199,7 @@ module coupler_types_mod
   !> Coupler data for 2D fields
   !> @ingroup coupler_types_mod
   type, public    :: coupler_2d_real8_field_type
-    character(len=48)                 :: name = ' ' !< name
+    character(len=48)                 :: field_name = ' ' !< name
     integer                           :: num_fields = 0 !< num_fields
     type(coupler_2d_real8_values_type), pointer, dimension(:)   :: field => NULL() !< field
     character(len=128)                :: flux_type = ' ' !< flux_type
@@ -224,7 +224,7 @@ module coupler_types_mod
   !> Coupler data for 2D values
   !> @ingroup coupler_types_mod
   type, public    :: coupler_2d_real4_values_type
-    character(len=44)       :: name = ' '  !< The diagnostic name for this array
+    character(len=44)       :: diag_name = ' '  !< The diagnostic name for this array
     real(r4_kind), pointer, contiguous, dimension(:,:) :: values => NULL() !< The pointer to the
                                            !! array of values for this field; this
                                            !! should be changed to allocatable
@@ -242,7 +242,7 @@ module coupler_types_mod
   !> Coupler data for 2D fields
   !> @ingroup coupler_types_mod
   type, public    :: coupler_2d_real4_field_type
-    character(len=44)                 :: name = ' ' !< name
+    character(len=44)                 :: field_name = ' ' !< name
     integer                           :: num_fields = 0 !< num_fields
     type(coupler_2d_real4_values_type), pointer, dimension(:)   :: field => NULL() !< field
     character(len=124)                :: flux_type = ' ' !< flux_type
@@ -283,7 +283,7 @@ module coupler_types_mod
   !> Coupler data for 1D values
   !> @ingroup coupler_types_mod
   type, public    :: coupler_1d_real8_values_type
-    character(len=48)           :: name = ' '  !< The diagnostic name for this array
+    character(len=48)           :: diag_name = ' '  !< The diagnostic name for this array
     real(r8_kind), pointer, dimension(:) :: values => NULL() !< The pointer to the array of values
     logical                     :: mean = .true. !< mean
     logical                     :: override = .false. !< override
@@ -298,7 +298,7 @@ module coupler_types_mod
   !> Coupler data for 1D fields
   !> @ingroup coupler_types_mod
   type, public    :: coupler_1d_real8_field_type
-    character(len=48)              :: name = ' ' !< name
+    character(len=48)              :: field_name = ' ' !< name
     integer                        :: num_fields = 0 !< num_fields
     type(coupler_1d_real8_values_type), pointer, dimension(:)   :: field => NULL() !< field
     character(len=128)             :: flux_type = ' ' !< flux_type
@@ -324,7 +324,7 @@ module coupler_types_mod
   !> Coupler data for 1D values
   !> @ingroup coupler_types_mod
   type, public    :: coupler_1d_real4_values_type
-    character(len=48)           :: name = ' '  !< The diagnostic name for this array
+    character(len=48)           :: diag_name = ' '  !< The diagnostic name for this array
     real(r4_kind), pointer, dimension(:) :: values => NULL() !< The pointer to the array of values
     logical                     :: mean = .true. !< mean
     logical                     :: override = .false. !< override
@@ -339,7 +339,7 @@ module coupler_types_mod
   !> Coupler data for 1D fields
   !> @ingroup coupler_types_mod
   type, public    :: coupler_1d_real4_field_type
-    character(len=48)              :: name = ' ' !< name
+    character(len=48)              :: field_name = ' ' !< name
     integer                        :: num_fields = 0 !< num_fields
     type(coupler_1d_real4_values_type), pointer, dimension(:)   :: field => NULL() !< field
     character(len=128)             :: flux_type = ' ' !< flux_type
@@ -808,7 +808,7 @@ contains
         endif
         allocate ( var%bc(var%num_bcs) )
         do n = 1, var%num_bcs
-          var%bc(n)%name = var_in%bc(n)%name
+          var%bc(n)%field_name = var_in%bc(n)%field_name
           var%bc(n)%atm_tr_index = var_in%bc(n)%atm_tr_index
           var%bc(n)%flux_type = var_in%bc(n)%flux_type
           var%bc(n)%implementation = var_in%bc(n)%implementation
@@ -826,9 +826,9 @@ contains
           allocate ( var%bc(n)%field(var%bc(n)%num_fields) )
           do m = 1, var%bc(n)%num_fields
             if (present(suffix)) then
-              var%bc(n)%field(m)%name = trim(var_in%bc(n)%field(m)%name) // trim(suffix)
+              var%bc(n)%field(m)%diag_name = trim(var_in%bc(n)%field(m)%diag_name) // trim(suffix)
             else
-              var%bc(n)%field(m)%name = var_in%bc(n)%field(m)%name
+              var%bc(n)%field(m)%diag_name = var_in%bc(n)%field(m)%diag_name
             endif
             var%bc(n)%field(m)%long_name = var_in%bc(n)%field(m)%long_name
             var%bc(n)%field(m)%units = var_in%bc(n)%field(m)%units
@@ -850,7 +850,7 @@ contains
         endif
         allocate ( var%bc_r4(var%num_bcs) )
         do n = 1, var%num_bcs
-          var%bc_r4(n)%name = var_in%bc_r4(n)%name
+          var%bc_r4(n)%field_name = var_in%bc_r4(n)%field_name
           var%bc_r4(n)%atm_tr_index = var_in%bc_r4(n)%atm_tr_index
           var%bc_r4(n)%flux_type = var_in%bc_r4(n)%flux_type
           var%bc_r4(n)%implementation = var_in%bc_r4(n)%implementation
@@ -868,9 +868,9 @@ contains
           allocate ( var%bc_r4(n)%field(var%bc_r4(n)%num_fields) )
           do m = 1, var%bc_r4(n)%num_fields
             if (present(suffix)) then
-              var%bc_r4(n)%field(m)%name = trim(var_in%bc_r4(n)%field(m)%name) // trim(suffix)
+              var%bc_r4(n)%field(m)%diag_name = trim(var_in%bc_r4(n)%field(m)%diag_name) // trim(suffix)
             else
-              var%bc_r4(n)%field(m)%name = var_in%bc_r4(n)%field(m)%name
+              var%bc_r4(n)%field(m)%diag_name = var_in%bc_r4(n)%field(m)%diag_name
             endif
             var%bc_r4(n)%field(m)%long_name = var_in%bc_r4(n)%field(m)%long_name
             var%bc_r4(n)%field(m)%units = var_in%bc_r4(n)%field(m)%units
@@ -971,7 +971,7 @@ contains
         endif
         allocate ( var%bc(var%num_bcs) )
         do n = 1, var%num_bcs
-          var%bc(n)%name = var_in%bc(n)%name
+          var%bc(n)%field_name = var_in%bc(n)%field_name
           var%bc(n)%atm_tr_index = var_in%bc(n)%atm_tr_index
           var%bc(n)%flux_type = var_in%bc(n)%flux_type
           var%bc(n)%implementation = var_in%bc(n)%implementation
@@ -989,9 +989,9 @@ contains
           allocate ( var%bc(n)%field(var%bc(n)%num_fields) )
           do m = 1, var%bc(n)%num_fields
             if (present(suffix)) then
-              var%bc(n)%field(m)%name = trim(var_in%bc(n)%field(m)%name) // trim(suffix)
+              var%bc(n)%field(m)%diag_name = trim(var_in%bc(n)%field(m)%diag_name) // trim(suffix)
             else
-              var%bc(n)%field(m)%name = var_in%bc(n)%field(m)%name
+              var%bc(n)%field(m)%diag_name = var_in%bc(n)%field(m)%diag_name
             endif
             var%bc(n)%field(m)%long_name = var_in%bc(n)%field(m)%long_name
             var%bc(n)%field(m)%units = var_in%bc(n)%field(m)%units
@@ -1012,7 +1012,7 @@ contains
         endif
         allocate ( var%bc_r4(var%num_bcs) )
         do n = 1, var%num_bcs
-          var%bc_r4(n)%name = var_in%bc_r4(n)%name
+          var%bc_r4(n)%field_name = var_in%bc_r4(n)%field_name
           var%bc_r4(n)%atm_tr_index = var_in%bc_r4(n)%atm_tr_index
           var%bc_r4(n)%flux_type = var_in%bc_r4(n)%flux_type
           var%bc_r4(n)%implementation = var_in%bc_r4(n)%implementation
@@ -1030,9 +1030,9 @@ contains
           allocate ( var%bc_r4(n)%field(var%bc_r4(n)%num_fields) )
           do m = 1, var%bc_r4(n)%num_fields
             if (present(suffix)) then
-              var%bc_r4(n)%field(m)%name = trim(var_in%bc_r4(n)%field(m)%name) // trim(suffix)
+              var%bc_r4(n)%field(m)%diag_name = trim(var_in%bc_r4(n)%field(m)%diag_name) // trim(suffix)
             else
-              var%bc_r4(n)%field(m)%name = var_in%bc_r4(n)%field(m)%name
+              var%bc_r4(n)%field(m)%diag_name = var_in%bc_r4(n)%field(m)%diag_name
             endif
             var%bc_r4(n)%field(m)%long_name = var_in%bc_r4(n)%field(m)%long_name
             var%bc_r4(n)%field(m)%units = var_in%bc_r4(n)%field(m)%units
@@ -1125,7 +1125,7 @@ contains
         endif
         allocate ( var%bc(var%num_bcs) )
         do n = 1, var%num_bcs
-          var%bc(n)%name = var_in%bc(n)%name
+          var%bc(n)%field_name = var_in%bc(n)%field_name
           var%bc(n)%atm_tr_index = var_in%bc(n)%atm_tr_index
           var%bc(n)%flux_type = var_in%bc(n)%flux_type
           var%bc(n)%implementation = var_in%bc(n)%implementation
@@ -1143,9 +1143,9 @@ contains
           allocate ( var%bc(n)%field(var%bc(n)%num_fields) )
           do m = 1, var%bc(n)%num_fields
             if (present(suffix)) then
-              var%bc(n)%field(m)%name = trim(var_in%bc(n)%field(m)%name) // trim(suffix)
+              var%bc(n)%field(m)%diag_name = trim(var_in%bc(n)%field(m)%diag_name) // trim(suffix)
             else
-              var%bc(n)%field(m)%name = var_in%bc(n)%field(m)%name
+              var%bc(n)%field(m)%diag_name = var_in%bc(n)%field(m)%diag_name
             endif
             var%bc(n)%field(m)%long_name = var_in%bc(n)%field(m)%long_name
             var%bc(n)%field(m)%units = var_in%bc(n)%field(m)%units
@@ -1166,7 +1166,7 @@ contains
         endif
         allocate ( var%bc_r4(var%num_bcs) )
         do n = 1, var%num_bcs
-          var%bc_r4(n)%name = var_in%bc_r4(n)%name
+          var%bc_r4(n)%field_name = var_in%bc_r4(n)%field_name
           var%bc_r4(n)%atm_tr_index = var_in%bc_r4(n)%atm_tr_index
           var%bc_r4(n)%flux_type = var_in%bc_r4(n)%flux_type
           var%bc_r4(n)%implementation = var_in%bc_r4(n)%implementation
@@ -1184,9 +1184,9 @@ contains
           allocate ( var%bc_r4(n)%field(var%bc_r4(n)%num_fields) )
           do m = 1, var%bc_r4(n)%num_fields
             if (present(suffix)) then
-              var%bc_r4(n)%field(m)%name = trim(var_in%bc_r4(n)%field(m)%name) // trim(suffix)
+              var%bc_r4(n)%field(m)%diag_name = trim(var_in%bc_r4(n)%field(m)%diag_name) // trim(suffix)
             else
-              var%bc_r4(n)%field(m)%name = var_in%bc_r4(n)%field(m)%name
+              var%bc_r4(n)%field(m)%diag_name = var_in%bc_r4(n)%field(m)%diag_name
             endif
             var%bc_r4(n)%field(m)%long_name = var_in%bc_r4(n)%field(m)%long_name
             var%bc_r4(n)%field(m)%units = var_in%bc_r4(n)%field(m)%units
@@ -1287,7 +1287,7 @@ contains
         endif
         allocate ( var%bc(var%num_bcs) )
         do n = 1, var%num_bcs
-          var%bc(n)%name = var_in%bc(n)%name
+          var%bc(n)%field_name = var_in%bc(n)%field_name
           var%bc(n)%atm_tr_index = var_in%bc(n)%atm_tr_index
           var%bc(n)%flux_type = var_in%bc(n)%flux_type
           var%bc(n)%implementation = var_in%bc(n)%implementation
@@ -1305,9 +1305,9 @@ contains
           allocate ( var%bc(n)%field(var%bc(n)%num_fields) )
           do m = 1, var%bc(n)%num_fields
             if (present(suffix)) then
-              var%bc(n)%field(m)%name = trim(var_in%bc(n)%field(m)%name) // trim(suffix)
+              var%bc(n)%field(m)%diag_name = trim(var_in%bc(n)%field(m)%diag_name) // trim(suffix)
             else
-              var%bc(n)%field(m)%name = var_in%bc(n)%field(m)%name
+              var%bc(n)%field(m)%diag_name = var_in%bc(n)%field(m)%diag_name
             endif
             var%bc(n)%field(m)%long_name = var_in%bc(n)%field(m)%long_name
             var%bc(n)%field(m)%units = var_in%bc(n)%field(m)%units
@@ -1328,7 +1328,7 @@ contains
         endif
         allocate ( var%bc_r4(var%num_bcs) )
         do n = 1, var%num_bcs
-          var%bc_r4(n)%name = var_in%bc_r4(n)%name
+          var%bc_r4(n)%field_name = var_in%bc_r4(n)%field_name
           var%bc_r4(n)%atm_tr_index = var_in%bc_r4(n)%atm_tr_index
           var%bc_r4(n)%flux_type = var_in%bc_r4(n)%flux_type
           var%bc_r4(n)%implementation = var_in%bc_r4(n)%implementation
@@ -1346,9 +1346,9 @@ contains
           allocate ( var%bc_r4(n)%field(var%bc_r4(n)%num_fields) )
           do m = 1, var%bc_r4(n)%num_fields
             if (present(suffix)) then
-              var%bc_r4(n)%field(m)%name = trim(var_in%bc_r4(n)%field(m)%name) // trim(suffix)
+              var%bc_r4(n)%field(m)%diag_name = trim(var_in%bc_r4(n)%field(m)%diag_name) // trim(suffix)
             else
-              var%bc_r4(n)%field(m)%name = var_in%bc_r4(n)%field(m)%name
+              var%bc_r4(n)%field(m)%diag_name = var_in%bc_r4(n)%field(m)%diag_name
             endif
             var%bc_r4(n)%field(m)%long_name = var_in%bc_r4(n)%field(m)%long_name
             var%bc_r4(n)%field(m)%units = var_in%bc_r4(n)%field(m)%units
@@ -1441,7 +1441,7 @@ contains
         endif
         allocate ( var%bc(var%num_bcs) )
         do n = 1, var%num_bcs
-          var%bc(n)%name = var_in%bc(n)%name
+          var%bc(n)%field_name = var_in%bc(n)%field_name
           var%bc(n)%atm_tr_index = var_in%bc(n)%atm_tr_index
           var%bc(n)%flux_type = var_in%bc(n)%flux_type
           var%bc(n)%implementation = var_in%bc(n)%implementation
@@ -1459,9 +1459,9 @@ contains
           allocate ( var%bc(n)%field(var%bc(n)%num_fields) )
           do m = 1, var%bc(n)%num_fields
             if (present(suffix)) then
-              var%bc(n)%field(m)%name = trim(var_in%bc(n)%field(m)%name) // trim(suffix)
+              var%bc(n)%field(m)%diag_name = trim(var_in%bc(n)%field(m)%diag_name) // trim(suffix)
             else
-              var%bc(n)%field(m)%name = var_in%bc(n)%field(m)%name
+              var%bc(n)%field(m)%diag_name = var_in%bc(n)%field(m)%diag_name
             endif
             var%bc(n)%field(m)%long_name = var_in%bc(n)%field(m)%long_name
             var%bc(n)%field(m)%units = var_in%bc(n)%field(m)%units
@@ -1483,7 +1483,7 @@ contains
         endif
         allocate ( var%bc_r4(var%num_bcs) )
         do n = 1, var%num_bcs
-          var%bc_r4(n)%name = var_in%bc_r4(n)%name
+          var%bc_r4(n)%field_name = var_in%bc_r4(n)%field_name
           var%bc_r4(n)%atm_tr_index = var_in%bc_r4(n)%atm_tr_index
           var%bc_r4(n)%flux_type = var_in%bc_r4(n)%flux_type
           var%bc_r4(n)%implementation = var_in%bc_r4(n)%implementation
@@ -1501,9 +1501,9 @@ contains
           allocate ( var%bc_r4(n)%field(var%bc_r4(n)%num_fields) )
           do m = 1, var%bc_r4(n)%num_fields
             if (present(suffix)) then
-              var%bc_r4(n)%field(m)%name = trim(var_in%bc_r4(n)%field(m)%name) // trim(suffix)
+              var%bc_r4(n)%field(m)%diag_name = trim(var_in%bc_r4(n)%field(m)%diag_name) // trim(suffix)
             else
-              var%bc_r4(n)%field(m)%name = var_in%bc_r4(n)%field(m)%name
+              var%bc_r4(n)%field(m)%diag_name = var_in%bc_r4(n)%field(m)%diag_name
             endif
             var%bc_r4(n)%field(m)%long_name = var_in%bc_r4(n)%field(m)%long_name
             var%bc_r4(n)%field(m)%units = var_in%bc_r4(n)%field(m)%units
@@ -1603,7 +1603,7 @@ contains
         endif
         allocate ( var%bc(var%num_bcs) )
         do n = 1, var%num_bcs
-          var%bc(n)%name = var_in%bc(n)%name
+          var%bc(n)%field_name = var_in%bc(n)%field_name
           var%bc(n)%atm_tr_index = var_in%bc(n)%atm_tr_index
           var%bc(n)%flux_type = var_in%bc(n)%flux_type
           var%bc(n)%implementation = var_in%bc(n)%implementation
@@ -1621,9 +1621,9 @@ contains
           allocate ( var%bc(n)%field(var%bc(n)%num_fields) )
           do m = 1, var%bc(n)%num_fields
             if (present(suffix)) then
-              var%bc(n)%field(m)%name = trim(var_in%bc(n)%field(m)%name) // trim(suffix)
+              var%bc(n)%field(m)%diag_name = trim(var_in%bc(n)%field(m)%diag_name) // trim(suffix)
             else
-              var%bc(n)%field(m)%name = var_in%bc(n)%field(m)%name
+              var%bc(n)%field(m)%diag_name = var_in%bc(n)%field(m)%diag_name
             endif
             var%bc(n)%field(m)%long_name = var_in%bc(n)%field(m)%long_name
             var%bc(n)%field(m)%units = var_in%bc(n)%field(m)%units
@@ -1645,7 +1645,7 @@ contains
         endif
         allocate ( var%bc_r4(var%num_bcs) )
         do n = 1, var%num_bcs
-          var%bc_r4(n)%name = var_in%bc_r4(n)%name
+          var%bc_r4(n)%field_name = var_in%bc_r4(n)%field_name
           var%bc_r4(n)%atm_tr_index = var_in%bc_r4(n)%atm_tr_index
           var%bc_r4(n)%flux_type = var_in%bc_r4(n)%flux_type
           var%bc_r4(n)%implementation = var_in%bc_r4(n)%implementation
@@ -1663,9 +1663,9 @@ contains
           allocate ( var%bc_r4(n)%field(var%bc_r4(n)%num_fields) )
           do m = 1, var%bc_r4(n)%num_fields
             if (present(suffix)) then
-              var%bc_r4(n)%field(m)%name = trim(var_in%bc_r4(n)%field(m)%name) // trim(suffix)
+              var%bc_r4(n)%field(m)%diag_name = trim(var_in%bc_r4(n)%field(m)%diag_name) // trim(suffix)
             else
-              var%bc_r4(n)%field(m)%name = var_in%bc_r4(n)%field(m)%name
+              var%bc_r4(n)%field(m)%diag_name = var_in%bc_r4(n)%field(m)%diag_name
             endif
             var%bc_r4(n)%field(m)%long_name = var_in%bc_r4(n)%field(m)%long_name
             var%bc_r4(n)%field(m)%units = var_in%bc_r4(n)%field(m)%units
@@ -1726,11 +1726,11 @@ contains
         if( associated(var_in%bc)) then
           if (field_index > var_in%bc(bc_index)%num_fields)&
             & call mpp_error(FATAL, "CT_copy_data_2d: field_index is present and exceeds num_fields for" //&
-            & trim(var_in%bc(bc_index)%name) )
+            & trim(var_in%bc(bc_index)%field_name) )
         else
           if (field_index > var_in%bc_r4(bc_index)%num_fields)&
             & call mpp_error(FATAL, "CT_copy_data_2d: field_index is present and exceeds num_fields for" //&
-            & trim(var_in%bc_r4(bc_index)%name) )
+            & trim(var_in%bc_r4(bc_index)%field_name) )
         endif
       endif
     elseif (present(field_index)) then
@@ -1872,11 +1872,11 @@ contains
         if( associated(var_in%bc)) then
           if (field_index > var_in%bc(bc_index)%num_fields)&
             & call mpp_error(FATAL, "CT_copy_data_3d: field_index is present and exceeds num_fields for" //&
-            & trim(var_in%bc(bc_index)%name) )
+            & trim(var_in%bc(bc_index)%field_name) )
         else
           if (field_index > var_in%bc_r4(bc_index)%num_fields)&
             & call mpp_error(FATAL, "CT_copy_data_3d: field_index is present and exceeds num_fields for" //&
-            & trim(var_in%bc_r4(bc_index)%name) )
+            & trim(var_in%bc_r4(bc_index)%field_name) )
         endif
       endif
     elseif (present(field_index)) then
@@ -2028,7 +2028,7 @@ contains
           & call mpp_error(FATAL, "CT_copy_data_2d_3d: bc_index is present and exceeds var_in%num_bcs.")
       if (present(field_index)) then ; if (field_index > var_in%bc(bc_index)%num_fields)&
           & call mpp_error(FATAL, "CT_copy_data_2d_3d: field_index is present and exceeds num_fields for" //&
-          & trim(var_in%bc(bc_index)%name) )
+          & trim(var_in%bc(bc_index)%field_name) )
       endif
     elseif (present(field_index)) then
       call mpp_error(FATAL, "CT_copy_data_2d_3d: bc_index must be present if field_index is present.")
@@ -2556,11 +2556,11 @@ contains
         if( associated(var_in%bc)) then
           if (field_index > var_in%bc(bc_index)%num_fields)&
               & call mpp_error(FATAL, "CT_increment_data_2d_2d: field_index is present and exceeds num_fields for" //&
-              & trim(var_in%bc(bc_index)%name) )
+              & trim(var_in%bc(bc_index)%field_name) )
         else
           if (field_index > var_in%bc_r4(bc_index)%num_fields)&
               & call mpp_error(FATAL, "CT_increment_data_2d_2d: field_index is present and exceeds num_fields for" //&
-              & trim(var_in%bc_r4(bc_index)%name) )
+              & trim(var_in%bc_r4(bc_index)%field_name) )
         endif
       endif
     elseif (present(field_index)) then
@@ -2714,12 +2714,12 @@ contains
       if(associated(var_in%bc)) then
         if (present(field_index)) then ; if (field_index > var_in%bc(bc_index)%num_fields)&
             & call mpp_error(FATAL, "CT_increment_data_3d_3d: field_index is present and exceeds num_fields for" //&
-            & trim(var_in%bc(bc_index)%name) )
+            & trim(var_in%bc(bc_index)%field_name) )
         endif
       else if(associated(var_in%bc_r4)) then
         if (present(field_index)) then ; if (field_index > var_in%bc_r4(bc_index)%num_fields)&
             & call mpp_error(FATAL, "CT_increment_data_3d_3d: field_index is present and exceeds num_fields for" //&
-            & trim(var_in%bc_r4(bc_index)%name) )
+            & trim(var_in%bc_r4(bc_index)%field_name) )
         endif
       endif
     elseif (present(field_index)) then
@@ -2868,7 +2868,7 @@ contains
       do n = 1, var%num_bcs
         do m = 1, var%bc(n)%num_fields
           var%bc(n)%field(m)%id_diag = register_diag_field(diag_name,&
-              & var%bc(n)%field(m)%name, axes(1:2), Time,&
+              & var%bc(n)%field(m)%diag_name, axes(1:2), Time,&
               & var%bc(n)%field(m)%long_name, var%bc(n)%field(m)%units)
         enddo
       enddo
@@ -2876,7 +2876,7 @@ contains
       do n = 1, var%num_bcs
         do m = 1, var%bc_r4(n)%num_fields
           var%bc_r4(n)%field(m)%id_diag = register_diag_field(diag_name,&
-              & var%bc_r4(n)%field(m)%name, axes(1:2), Time,&
+              & var%bc_r4(n)%field(m)%diag_name, axes(1:2), Time,&
               & var%bc_r4(n)%field(m)%long_name, var%bc_r4(n)%field(m)%units)
         enddo
       enddo
@@ -2924,7 +2924,7 @@ contains
       do n = 1, var%num_bcs
         do m = 1, var%bc(n)%num_fields
           var%bc(n)%field(m)%id_diag = register_diag_field(diag_name,&
-              & var%bc(n)%field(m)%name, axes(1:3), Time,&
+              & var%bc(n)%field(m)%diag_name, axes(1:3), Time,&
               & var%bc(n)%field(m)%long_name, var%bc(n)%field(m)%units )
         enddo
       enddo
@@ -2932,7 +2932,7 @@ contains
       do n = 1, var%num_bcs
         do m = 1, var%bc_r4(n)%num_fields
           var%bc_r4(n)%field(m)%id_diag = register_diag_field(diag_name,&
-              & var%bc_r4(n)%field(m)%name, axes(1:3), Time,&
+              & var%bc_r4(n)%field(m)%diag_name, axes(1:3), Time,&
               & var%bc_r4(n)%field(m)%long_name, var%bc_r4(n)%field(m)%units )
         enddo
       enddo
@@ -3122,11 +3122,11 @@ contains
 
         do m = 1, var%bc(n)%num_fields
           if (file_is_open(f)) then
-              if( to_read .and. variable_exists(bc_rest_files(f), var%bc(n)%field(m)%name)) then
+              if( to_read .and. variable_exists(bc_rest_files(f), var%bc(n)%field(m)%diag_name)) then
                   !< If reading get the dimension names from the file
-                  allocate(dim_names(get_variable_num_dimensions(bc_rest_files(f), var%bc(n)%field(m)%name)))
+                  allocate(dim_names(get_variable_num_dimensions(bc_rest_files(f), var%bc(n)%field(m)%diag_name)))
                   call get_variable_dimension_names(bc_rest_files(f), &
-                  & var%bc(n)%field(m)%name, dim_names)
+                  & var%bc(n)%field(m)%diag_name, dim_names)
               else
                   !< If writing use dummy dimension names
                   allocate(dim_names(3))
@@ -3136,7 +3136,7 @@ contains
               endif !< to_read
 
               call register_restart_field(bc_rest_files(f),&
-              & var%bc(n)%field(m)%name, var%bc(n)%field(m)%values, dim_names, &
+              & var%bc(n)%field(m)%diag_name, var%bc(n)%field(m)%values, dim_names, &
               & is_optional=var%bc(n)%field(m)%may_init )
 
               deallocate(dim_names)
@@ -3185,11 +3185,11 @@ contains
 
         do m = 1, var%bc_r4(n)%num_fields
           if (file_is_open(f)) then
-              if( to_read .and. variable_exists(bc_rest_files(f), var%bc_r4(n)%field(m)%name)) then
+              if( to_read .and. variable_exists(bc_rest_files(f), var%bc_r4(n)%field(m)%diag_name)) then
                   !< If reading get the dimension names from the file
-                  allocate(dim_names(get_variable_num_dimensions(bc_rest_files(f), var%bc_r4(n)%field(m)%name)))
+                  allocate(dim_names(get_variable_num_dimensions(bc_rest_files(f), var%bc_r4(n)%field(m)%diag_name)))
                   call get_variable_dimension_names(bc_rest_files(f), &
-                  & var%bc_r4(n)%field(m)%name, dim_names)
+                  & var%bc_r4(n)%field(m)%diag_name, dim_names)
               else
                   !< If writing use dummy dimension names
                   allocate(dim_names(3))
@@ -3199,7 +3199,7 @@ contains
               endif !< to_read
 
               call register_restart_field(bc_rest_files(f),&
-              & var%bc_r4(n)%field(m)%name, var%bc_r4(n)%field(m)%values, dim_names, &
+              & var%bc_r4(n)%field(m)%diag_name, var%bc_r4(n)%field(m)%values, dim_names, &
               & is_optional=var%bc_r4(n)%field(m)%may_init )
 
               deallocate(dim_names)
@@ -3411,11 +3411,11 @@ contains
 
         do m = 1, var%bc(n)%num_fields
           if (file_is_open(f)) then
-              if( to_read .and. variable_exists(bc_rest_files(f), var%bc(n)%field(m)%name)) then
+              if( to_read .and. variable_exists(bc_rest_files(f), var%bc(n)%field(m)%diag_name)) then
                   !< If reading get the dimension names from the file
-                  allocate(dim_names(get_variable_num_dimensions(bc_rest_files(f), var%bc(n)%field(m)%name)))
+                  allocate(dim_names(get_variable_num_dimensions(bc_rest_files(f), var%bc(n)%field(m)%diag_name)))
                   call get_variable_dimension_names(bc_rest_files(f), &
-                  & var%bc(n)%field(m)%name, dim_names)
+                  & var%bc(n)%field(m)%diag_name, dim_names)
               else
                   !< If writing use dummy dimension names
                   allocate(dim_names(4))
@@ -3426,7 +3426,7 @@ contains
               endif !< to_read
 
               call register_restart_field(bc_rest_files(f),&
-                  & var%bc(n)%field(m)%name, var%bc(n)%field(m)%values, dim_names, &
+                  & var%bc(n)%field(m)%diag_name, var%bc(n)%field(m)%values, dim_names, &
                   & is_optional=var%bc(n)%field(m)%may_init )
               deallocate(dim_names)
           endif !< If file_is_open
@@ -3479,11 +3479,11 @@ contains
 
         do m = 1, var%bc_r4(n)%num_fields
           if (file_is_open(f)) then
-              if( to_read .and. variable_exists(bc_rest_files(f), var%bc_r4(n)%field(m)%name)) then
+              if( to_read .and. variable_exists(bc_rest_files(f), var%bc_r4(n)%field(m)%diag_name)) then
                   !< If reading get the dimension names from the file
-                  allocate(dim_names(get_variable_num_dimensions(bc_rest_files(f), var%bc_r4(n)%field(m)%name)))
+                  allocate(dim_names(get_variable_num_dimensions(bc_rest_files(f), var%bc_r4(n)%field(m)%diag_name)))
                   call get_variable_dimension_names(bc_rest_files(f), &
-                  & var%bc_r4(n)%field(m)%name, dim_names)
+                  & var%bc_r4(n)%field(m)%diag_name, dim_names)
               else
                   !< If writing use dummy dimension names
                   allocate(dim_names(4))
@@ -3494,7 +3494,7 @@ contains
               endif !< to_read
 
               call register_restart_field(bc_rest_files(f),&
-                  & var%bc_r4(n)%field(m)%name, var%bc_r4(n)%field(m)%values, dim_names, &
+                  & var%bc_r4(n)%field(m)%diag_name, var%bc_r4(n)%field(m)%values, dim_names, &
                   & is_optional=var%bc_r4(n)%field(m)%may_init )
               deallocate(dim_names)
           endif !< If file_is_open
@@ -3548,10 +3548,10 @@ contains
         do m = 1, var%bc(n)%num_fields
           var_set = .false.
           if (check_if_open(var%bc(n)%fms2_io_rest_type)) then
-              var_set = variable_exists(var%bc(n)%fms2_io_rest_type, var%bc(n)%field(m)%name)
+              var_set = variable_exists(var%bc(n)%fms2_io_rest_type, var%bc(n)%field(m)%diag_name)
           endif
 
-          if (.not.var_set) unset_varname = trim(var%bc(n)%field(m)%name)
+          if (.not.var_set) unset_varname = trim(var%bc(n)%field(m)%diag_name)
           if (var_set) any_set = .true.
           if (all_set) all_set = var_set
           if (var_set) any_var_set = .true.
@@ -3563,7 +3563,7 @@ contains
           if (test_by_field .and. (all_var_set .neqv. any_var_set)) call mpp_error(FATAL,&
               & "CT_restore_state_2d: test_by_field is true, and "//&
               & trim(unset_varname)//" was not read but some other fields in "//&
-              & trim(trim(var%bc(n)%name))//" were.")
+              & trim(trim(var%bc(n)%field_name))//" were.")
         endif
       enddo
     else if(associated(var%bc_r4)) then
@@ -3573,10 +3573,10 @@ contains
         do m = 1, var%bc_r4(n)%num_fields
           var_set = .false.
           if (check_if_open(var%bc_r4(n)%fms2_io_rest_type)) then
-              var_set = variable_exists(var%bc_r4(n)%fms2_io_rest_type, var%bc_r4(n)%field(m)%name)
+              var_set = variable_exists(var%bc_r4(n)%fms2_io_rest_type, var%bc_r4(n)%field(m)%diag_name)
           endif
 
-          if (.not.var_set) unset_varname = trim(var%bc_r4(n)%field(m)%name)
+          if (.not.var_set) unset_varname = trim(var%bc_r4(n)%field(m)%diag_name)
           if (var_set) any_set = .true.
           if (all_set) all_set = var_set
           if (var_set) any_var_set = .true.
@@ -3588,7 +3588,7 @@ contains
           if (test_by_field .and. (all_var_set .neqv. any_var_set)) call mpp_error(FATAL,&
               & "CT_restore_state_2d: test_by_field is true, and "//&
               & trim(unset_varname)//" was not read but some other fields in "//&
-              & trim(trim(var%bc_r4(n)%name))//" were.")
+              & trim(trim(var%bc_r4(n)%field_name))//" were.")
         endif
       enddo
     else
@@ -3656,10 +3656,10 @@ contains
         do m = 1, var%bc(n)%num_fields
           var_set = .false.
           if (check_if_open(var%bc(n)%fms2_io_rest_type)) then
-              var_set = variable_exists(var%bc(n)%fms2_io_rest_type, var%bc(n)%field(m)%name)
+              var_set = variable_exists(var%bc(n)%fms2_io_rest_type, var%bc(n)%field(m)%diag_name)
           endif
 
-          if (.not.var_set) unset_varname = trim(var%bc(n)%field(m)%name)
+          if (.not.var_set) unset_varname = trim(var%bc(n)%field(m)%diag_name)
 
           if (var_set) any_set = .true.
           if (all_set) all_set = var_set
@@ -3672,7 +3672,7 @@ contains
           if (test_by_field .and. (all_var_set .neqv. any_var_set)) call mpp_error(FATAL,&
               & "CT_restore_state_3d: test_by_field is true, and "//&
               & trim(unset_varname)//" was not read but some other fields in "//&
-              & trim(trim(var%bc(n)%name))//" were.")
+              & trim(trim(var%bc(n)%field_name))//" were.")
         endif
       enddo
     else if(associated(var%bc_r4)) then
@@ -3682,10 +3682,10 @@ contains
         do m = 1, var%bc_r4(n)%num_fields
           var_set = .false.
           if (check_if_open(var%bc_r4(n)%fms2_io_rest_type)) then
-              var_set = variable_exists(var%bc_r4(n)%fms2_io_rest_type, var%bc_r4(n)%field(m)%name)
+              var_set = variable_exists(var%bc_r4(n)%fms2_io_rest_type, var%bc_r4(n)%field(m)%diag_name)
           endif
 
-          if (.not.var_set) unset_varname = trim(var%bc_r4(n)%field(m)%name)
+          if (.not.var_set) unset_varname = trim(var%bc_r4(n)%field(m)%diag_name)
 
           if (var_set) any_set = .true.
           if (all_set) all_set = var_set
@@ -3698,7 +3698,7 @@ contains
           if (test_by_field .and. (all_var_set .neqv. any_var_set)) call mpp_error(FATAL,&
               & "CT_restore_state_3d: test_by_field is true, and "//&
               & trim(unset_varname)//" was not read but some other fields in "//&
-              & trim(trim(var%bc(n)%name))//" were.")
+              & trim(trim(var%bc(n)%field_name))//" were.")
         endif
       enddo
     else
@@ -3744,13 +3744,13 @@ contains
     if(associated(var%bc) .or. var%num_bcs .lt. 1) then
       do n = 1, var%num_bcs
         do m = 1, var%bc(n)%num_fields
-          call data_override(gridname, var%bc(n)%field(m)%name, var%bc(n)%field(m)%values, Time)
+          call data_override(gridname, var%bc(n)%field(m)%diag_name, var%bc(n)%field(m)%values, Time)
         enddo
       enddo
     else if(associated(var%bc_r4)) then
       do n = 1, var%num_bcs
         do m = 1, var%bc_r4(n)%num_fields
-          call data_override(gridname, var%bc_r4(n)%field(m)%name, var%bc_r4(n)%field(m)%values, Time)
+          call data_override(gridname, var%bc_r4(n)%field(m)%diag_name, var%bc_r4(n)%field(m)%values, Time)
         enddo
       enddo
     else
@@ -3784,13 +3784,13 @@ contains
     if(associated(var%bc) .or. var%num_bcs .lt. 1) then
       do n = 1, var%num_bcs
         do m = 1, var%bc(n)%num_fields
-          call data_override(gridname, var%bc(n)%field(m)%name, var%bc(n)%field(m)%values, Time)
+          call data_override(gridname, var%bc(n)%field(m)%diag_name, var%bc(n)%field(m)%values, Time)
         enddo
       enddo
     else if(associated(var%bc_r4)) then
       do n = 1, var%num_bcs
         do m = 1, var%bc_r4(n)%num_fields
-          call data_override(gridname, var%bc_r4(n)%field(m)%name, var%bc_r4(n)%field(m)%values, Time)
+          call data_override(gridname, var%bc_r4(n)%field(m)%diag_name, var%bc_r4(n)%field(m)%values, Time)
         enddo
       enddo
     else
@@ -3827,9 +3827,9 @@ contains
       do n = 1, var%num_bcs
         do m = 1, var%bc(n)%num_fields
           if (present(name_lead)) then
-            var_name = trim(name_lead)//trim(var%bc(n)%field(m)%name)
+            var_name = trim(name_lead)//trim(var%bc(n)%field(m)%diag_name)
           else
-            var_name = trim(var%bc(n)%field(m)%name)
+            var_name = trim(var%bc(n)%field(m)%diag_name)
           endif
           chks = mpp_chksum(var%bc(n)%field(m)%values(var%isc:var%iec,var%jsc:var%jec))
           if(outunit.ne.0) write(outunit, '("   CHECKSUM:: ",A40," = ",Z20)') trim(var_name), chks
@@ -3839,9 +3839,9 @@ contains
       do n = 1, var%num_bcs
         do m = 1, var%bc_r4(n)%num_fields
           if (present(name_lead)) then
-            var_name = trim(name_lead)//trim(var%bc_r4(n)%field(m)%name)
+            var_name = trim(name_lead)//trim(var%bc_r4(n)%field(m)%diag_name)
           else
-            var_name = trim(var%bc_r4(n)%field(m)%name)
+            var_name = trim(var%bc_r4(n)%field(m)%diag_name)
           endif
           chks = mpp_chksum(var%bc_r4(n)%field(m)%values(var%isc:var%iec,var%jsc:var%jec))
           if(outunit.ne.0) write(outunit, '("   CHECKSUM:: ",A40," = ",Z20)') trim(var_name), chks
@@ -3879,9 +3879,9 @@ contains
       do n = 1, var%num_bcs
         do m = 1, var%bc(n)%num_fields
           if (present(name_lead)) then
-            var_name = trim(name_lead)//trim(var%bc(n)%field(m)%name)
+            var_name = trim(name_lead)//trim(var%bc(n)%field(m)%diag_name)
           else
-            var_name = trim(var%bc(n)%field(m)%name)
+            var_name = trim(var%bc(n)%field(m)%diag_name)
           endif
           chks = mpp_chksum(var%bc(n)%field(m)%values(var%isc:var%iec,var%jsc:var%jec,:))
           if(outunit.ne.0) write(outunit, '("   CHECKSUM:: ",A40," = ",Z20)') trim(var_name), chks
@@ -3891,9 +3891,9 @@ contains
       do n = 1, var%num_bcs
         do m = 1, var%bc_r4(n)%num_fields
           if (present(name_lead)) then
-            var_name = trim(name_lead)//trim(var%bc_r4(n)%field(m)%name)
+            var_name = trim(name_lead)//trim(var%bc_r4(n)%field(m)%diag_name)
           else
-            var_name = trim(var%bc_r4(n)%field(m)%name)
+            var_name = trim(var%bc_r4(n)%field(m)%diag_name)
           endif
           chks = mpp_chksum(var%bc_r4(n)%field(m)%values(var%isc:var%iec,var%jsc:var%jec,:))
           if(outunit.ne.0) write(outunit, '("   CHECKSUM:: ",A40," = ",Z20)') trim(var_name), chks
@@ -4084,7 +4084,7 @@ contains
       var%bc(n)%rest_type => bc_rest_files(f)
       do m = 1, var%bc(n)%num_fields
         var%bc(n)%field(m)%id_rest = fms_io_register_restart_field(bc_rest_files(f),&
-            & rest_file_names(f), var%bc(n)%field(m)%name, var%bc(n)%field(m)%values,&
+            & rest_file_names(f), var%bc(n)%field(m)%diag_name, var%bc(n)%field(m)%values,&
             & mpp_domain, mandatory=.not.var%bc(n)%field(m)%may_init )
       enddo
     enddo
@@ -4115,7 +4115,7 @@ contains
 
       var%bc(n)%rest_type => rest_file
       do m = 1, var%bc(n)%num_fields
-        var_name = trim(var%bc(n)%field(m)%name)
+        var_name = trim(var%bc(n)%field(m)%diag_name)
         if (present(varname_prefix)) var_name = trim(varname_prefix)//trim(var_name)
         var%bc(n)%field(m)%id_rest = fms_io_register_restart_field(rest_file,&
             & file_name, var_name, var%bc(n)%field(m)%values,&
@@ -4173,7 +4173,7 @@ contains
       var%bc(n)%rest_type => bc_rest_files(f)
       do m = 1, var%bc(n)%num_fields
         var%bc(n)%field(m)%id_rest = fms_io_register_restart_field(bc_rest_files(f),&
-            & rest_file_names(f), var%bc(n)%field(m)%name, var%bc(n)%field(m)%values,&
+            & rest_file_names(f), var%bc(n)%field(m)%diag_name, var%bc(n)%field(m)%values,&
             & mpp_domain, mandatory=.not.var%bc(n)%field(m)%may_init )
       enddo
     enddo
@@ -4202,7 +4202,7 @@ contains
 
       var%bc(n)%rest_type => rest_file
       do m = 1, var%bc(n)%num_fields
-        var_name = trim(var%bc(n)%field(m)%name)
+        var_name = trim(var%bc(n)%field(m)%diag_name)
         if (present(varname_prefix)) var_name = trim(varname_prefix)//trim(var_name)
         var%bc(n)%field(m)%id_rest = fms_io_register_restart_field(rest_file,&
             & file_name, var_name, var%bc(n)%field(m)%values,&
@@ -4251,7 +4251,7 @@ contains
           endif
         endif
 
-        if (.not.var_set) unset_varname = trim(var%bc(n)%field(m)%name)
+        if (.not.var_set) unset_varname = trim(var%bc(n)%field(m)%diag_name)
         if (var_set) any_set = .true.
         if (all_set) all_set = var_set
         if (var_set) any_var_set = .true.
@@ -4263,7 +4263,7 @@ contains
         if (test_by_field .and. (all_var_set .neqv. any_var_set)) call mpp_error(FATAL,&
             & "mpp_io_CT_restore_state_2d: test_by_field is true, and "//&
             & trim(unset_varname)//" was not read but some other fields in "//&
-            & trim(trim(var%bc(n)%name))//" were.")
+            & trim(trim(var%bc(n)%field_name))//" were.")
       endif
     enddo
 
@@ -4321,7 +4321,7 @@ contains
           endif
         endif
 
-        if (.not.var_set) unset_varname = trim(var%bc(n)%field(m)%name)
+        if (.not.var_set) unset_varname = trim(var%bc(n)%field(m)%diag_name)
 
         if (var_set) any_set = .true.
         if (all_set) all_set = var_set
@@ -4334,7 +4334,7 @@ contains
         if (test_by_field .and. (all_var_set .neqv. any_var_set)) call mpp_error(FATAL,&
             & "mpp_io_CT_restore_state_3d: test_by_field is true, and "//&
             & trim(unset_varname)//" was not read but some other fields in "//&
-            & trim(trim(var%bc(n)%name))//" were.")
+            & trim(trim(var%bc(n)%field_name))//" were.")
       endif
     enddo
 

--- a/coupler/ensemble_manager.F90
+++ b/coupler/ensemble_manager.F90
@@ -184,12 +184,12 @@ contains
 !! @throw FATAL, "get_ensemble_filter_pelist: size of pelist argument < ensemble_size * land_npes_pm"
 !! @throw FATAL, "get_ensemble_filter_pelist: size of pelist argument < ensemble_size * ice_npes_pm"
 !! @throw FATAL, "get_ensemble_filter_pelist: unknown argument name=[name]"
-  subroutine get_ensemble_filter_pelist(pelist, name)
+  subroutine get_ensemble_filter_pelist(pelist, component_name)
 
     integer, intent(inout) :: pelist(:) !< Returned filter pe list
-    character(len=*), intent(in)  :: name !< Ensemble component name
+    character(len=*), intent(in)  :: component_name !< Ensemble component name
 
-    select case(name)
+    select case(component_name)
     case('ocean')
        if (size(pelist) < ensemble_size * ocean_npes_pm)&
             call mpp_error(FATAL,'get_ensemble_filter_pelist: size of pelist argument < ensemble_size * ocean_npes_pm')
@@ -219,7 +219,7 @@ contains
             ensemble_pelist_ice_filter(1:ensemble_size*ice_npes_pm)
 
     case default
-       call mpp_error(FATAL,'get_ensemble_filter_pelist: unknown argument name='//name)
+       call mpp_error(FATAL,'get_ensemble_filter_pelist: unknown argument name='//component_name)
     end select
 
 

--- a/coupler/include/coupler_types.inc
+++ b/coupler/include/coupler_types.inc
@@ -57,7 +57,7 @@
           & call mpp_error(FATAL, "CT_rescale_data_2d: bc_index is present and exceeds var%num_bcs.")
       if (present(field_index)) then ; if (field_index > var%FMS_CP_BC_TYPE_(bc_index)%num_fields)&
           & call mpp_error(FATAL, "CT_rescale_data_2d: field_index is present and exceeds num_fields for" //&
-          & trim(var%FMS_CP_BC_TYPE_(bc_index)%name) )
+          & trim(var%FMS_CP_BC_TYPE_(bc_index)%field_name) )
       endif
     elseif (present(field_index)) then
       call mpp_error(FATAL, "CT_rescale_data_2d: bc_index must be present if field_index is present.")
@@ -148,7 +148,7 @@
           & call mpp_error(FATAL, "CT_rescale_data_2d: bc_index is present and exceeds var%num_bcs.")
       if (present(field_index)) then ; if (field_index > var%FMS_CP_BC_TYPE_(bc_index)%num_fields)&
           & call mpp_error(FATAL, "CT_rescale_data_2d: field_index is present and exceeds num_fields for" //&
-          & trim(var%FMS_CP_BC_TYPE_(bc_index)%name) )
+          & trim(var%FMS_CP_BC_TYPE_(bc_index)%field_name) )
       endif
     elseif (present(field_index)) then
       call mpp_error(FATAL, "CT_rescale_data_2d: bc_index must be present if field_index is present.")
@@ -221,7 +221,7 @@
   !! normalized weight array must match the array sizes of the coupler_3d_bc_type.
   !!
   !! @throw FATAL, "bc_index is present and exceeds var_in%num_bcs."
-  !! @throw FATAL, "field_index is present and exceeds num_fields for var_in%FMS_CP_BC_TYPE_(bc_incdx)%name"
+  !! @throw FATAL, "field_index is present and exceeds num_fields for var_in%FMS_CP_BC_TYPE_(bc_incdx)%field_name"
   !! @throw FATAL, "bc_index must be present if field_index is present."
   !! @throw FATAL, "There is an i-direction computational domain size mismatch."
   !! @throw FATAL, "There is an j-direction computational domain size mismatch."
@@ -270,7 +270,7 @@
           & call mpp_error(FATAL, "CT_increment_data_2d_3d: bc_index is present and exceeds var_in%num_bcs.")
       if (present(field_index)) then ; if (field_index > var_in%FMS_CP_BC_TYPE_(bc_index)%num_fields)&
           & call mpp_error(FATAL, "CT_increment_data_2d_3d: field_index is present and exceeds num_fields for" //&
-          & trim(var_in%FMS_CP_BC_TYPE_(bc_index)%name) )
+          & trim(var_in%FMS_CP_BC_TYPE_(bc_index)%field_name) )
       endif
     elseif (present(field_index)) then
       call mpp_error(FATAL, "CT_increment_data_2d_3d: bc_index must be present if field_index is present.")
@@ -365,7 +365,7 @@
   !! Extract a single 2-d field from a coupler_2d_bc_type into a two-dimensional array.
   !!
   !! @throw FATAL, "bc_index is present and exceeds var_in%num_bcs."
-  !! @throw FATAL, "field_index exceeds num_fields for var_in%FMS_CP_BC_TYPE_(bc_incdx)%name"
+  !! @throw FATAL, "field_index exceeds num_fields for var_in%FMS_CP_BC_TYPE_(bc_incdx)%field_name"
   !! @throw FATAL, "Excessive i-direction halo size for the input structure."
   !! @throw FATAL, "Excessive j-direction halo size for the input structure."
   !! @throw FATAL, "Disordered i-dimension index bound list"
@@ -422,7 +422,7 @@
         & call mpp_error(FATAL, trim(error_header)//" bc_index exceeds var_in%num_bcs.")
     if (field_index > var_in%FMS_CP_BC_TYPE_(bc_index)%num_fields)&
         & call mpp_error(FATAL, trim(error_header)//" field_index exceeds num_fields for" //&
-        & trim(var_in%FMS_CP_BC_TYPE_(bc_index)%name) )
+        & trim(var_in%FMS_CP_BC_TYPE_(bc_index)%field_name) )
 
     ! Do error checking on the i-dimension and determine the array offsets.
     if (present(idim)) then
@@ -502,7 +502,7 @@
   !! Extract a single k-level of a 3-d field from a coupler_3d_bc_type into a two-dimensional array.
   !!
   !! @throw FATAL, "bc_index is present and exceeds var_in%num_bcs."
-  !! @throw FATAL, "field_index exceeds num_fields for var_in%FMS_CP_BC_TYPE_(bc_incdx)%name"
+  !! @throw FATAL, "field_index exceeds num_fields for var_in%FMS_CP_BC_TYPE_(bc_incdx)%field_name"
   !! @throw FATAL, "Excessive i-direction halo size for the input structure."
   !! @throw FATAL, "Excessive j-direction halo size for the input structure."
   !! @throw FATAL, "Disordered i-dimension index bound list"
@@ -560,7 +560,7 @@
         & call mpp_error(FATAL, trim(error_header)//" bc_index exceeds var_in%num_bcs.")
     if (field_index > var_in%FMS_CP_BC_TYPE_(bc_index)%num_fields)&
         & call mpp_error(FATAL, trim(error_header)//" field_index exceeds num_fields for" //&
-        & trim(var_in%FMS_CP_BC_TYPE_(bc_index)%name) )
+        & trim(var_in%FMS_CP_BC_TYPE_(bc_index)%field_name) )
 
     ! Do error checking on the i-dimension and determine the array offsets.
     if (present(idim)) then
@@ -646,7 +646,7 @@
   !! Extract a single 3-d field from a coupler_3d_bc_type into a three-dimensional array.
   !!
   !! @throw FATAL, "bc_index is present and exceeds var_in%num_bcs."
-  !! @throw FATAL, "field_index exceeds num_fields for var_in%FMS_CP_BC_TYPE_(bc_incdx)%name"
+  !! @throw FATAL, "field_index exceeds num_fields for var_in%FMS_CP_BC_TYPE_(bc_incdx)%field_name"
   !! @throw FATAL, "Excessive i-direction halo size for the input structure."
   !! @throw FATAL, "Excessive j-direction halo size for the input structure."
   !! @throw FATAL, "Disordered i-dimension index bound list"
@@ -704,7 +704,7 @@
         & call mpp_error(FATAL, trim(error_header)//" bc_index exceeds var_in%num_bcs.")
     if (field_index > var_in%FMS_CP_BC_TYPE_(bc_index)%num_fields)&
         & call mpp_error(FATAL, trim(error_header)//" field_index exceeds num_fields for" //&
-        & trim(var_in%FMS_CP_BC_TYPE_(bc_index)%name) )
+        & trim(var_in%FMS_CP_BC_TYPE_(bc_index)%field_name) )
 
     ! Do error checking on the i-dimension and determine the array offsets.
     if (present(idim)) then
@@ -794,7 +794,7 @@
   !! Set a single 2-d field in a coupler_3d_bc_type from a two-dimensional array.
   !!
   !! @throw FATAL, "bc_index is present and exceeds var_in%num_bcs."
-  !! @throw FATAL, "field_index exceeds num_fields for var_in%FMS_CP_BC_TYPE_(bc_incdx)%name"
+  !! @throw FATAL, "field_index exceeds num_fields for var_in%FMS_CP_BC_TYPE_(bc_incdx)%field_name"
   !! @throw FATAL, "Excessive i-direction halo size for the input structure."
   !! @throw FATAL, "Excessive j-direction halo size for the input structure."
   !! @throw FATAL, "Disordered i-dimension index bound list"
@@ -847,7 +847,7 @@
         call mpp_error(FATAL, trim(error_header)//" bc_index exceeds var%num_bcs.")
     if (field_index > var%FMS_CP_BC_TYPE_(bc_index)%num_fields)&
         & call mpp_error(FATAL, trim(error_header)//" field_index exceeds num_fields for" //&
-        & trim(var%FMS_CP_BC_TYPE_(bc_index)%name) )
+        & trim(var%FMS_CP_BC_TYPE_(bc_index)%field_name) )
 
     ! Do error checking on the i-dimension and determine the array offsets.
     if (present(idim)) then
@@ -928,7 +928,7 @@
   !! two-dimensional array.
   !!
   !! @throw FATAL, "bc_index is present and exceeds var_in%num_bcs."
-  !! @throw FATAL, "field_index exceeds num_fields for var_in%FMS_CP_BC_TYPE_(bc_incdx)%name"
+  !! @throw FATAL, "field_index exceeds num_fields for var_in%FMS_CP_BC_TYPE_(bc_incdx)%field_name"
   !! @throw FATAL, "Excessive i-direction halo size for the input structure."
   !! @throw FATAL, "Excessive j-direction halo size for the input structure."
   !! @throw FATAL, "Disordered i-dimension index bound list"
@@ -984,7 +984,7 @@
         & call mpp_error(FATAL, trim(error_header)//" bc_index exceeds var%num_bcs.")
     if (field_index > var%FMS_CP_BC_TYPE_(bc_index)%num_fields)&
         & call mpp_error(FATAL, trim(error_header)//" field_index exceeds num_fields for" //&
-        & trim(var%FMS_CP_BC_TYPE_(bc_index)%name) )
+        & trim(var%FMS_CP_BC_TYPE_(bc_index)%field_name) )
 
     ! Do error checking on the i-dimension and determine the array offsets.
     if (present(idim)) then
@@ -1070,7 +1070,7 @@
   !! This subroutine sets a single 3-d field in a coupler_3d_bc_type from a three-dimensional array.
   !!
   !! @throw FATAL, "bc_index is present and exceeds var_in%num_bcs."
-  !! @throw FATAL, "field_index exceeds num_fields for var_in%FMS_CP_BC_TYPE_(bc_incdx)%name"
+  !! @throw FATAL, "field_index exceeds num_fields for var_in%FMS_CP_BC_TYPE_(bc_incdx)%field_name"
   !! @throw FATAL, "Excessive i-direction halo size for the input structure."
   !! @throw FATAL, "Excessive j-direction halo size for the input structure."
   !! @throw FATAL, "Disordered i-dimension index bound list"
@@ -1125,7 +1125,7 @@
         & call mpp_error(FATAL, trim(error_header)//" bc_index exceeds var%num_bcs.")
     if (field_index > var%FMS_CP_BC_TYPE_(bc_index)%num_fields)&
         & call mpp_error(FATAL, trim(error_header)//" field_index exceeds num_fields for" //&
-        & trim(var%FMS_CP_BC_TYPE_(bc_index)%name) )
+        & trim(var%FMS_CP_BC_TYPE_(bc_index)%field_name) )
 
     ! Do error checking on the i-dimension and determine the array offsets.
     if (present(idim)) then

--- a/diag_integral/diag_integral.F90
+++ b/diag_integral/diag_integral.F90
@@ -393,9 +393,9 @@ end subroutine diag_integral_init
 !! @param [in] <name> Name of the field to be integrated
 !! @param [in] <format> Output format of the field to be integrated
 !!
-subroutine diag_integral_field_init (name, format)
+subroutine diag_integral_field_init (fieldname, format)
 
-character(len=*), intent(in) :: name !< Name of the field to be integrated
+character(len=*), intent(in) :: fieldname !< Name of the field to be integrated
 character(len=*), intent(in) :: format !< Output format of the field to be integrated
 
 !-------------------------------------------------------------------------------
@@ -411,7 +411,7 @@ character(len=*), intent(in) :: format !< Output format of the field to be integ
 !-------------------------------------------------------------------------------
 !    make sure the integral name is not too long.
 !-------------------------------------------------------------------------------
-      if (len(name) > max_len_name )  then
+      if (len(fieldname) > max_len_name )  then
         call error_mesg ('diag_integral_mod',  &
                 ' integral name too long', FATAL)
       endif
@@ -420,7 +420,7 @@ character(len=*), intent(in) :: format !< Output format of the field to be integ
 !    check to be sure the integral name has not already been
 !    initialized.
 !-------------------------------------------------------------------------------
-      field = get_field_index (name)
+      field = get_field_index (fieldname)
       if (field /= 0)   then
         call error_mesg ('diag_integral_mod', &
                              'integral name already exists', FATAL)
@@ -441,7 +441,7 @@ character(len=*), intent(in) :: format !< Output format of the field to be integ
 !    initialize its value and the number of grid points that have been
 !    counted to zero.
 !-------------------------------------------------------------------------------
-      field_name   (num_field) = name
+      field_name   (num_field) = fieldname
       field_format (num_field) = format
       field_sum    (num_field) = 0.0_r8_kind
       field_count  (num_field) = 0
@@ -639,9 +639,9 @@ end function set_axis_time
 !! @param [in] <name> Name associated with an integral
 !! @param [out] <index>
 !!
-function get_field_index (name) result (index)
+function get_field_index (fieldname) result (index)
 
-character(len=*),  intent(in) :: name !< Name associated with an integral
+character(len=*),  intent(in) :: fieldname !< Name associated with an integral
 integer                       :: index
 
 !-------------------------------------------------------------------------------
@@ -650,7 +650,7 @@ integer                       :: index
       integer :: nc
       integer :: i
 
-      nc = len_trim (name)
+      nc = len_trim (fieldname)
       if (nc > max_len_name)  then
         call error_mesg ('diag_integral_mod',  &
                                         'name too long', FATAL)
@@ -663,7 +663,7 @@ integer                       :: index
 !-------------------------------------------------------------------------------
       index = 0
       do i = 1, num_field
-        if (name(1:nc) ==     &
+        if (fieldname(1:nc) ==     &
                        field_name(i) (1:len_trim(field_name(i))) ) then
           index = i
           exit

--- a/diag_manager/diag_data.F90
+++ b/diag_manager/diag_data.F90
@@ -109,7 +109,7 @@ use platform_mod
      INTEGER             :: type !< Data type of attribute values (NF_INT, NF_FLOAT, NF_CHAR)
      INTEGER             :: len !< Number of values in attribute, or if a character string then
                                 !! length of the string.
-     CHARACTER(len=128)  :: name !< Name of the attribute
+     CHARACTER(len=128)  :: att_name !< Name of the attribute
      CHARACTER(len=1280) :: catt !< Character string to hold character value of attribute
      REAL, allocatable, DIMENSION(:)    :: fatt !< REAL array to hold value of REAL attributes
      INTEGER, allocatable, DIMENSION(:) :: iatt !< INTEGER array to hold value of INTEGER attributes
@@ -131,7 +131,7 @@ use platform_mod
   !> @brief Type to define the diagnostic files that will be written as defined by the diagnostic table.
   !> @ingroup diag_data_mod
   TYPE file_type
-     CHARACTER(len=128) :: name !< Name of the output file.
+     CHARACTER(len=128) :: filename !< Name of the output file.
      CHARACTER(len=128) :: long_name
      INTEGER, DIMENSION(max_fields_per_file) :: fields
      INTEGER :: num_fields
@@ -255,7 +255,7 @@ use platform_mod
   !> @brief Type to hold the diagnostic axis description.
   !> @ingroup diag_data_mod
   TYPE diag_axis_type
-     CHARACTER(len=128) :: name
+     CHARACTER(len=128) :: axis_name
      CHARACTER(len=256) :: units, long_name
      CHARACTER(len=1) :: cart_name
      REAL, DIMENSION(:), POINTER :: diag_type_data

--- a/diag_manager/diag_manager.F90
+++ b/diag_manager/diag_manager.F90
@@ -583,13 +583,13 @@ CONTAINS
           output_fields(ind)%next_output = diag_time_inc(diag_file_init_time, freq, output_units, err_msg=msg)
           IF ( msg /= '' ) THEN
              IF ( fms_error_handler('diag_manager_mod::register_diag_field',&
-                  & ' file='//TRIM(files(file_num)%name)//': '//TRIM(msg),err_msg)) RETURN
+                  & ' file='//TRIM(files(file_num)%filename)//': '//TRIM(msg),err_msg)) RETURN
           END IF
           output_fields(ind)%next_next_output = &
                & diag_time_inc(output_fields(ind)%next_output, freq, output_units, err_msg=msg)
           IF ( msg /= '' ) THEN
              IF ( fms_error_handler('diag_manager_mod::register_diag_field',&
-                  &' file='//TRIM(files(file_num)%name)//': '//TRIM(msg),err_msg) ) RETURN
+                  &' file='//TRIM(files(file_num)%filename)//': '//TRIM(msg),err_msg) ) RETURN
           END IF
           IF ( debug_diag_manager .AND. mpp_pe() == mpp_root_pe() .AND. output_fields(ind)%local_output ) THEN
              WRITE (msg,'(" lon(",F5.1,", ",F5.1,"), lat(",F5.1,", ",F5.1,"), dep(",F5.1,", ",F5.1,")")') &
@@ -733,11 +733,11 @@ CONTAINS
           file_num = output_fields(out_num)%output_file
           IF(input_fields(field)%local) THEN
              CALL init_output_field(module_name, field_name,output_fields(out_num)%output_name,&
-                  & files(file_num)%name,output_fields(out_num)%time_method, output_fields(out_num)%pack,&
+                  & files(file_num)%filename,output_fields(out_num)%time_method, output_fields(out_num)%pack,&
                   & tile, input_fields(field)%local_coord)
           ELSE
              CALL init_output_field(module_name, field_name,output_fields(out_num)%output_name,&
-                  & files(file_num)%name,output_fields(out_num)%time_method, output_fields(out_num)%pack, tile)
+                  & files(file_num)%filename,output_fields(out_num)%time_method, output_fields(out_num)%pack, tile)
           END IF
        END DO
        field = register_static_field
@@ -903,7 +903,7 @@ CONTAINS
                                "Diagnostics living on a structured grid" &
                                //" and an unstructured grid cannot exist" &
                                //" in the same file (" &
-                               //trim(files(file_num)%name)//")", &
+                               //trim(files(file_num)%filename)//")", &
                                FATAL)
            elseif (.not. files(file_num)%use_domain2D) then
                files(file_num)%use_domain2D = .true.
@@ -914,7 +914,7 @@ CONTAINS
                                "Diagnostics living on a structured grid" &
                                //" and an unstructured grid cannot exist" &
                                //" in the same file (" &
-                               //trim(files(file_num)%name)//")", &
+                               //trim(files(file_num)%filename)//")", &
                                FATAL)
            elseif (.not. files(file_num)%use_domainUG) then
                files(file_num)%use_domainUG = .true.
@@ -1265,12 +1265,12 @@ CONTAINS
     ! Get the base file name
     ! Verify asso_file_name is long enough to hold the file name,
     ! plus 17 for the additional '.ens_??.tile?.nc' (and a null character)
-    IF ( LEN_TRIM(files(cm_file_num)%name)+17 > LEN(asso_file_name) ) THEN
+    IF ( LEN_TRIM(files(cm_file_num)%filename)+17 > LEN(asso_file_name) ) THEN
        CALL error_mesg ('diag_manager_mod::add_associated_files',&
             & 'Length of asso_file_name is not long enough to hold the associated file name. '&
             & //'Contact the developer', FATAL)
     ELSE
-       asso_file_name = TRIM(files(cm_file_num)%name)
+       asso_file_name = TRIM(files(cm_file_num)%filename)
     END IF
 
     ! Add the ensemble number string into the file name
@@ -3769,7 +3769,7 @@ CONTAINS
        CALL mpp_sum (files(file)%bytes_written)
        IF ( mpp_pe() == mpp_root_pe() )&
             & WRITE (stdout_unit,'(a,i12,a,a)') 'Diag_Manager: ',files(file)%bytes_written, &
-            & ' bytes of data written to file ',TRIM(files(file)%name)
+            & ' bytes of data written to file ',TRIM(files(file)%filename)
     END IF
   END SUBROUTINE closing_file
 
@@ -4015,7 +4015,7 @@ CONTAINS
     INTEGER :: hour !< components of the base date
     INTEGER :: minute !< components of the base date
     INTEGER :: second !< components of the base date
-    CHARACTER(32)  :: name  !< name of the axis
+    CHARACTER(32)  :: axis_name  !< name of the axis
     CHARACTER(128) :: units !< units of time
 
     CALL get_base_date(year, month, day, hour, minute, second)
@@ -4029,26 +4029,26 @@ CONTAINS
     END DO
 
     ! define edges
-    name = ''
-    WRITE (name,'(a,i2.2)') 'time_of_day_edges_', n_samples
-    edges_id = get_axis_num(name, 'diurnal')
+    axis_name = ''
+    WRITE (axis_name,'(a,i2.2)') 'time_of_day_edges_', n_samples
+    edges_id = get_axis_num(axis_name, 'diurnal')
     IF ( edges_id <= 0 ) THEN
-       edges_id =  diag_axis_init(name,edges,units,'N','time of day edges', set_name='diurnal')
+       edges_id =  diag_axis_init(axis_name,edges,units,'N','time of day edges', set_name='diurnal')
     END IF
 
     ! define axis itself
-    name = ''
-    WRITE (name,'(a,i2.2)') 'time_of_day_', n_samples
-    init_diurnal_axis = get_axis_num(name, 'diurnal')
+    axis_name = ''
+    WRITE (axis_name,'(a,i2.2)') 'time_of_day_', n_samples
+    init_diurnal_axis = get_axis_num(axis_name, 'diurnal')
     IF ( init_diurnal_axis <= 0 ) THEN
-       init_diurnal_axis = diag_axis_init(name, center_data, units, 'N', 'time of day', &
+       init_diurnal_axis = diag_axis_init(axis_name, center_data, units, 'N', 'time of day', &
                            set_name='diurnal', edges=edges_id)
     END IF
   END FUNCTION init_diurnal_axis
 
-  SUBROUTINE diag_field_attribute_init(diag_field_id, name, type, cval, ival, rval)
+  SUBROUTINE diag_field_attribute_init(diag_field_id, att_name, type, cval, ival, rval)
     INTEGER, INTENT(in) :: diag_field_id !< input field ID, obtained from diag_manager_mod::register_diag_field.
-    CHARACTER(len=*), INTENT(in) :: name !< Name of the attribute
+    CHARACTER(len=*), INTENT(in) :: att_name !< Name of the attribute
     INTEGER, INTENT(in) :: type !< NetCDF type (NF90_FLOAT, NF90_INT, NF90_CHAR)
     CHARACTER(len=*), INTENT(in), OPTIONAL :: cval !< Character string attribute value
     INTEGER, DIMENSION(:), INTENT(in), OPTIONAL :: ival !< Integer attribute value(s)
@@ -4063,7 +4063,7 @@ CONTAINS
        !   after first send_data call.  Too late.
        ! </ERROR>
        CALL error_mesg('diag_manager_mod::diag_field_add_attribute', 'Attempting to add attribute "'&
-            &//TRIM(name)//'" to module/input_field "'//TRIM(input_fields(diag_field_id)%module_name)//'/'&
+            &//TRIM(att_name)//'" to module/input_field "'//TRIM(input_fields(diag_field_id)%module_name)//'/'&
             &//TRIM(input_fields(diag_field_id)%field_name)//'" after first send_data call.  Too late.', FATAL)
     END IF
 
@@ -4080,7 +4080,7 @@ CONTAINS
           ! Check if attribute already exists
           this_attribute = 0
           DO i=1, output_fields(out_field)%num_attributes
-             IF ( TRIM(output_fields(out_field)%attributes(i)%name) .EQ. TRIM(name) ) THEN
+             IF ( TRIM(output_fields(out_field)%attributes(i)%att_name) .EQ. TRIM(att_name) ) THEN
                 this_attribute = i
                 EXIT
              END IF
@@ -4092,7 +4092,7 @@ CONTAINS
              !   Contact the developers
              ! </ERROR>
              CALL error_mesg('diag_manager_mod::diag_field_add_attribute',&
-                  & 'Attribute "'//TRIM(name)//'" already defined for module/input_field "'&
+                  & 'Attribute "'//TRIM(att_name)//'" already defined for module/input_field "'&
                   &//TRIM(input_fields(diag_field_id)%module_name)//'/'&
                   &//TRIM(input_fields(diag_field_id)%field_name)//'".  Contact the developers.', FATAL)
           ELSE IF ( this_attribute.NE.0 .AND. type.EQ.NF90_CHAR .AND. debug_diag_manager ) THEN
@@ -4101,7 +4101,7 @@ CONTAINS
              !   Prepending.
              ! </ERROR>
              CALL error_mesg('diag_manager_mod::diag_field_add_attribute',&
-                  & 'Attribute "'//TRIM(name)//'" already defined for module/input_field "'&
+                  & 'Attribute "'//TRIM(att_name)//'" already defined for module/input_field "'&
                   &//TRIM(input_fields(diag_field_id)%module_name)//'/'&
                   &//TRIM(input_fields(diag_field_id)%field_name)//'".  Prepending.', NOTE)
           ELSE IF ( this_attribute.EQ.0 ) THEN
@@ -4117,13 +4117,13 @@ CONTAINS
                 ! </ERROR>
                 CALL error_mesg('diag_manager_mod::diag_field_add_attribute',&
                      & 'Number of attributes exceeds max_field_attributes for attribute "'&
-                     &//TRIM(name)//'" to module/input_field "'//TRIM(input_fields(diag_field_id)%module_name)//'/'&
+                     &//TRIM(att_name)//'" to module/input_field "'//TRIM(input_fields(diag_field_id)%module_name)//'/'&
                      &//TRIM(input_fields(diag_field_id)%field_name)&
                      &//'".  Increase diag_manager_nml:max_field_attributes.', FATAL)
              ELSE
                 output_fields(out_field)%num_attributes = this_attribute
                 ! Set name and type
-                output_fields(out_field)%attributes(this_attribute)%name = name
+                output_fields(out_field)%attributes(this_attribute)%att_name = att_name
                 output_fields(out_field)%attributes(this_attribute)%type = type
                 ! Initialize catt to a blank string, as len_trim doesn't always work on an uninitialized string
                 output_fields(out_field)%attributes(this_attribute)%catt = ''
@@ -4140,7 +4140,7 @@ CONTAINS
                 ! </ERROR>
                 CALL error_mesg('diag_manager_mod::diag_field_add_attribute',&
                      & 'Attribute type claims INTEGER, but ival not present for attribute "'&
-                     &//TRIM(name)//'" to module/input_field "'//TRIM(input_fields(diag_field_id)%module_name)//'/'&
+                     &//TRIM(att_name)//'" to module/input_field "'//TRIM(input_fields(diag_field_id)%module_name)//'/'&
                      &//TRIM(input_fields(diag_field_id)%field_name)//'". Contact then developers.', FATAL)
              END IF
              length = SIZE(ival)
@@ -4151,7 +4151,7 @@ CONTAINS
                 !   Unable to allocate iatt for attribute <name> to module/input_field <module_name>/<field_name>
                 ! </ERROR>
                 CALL error_mesg('diag_manager_mod::diag_field_add_attribute','Unable to allocate iatt for attribute "'&
-                     &//TRIM(name)//'" to module/input_field "'//TRIM(input_fields(diag_field_id)%module_name)//'/'&
+                     &//TRIM(att_name)//'" to module/input_field "'//TRIM(input_fields(diag_field_id)%module_name)//'/'&
                      &//TRIM(input_fields(diag_field_id)%field_name)//'"', FATAL)
              END IF
              ! Set remaining fields
@@ -4166,7 +4166,7 @@ CONTAINS
                 ! </ERROR>
                 CALL error_mesg('diag_manager_mod::diag_field_add_attribute',&
                      & 'Attribute type claims REAL, but rval not present for attribute "'&
-                     &//TRIM(name)//'" to module/input_field "'//TRIM(input_fields(diag_field_id)%module_name)//'/'&
+                     &//TRIM(att_name)//'" to module/input_field "'//TRIM(input_fields(diag_field_id)%module_name)//'/'&
                      &//TRIM(input_fields(diag_field_id)%field_name)//'". Contact the developers.', FATAL)
              END IF
              length = SIZE(rval)
@@ -4177,7 +4177,7 @@ CONTAINS
                 !   Unable to allocate fatt for attribute <name> to module/input_field <module_name>/<field_name>
                 ! </ERROR>
                 CALL error_mesg('diag_manager_mod::diag_field_add_attribute','Unable to allocate fatt for attribute "'&
-                     &//TRIM(name)//'" to module/input_field "'//TRIM(input_fields(diag_field_id)%module_name)//'/'&
+                     &//TRIM(att_name)//'" to module/input_field "'//TRIM(input_fields(diag_field_id)%module_name)//'/'&
                      &//TRIM(input_fields(diag_field_id)%field_name)//'"', FATAL)
              END IF
              ! Set remaining fields
@@ -4192,17 +4192,17 @@ CONTAINS
                 ! </ERROR>
                 CALL error_mesg('diag_manager_mod::diag_field_add_attribute',&
                      & 'Attribute type claims CHARACTER, but cval not present for attribute "'&
-                     &//TRIM(name)//'" to module/input_field "'//TRIM(input_fields(diag_field_id)%module_name)//'/'&
+                     &//TRIM(att_name)//'" to module/input_field "'//TRIM(input_fields(diag_field_id)%module_name)//'/'&
                      &//TRIM(input_fields(diag_field_id)%field_name)//'". Contact the developers.', FATAL)
              END IF
-             CALL prepend_attribute(output_fields(out_field), TRIM(name), TRIM(cval))
+             CALL prepend_attribute(output_fields(out_field), TRIM(att_name), TRIM(cval))
           CASE default
              ! <ERROR STATUS="FATAL">
              !   Unknown attribute type for attribute <name> to module/input_field <module_name>/<field_name>.
              !   Contact the developers.
              ! </ERROR>
              CALL error_mesg('diag_manager_mod::diag_field_add_attribute', 'Unknown attribute type for attribute "'&
-                  &//TRIM(name)//'" to module/input_field "'//TRIM(input_fields(diag_field_id)%module_name)//'/'&
+                  &//TRIM(att_name)//'" to module/input_field "'//TRIM(input_fields(diag_field_id)%module_name)//'/'&
                   &//TRIM(input_fields(diag_field_id)%field_name)//'". Contact the developers.', FATAL)
           END SELECT
        END DO

--- a/drifters/drifters.F90
+++ b/drifters/drifters.F90
@@ -230,7 +230,7 @@ contains
     if(ermesg/='') return
 
     ! Set meta data
-    call drifters_io_set_time_units(self%io, name=self%input%time_units, &
+    call drifters_io_set_time_units(self%io, time_unit_name=self%input%time_units, &
          & ermesg=ermesg)
 
     call drifters_io_set_position_names(self%io, names=self%input%position_names, &

--- a/drifters/drifters_io.F90
+++ b/drifters/drifters_io.F90
@@ -130,16 +130,16 @@ contains
   end subroutine drifters_io_del
 
 !###############################################################################
-  subroutine drifters_io_set_time_units(self, name, ermesg)
+  subroutine drifters_io_set_time_units(self, time_unit_name, ermesg)
     type(drifters_io_type)        :: self
-    character(len=*), intent(in)  :: name
+    character(len=*), intent(in)  :: time_unit_name
     character(len=*), intent(out) :: ermesg
 
     integer ier
 
     ermesg = ''
     ier = nf_put_att_text(self%ncid, NF_GLOBAL, &
-         & 'time_units', len_trim(name), trim(name))
+         & 'time_units', len_trim(time_unit_name), trim(time_unit_name))
     if(ier/=NF_NOERR) &
          & ermesg = 'drifters_io_set_time_units::failed to add time_units attribute ' &
          & //nf_strerror(ier)

--- a/exchange/xgrid.F90
+++ b/exchange/xgrid.F90
@@ -1457,15 +1457,15 @@ end subroutine get_grid_version2
 
 !#######################################################################
 !> @brief Read the area elements from NetCDF file
-subroutine get_area_elements_fms2_io(fileobj, name, get_area_data)
+subroutine get_area_elements_fms2_io(fileobj, field_name, get_area_data)
   type(FmsNetcdfDomainFile_t), intent(in) :: fileobj
-  character(len=*), intent(in)            :: name
+  character(len=*), intent(in)            :: field_name
   real(r8_kind), intent(out)              :: get_area_data(:,:)
 
-  if(variable_exists(fileobj, name)) then
-     call read_data(fileobj, name, get_area_data)
+  if(variable_exists(fileobj, field_name)) then
+     call read_data(fileobj, field_name, get_area_data)
   else
-     call error_mesg('xgrid_mod', 'no field named '//trim(name)//' in grid file '//trim(fileobj%path)// &
+     call error_mesg('xgrid_mod', 'no field named '//trim(field_name)//' in grid file '//trim(fileobj%path)// &
                      ' Will set data to negative values...', NOTE)
      ! area elements no present in grid_spec file, set to negative values....
      get_area_data = -1.0_r8_kind

--- a/field_manager/fm_util.F90
+++ b/field_manager/fm_util.F90
@@ -367,7 +367,7 @@ integer                                 :: ind
 integer                                 :: list_length
 integer                                 :: good_length
 character(len=fm_type_name_len)         :: typ
-character(len=fm_field_name_len)        :: name
+character(len=fm_field_name_len)        :: field_name
 logical                                 :: found
 character(len=256)                      :: error_header
 character(len=256)                      :: warn_header
@@ -467,15 +467,15 @@ elseif (list_length .gt. good_length) then  !}{
        list_length, ' > ', good_length, ') in list ', trim(list)
 
   write (out_unit,*) trim(error_header), ' Start of list of fields'
-  do while (fm_loop_over_list(list, name, typ, ind))  !{
+  do while (fm_loop_over_list(list, field_name, typ, ind))  !{
     found = .false.
     do i = 1, good_length  !{
-      found = found .or. (name .eq. good_fields(i))
+      found = found .or. (field_name .eq. good_fields(i))
     enddo  !} i
     if (found) then  !{
-      write (out_unit,*) 'Good list field: "', trim(name), '"'
+      write (out_unit,*) 'Good list field: "', trim(field_name), '"'
     else  !}{
-      write (out_unit,*) 'EXTRA list field: "', trim(name), '"'
+      write (out_unit,*) 'EXTRA list field: "', trim(field_name), '"'
     endif  !}
   enddo  !}
   write (out_unit,*) trim(error_header), ' End of list of fields'
@@ -496,7 +496,7 @@ end subroutine fm_util_check_for_bad_fields  !}
 !#######################################################################
 
 !> Get the length of an element of the Field Manager tree
-function fm_util_get_length(name, caller)       &
+function fm_util_get_length(field_name, caller)       &
          result (field_length)  !{
 
 implicit none
@@ -511,7 +511,7 @@ integer :: field_length
 !       arguments
 !
 
-character(len=*), intent(in)            :: name
+character(len=*), intent(in)            :: field_name
 character(len=*), intent(in), optional  :: caller
 
 !
@@ -550,7 +550,7 @@ note_header = '==>Note from ' // trim(mod_name) //     &
 !       check that a name is given (fatal if not)
 !
 
-if (name .eq. ' ') then  !{
+if (field_name .eq. ' ') then  !{
   call mpp_error(FATAL, trim(error_header) // ' Empty name given')
 endif  !}
 
@@ -558,9 +558,9 @@ endif  !}
 !       Get the field's length
 !
 
-field_length = fm_get_length(name)
+field_length = fm_get_length(field_name)
 if (field_length .lt. 0) then  !{
-  call mpp_error(FATAL, trim(error_header) // ' Problem getting length of ' // trim(name))
+  call mpp_error(FATAL, trim(error_header) // ' Problem getting length of ' // trim(field_name))
 endif  !}
 
 return
@@ -570,7 +570,7 @@ end function fm_util_get_length  !}
 !#######################################################################
 
 !> Get the index of an element of a string in the Field Manager tree
-function fm_util_get_index_string(name, string, caller)       &
+function fm_util_get_index_string(field_name, string, caller)       &
          result (fm_index)  !{
 
 implicit none
@@ -585,7 +585,7 @@ integer :: fm_index
 !       arguments
 !
 
-character(len=*), intent(in)            :: name
+character(len=*), intent(in)            :: field_name
 character(len=*), intent(in)            :: string
 character(len=*), intent(in), optional  :: caller
 
@@ -630,7 +630,7 @@ note_header = '==>Note from ' // trim(mod_name) //     &
 !       check that a name is given (fatal if not)
 !
 
-if (name .eq. ' ') then  !{
+if (field_name .eq. ' ') then  !{
   call mpp_error(FATAL, trim(error_header) // ' Empty name given')
 endif  !}
 
@@ -639,17 +639,17 @@ endif  !}
 !
 
 fm_index = 0
-fm_type = fm_get_type(name)
+fm_type = fm_get_type(field_name)
 if (fm_type .eq. 'string') then  !{
-  length = fm_get_length(name)
+  length = fm_get_length(field_name)
   if (length .lt. 0) then  !{
-    call mpp_error(FATAL, trim(error_header) // ' Problem getting length of ' // trim(name))
+    call mpp_error(FATAL, trim(error_header) // ' Problem getting length of ' // trim(field_name))
   endif  !}
   if (length .gt. 0) then  !{
     do i = 1, length  !{
-      if (.not. fm_get_value(name, fm_string, index = i)) then  !{
+      if (.not. fm_get_value(field_name, fm_string, index = i)) then  !{
         write (index_str,*) '(', i, ')'
-        call mpp_error(FATAL, trim(error_header) // ' Problem getting ' // trim(name) // trim(index_str))
+        call mpp_error(FATAL, trim(error_header) // ' Problem getting ' // trim(field_name) // trim(index_str))
       endif  !}
       if (fm_string .eq. string) then  !{
         fm_index = i
@@ -658,9 +658,9 @@ if (fm_type .eq. 'string') then  !{
     enddo  !} i
   endif  !}
 elseif (fm_type .eq. ' ') then  !}{
-  call mpp_error(FATAL, trim(error_header) // ' Array does not exist: ' // trim(name))
+  call mpp_error(FATAL, trim(error_header) // ' Array does not exist: ' // trim(field_name))
 else  !}{
- call mpp_error(FATAL, trim(error_header) // ' Wrong type for ' // trim(name) // ', found (' // trim(fm_type) // ')')
+ call mpp_error(FATAL, trim(error_header) // ' Wrong type for ' // trim(field_name) //', found ('// trim(fm_type) //')')
 endif  !}
 
 !if (fm_index .eq. 0) then  !{
@@ -674,7 +674,7 @@ end function fm_util_get_index_string  !}
 !#######################################################################
 
 !> Get the length of an element of the Field Manager tree
-function fm_util_get_index_list(name, caller)       &
+function fm_util_get_index_list(field_name, caller)       &
          result (fm_index)  !{
 
 implicit none
@@ -689,7 +689,7 @@ integer :: fm_index
 !       arguments
 !
 
-character(len=*), intent(in)            :: name
+character(len=*), intent(in)            :: field_name
 character(len=*), intent(in), optional  :: caller
 
 !
@@ -729,7 +729,7 @@ note_header = '==>Note from ' // trim(mod_name) //     &
 !       check that a name is given (fatal if not)
 !
 
-if (name .eq. ' ') then  !{
+if (field_name .eq. ' ') then  !{
   call mpp_error(FATAL, trim(error_header) // ' Empty name given')
 endif  !}
 
@@ -738,16 +738,16 @@ endif  !}
 !
 
 fm_index = 0
-fm_type = fm_get_type(name)
+fm_type = fm_get_type(field_name)
 if (fm_type .eq. 'list') then  !{
-  fm_index = fm_get_index(name)
+  fm_index = fm_get_index(field_name)
   if (fm_index .le. 0) then  !{
-    call mpp_error(FATAL, trim(error_header) // ' List does not exist: ' // trim(name))
+    call mpp_error(FATAL, trim(error_header) // ' List does not exist: ' // trim(field_name))
   endif  !}
 elseif (fm_type .eq. ' ') then  !}{
-  call mpp_error(FATAL, trim(error_header) // ' List does not exist: ' // trim(name))
+  call mpp_error(FATAL, trim(error_header) // ' List does not exist: ' // trim(field_name))
 else  !}{
- call mpp_error(FATAL, trim(error_header) // ' Wrong type for ' // trim(name) // ', found (' // trim(fm_type) // ')')
+ call mpp_error(FATAL, trim(error_header) // ' Wrong type for ' // trim(field_name) // ', found (' // trim(fm_type) // ')')
 endif  !}
 
 
@@ -759,7 +759,7 @@ end function fm_util_get_index_list  !}
 !#######################################################################
 
 !> Get an integer value from the Field Manager tree.
-function fm_util_get_integer_array(name, caller)            &
+function fm_util_get_integer_array(field_name, caller)            &
          result (array)  !{
 
 implicit none
@@ -774,7 +774,7 @@ integer, pointer, dimension(:) :: array
 !       arguments
 !
 
-character(len=*), intent(in)            :: name
+character(len=*), intent(in)            :: field_name
 character(len=*), intent(in), optional  :: caller
 
 !
@@ -819,29 +819,29 @@ note_header = '==>Note from ' // trim(mod_name) //     &
 !       check that a name is given (fatal if not)
 !
 
-if (name .eq. ' ') then  !{
+if (field_name .eq. ' ') then  !{
   call mpp_error(FATAL, trim(error_header) // ' Empty name given')
 endif  !}
 
-fm_type = fm_get_type(name)
+fm_type = fm_get_type(field_name)
 if (fm_type .eq. 'integer') then  !{
-  length = fm_get_length(name)
+  length = fm_get_length(field_name)
   if (length .lt. 0) then  !{
-    call mpp_error(FATAL, trim(error_header) // ' Problem getting length of ' // trim(name))
+    call mpp_error(FATAL, trim(error_header) // ' Problem getting length of ' // trim(field_name))
   endif  !}
   if (length .gt. 0) then  !{
     allocate(array(length))
     do i = 1, length  !{
-      if (.not. fm_get_value(name, array(i), index = i)) then  !{
+      if (.not. fm_get_value(field_name, array(i), index = i)) then  !{
         write (index_str,*) '(', i, ')'
-        call mpp_error(FATAL, trim(error_header) // ' Problem getting ' // trim(name) // trim(index_str))
+        call mpp_error(FATAL, trim(error_header) // ' Problem getting ' // trim(field_name) // trim(index_str))
       endif  !}
     enddo  !} i
   endif  !}
 elseif (fm_type .eq. ' ') then  !}{
-  call mpp_error(FATAL, trim(error_header) // ' Array does not exist: ' // trim(name))
+  call mpp_error(FATAL, trim(error_header) // ' Array does not exist: ' // trim(field_name))
 else  !}{
- call mpp_error(FATAL, trim(error_header) // ' Wrong type for ' // trim(name) // ', found (' // trim(fm_type) // ')')
+ call mpp_error(FATAL, trim(error_header) // ' Wrong type for ' // trim(field_name) //', found ('// trim(fm_type) //')')
 endif  !}
 
 return
@@ -851,7 +851,7 @@ end function fm_util_get_integer_array  !}
 !#######################################################################
 
 !> Get a logical value from the Field Manager tree.
-function fm_util_get_logical_array(name, caller)            &
+function fm_util_get_logical_array(field_name, caller)            &
          result (array)  !{
 
 implicit none
@@ -866,7 +866,7 @@ logical, pointer, dimension(:) :: array
 !       arguments
 !
 
-character(len=*), intent(in)            :: name
+character(len=*), intent(in)            :: field_name
 character(len=*), intent(in), optional  :: caller
 
 !
@@ -911,29 +911,29 @@ note_header = '==>Note from ' // trim(mod_name) //     &
 !       check that a name is given (fatal if not)
 !
 
-if (name .eq. ' ') then  !{
+if (field_name .eq. ' ') then  !{
   call mpp_error(FATAL, trim(error_header) // ' Empty name given')
 endif  !}
 
-fm_type = fm_get_type(name)
+fm_type = fm_get_type(field_name)
 if (fm_type .eq. 'logical') then  !{
-  length = fm_get_length(name)
+  length = fm_get_length(field_name)
   if (length .lt. 0) then  !{
-    call mpp_error(FATAL, trim(error_header) // ' Problem getting length of ' // trim(name))
+    call mpp_error(FATAL, trim(error_header) // ' Problem getting length of ' // trim(field_name))
   endif  !}
   if (length .gt. 0) then  !{
     allocate(array(length))
     do i = 1, length  !{
-      if (.not. fm_get_value(name, array(i), index = i)) then  !{
+      if (.not. fm_get_value(field_name, array(i), index = i)) then  !{
         write (index_str,*) '(', i, ')'
-        call mpp_error(FATAL, trim(error_header) // ' Problem getting ' // trim(name) // trim(index_str))
+        call mpp_error(FATAL, trim(error_header) // ' Problem getting ' // trim(field_name) // trim(index_str))
       endif  !}
     enddo  !} i
   endif  !}
 elseif (fm_type .eq. ' ') then  !}{
-  call mpp_error(FATAL, trim(error_header) // ' Array does not exist: ' // trim(name))
+  call mpp_error(FATAL, trim(error_header) // ' Array does not exist: ' // trim(field_name))
 else  !}{
- call mpp_error(FATAL, trim(error_header) // ' Wrong type for ' // trim(name) // ', found (' // trim(fm_type) // ')')
+ call mpp_error(FATAL, trim(error_header) // ' Wrong type for ' // trim(field_name) //', found ('// trim(fm_type) //')')
 endif  !}
 
 return
@@ -943,7 +943,7 @@ end function fm_util_get_logical_array  !}
 !#######################################################################
 
 !> Get a real value from the Field Manager tree.
-function fm_util_get_real_array(name, caller)            &
+function fm_util_get_real_array(field_name, caller)            &
          result (array)  !{
 
 implicit none
@@ -958,7 +958,7 @@ real(r8_kind), pointer, dimension(:) :: array
 !       arguments
 !
 
-character(len=*), intent(in)            :: name
+character(len=*), intent(in)            :: field_name
 character(len=*), intent(in), optional  :: caller
 
 !
@@ -1003,29 +1003,29 @@ note_header = '==>Note from ' // trim(mod_name) //     &
 !       check that a name is given (fatal if not)
 !
 
-if (name .eq. ' ') then  !{
+if (field_name .eq. ' ') then  !{
   call mpp_error(FATAL, trim(error_header) // ' Empty name given')
 endif  !}
 
-fm_type = fm_get_type(name)
+fm_type = fm_get_type(field_name)
 if (fm_type .eq. 'real') then  !{
-  length = fm_get_length(name)
+  length = fm_get_length(field_name)
   if (length .lt. 0) then  !{
-    call mpp_error(FATAL, trim(error_header) // ' Problem getting length of ' // trim(name))
+    call mpp_error(FATAL, trim(error_header) // ' Problem getting length of ' // trim(field_name))
   endif  !}
   if (length .gt. 0) then  !{
     allocate(array(length))
     do i = 1, length  !{
-      if (.not. fm_get_value(name, array(i), index = i)) then  !{
+      if (.not. fm_get_value(field_name, array(i), index = i)) then  !{
         write (index_str,*) '(', i, ')'
-        call mpp_error(FATAL, trim(error_header) // ' Problem getting ' // trim(name) // trim(index_str))
+        call mpp_error(FATAL, trim(error_header) // ' Problem getting ' // trim(field_name) // trim(index_str))
       endif  !}
     enddo  !} i
   endif  !}
 elseif (fm_type .eq. ' ') then  !}{
-  call mpp_error(FATAL, trim(error_header) // ' Array does not exist: ' // trim(name))
+  call mpp_error(FATAL, trim(error_header) // ' Array does not exist: ' // trim(field_name))
 else  !}{
- call mpp_error(FATAL, trim(error_header) // ' Wrong type for ' // trim(name) // ', found (' // trim(fm_type) // ')')
+ call mpp_error(FATAL, trim(error_header) // ' Wrong type for ' // trim(field_name) //', found ('// trim(fm_type) //')')
 endif  !}
 
 return
@@ -1036,7 +1036,7 @@ end function fm_util_get_real_array  !}
 
 
 !> Get a string value from the Field Manager tree.
-function fm_util_get_string_array(name, caller)            &
+function fm_util_get_string_array(field_name, caller)            &
          result (array)  !{
 
 implicit none
@@ -1051,7 +1051,7 @@ character(len=fm_string_len), pointer, dimension(:) :: array
 !       arguments
 !
 
-character(len=*), intent(in)            :: name
+character(len=*), intent(in)            :: field_name
 character(len=*), intent(in), optional  :: caller
 
 !
@@ -1096,29 +1096,29 @@ note_header = '==>Note from ' // trim(mod_name) //     &
 !       check that a name is given (fatal if not)
 !
 
-if (name .eq. ' ') then  !{
+if (field_name .eq. ' ') then  !{
   call mpp_error(FATAL, trim(error_header) // ' Empty name given')
 endif  !}
 
-fm_type = fm_get_type(name)
+fm_type = fm_get_type(field_name)
 if (fm_type .eq. 'string') then  !{
-  length = fm_get_length(name)
+  length = fm_get_length(field_name)
   if (length .lt. 0) then  !{
-    call mpp_error(FATAL, trim(error_header) // ' Problem getting length of ' // trim(name))
+    call mpp_error(FATAL, trim(error_header) // ' Problem getting length of ' // trim(field_name))
   endif  !}
   if (length .gt. 0) then  !{
     allocate(array(length))
     do i = 1, length  !{
-      if (.not. fm_get_value(name, array(i), index = i)) then  !{
+      if (.not. fm_get_value(field_name, array(i), index = i)) then  !{
         write (index_str,*) '(', i, ')'
-        call mpp_error(FATAL, trim(error_header) // ' Problem getting ' // trim(name) // trim(index_str))
+        call mpp_error(FATAL, trim(error_header) // ' Problem getting ' // trim(field_name) // trim(index_str))
       endif  !}
     enddo  !} i
   endif  !}
 elseif (fm_type .eq. ' ') then  !}{
-  call mpp_error(FATAL, trim(error_header) // ' Array does not exist: ' // trim(name))
+  call mpp_error(FATAL, trim(error_header) // ' Array does not exist: ' // trim(field_name))
 else  !}{
- call mpp_error(FATAL, trim(error_header) // ' Wrong type for ' // trim(name) // ', found (' // trim(fm_type) // ')')
+ call mpp_error(FATAL, trim(error_header) // ' Wrong type for ' // trim(field_name) //', found ('// trim(fm_type) //')')
 endif  !}
 
 return
@@ -1128,7 +1128,7 @@ end function fm_util_get_string_array  !}
 !#######################################################################
 
 !> Get an integer value from the Field Manager tree.
-function fm_util_get_integer(name, caller, index, default_value, scalar)            &
+function fm_util_get_integer(field_name, caller, index, default_value, scalar)            &
          result (ival)  !{
 
 implicit none
@@ -1143,7 +1143,7 @@ integer :: ival
 !       arguments
 !
 
-character(len=*), intent(in)            :: name
+character(len=*), intent(in)            :: field_name
 character(len=*), intent(in), optional  :: caller
 integer, intent(in), optional           :: index
 integer, intent(in), optional           :: default_value
@@ -1188,7 +1188,7 @@ note_header = '==>Note from ' // trim(mod_name) //     &
 !       check that a name is given (fatal if not)
 !
 
-if (name .eq. ' ') then  !{
+if (field_name .eq. ' ') then  !{
   call mpp_error(FATAL, trim(error_header) // ' Empty name given')
 endif  !}
 
@@ -1199,11 +1199,11 @@ endif  !}
 
 if (present(scalar)) then  !{
   if (scalar) then  !{
-    field_length = fm_get_length(name)
+    field_length = fm_get_length(field_name)
     if (field_length .lt. 0) then  !{
-      call mpp_error(FATAL, trim(error_header) // ' Problem getting length of ' // trim(name))
+      call mpp_error(FATAL, trim(error_header) // ' Problem getting length of ' // trim(field_name))
     elseif (field_length .gt. 1) then  !}{
-      call mpp_error(FATAL, trim(error_header) // trim(name) // ' not scalar')
+      call mpp_error(FATAL, trim(error_header) // trim(field_name) // ' not scalar')
     endif  !}
   endif  !}
 endif  !}
@@ -1221,17 +1221,17 @@ else  !}{
   index_t = 1
 endif  !}
 
-fm_type = fm_get_type(name)
+fm_type = fm_get_type(field_name)
 if (fm_type .eq. 'integer') then  !{
-  if (.not. fm_get_value(name, ival, index = index_t)) then  !{
-    call mpp_error(FATAL, trim(error_header) // ' Problem getting ' // trim(name))
+  if (.not. fm_get_value(field_name, ival, index = index_t)) then  !{
+    call mpp_error(FATAL, trim(error_header) // ' Problem getting ' // trim(field_name))
   endif  !}
 elseif (fm_type .eq. ' ' .and. present(default_value)) then  !}{
   ival = default_value
 elseif (fm_type .eq. ' ') then  !}{
-  call mpp_error(FATAL, trim(error_header) // ' Field does not exist: ' // trim(name))
+  call mpp_error(FATAL, trim(error_header) // ' Field does not exist: ' // trim(field_name))
 else  !}{
- call mpp_error(FATAL, trim(error_header) // ' Wrong type for ' // trim(name) // ', found (' // trim(fm_type) // ')')
+ call mpp_error(FATAL, trim(error_header) // ' Wrong type for ' // trim(field_name) //', found ('// trim(fm_type) //')')
 endif  !}
 
 return
@@ -1241,7 +1241,7 @@ end function fm_util_get_integer  !}
 !#######################################################################
 
 !> Get a logical value from the Field Manager tree.
-function fm_util_get_logical(name, caller, index, default_value, scalar)            &
+function fm_util_get_logical(field_name, caller, index, default_value, scalar)            &
          result (lval)  !{
 
 implicit none
@@ -1256,7 +1256,7 @@ logical :: lval
 !       arguments
 !
 
-character(len=*), intent(in)            :: name
+character(len=*), intent(in)            :: field_name
 character(len=*), intent(in), optional  :: caller
 integer, intent(in), optional           :: index
 logical, intent(in), optional           :: default_value
@@ -1301,7 +1301,7 @@ note_header = '==>Note from ' // trim(mod_name) //     &
 !       check that a name is given (fatal if not)
 !
 
-if (name .eq. ' ') then  !{
+if (field_name .eq. ' ') then  !{
   call mpp_error(FATAL, trim(error_header) // ' Empty name given')
 endif  !}
 
@@ -1312,11 +1312,11 @@ endif  !}
 
 if (present(scalar)) then  !{
   if (scalar) then  !{
-    field_length = fm_get_length(name)
+    field_length = fm_get_length(field_name)
     if (field_length .lt. 0) then  !{
-      call mpp_error(FATAL, trim(error_header) // ' Problem getting length of ' // trim(name))
+      call mpp_error(FATAL, trim(error_header) // ' Problem getting length of ' // trim(field_name))
     elseif (field_length .gt. 1) then  !}{
-      call mpp_error(FATAL, trim(error_header) // trim(name) // ' not scalar')
+      call mpp_error(FATAL, trim(error_header) // trim(field_name) // ' not scalar')
     endif  !}
   endif  !}
 endif  !}
@@ -1334,17 +1334,17 @@ else  !}{
   index_t = 1
 endif  !}
 
-fm_type = fm_get_type(name)
+fm_type = fm_get_type(field_name)
 if (fm_type .eq. 'logical') then  !{
-  if (.not. fm_get_value(name, lval, index = index_t)) then  !{
-    call mpp_error(FATAL, trim(error_header) // ' Problem getting ' // trim(name))
+  if (.not. fm_get_value(field_name, lval, index = index_t)) then  !{
+    call mpp_error(FATAL, trim(error_header) // ' Problem getting ' // trim(field_name))
   endif  !}
 elseif (fm_type .eq. ' ' .and. present(default_value)) then  !}{
   lval = default_value
 elseif (fm_type .eq. ' ') then  !}{
-  call mpp_error(FATAL, trim(error_header) // ' Field does not exist: ' // trim(name))
+  call mpp_error(FATAL, trim(error_header) // ' Field does not exist: ' // trim(field_name))
 else  !}{
- call mpp_error(FATAL, trim(error_header) // ' Wrong type for ' // trim(name) // ', found (' // trim(fm_type) // ')')
+ call mpp_error(FATAL, trim(error_header) // ' Wrong type for ' // trim(field_name) //', found ('// trim(fm_type) //')')
 endif  !}
 
 return
@@ -1355,7 +1355,7 @@ end function fm_util_get_logical  !}
 
 
 !> Get a real value from the Field Manager tree.
-function fm_util_get_real(name, caller, index, default_value, scalar)           &
+function fm_util_get_real(field_name, caller, index, default_value, scalar)           &
          result (rval)  !{
 
 implicit none
@@ -1370,7 +1370,7 @@ real(r8_kind) :: rval
 !       arguments
 !
 
-character(len=*), intent(in)            :: name
+character(len=*), intent(in)            :: field_name
 character(len=*), intent(in), optional  :: caller
 integer, intent(in), optional           :: index
 real(r8_kind), intent(in), optional     :: default_value
@@ -1416,7 +1416,7 @@ note_header = '==>Note from ' // trim(mod_name) //     &
 !       check that a name is given (fatal if not)
 !
 
-if (name .eq. ' ') then  !{
+if (field_name .eq. ' ') then  !{
   call mpp_error(FATAL, trim(error_header) // ' Empty name given')
 endif  !}
 
@@ -1427,11 +1427,11 @@ endif  !}
 
 if (present(scalar)) then  !{
   if (scalar) then  !{
-    field_length = fm_get_length(name)
+    field_length = fm_get_length(field_name)
     if (field_length .lt. 0) then  !{
-      call mpp_error(FATAL, trim(error_header) // ' Problem getting length of ' // trim(name))
+      call mpp_error(FATAL, trim(error_header) // ' Problem getting length of ' // trim(field_name))
     elseif (field_length .gt. 1) then  !}{
-      call mpp_error(FATAL, trim(error_header) // trim(name) // ' not scalar')
+      call mpp_error(FATAL, trim(error_header) // trim(field_name) // ' not scalar')
     endif  !}
   endif  !}
 endif  !}
@@ -1449,22 +1449,22 @@ else  !}{
   index_t = 1
 endif  !}
 
-fm_type = fm_get_type(name)
+fm_type = fm_get_type(field_name)
 if (fm_type .eq. 'real') then  !{
-  if (.not. fm_get_value(name, rval, index = index_t)) then  !{
-    call mpp_error(FATAL, trim(error_header) // ' Problem getting ' // trim(name))
+  if (.not. fm_get_value(field_name, rval, index = index_t)) then  !{
+    call mpp_error(FATAL, trim(error_header) // ' Problem getting ' // trim(field_name))
   endif  !}
 else if (fm_type .eq. 'integer') then
-  if (.not. fm_get_value(name, ivalue, index = index_t)) then
-    call mpp_error(FATAL, trim(error_header) // ' Problem getting ' // trim(name))
+  if (.not. fm_get_value(field_name, ivalue, index = index_t)) then
+    call mpp_error(FATAL, trim(error_header) // ' Problem getting ' // trim(field_name))
   endif
   rval = real(ivalue,r8_kind)
 elseif (fm_type .eq. ' ' .and. present(default_value)) then  !}{
   rval = default_value
 elseif (fm_type .eq. ' ') then  !}{
-  call mpp_error(FATAL, trim(error_header) // ' Field does not exist: ' // trim(name))
+  call mpp_error(FATAL, trim(error_header) // ' Field does not exist: ' // trim(field_name))
 else  !}{
- call mpp_error(FATAL, trim(error_header) // ' Wrong type for ' // trim(name) // ', found (' // trim(fm_type) // ')')
+ call mpp_error(FATAL, trim(error_header) // ' Wrong type for ' // trim(field_name) //', found ('// trim(fm_type) //')')
 endif  !}
 
 return
@@ -1476,7 +1476,7 @@ end function fm_util_get_real  !}
 
 
 !> Get a string value from the Field Manager tree.
-function fm_util_get_string(name, caller, index, default_value, scalar)            &
+function fm_util_get_string(field_name, caller, index, default_value, scalar)            &
          result (sval)  !{
 
 implicit none
@@ -1491,7 +1491,7 @@ character(len=fm_string_len) :: sval
 !       arguments
 !
 
-character(len=*), intent(in)            :: name
+character(len=*), intent(in)            :: field_name
 character(len=*), intent(in), optional  :: caller
 integer, intent(in), optional           :: index
 character(len=*), intent(in), optional  :: default_value
@@ -1536,7 +1536,7 @@ note_header = '==>Note from ' // trim(mod_name) //     &
 !       check that a name is given (fatal if not)
 !
 
-if (name .eq. ' ') then  !{
+if (field_name .eq. ' ') then  !{
   call mpp_error(FATAL, trim(error_header) // ' Empty name given')
 endif  !}
 
@@ -1547,11 +1547,11 @@ endif  !}
 
 if (present(scalar)) then  !{
   if (scalar) then  !{
-    field_length = fm_get_length(name)
+    field_length = fm_get_length(field_name)
     if (field_length .lt. 0) then  !{
-      call mpp_error(FATAL, trim(error_header) // ' Problem getting length of ' // trim(name))
+      call mpp_error(FATAL, trim(error_header) // ' Problem getting length of ' // trim(field_name))
     elseif (field_length .gt. 1) then  !}{
-      call mpp_error(FATAL, trim(error_header) // trim(name) // ' not scalar')
+      call mpp_error(FATAL, trim(error_header) // trim(field_name) // ' not scalar')
     endif  !}
   endif  !}
 endif  !}
@@ -1569,17 +1569,17 @@ else  !}{
   index_t = 1
 endif  !}
 
-fm_type = fm_get_type(name)
+fm_type = fm_get_type(field_name)
 if (fm_type .eq. 'string') then  !{
-  if (.not. fm_get_value(name, sval, index = index_t)) then  !{
-    call mpp_error(FATAL, trim(error_header) // ' Problem getting ' // trim(name))
+  if (.not. fm_get_value(field_name, sval, index = index_t)) then  !{
+    call mpp_error(FATAL, trim(error_header) // ' Problem getting ' // trim(field_name))
   endif  !}
 elseif (fm_type .eq. ' ' .and. present(default_value)) then  !}{
   sval = default_value
 elseif (fm_type .eq. ' ') then  !}{
-  call mpp_error(FATAL, trim(error_header) // ' Field does not exist: ' // trim(name))
+  call mpp_error(FATAL, trim(error_header) // ' Field does not exist: ' // trim(field_name))
 else  !}{
- call mpp_error(FATAL, trim(error_header) // ' Wrong type for ' // trim(name) // ', found (' // trim(fm_type) // ')')
+ call mpp_error(FATAL, trim(error_header) // ' Wrong type for ' // trim(field_name) //', found ('// trim(fm_type) //')')
 endif  !}
 
 return
@@ -1589,7 +1589,7 @@ end function fm_util_get_string  !}
 !#######################################################################
 
 !> Set an integer array in the Field Manager tree.
-subroutine fm_util_set_value_integer_array(name, ival, length, caller, no_overwrite, good_name_list)  !{
+subroutine fm_util_set_value_integer_array(field_name, ival, length, caller, no_overwrite, good_name_list)  !{
 
 implicit none
 
@@ -1597,7 +1597,7 @@ implicit none
 !       arguments
 !
 
-character(len=*), intent(in)                            :: name
+character(len=*), intent(in)                            :: field_name
 integer, intent(in)                                     :: length
 integer, intent(in)                                     :: ival(length)
 character(len=*), intent(in), optional                  :: caller
@@ -1647,7 +1647,7 @@ note_header = '==>Note from ' // trim(mod_name) //     &
 !       check that a name is given (fatal if not)
 !
 
-if (name .eq. ' ') then  !{
+if (field_name .eq. ' ') then  !{
   call mpp_error(FATAL, trim(error_header) // ' Empty name given')
 endif  !}
 
@@ -1684,36 +1684,36 @@ endif  !}
 !
 
 if (length .eq. 0) then  !{
-  if (.not. (no_overwrite_use .and. fm_exists(name))) then  !{
-    field_index = fm_new_value(name, 0, index = 0)
+  if (.not. (no_overwrite_use .and. fm_exists(field_name))) then  !{
+    field_index = fm_new_value(field_name, 0, index = 0)
     if (field_index .le. 0) then  !{
       write (str_error,*) ' with length = ', length
-      call mpp_error(FATAL, trim(error_header) // ' Problem setting ' // trim(name) // trim(str_error))
+      call mpp_error(FATAL, trim(error_header) // ' Problem setting ' // trim(field_name) // trim(str_error))
     endif  !}
   endif  !}
 else  !}{
-  if (no_overwrite_use .and. fm_exists(name)) then  !{
-    field_length = fm_get_length(name)
+  if (no_overwrite_use .and. fm_exists(field_name)) then  !{
+    field_length = fm_get_length(field_name)
     if (field_length .lt. 0) then  !{
-      call mpp_error(FATAL, trim(error_header) // ' Problem getting length of ' // trim(name))
+      call mpp_error(FATAL, trim(error_header) // ' Problem getting length of ' // trim(field_name))
     endif  !}
     do n = field_length + 1, length  !{
-      field_index = fm_new_value(name, ival(n), index = n)
+      field_index = fm_new_value(field_name, ival(n), index = n)
       if (field_index .le. 0) then  !{
         write (str_error,*) ' with index = ', n
-        call mpp_error(FATAL, trim(error_header) // ' Problem setting ' // trim(name) // trim(str_error))
+        call mpp_error(FATAL, trim(error_header) // ' Problem setting ' // trim(field_name) // trim(str_error))
       endif  !}
     enddo  !} n
   else  !}{
-    field_index = fm_new_value(name, ival(1))
+    field_index = fm_new_value(field_name, ival(1))
     if (field_index .le. 0) then  !{
-      call mpp_error(FATAL, trim(error_header) // ' Problem setting ' // trim(name))
+      call mpp_error(FATAL, trim(error_header) // ' Problem setting ' // trim(field_name))
     endif  !}
     do n = 2, length  !{
-      field_index = fm_new_value(name, ival(n), index = n)
+      field_index = fm_new_value(field_name, ival(n), index = n)
       if (field_index .le. 0) then  !{
         write (str_error,*) ' with index = ', n
-        call mpp_error(FATAL, trim(error_header) // ' Problem setting ' // trim(name) // trim(str_error))
+        call mpp_error(FATAL, trim(error_header) // ' Problem setting ' // trim(field_name) // trim(str_error))
       endif  !}
     enddo  !} n
   endif  !}
@@ -1726,15 +1726,15 @@ endif  !}
 
 if (good_name_list_use .ne. ' ') then  !{
   if (fm_exists(good_name_list_use)) then  !{
-    add_name = fm_util_get_index_string(good_name_list_use, name,               &
+    add_name = fm_util_get_index_string(good_name_list_use, field_name,               &
        caller = caller_str) .le. 0              ! true if name does not exist in string array
   else  !}{
     add_name = .true.                           ! always add to new list
   endif  !}
-  if (add_name .and. fm_exists(name)) then  !{
-    if (fm_new_value(good_name_list_use, name, append = .true., create = .true.) .le. 0) then  !{
+  if (add_name .and. fm_exists(field_name)) then  !{
+    if (fm_new_value(good_name_list_use, field_name, append = .true., create = .true.) .le. 0) then  !{
       call mpp_error(FATAL, trim(error_header) //                               &
-           ' Could not add ' // trim(name) // ' to "' // trim(good_name_list_use) // '" list')
+           ' Could not add ' // trim(field_name) // ' to "' // trim(good_name_list_use) // '" list')
     endif  !}
   endif  !}
 endif  !}
@@ -1746,7 +1746,7 @@ end subroutine fm_util_set_value_integer_array  !}
 !#######################################################################
 
 !> Set a logical array in the Field Manager tree.
-subroutine fm_util_set_value_logical_array(name, lval, length, caller, no_overwrite, good_name_list)  !{
+subroutine fm_util_set_value_logical_array(field_name, lval, length, caller, no_overwrite, good_name_list)  !{
 
 implicit none
 
@@ -1754,7 +1754,7 @@ implicit none
 !       arguments
 !
 
-character(len=*), intent(in)                            :: name
+character(len=*), intent(in)                            :: field_name
 integer, intent(in)                                     :: length
 logical, intent(in)                                     :: lval(length)
 character(len=*), intent(in), optional                  :: caller
@@ -1804,7 +1804,7 @@ note_header = '==>Note from ' // trim(mod_name) //     &
 !       check that a name is given (fatal if not)
 !
 
-if (name .eq. ' ') then  !{
+if (field_name .eq. ' ') then  !{
   call mpp_error(FATAL, trim(error_header) // ' Empty name given')
 endif  !}
 
@@ -1841,36 +1841,36 @@ endif  !}
 !
 
 if (length .eq. 0) then  !{
-  if (.not. (no_overwrite_use .and. fm_exists(name))) then  !{
-    field_index = fm_new_value(name, .false., index = 0)
+  if (.not. (no_overwrite_use .and. fm_exists(field_name))) then  !{
+    field_index = fm_new_value(field_name, .false., index = 0)
     if (field_index .le. 0) then  !{
       write (str_error,*) ' with length = ', length
-      call mpp_error(FATAL, trim(error_header) // ' Problem setting ' // trim(name) // trim(str_error))
+      call mpp_error(FATAL, trim(error_header) // ' Problem setting ' // trim(field_name) // trim(str_error))
     endif  !}
   endif  !}
 else  !}{
-  if (no_overwrite_use .and. fm_exists(name)) then  !{
-    field_length = fm_get_length(name)
+  if (no_overwrite_use .and. fm_exists(field_name)) then  !{
+    field_length = fm_get_length(field_name)
     if (field_length .lt. 0) then  !{
-      call mpp_error(FATAL, trim(error_header) // ' Problem getting length of ' // trim(name))
+      call mpp_error(FATAL, trim(error_header) // ' Problem getting length of ' // trim(field_name))
     endif  !}
     do n = field_length + 1, length  !{
-      field_index = fm_new_value(name, lval(n), index = n)
+      field_index = fm_new_value(field_name, lval(n), index = n)
       if (field_index .le. 0) then  !{
         write (str_error,*) ' with index = ', n
-        call mpp_error(FATAL, trim(error_header) // ' Problem setting ' // trim(name) // trim(str_error))
+        call mpp_error(FATAL, trim(error_header) // ' Problem setting ' // trim(field_name) // trim(str_error))
       endif  !}
     enddo  !} n
   else  !}{
-    field_index = fm_new_value(name, lval(1))
+    field_index = fm_new_value(field_name, lval(1))
     if (field_index .le. 0) then  !{
-      call mpp_error(FATAL, trim(error_header) // ' Problem setting ' // trim(name))
+      call mpp_error(FATAL, trim(error_header) // ' Problem setting ' // trim(field_name))
     endif  !}
     do n = 2, length  !{
-      field_index = fm_new_value(name, lval(n), index = n)
+      field_index = fm_new_value(field_name, lval(n), index = n)
       if (field_index .le. 0) then  !{
         write (str_error,*) ' with index = ', n
-        call mpp_error(FATAL, trim(error_header) // ' Problem setting ' // trim(name) // trim(str_error))
+        call mpp_error(FATAL, trim(error_header) // ' Problem setting ' // trim(field_name) // trim(str_error))
       endif  !}
     enddo  !} n
   endif  !}
@@ -1883,15 +1883,15 @@ endif  !}
 
 if (good_name_list_use .ne. ' ') then  !{
   if (fm_exists(good_name_list_use)) then  !{
-    add_name = fm_util_get_index_string(good_name_list_use, name,               &
+    add_name = fm_util_get_index_string(good_name_list_use, field_name,               &
        caller = caller_str) .le. 0              ! true if name does not exist in string array
   else  !}{
     add_name = .true.                           ! always add to new list
   endif  !}
-  if (add_name .and. fm_exists(name)) then  !{
-    if (fm_new_value(good_name_list_use, name, append = .true., create = .true.) .le. 0) then  !{
+  if (add_name .and. fm_exists(field_name)) then  !{
+    if (fm_new_value(good_name_list_use, field_name, append = .true., create = .true.) .le. 0) then  !{
       call mpp_error(FATAL, trim(error_header) //                               &
-           ' Could not add ' // trim(name) // ' to "' // trim(good_name_list_use) // '" list')
+           ' Could not add ' // trim(field_name) // ' to "' // trim(good_name_list_use) // '" list')
     endif  !}
   endif  !}
 endif  !}
@@ -1903,7 +1903,7 @@ end subroutine fm_util_set_value_logical_array  !}
 !#######################################################################
 
 !> Set a string array in the Field Manager tree.
-subroutine fm_util_set_value_string_array(name, sval, length, caller, no_overwrite, good_name_list)  !{
+subroutine fm_util_set_value_string_array(field_name, sval, length, caller, no_overwrite, good_name_list)  !{
 
 implicit none
 
@@ -1911,7 +1911,7 @@ implicit none
 !       arguments
 !
 
-character(len=*), intent(in)                            :: name
+character(len=*), intent(in)                            :: field_name
 integer, intent(in)                                     :: length
 character(len=*), intent(in)                            :: sval(length)
 character(len=*), intent(in), optional                  :: caller
@@ -1961,7 +1961,7 @@ note_header = '==>Note from ' // trim(mod_name) //     &
 !       check that a name is given (fatal if not)
 !
 
-if (name .eq. ' ') then  !{
+if (field_name .eq. ' ') then  !{
   call mpp_error(FATAL, trim(error_header) // ' Empty name given')
 endif  !}
 
@@ -1998,36 +1998,36 @@ endif  !}
 !
 
 if (length .eq. 0) then  !{
-  if (.not. (no_overwrite_use .and. fm_exists(name))) then  !{
-    field_index = fm_new_value(name, ' ', index = 0)
+  if (.not. (no_overwrite_use .and. fm_exists(field_name))) then  !{
+    field_index = fm_new_value(field_name, ' ', index = 0)
     if (field_index .le. 0) then  !{
       write (str_error,*) ' with length = ', length
-      call mpp_error(FATAL, trim(error_header) // ' Problem setting ' // trim(name) // trim(str_error))
+      call mpp_error(FATAL, trim(error_header) // ' Problem setting ' // trim(field_name) // trim(str_error))
     endif  !}
   endif  !}
 else  !}{
-  if (no_overwrite_use .and. fm_exists(name)) then  !{
-    field_length = fm_get_length(name)
+  if (no_overwrite_use .and. fm_exists(field_name)) then  !{
+    field_length = fm_get_length(field_name)
     if (field_length .lt. 0) then  !{
-      call mpp_error(FATAL, trim(error_header) // ' Problem getting length of ' // trim(name))
+      call mpp_error(FATAL, trim(error_header) // ' Problem getting length of ' // trim(field_name))
     endif  !}
     do n = field_length + 1, length  !{
-      field_index = fm_new_value(name, sval(n), index = n)
+      field_index = fm_new_value(field_name, sval(n), index = n)
       if (field_index .le. 0) then  !{
         write (str_error,*) ' with index = ', n
-        call mpp_error(FATAL, trim(error_header) // ' Problem setting ' // trim(name) // trim(str_error))
+        call mpp_error(FATAL, trim(error_header) // ' Problem setting ' // trim(field_name) // trim(str_error))
       endif  !}
     enddo  !} n
   else  !}{
-    field_index = fm_new_value(name, sval(1))
+    field_index = fm_new_value(field_name, sval(1))
     if (field_index .le. 0) then  !{
-      call mpp_error(FATAL, trim(error_header) // ' Problem setting ' // trim(name))
+      call mpp_error(FATAL, trim(error_header) // ' Problem setting ' // trim(field_name))
     endif  !}
     do n = 2, length  !{
-      field_index = fm_new_value(name, sval(n), index = n)
+      field_index = fm_new_value(field_name, sval(n), index = n)
       if (field_index .le. 0) then  !{
         write (str_error,*) ' with index = ', n
-        call mpp_error(FATAL, trim(error_header) // ' Problem setting ' // trim(name) // trim(str_error))
+        call mpp_error(FATAL, trim(error_header) // ' Problem setting ' // trim(field_name) // trim(str_error))
       endif  !}
     enddo  !} n
   endif  !}
@@ -2040,15 +2040,15 @@ endif  !}
 
 if (good_name_list_use .ne. ' ') then  !{
   if (fm_exists(good_name_list_use)) then  !{
-    add_name = fm_util_get_index_string(good_name_list_use, name,               &
+    add_name = fm_util_get_index_string(good_name_list_use, field_name,               &
        caller = caller_str) .le. 0              ! true if name does not exist in string array
   else  !}{
     add_name = .true.                           ! always add to new list
   endif  !}
-  if (add_name .and. fm_exists(name)) then  !{
-    if (fm_new_value(good_name_list_use, name, append = .true., create = .true.) .le. 0) then  !{
+  if (add_name .and. fm_exists(field_name)) then  !{
+    if (fm_new_value(good_name_list_use, field_name, append = .true., create = .true.) .le. 0) then  !{
       call mpp_error(FATAL, trim(error_header) //                               &
-           ' Could not add ' // trim(name) // ' to "' // trim(good_name_list_use) // '" list')
+           ' Could not add ' // trim(field_name) // ' to "' // trim(good_name_list_use) // '" list')
     endif  !}
   endif  !}
 endif  !}
@@ -2060,7 +2060,7 @@ end subroutine fm_util_set_value_string_array  !}
 !#######################################################################
 
 !> Set an integer value in the Field Manager tree.
-subroutine fm_util_set_value_integer(name, ival, caller, index, append, no_create,        &
+subroutine fm_util_set_value_integer(field_name, ival, caller, index, append, no_create,        &
      no_overwrite, good_name_list)  !{
 
 implicit none
@@ -2069,7 +2069,7 @@ implicit none
 !       arguments
 !
 
-character(len=*), intent(in)            :: name
+character(len=*), intent(in)            :: field_name
 integer, intent(in)                     :: ival
 character(len=*), intent(in), optional  :: caller
 integer, intent(in), optional           :: index
@@ -2121,7 +2121,7 @@ note_header = '==>Note from ' // trim(mod_name) //     &
 !       check that a name is given (fatal if not)
 !
 
-if (name .eq. ' ') then  !{
+if (field_name .eq. ' ') then  !{
   call mpp_error(FATAL, trim(error_header) // ' Empty name given')
 endif  !}
 
@@ -2157,50 +2157,50 @@ if (present(no_create)) then  !{
   create = .not. no_create
   if (no_create .and. (present(append) .or. present(index))) then  !{
     call mpp_error(FATAL, trim(error_header) // &
-                   &  ' append or index are present when no_create is true for ' // trim(name))
+                   &  ' append or index are present when no_create is true for ' // trim(field_name))
   endif  !}
 else  !}{
   create = .true.
 endif  !}
 
 if (present(index)) then  !{
-  if (fm_exists(name)) then  !{
-    field_length = fm_get_length(name)
+  if (fm_exists(field_name)) then  !{
+    field_length = fm_get_length(field_name)
     if (field_length .lt. 0) then  !{
-      call mpp_error(FATAL, trim(error_header) // ' Problem getting length of ' // trim(name))
+      call mpp_error(FATAL, trim(error_header) // ' Problem getting length of ' // trim(field_name))
     endif  !}
     if (.not. (no_overwrite_use .and. field_length .ge. index)) then  !{
-      field_index = fm_new_value(name, ival, index = index)
+      field_index = fm_new_value(field_name, ival, index = index)
       if (field_index .le. 0) then  !{
         write (str_error,*) ' with index = ', index
-        call mpp_error(FATAL, trim(error_header) // ' Problem overwriting ' // trim(name) // trim(str_error))
+        call mpp_error(FATAL, trim(error_header) // ' Problem overwriting ' // trim(field_name) // trim(str_error))
       endif  !}
     endif  !}
   else  !}{
-    field_index = fm_new_value(name, ival, index = index)
+    field_index = fm_new_value(field_name, ival, index = index)
     if (field_index .le. 0) then  !{
       write (str_error,*) ' with index = ', index
-      call mpp_error(FATAL, trim(error_header) // ' Problem setting ' // trim(name) // trim(str_error))
+      call mpp_error(FATAL, trim(error_header) // ' Problem setting ' // trim(field_name) // trim(str_error))
     endif  !}
   endif  !}
 elseif (present(append)) then  !}{
-  field_index = fm_new_value(name, ival, append = append)
+  field_index = fm_new_value(field_name, ival, append = append)
   if (field_index .le. 0) then  !{
     write (str_error,*) ' with append = ', append
-    call mpp_error(FATAL, trim(error_header) // ' Problem setting ' // trim(name) // trim(str_error))
+    call mpp_error(FATAL, trim(error_header) // ' Problem setting ' // trim(field_name) // trim(str_error))
   endif  !}
 else  !}{
-  if (fm_exists(name)) then  !{
+  if (fm_exists(field_name)) then  !{
     if (.not. no_overwrite_use) then  !{
-      field_index = fm_new_value(name, ival)
+      field_index = fm_new_value(field_name, ival)
       if (field_index .le. 0) then  !{
-        call mpp_error(FATAL, trim(error_header) // ' Problem overwriting ' // trim(name))
+        call mpp_error(FATAL, trim(error_header) // ' Problem overwriting ' // trim(field_name))
       endif  !}
     endif  !}
   elseif (create) then  !}{
-    field_index = fm_new_value(name, ival)
+    field_index = fm_new_value(field_name, ival)
     if (field_index .le. 0) then  !{
-      call mpp_error(FATAL, trim(error_header) // ' Problem creating ' // trim(name))
+      call mpp_error(FATAL, trim(error_header) // ' Problem creating ' // trim(field_name))
     endif  !}
   endif  !}
 endif  !}
@@ -2212,15 +2212,15 @@ endif  !}
 
 if (good_name_list_use .ne. ' ') then  !{
   if (fm_exists(good_name_list_use)) then  !{
-    add_name = fm_util_get_index_string(good_name_list_use, name,               &
+    add_name = fm_util_get_index_string(good_name_list_use, field_name,               &
        caller = caller_str) .le. 0              ! true if name does not exist in string array
   else  !}{
     add_name = .true.                           ! always add to new list
   endif  !}
-  if (add_name .and. fm_exists(name)) then  !{
-    if (fm_new_value(good_name_list_use, name, append = .true., create = .true.) .le. 0) then  !{
+  if (add_name .and. fm_exists(field_name)) then  !{
+    if (fm_new_value(good_name_list_use, field_name, append = .true., create = .true.) .le. 0) then  !{
       call mpp_error(FATAL, trim(error_header) //                               &
-           ' Could not add ' // trim(name) // ' to "' // trim(good_name_list_use) // '" list')
+           ' Could not add ' // trim(field_name) // ' to "' // trim(good_name_list_use) // '" list')
     endif  !}
   endif  !}
 endif  !}
@@ -2232,7 +2232,7 @@ end subroutine fm_util_set_value_integer  !}
 !#######################################################################
 
 !> Set a logical value in the Field Manager tree.
-subroutine fm_util_set_value_logical(name, lval, caller, index, append, no_create,        &
+subroutine fm_util_set_value_logical(field_name, lval, caller, index, append, no_create,        &
      no_overwrite, good_name_list)  !{
 
 implicit none
@@ -2241,7 +2241,7 @@ implicit none
 !       arguments
 !
 
-character(len=*), intent(in)            :: name
+character(len=*), intent(in)            :: field_name
 logical, intent(in)                     :: lval
 character(len=*), intent(in), optional  :: caller
 integer, intent(in), optional           :: index
@@ -2293,7 +2293,7 @@ note_header = '==>Note from ' // trim(mod_name) //     &
 !       check that a name is given (fatal if not)
 !
 
-if (name .eq. ' ') then  !{
+if (field_name .eq. ' ') then  !{
   call mpp_error(FATAL, trim(error_header) // ' Empty name given')
 endif  !}
 
@@ -2329,50 +2329,50 @@ if (present(no_create)) then  !{
   create = .not. no_create
   if (no_create .and. (present(append) .or. present(index))) then  !{
     call mpp_error(FATAL, trim(error_header) // &
-                   &  ' append or index are present when no_create is true for ' // trim(name))
+                   &  ' append or index are present when no_create is true for ' // trim(field_name))
   endif  !}
 else  !}{
   create = .true.
 endif  !}
 
 if (present(index)) then  !{
-  if (fm_exists(name)) then  !{
-    field_length = fm_get_length(name)
+  if (fm_exists(field_name)) then  !{
+    field_length = fm_get_length(field_name)
     if (field_length .lt. 0) then  !{
-      call mpp_error(FATAL, trim(error_header) // ' Problem getting length of ' // trim(name))
+      call mpp_error(FATAL, trim(error_header) // ' Problem getting length of ' // trim(field_name))
     endif  !}
     if (.not. (no_overwrite_use .and. field_length .ge. index)) then  !{
-      field_index = fm_new_value(name, lval, index = index)
+      field_index = fm_new_value(field_name, lval, index = index)
       if (field_index .le. 0) then  !{
         write (str_error,*) ' with index = ', index
-        call mpp_error(FATAL, trim(error_header) // ' Problem overwriting ' // trim(name) // trim(str_error))
+        call mpp_error(FATAL, trim(error_header) // ' Problem overwriting ' // trim(field_name) // trim(str_error))
       endif  !}
     endif  !}
   else  !}{
-    field_index = fm_new_value(name, lval, index = index)
+    field_index = fm_new_value(field_name, lval, index = index)
     if (field_index .le. 0) then  !{
       write (str_error,*) ' with index = ', index
-      call mpp_error(FATAL, trim(error_header) // ' Problem setting ' // trim(name) // trim(str_error))
+      call mpp_error(FATAL, trim(error_header) // ' Problem setting ' // trim(field_name) // trim(str_error))
     endif  !}
   endif  !}
 elseif (present(append)) then  !}{
-  field_index = fm_new_value(name, lval, append = append)
+  field_index = fm_new_value(field_name, lval, append = append)
   if (field_index .le. 0) then  !{
     write (str_error,*) ' with append = ', append
-    call mpp_error(FATAL, trim(error_header) // ' Problem setting ' // trim(name) // trim(str_error))
+    call mpp_error(FATAL, trim(error_header) // ' Problem setting ' // trim(field_name) // trim(str_error))
   endif  !}
 else  !}{
-  if (fm_exists(name)) then  !{
+  if (fm_exists(field_name)) then  !{
     if (.not. no_overwrite_use) then  !{
-      field_index = fm_new_value(name, lval)
+      field_index = fm_new_value(field_name, lval)
       if (field_index .le. 0) then  !{
-        call mpp_error(FATAL, trim(error_header) // ' Problem overwriting ' // trim(name))
+        call mpp_error(FATAL, trim(error_header) // ' Problem overwriting ' // trim(field_name))
       endif  !}
     endif  !}
   elseif (create) then  !}{
-    field_index = fm_new_value(name, lval)
+    field_index = fm_new_value(field_name, lval)
     if (field_index .le. 0) then  !{
-      call mpp_error(FATAL, trim(error_header) // ' Problem creating ' // trim(name))
+      call mpp_error(FATAL, trim(error_header) // ' Problem creating ' // trim(field_name))
     endif  !}
   endif  !}
 endif  !}
@@ -2384,15 +2384,15 @@ endif  !}
 
 if (good_name_list_use .ne. ' ') then  !{
   if (fm_exists(good_name_list_use)) then  !{
-    add_name = fm_util_get_index_string(good_name_list_use, name,               &
+    add_name = fm_util_get_index_string(good_name_list_use, field_name,               &
        caller = caller_str) .le. 0              ! true if name does not exist in string array
   else  !}{
     add_name = .true.                           ! always add to new list
   endif  !}
-  if (add_name .and. fm_exists(name)) then  !{
-    if (fm_new_value(good_name_list_use, name, append = .true., create = .true.) .le. 0) then  !{
+  if (add_name .and. fm_exists(field_name)) then  !{
+    if (fm_new_value(good_name_list_use, field_name, append = .true., create = .true.) .le. 0) then  !{
       call mpp_error(FATAL, trim(error_header) //                               &
-           ' Could not add ' // trim(name) // ' to "' // trim(good_name_list_use) // '" list')
+           ' Could not add ' // trim(field_name) // ' to "' // trim(good_name_list_use) // '" list')
     endif  !}
   endif  !}
 endif  !}
@@ -2403,7 +2403,7 @@ end subroutine fm_util_set_value_logical  !}
 
 !#######################################################################
 !> Set a string value in the Field Manager tree.
-subroutine fm_util_set_value_string(name, sval, caller, index, append, no_create,        &
+subroutine fm_util_set_value_string(field_name, sval, caller, index, append, no_create,        &
      no_overwrite, good_name_list)  !{
 
 implicit none
@@ -2412,7 +2412,7 @@ implicit none
 !       arguments
 !
 
-character(len=*), intent(in)            :: name
+character(len=*), intent(in)            :: field_name
 character(len=*), intent(in)            :: sval
 character(len=*), intent(in), optional  :: caller
 integer, intent(in), optional           :: index
@@ -2464,7 +2464,7 @@ note_header = '==>Note from ' // trim(mod_name) //     &
 !       check that a name is given (fatal if not)
 !
 
-if (name .eq. ' ') then  !{
+if (field_name .eq. ' ') then  !{
   call mpp_error(FATAL, trim(error_header) // ' Empty name given')
 endif  !}
 
@@ -2500,50 +2500,50 @@ if (present(no_create)) then  !{
   create = .not. no_create
   if (no_create .and. (present(append) .or. present(index))) then  !{
     call mpp_error(FATAL, trim(error_header) // &
-                   &  ' append or index are present when no_create is true for ' // trim(name))
+                   &  ' append or index are present when no_create is true for ' // trim(field_name))
   endif  !}
 else  !}{
   create = .true.
 endif  !}
 
 if (present(index)) then  !{
-  if (fm_exists(name)) then  !{
-    field_length = fm_get_length(name)
+  if (fm_exists(field_name)) then  !{
+    field_length = fm_get_length(field_name)
     if (field_length .lt. 0) then  !{
-      call mpp_error(FATAL, trim(error_header) // ' Problem getting length of ' // trim(name))
+      call mpp_error(FATAL, trim(error_header) // ' Problem getting length of ' // trim(field_name))
     endif  !}
     if (.not. (no_overwrite_use .and. field_length .ge. index)) then  !{
-      field_index = fm_new_value(name, sval, index = index)
+      field_index = fm_new_value(field_name, sval, index = index)
       if (field_index .le. 0) then  !{
         write (str_error,*) ' with index = ', index
-        call mpp_error(FATAL, trim(error_header) // ' Problem overwriting ' // trim(name) // trim(str_error))
+        call mpp_error(FATAL, trim(error_header) // ' Problem overwriting ' // trim(field_name) // trim(str_error))
       endif  !}
     endif  !}
   else  !}{
-    field_index = fm_new_value(name, sval, index = index)
+    field_index = fm_new_value(field_name, sval, index = index)
     if (field_index .le. 0) then  !{
       write (str_error,*) ' with index = ', index
-      call mpp_error(FATAL, trim(error_header) // ' Problem setting ' // trim(name) // trim(str_error))
+      call mpp_error(FATAL, trim(error_header) // ' Problem setting ' // trim(field_name) // trim(str_error))
     endif  !}
   endif  !}
 elseif (present(append)) then  !}{
-  field_index = fm_new_value(name, sval, append = append)
+  field_index = fm_new_value(field_name, sval, append = append)
   if (field_index .le. 0) then  !{
     write (str_error,*) ' with append = ', append
-    call mpp_error(FATAL, trim(error_header) // ' Problem setting ' // trim(name) // trim(str_error))
+    call mpp_error(FATAL, trim(error_header) // ' Problem setting ' // trim(field_name) // trim(str_error))
   endif  !}
 else  !}{
-  if (fm_exists(name)) then  !{
+  if (fm_exists(field_name)) then  !{
     if (.not. no_overwrite_use) then  !{
-      field_index = fm_new_value(name, sval)
+      field_index = fm_new_value(field_name, sval)
       if (field_index .le. 0) then  !{
-        call mpp_error(FATAL, trim(error_header) // ' Problem overwriting ' // trim(name))
+        call mpp_error(FATAL, trim(error_header) // ' Problem overwriting ' // trim(field_name))
       endif  !}
     endif  !}
   elseif (create) then  !}{
-    field_index = fm_new_value(name, sval)
+    field_index = fm_new_value(field_name, sval)
     if (field_index .le. 0) then  !{
-      call mpp_error(FATAL, trim(error_header) // ' Problem creating ' // trim(name))
+      call mpp_error(FATAL, trim(error_header) // ' Problem creating ' // trim(field_name))
     endif  !}
   endif  !}
 endif  !}
@@ -2555,15 +2555,15 @@ endif  !}
 
 if (good_name_list_use .ne. ' ') then  !{
   if (fm_exists(good_name_list_use)) then  !{
-    add_name = fm_util_get_index_string(good_name_list_use, name,               &
+    add_name = fm_util_get_index_string(good_name_list_use, field_name,               &
        caller = caller_str) .le. 0              ! true if name does not exist in string array
   else  !}{
     add_name = .true.                           ! always add to new list
   endif  !}
-  if (add_name .and. fm_exists(name)) then  !{
-    if (fm_new_value(good_name_list_use, name, append = .true., create = .true.) .le. 0) then  !{
+  if (add_name .and. fm_exists(field_name)) then  !{
+    if (fm_new_value(good_name_list_use, field_name, append = .true., create = .true.) .le. 0) then  !{
       call mpp_error(FATAL, trim(error_header) //                               &
-           ' Could not add ' // trim(name) // ' to "' // trim(good_name_list_use) // '" list')
+           ' Could not add ' // trim(field_name) // ' to "' // trim(good_name_list_use) // '" list')
     endif  !}
   endif  !}
 endif  !}
@@ -2575,7 +2575,7 @@ end subroutine fm_util_set_value_string  !}
 !#######################################################################
 
 !> Start processing a namelist
-subroutine fm_util_start_namelist(path, name, caller, no_overwrite, check)  !{
+subroutine fm_util_start_namelist(path, field_name, caller, no_overwrite, check)  !{
 
 implicit none
 
@@ -2584,7 +2584,7 @@ implicit none
 !
 
 character(len=*), intent(in)            :: path
-character(len=*), intent(in)            :: name
+character(len=*), intent(in)            :: field_name
 character(len=*), intent(in), optional  :: caller
 logical,          intent(in), optional  :: no_overwrite
 logical,          intent(in), optional  :: check
@@ -2630,7 +2630,7 @@ note_header = '==>Note from ' // trim(mod_name) //     &
 !       check that a name is given (fatal if not)
 !
 
-if (name .eq. ' ') then  !{
+if (field_name .eq. ' ') then  !{
   call mpp_error(FATAL, trim(error_header) // ' Empty name given')
 endif  !}
 
@@ -2639,12 +2639,12 @@ endif  !}
 !
 
 if (path .eq. ' ') then  !{
-  path_name = name
+  path_name = field_name
 else  !}{
-  path_name = trim(path) // '/' // name
+  path_name = trim(path) // '/' // field_name
 endif  !}
 save_path = path
-save_name = name
+save_name = field_name
 
 !
 !       set the default caller string, if desired
@@ -2715,9 +2715,9 @@ endif  !}
 !
 
 if (fm_new_value('/ocean_mod/GOOD/namelists/' // trim(path) // '/good_values',    &
-                 name, append = .true., create = .true.) .le. 0) then  !{
+                 field_name, append = .true., create = .true.) .le. 0) then  !{
   call mpp_error(FATAL, trim(error_header) //                           &
-       ' Could not add ' // trim(name) // ' to "' // trim(path) // '/good_values" list')
+       ' Could not add ' // trim(field_name) // ' to "' // trim(path) // '/good_values" list')
 endif  !}
 
 !
@@ -2740,7 +2740,7 @@ end subroutine fm_util_start_namelist  !}
 !#######################################################################
 
 !> Finish up processing a namelist
-subroutine fm_util_end_namelist(path, name, caller, check)  !{
+subroutine fm_util_end_namelist(path, field_name, caller, check)  !{
 
 implicit none
 
@@ -2749,7 +2749,7 @@ implicit none
 !
 
 character(len=*), intent(in)            :: path
-character(len=*), intent(in)            :: name
+character(len=*), intent(in)            :: field_name
 character(len=*), intent(in), optional  :: caller
 logical,          intent(in), optional  :: check
 
@@ -2791,7 +2791,7 @@ note_header = '==>Note from ' // trim(mod_name) //     &
 !       check that a path is given (fatal if not)
 !
 
-if (name .eq. ' ') then  !{
+if (field_name .eq. ' ') then  !{
   call mpp_error(FATAL, trim(error_header) // ' Empty name given')
 endif  !}
 
@@ -2803,9 +2803,9 @@ endif  !}
 if (path .ne. save_path) then  !{
   call mpp_error(FATAL, trim(error_header) // &
                  &  ' Path "' // trim(path) // '" does not match saved path "' // trim(save_path) // '"')
-elseif (name .ne. save_name) then  !}{
+elseif (field_name .ne. save_name) then  !}{
   call mpp_error(FATAL, trim(error_header) // &
-                 &  ' Name "' // trim(name) // '" does not match saved name "' // trim(save_name) // '"')
+                 &  ' Name "' // trim(field_name) // '" does not match saved name "' // trim(save_name) // '"')
 endif  !}
 
 !
@@ -2813,9 +2813,9 @@ endif  !}
 !
 
 if (path .eq. ' ') then  !{
-  path_name = name
+  path_name = field_name
 else  !}{
-  path_name = trim(path) // '/' // name
+  path_name = trim(path) // '/' // field_name
 endif  !}
 save_path = ' '
 save_name = ' '

--- a/field_manager/fm_util.F90
+++ b/field_manager/fm_util.F90
@@ -747,7 +747,7 @@ if (fm_type .eq. 'list') then  !{
 elseif (fm_type .eq. ' ') then  !}{
   call mpp_error(FATAL, trim(error_header) // ' List does not exist: ' // trim(field_name))
 else  !}{
- call mpp_error(FATAL, trim(error_header) // ' Wrong type for ' // trim(field_name) // ', found (' // trim(fm_type) // ')')
+ call mpp_error(FATAL, trim(error_header) // ' Wrong type for ' // trim(field_name) //', found ('// trim(fm_type) //')')
 endif  !}
 
 

--- a/field_manager/fm_yaml.F90
+++ b/field_manager/fm_yaml.F90
@@ -63,7 +63,7 @@ end type fmAttr_t
 type, public :: fmVar_t
   integer                                     :: yfid                  !< file id of a yaml file
   integer                                     :: id                    !< block id of this var
-  character(len=:), allocatable               :: name                  !< name of the variable
+  character(len=:), allocatable               :: var_name              !< name of the variable
   integer, dimension(:), allocatable          :: key_ids               !< key ids for params
   character(len=:), dimension(:), allocatable :: keys                  !< names of params
   character(len=:), dimension(:), allocatable :: values                !< values of params
@@ -85,7 +85,7 @@ end type fmVar_t
 type, public :: fmModel_t
   integer                       :: yfid                !< file id of a yaml file
   integer                       :: id                  !< block id of this model
-  character(len=:), allocatable :: name                !< name of the model
+  character(len=:), allocatable :: model_name          !< name of the model
   character(len=7)              :: blockname="varlist" !< name of the root block
   integer                       :: nchildren           !< number of var types
   integer, allocatable          :: child_ids(:)        !< array of var ids
@@ -104,7 +104,7 @@ end type fmModel_t
 type, public :: fmType_t
   integer                       :: yfid                !< file id of a yaml file
   integer                       :: id                  !< block id of this type
-  character(len=:), allocatable :: name                !< name of the type
+  character(len=:), allocatable :: type_name           !< name of the type
   character(len=7)              :: blockname="modlist" !< name of the root block
   integer                       :: nchildren           !< number of model types
   integer, allocatable          :: child_ids(:)        !< array of model ids
@@ -263,7 +263,7 @@ end subroutine destruct_fmTable_t
 subroutine destruct_fmType_t(this)
   class (fmType_t) :: this !< type object
 
-  if (allocated(this%name)) deallocate(this%name)
+  if (allocated(this%type_name)) deallocate(this%type_name)
   if (allocated(this%child_ids)) deallocate(this%child_ids)
   if (allocated(this%children)) then
     do type_i=1,this%nchildren
@@ -279,7 +279,7 @@ end subroutine destruct_fmType_t
 subroutine destruct_fmModel_t(this)
   class (fmModel_t) :: this !< model object
 
-  if (allocated(this%name)) deallocate(this%name)
+  if (allocated(this%model_name)) deallocate(this%model_name)
   if (allocated(this%child_ids)) deallocate(this%child_ids)
   if (allocated(this%children)) then
     do model_i=1,this%nchildren
@@ -295,7 +295,7 @@ end subroutine destruct_fmModel_t
 subroutine destruct_fmVar_t(this)
   class (fmVar_t) :: this !< variable object
 
-  if (allocated(this%name)) deallocate(this%name)
+  if (allocated(this%var_name)) deallocate(this%var_name)
   if (allocated(this%key_ids)) deallocate(this%key_ids)
   if (allocated(this%keys)) deallocate(this%keys)
   if (allocated(this%values)) deallocate(this%values)
@@ -345,7 +345,7 @@ subroutine get_name_fmType_t(this)
   allocate(key_ids(nkeys))
   call get_key_ids(this%yfid, this%id, key_ids)
   call get_key_value(this%yfid, key_ids(1), key_value)
-  this%name = trim(key_value)
+  this%type_name = trim(key_value)
 end subroutine get_name_fmType_t
 
 !> @brief gets the block ids for children of this type.
@@ -367,7 +367,7 @@ subroutine get_name_fmModel_t(this)
   allocate(key_ids(nkeys))
   call get_key_ids(this%yfid, this%id, key_ids)
   call get_key_value(this%yfid, key_ids(1), key_value)
-  this%name = trim(key_value)
+  this%model_name = trim(key_value)
 end subroutine get_name_fmModel_t
 
 !> @brief gets the block ids for children of this type.
@@ -393,7 +393,7 @@ subroutine get_name_fmVar_t(this)
   allocate(key_ids(nkeys))
   call get_key_ids(this%yfid, this%id, key_ids)
   call get_key_value(this%yfid, key_ids(1), key_value)
-  this%name = trim(key_value)
+  this%var_name = trim(key_value)
   if (nkeys .gt. 1) then
     maxln = 0
     maxlv = 0

--- a/mpp/include/mpp_comm_mpi.inc
+++ b/mpp/include/mpp_comm_mpi.inc
@@ -69,7 +69,7 @@
   peset(:)%group = -1
   peset(:)%start = -1
   peset(:)%log2stride = -1
-  peset(:)%name  = " "
+  peset(:)%pelist_name  = " "
   !0=single-PE, initialized so that count returns 1
   peset(0)%count = 1
   allocate( peset(0)%list(1) )
@@ -229,10 +229,10 @@ subroutine mpp_exit()
         tavg = t; call mpp_sum(tavg); tavg = tavg/mpp_npes()
         tstd = (t-tavg)**2; call mpp_sum(tstd); tstd = sqrt( tstd/mpp_npes() )
         if( pe.EQ.root_pe )write( out_unit,'(a32,i10,4f14.6,f7.3,3i6)' ) &
-             clocks(i)%name, clocks(i)%hits, tmin, tmax, tavg, tstd, tavg/t_total, &
+             clocks(i)%clock_name, clocks(i)%hits, tmin, tmax, tavg, tstd, tavg/t_total, &
              clocks(i)%grain, minval(peset(clocks(i)%peset_num)%list), &
              maxval(peset(clocks(i)%peset_num)%list)
-        write(log_unit,'(a32,f14.6)') clocks(i)%name, clocks(i)%total_ticks*tick_rate
+        write(log_unit,'(a32,f14.6)') clocks(i)%clock_name, clocks(i)%total_ticks*tick_rate
      end do
 
      if( ANY(clocks(1:clock_num)%detailed) .AND. pe.EQ.root_pe )write( out_unit,'(/32x,a)' ) &
@@ -262,7 +262,7 @@ subroutine mpp_exit()
               tavg = t; call mpp_sum(tavg); tavg = tavg/mpp_npes()
               tstd = (t-tavg)**2; call mpp_sum(tstd); tstd = sqrt( tstd/mpp_npes() )
               if( pe.EQ.root_pe )write( out_unit,'(a32,4f11.3,5es11.3)' ) &
-                   trim(clocks(i)%name)//' '//trim(clocks(i)%events(j)%name), &
+                   trim(clocks(i)%clock_name)//' '//trim(clocks(i)%events(j)%event_name), &
                    tmin, tmax, tavg, tstd, mmin, mmax, mavg, mstd, mavg/tavg
            end if
         end do

--- a/mpp/include/mpp_comm_nocomm.inc
+++ b/mpp/include/mpp_comm_nocomm.inc
@@ -176,10 +176,10 @@ subroutine mpp_exit()
         tavg = t; call mpp_sum(tavg); tavg = tavg/mpp_npes()
         tstd = (t-tavg)**2; call mpp_sum(tstd); tstd = sqrt( tstd/mpp_npes() )
         if( pe.EQ.root_pe )write( out_unit,'(a32,i10,4f14.6,f7.3,3i6)' ) &
-             clocks(i)%name, clocks(i)%hits, tmin, tmax, tavg, tstd, tavg/t_total, &
+             clocks(i)%clock_name, clocks(i)%hits, tmin, tmax, tavg, tstd, tavg/t_total, &
              clocks(i)%grain, minval(peset(clocks(i)%peset_num)%list), &
              maxval(peset(clocks(i)%peset_num)%list)
-        if (pe.NE.root_pe) write(out_unit,'(a32,f14.6)') clocks(i)%name, clocks(i)%total_ticks*tick_rate
+        if (pe.NE.root_pe) write(out_unit,'(a32,f14.6)') clocks(i)%clock_name, clocks(i)%total_ticks*tick_rate
      end do
      if( ANY(clocks(1:clock_num)%detailed) .AND. pe.EQ.root_pe )write( out_unit,'(/32x,a)' ) &
           '       tmin       tmax       tavg       tstd       mmin       mmax       mavg       mstd  mavg/tavg'
@@ -205,7 +205,7 @@ subroutine mpp_exit()
               tavg = t; call mpp_sum(tavg); tavg = tavg/mpp_npes()
               tstd = (t-tavg)**2; call mpp_sum(tstd); tstd = sqrt( tstd/mpp_npes() )
               if( pe.EQ.root_pe )write( out_unit,'(a32,4f11.3,5es11.3)' ) &
-                   trim(clocks(i)%name)//' '//trim(clocks(i)%events(j)%name), &
+                   trim(clocks(i)%clock_name)//' '//trim(clocks(i)%events(j)%event_name), &
                    tmin, tmax, tavg, tstd, mmin, mmax, mavg, mstd, mavg/tavg
            end if
         end do

--- a/mpp/include/mpp_define_nest_domains.inc
+++ b/mpp/include/mpp_define_nest_domains.inc
@@ -132,7 +132,7 @@ subroutine mpp_define_nest_domains(nest_domain, domain, num_nest, nest_level, ti
              "the len_trim of optional argument name ="//trim(name)// &
              " is greater than NAME_LENGTH, change the argument name or increase NAME_LENGTH")
      endif
-     nest_domain%name = name
+     nest_domain%domain_name = name
   endif
 
   extra_halo_local = 0
@@ -601,12 +601,12 @@ end subroutine define_nest_level_type
 
 
 !###############################################################################
-subroutine compute_overlap_coarse_to_fine(nest_domain, overlap, extra_halo, position, name)
+subroutine compute_overlap_coarse_to_fine(nest_domain, overlap, extra_halo, position, domain_name)
   type(nest_level_type),  intent(inout) :: nest_domain
   type(nestSpec),         intent(inout) :: overlap
   integer,                intent(in   ) :: extra_halo
   integer,                intent(in   ) :: position
-  character(len=*),       intent(in   ) :: name
+  character(len=*),       intent(in   ) :: domain_name
 
   type(domain2D), pointer :: domain_fine  =>NULL()
   type(domain2D), pointer :: domain_coarse=>NULL()
@@ -1099,7 +1099,7 @@ subroutine compute_overlap_coarse_to_fine(nest_domain, overlap, extra_halo, posi
      endif
   endif
 
-  if(debug_message_passing) call debug_message_size(overlap, name)
+  if(debug_message_passing) call debug_message_size(overlap, domain_name)
 
 
 end subroutine compute_overlap_coarse_to_fine
@@ -1107,11 +1107,11 @@ end subroutine compute_overlap_coarse_to_fine
 !###############################################################################
 !> This routine will compute the send and recv information between overlapped nesting
 !! region. The data is assumed on T-cell center.
-subroutine compute_overlap_fine_to_coarse(nest_domain, overlap, position, name)
+subroutine compute_overlap_fine_to_coarse(nest_domain, overlap, position, domain_name)
   type(nest_level_type),  intent(inout) :: nest_domain
   type(nestSpec),         intent(inout) :: overlap
   integer,                intent(in   ) :: position
-  character(len=*),       intent(in   ) :: name
+  character(len=*),       intent(in   ) :: domain_name
 
   !--- local variables
 
@@ -1343,7 +1343,7 @@ subroutine compute_overlap_fine_to_coarse(nest_domain, overlap, position, name)
 
   endif
 
-  if(debug_message_passing) call debug_message_size(overlap, name)
+  if(debug_message_passing) call debug_message_size(overlap, domain_name)
 
   deallocate(isl_coarse, iel_coarse, jsl_coarse, jel_coarse)
   deallocate(isl_fine, iel_fine, jsl_fine, jel_fine)
@@ -1371,9 +1371,9 @@ function find_index(array, index_data, start_pos)
 
 end function find_index
 
-subroutine  debug_message_size(overlap, name)
+subroutine  debug_message_size(overlap, domain_name)
    type(nestSpec),   intent(in) :: overlap
-   character(len=*), intent(in) :: name
+   character(len=*), intent(in) :: domain_name
    integer, allocatable :: msg1(:), msg2(:), msg3(:), pelist(:)
    integer :: m, n, l, npes, msgsize
    integer :: is, ie, js, je, outunit
@@ -1413,13 +1413,13 @@ subroutine  debug_message_size(overlap, name)
 
       do m = 1, npes
          if(msg1(m) .NE. msg2(m)) then
-            print*, "debug_message_size: My pe = ", mpp_pe(), ",name =", trim(name),", from pe=", &
+            print*, "debug_message_size: My pe = ", mpp_pe(), ",name =", trim(domain_name),", from pe=", &
                  pelist(m), ":send size = ", msg1(m), ", recv size = ", msg2(m)
             call mpp_error(FATAL, "debug_message_size: mismatch on send and recv size")
          endif
       enddo
       write(outunit,*)"NOTE from compute_overlap_fine_to_coarse: "// &
-           "message sizes are matched between send and recv for "//trim(name)
+           "message sizes are matched between send and recv for "//trim(domain_name)
       deallocate(msg1, msg2, msg3, pelist)
 
 end subroutine  debug_message_size
@@ -1554,14 +1554,14 @@ function search_C2F_nest_overlap(nest_domain, nest_level, extra_halo, position)
     integer,                intent(in)    :: position, nest_level
     type(nestSpec),         pointer       :: search_C2F_nest_overlap
     type(nestSpec),        pointer        :: update_ref
-    character(len=128)                    :: name
+    character(len=128)                    :: domain_name
 
     if(nest_level < 1 .OR. nest_level > nest_domain%num_level) call mpp_error(FATAL, &
       "mpp_define_nest_domains.inc(search_C2F_nest_overlap): nest_level should be between 1 and nest_domain%num_level")
 
     select case(position)
     case (CENTER)
-       name = trim(nest_domain%name)//" T-cell"
+       domain_name = trim(nest_domain%domain_name)//" T-cell"
        update_ref => nest_domain%nest(nest_level)%C2F_T
     case (CORNER)
        update_ref => nest_domain%nest(nest_level)%C2F_C
@@ -1585,7 +1585,7 @@ function search_C2F_nest_overlap(nest_domain, nest_level, extra_halo, position)
           allocate(search_C2F_nest_overlap%next)
           search_C2F_nest_overlap => search_C2F_nest_overlap%next
           call compute_overlap_coarse_to_fine(nest_domain%nest(nest_level), search_C2F_nest_overlap, &
-                                             &  extra_halo, position, name)
+                                             &  extra_halo, position, domain_name)
           exit
        else
           search_C2F_nest_overlap => search_C2F_nest_overlap%next

--- a/mpp/include/mpp_do_check.fh
+++ b/mpp/include/mpp_do_check.fh
@@ -104,14 +104,14 @@
 
          do m = 0, nlist-1
             if(msg1(m) .NE. msg2(m)) then
-               print*, "My pe = ", mpp_pe(), ",domain name =", trim(domain%name), ",from pe=", &
+               print*, "My pe = ", mpp_pe(), ",domain name =", trim(domain%domain_name), ",from pe=", &
                     domain%list(m)%pe, ":send size = ", msg1(m), ", recv size = ", msg2(m)
                call mpp_error(FATAL, "mpp_do_check: mismatch on send and recv size")
             endif
          enddo
          call mpp_sync_self()
          write(outunit,*)"NOTE from mpp_do_check: message sizes are matched between send and recv for domain " &
-              //trim(domain%name)
+              //trim(domain%domain_name)
          deallocate(msg1, msg2)
       endif
 

--- a/mpp/include/mpp_do_checkV.fh
+++ b/mpp/include/mpp_do_checkV.fh
@@ -166,7 +166,7 @@
          call mpp_sync_self(check=EVENT_RECV)
          do m = 0, nlist-1
             if(msg1(m) .NE. msg2(m)) then
-               print*, "My pe = ", mpp_pe(), ",domain name =", trim(domain%name), ",from pe=", &
+               print*, "My pe = ", mpp_pe(), ",domain name =", trim(domain%domain_name), ",from pe=", &
                     domain%list(m)%pe, ":send size = ", msg1(m), ", recv size = ", msg2(m)
                call mpp_error(FATAL, "mpp_do_checkV: mismatch on send and recv size")
             endif
@@ -174,7 +174,7 @@
 
          call mpp_sync_self()
          write(outunit,*)"NOTE from mpp_do_checkV: message sizes are matched between send and recv for domain " &
-              //trim(domain%name)
+              //trim(domain%domain_name)
          deallocate(msg1, msg2)
       endif
 

--- a/mpp/include/mpp_do_get_boundary.fh
+++ b/mpp/include/mpp_do_get_boundary.fh
@@ -132,14 +132,14 @@ subroutine MPP_DO_GET_BOUNDARY_3D_( f_addrs, domain, bound, b_addrs, bsize, ke, 
 
       do m = 0, nlist-1
          if(msg1(m) .NE. msg2(m)) then
-            print*, "My pe = ", mpp_pe(), ",domain name =", trim(domain%name), ",from pe=", &
+            print*, "My pe = ", mpp_pe(), ",domain name =", trim(domain%domain_name), ",from pe=", &
                domain%list(m)%pe, ":send size = ", msg1(m), ", recv size = ", msg2(m)
             call mpp_error(FATAL, "mpp_do_get_boundary: mismatch on send and recv size")
          endif
       enddo
       call mpp_sync_self()
       write(outunit,*)"NOTE from mpp_do_get_boundary: message sizes are matched between send and recv for domain " &
-                       //trim(domain%name)
+                       //trim(domain%domain_name)
       deallocate(msg1, msg2)
   endif
   !recv
@@ -561,7 +561,7 @@ subroutine MPP_DO_GET_BOUNDARY_3D_V_(f_addrsx, f_addrsy, domain, boundx, boundy,
       call mpp_sync_self(check=EVENT_RECV)
       do m = 0, nlist-1
          if(msg1(m) .NE. msg2(m)) then
-            print*, "My pe = ", mpp_pe(), ",domain name =", trim(domain%name), ",from pe=", &
+            print*, "My pe = ", mpp_pe(), ",domain name =", trim(domain%domain_name), ",from pe=", &
                domain%list(m)%pe, ":send size = ", msg1(m), ", recv size = ", msg2(m)
             call mpp_error(FATAL, "mpp_do_get_boundaryV: mismatch on send and recv size")
          endif
@@ -569,7 +569,7 @@ subroutine MPP_DO_GET_BOUNDARY_3D_V_(f_addrsx, f_addrsy, domain, boundx, boundy,
 
       call mpp_sync_self()
       write(outunit,*)"NOTE from mpp_do_get_boundary_V: message sizes are matched between send and recv for domain " &
-                       //trim(domain%name)
+                       //trim(domain%domain_name)
       deallocate(msg1, msg2)
   endif
 

--- a/mpp/include/mpp_do_get_boundary_ad.fh
+++ b/mpp/include/mpp_do_get_boundary_ad.fh
@@ -134,14 +134,14 @@ subroutine MPP_DO_GET_BOUNDARY_AD_3D_( f_addrs, domain, bound, b_addrs, bsize, k
 
       do m = 0, nlist-1
          if(msg1(m) .NE. msg2(m)) then
-            print*, "My pe = ", mpp_pe(), ",domain name =", trim(domain%name), ",from pe=", &
+            print*, "My pe = ", mpp_pe(), ",domain name =", trim(domain%domain_name), ",from pe=", &
                domain%list(m)%pe, ":send size = ", msg1(m), ", recv size = ", msg2(m)
             call mpp_error(FATAL, "mpp_do_get_boundary: mismatch on send and recv size")
          endif
       enddo
       call mpp_sync_self()
       write(outunit,*)"NOTE from mpp_do_get_boundary: message sizes are matched between send and recv for domain " &
-                       //trim(domain%name)
+                       //trim(domain%domain_name)
       deallocate(msg1, msg2)
   endif
   !recv
@@ -563,7 +563,7 @@ subroutine MPP_DO_GET_BOUNDARY_AD_3D_V_(f_addrsx, f_addrsy, domain, boundx, boun
       call mpp_sync_self(check=EVENT_RECV)
       do m = 0, nlist-1
          if(msg1(m) .NE. msg2(m)) then
-            print*, "My pe = ", mpp_pe(), ",domain name =", trim(domain%name), ",from pe=", &
+            print*, "My pe = ", mpp_pe(), ",domain name =", trim(domain%domain_name), ",from pe=", &
                domain%list(m)%pe, ":send size = ", msg1(m), ", recv size = ", msg2(m)
             call mpp_error(FATAL, "mpp_do_get_boundaryV: mismatch on send and recv size")
          endif
@@ -571,7 +571,7 @@ subroutine MPP_DO_GET_BOUNDARY_AD_3D_V_(f_addrsx, f_addrsy, domain, boundx, boun
 
       call mpp_sync_self()
       write(outunit,*)"NOTE from mpp_do_get_boundary_V: message sizes are matched between send and recv for domain " &
-                       //trim(domain%name)
+                       //trim(domain%domain_name)
       deallocate(msg1, msg2)
   endif
 

--- a/mpp/include/mpp_do_update.fh
+++ b/mpp/include/mpp_do_update.fh
@@ -119,13 +119,13 @@
 
          do m = 0, nlist-1
             if(msg1(m) .NE. msg2(m)) then
-               print*, "My pe = ", mpp_pe(), ",domain name =", trim(domain%name), ",from pe=", &
+               print*, "My pe = ", mpp_pe(), ",domain name =", trim(domain%domain_name), ",from pe=", &
                     domain%list(m)%pe, ":send size = ", msg1(m), ", recv size = ", msg2(m)
                call mpp_error(FATAL, "mpp_do_update: mismatch on send and recv size")
             endif
          enddo
          write(outunit,*)"NOTE from mpp_do_update: message sizes are matched between send and recv for domain " &
-                          //trim(domain%name)
+                          //trim(domain%domain_name)
          deallocate(msg1, msg2, msg3)
       endif
 

--- a/mpp/include/mpp_do_updateV.fh
+++ b/mpp/include/mpp_do_updateV.fh
@@ -199,7 +199,7 @@
 !         call mpp_sync_self(check=EVENT_RECV)
          do m = 0, nlist-1
             if(msg1(m) .NE. msg2(m)) then
-               print*, "My pe = ", mpp_pe(), ",domain name =", trim(domain%name), ",from pe=", &
+               print*, "My pe = ", mpp_pe(), ",domain name =", trim(domain%domain_name), ",from pe=", &
                     domain%list(m)%pe, ":send size = ", msg1(m), ", recv size = ", msg2(m)
                call mpp_error(FATAL, "mpp_do_updateV: mismatch on send and recv size")
             endif
@@ -207,7 +207,7 @@
 
 !         call mpp_sync_self()
          write(outunit,*)"NOTE from mpp_do_updateV: message sizes are matched between send and recv for domain " &
-              //trim(domain%name)
+              //trim(domain%domain_name)
          deallocate(msg1, msg2, msg3)
       endif
 

--- a/mpp/include/mpp_do_updateV_ad.fh
+++ b/mpp/include/mpp_do_updateV_ad.fh
@@ -194,7 +194,7 @@
          call mpp_sync_self(check=EVENT_RECV)
          do m = 0, nlist-1
             if(msg1(m) .NE. msg2(m)) then
-               print*, "My pe = ", mpp_pe(), ",domain name =", trim(domain%name), ",from pe=", &
+               print*, "My pe = ", mpp_pe(), ",domain name =", trim(domain%domain_name), ",from pe=", &
                     domain%list(m)%pe, ":send size = ", msg1(m), ", recv size = ", msg2(m)
                call mpp_error(FATAL, "mpp_do_updateV: mismatch on send and recv size")
             endif
@@ -202,7 +202,7 @@
 
          call mpp_sync_self()
          write(outunit,*)"NOTE from mpp_do_updateV: message sizes are matched between send and recv for domain " &
-              //trim(domain%name)
+              //trim(domain%domain_name)
          deallocate(msg1, msg2)
       endif
 

--- a/mpp/include/mpp_do_update_ad.fh
+++ b/mpp/include/mpp_do_update_ad.fh
@@ -127,13 +127,13 @@
 
          do m = 0, nlist-1
             if(msg1(m) .NE. msg2(m)) then
-               print*, "My pe = ", mpp_pe(), ",domain name =", trim(domain%name), ",from pe=", &
+               print*, "My pe = ", mpp_pe(), ",domain name =", trim(domain%domain_name), ",from pe=", &
                     domain%list(m)%pe, ":send size = ", msg1(m), ", recv size = ", msg2(m)
                call mpp_error(FATAL, "mpp_do_update: mismatch on send and recv size")
             endif
          enddo
          write(outunit,*)"NOTE from mpp_do_update: message sizes are matched between send and recv for domain " &
-                          //trim(domain%name)
+                          //trim(domain%domain_name)
          deallocate(msg1, msg2, msg3)
       endif
 

--- a/mpp/include/mpp_domains_define.inc
+++ b/mpp/include/mpp_domains_define.inc
@@ -469,7 +469,7 @@
 
     if(io_layout(1) * io_layout(2) .LE. 0) then
        call mpp_error(NOTE,  &
-         "mpp_domains_define.inc(mpp_define_io_domain): io domain will not be defined for "//trim(domain%name)// &
+         "mpp_domains_define.inc(mpp_define_io_domain): io domain will not be defined for "//trim(domain%domain_name)//&
          " when one or both entry of io_layout is not positive")
        return
     endif
@@ -481,13 +481,13 @@
        "mpp_domains_define.inc(mpp_define_io_domain): io_domain is already defined")
 
     if(mod(layout(1), io_layout(1)) .NE. 0) call mpp_error(FATAL, &
-       "mpp_domains_define.inc(mpp_define_io_domain): "//trim(domain%name)// &
+       "mpp_domains_define.inc(mpp_define_io_domain): "//trim(domain%domain_name)// &
                              & " domain layout(1) must be divided by io_layout(1)")
     if(mod(layout(2), io_layout(2)) .NE. 0) call mpp_error(FATAL, &
-       "mpp_domains_define.inc(mpp_define_io_domain): "//trim(domain%name)// &
+       "mpp_domains_define.inc(mpp_define_io_domain): "//trim(domain%domain_name)// &
                              & " domain layout(2) must be divided by io_layout(2)")
     if(size(domain%x(:)) > 1) call mpp_error(FATAL, &
-       "mpp_domains_define.inc(mpp_define_io_domain): "//trim(domain%name)// &
+       "mpp_domains_define.inc(mpp_define_io_domain): "//trim(domain%domain_name)// &
        ": multiple tile per pe is not supported yet for this routine")
 
     if (associated(domain%io_domain)) deallocate(domain%io_domain) !< Check if associated
@@ -665,12 +665,12 @@
        if(len_trim(name) > NAME_LENGTH) call mpp_error(FATAL,  &
             "mpp_domains_define.inc(mpp_define_domains2D): the len_trim of optional argument name ="//trim(name)// &
             " is greater than NAME_LENGTH, change the argument name or increase NAME_LENGTH")
-       domain%name = name
+       domain%domain_name = name
     endif
     if(size(global_indices(:)) .NE. 4) call mpp_error(FATAL,   &
-       "mpp_define_domains2D: size of global_indices should be 4 for "//trim(domain%name) )
+       "mpp_define_domains2D: size of global_indices should be 4 for "//trim(domain%domain_name) )
     if(size(layout(:)) .NE. 2) call mpp_error(FATAL,"mpp_define_domains2D: size of layout should be 2 for "// &
-       & trim(domain%name) )
+       & trim(domain%domain_name) )
 
     ndivx = layout(1); ndivy = layout(2)
     isg = global_indices(1); ieg = global_indices(2); jsg = global_indices(3); jeg = global_indices(4)
@@ -709,18 +709,20 @@
     if(PRESENT(y_cyclic_offset)) y_offset = y_cyclic_offset
     if(x_offset*y_offset .NE. 0) call mpp_error(FATAL, &
        'MPP_DEFINE_DOMAINS2D: At least one of x_cyclic_offset and y_cyclic_offset must be zero for '// &
-       & trim(domain%name))
+       & trim(domain%domain_name))
 
     !--- x_cyclic_offset and y_cyclic_offset should no larger than the global grid size.
     if(abs(x_offset) > jeg-jsg+1) call mpp_error(FATAL, &
-         'MPP_DEFINE_DOMAINS2D: absolute value of x_cyclic_offset is greater than jeg-jsg+1 for '//trim(domain%name))
+         'MPP_DEFINE_DOMAINS2D: absolute value of x_cyclic_offset is greater than jeg-jsg+1 for '// &
+	 & trim(domain%domain_name))
     if(abs(y_offset) > ieg-isg+1) call mpp_error(FATAL, &
-         'MPP_DEFINE_DOMAINS2D: absolute value of y_cyclic_offset is greater than ieg-isg+1 for '//trim(domain%name))
+         'MPP_DEFINE_DOMAINS2D: absolute value of y_cyclic_offset is greater than ieg-isg+1 for '// &
+	 & trim(domain%domain_name))
 
     !--- when there is more than one tile on one processor, all the tile will limited on this processor
     if( tile > 1 .AND. size(pes(:)) > 1) call mpp_error(FATAL, &
          'MPP_DEFINE_DOMAINS2D: there are more than one tile on this pe, '// &
-         'all the tile should be limited on this pe for '//trim(domain%name))
+         'all the tile should be limited on this pe for '//trim(domain%domain_name))
 
     !--- the position of current pe is changed due to mosaic, because  pes
     !--- is only part of the pelist in mosaic (pesall). We assume the pe
@@ -761,7 +763,7 @@
     if( PRESENT(maskmap) )then
        if( size(maskmap,1).NE.ndivx .OR. size(maskmap,2).NE.ndivy ) &
             call mpp_error( FATAL, 'MPP_DEFINE_DOMAINS2D: maskmap array does not match layout for '// &
-                           & trim(domain%name) )
+                           & trim(domain%domain_name) )
        mask(:,:) = maskmap(:,:)
     end if
     !number of unmask domains in layout must equal number of PEs assigned
@@ -769,13 +771,13 @@
     if( n.NE.size(pes(:)) )then
        write( text,'(i8)' )n
        call mpp_error( FATAL, 'MPP_DEFINE_DOMAINS2D: incorrect number of PEs assigned for ' // &
-            'this layout and maskmap. Use '//text//' PEs for this domain decomposition for '//trim(domain%name) )
+            'this layout and maskmap. Use '//text//' PEs for this domain decomposition for '//trim(domain%domain_name) )
     end if
 
     memory_xsize = 0; memory_ysize = 0
     if(present(memory_size)) then
        if(size(memory_size(:)) .NE. 2) call mpp_error(FATAL,  &
-             "mpp_define_domains2D: size of memory_size should be 2 for "//trim(domain%name))
+             "mpp_define_domains2D: size of memory_size should be 2 for "//trim(domain%domain_name))
        memory_xsize = memory_size(1)
        memory_ysize = memory_size(2)
     end if
@@ -854,7 +856,7 @@
        domain%io_layout = layout
        domain%tile_root_pe  = pes(0)
        if( ipos.EQ.NULL_PE .OR. jpos.EQ.NULL_PE ) &
-            call mpp_error( FATAL, 'MPP_DEFINE_DOMAINS2D: pelist must include this PE for '//trim(domain%name) )
+            call mpp_error( FATAL, 'MPP_DEFINE_DOMAINS2D: pelist must include this PE for '//trim(domain%domain_name) )
        if( debug ) then
          errunit = stderr()
          write( errunit, * )'pe, tile, ipos, jpos=', mpp_pe(), tile, ipos, jpos, ' pearray(:,jpos)=', &
@@ -913,7 +915,7 @@
                  'MPP_DEFINE_DOMAINS: the domain could not be crossed when west is folded')
              endif
              if( domain%x(tile)%cyclic )call mpp_error( FATAL, &
-                   'MPP_DEFINE_DOMAINS: an axis cannot be both folded west and cyclic for '//trim(domain%name) )
+                   'MPP_DEFINE_DOMAINS: an axis cannot be both folded west and cyclic for '//trim(domain%domain_name) )
              domain%fold = domain%fold + FOLD_WEST_EDGE
              nfold = nfold+1
           endif
@@ -925,7 +927,7 @@
                  'MPP_DEFINE_DOMAINS: the domain could not be crossed when north is folded')
              endif
              if( domain%x(tile)%cyclic )call mpp_error( FATAL, &
-                  'MPP_DEFINE_DOMAINS: an axis cannot be both folded east and cyclic for '//trim(domain%name) )
+                  'MPP_DEFINE_DOMAINS: an axis cannot be both folded east and cyclic for '//trim(domain%domain_name) )
              domain%fold = domain%fold + FOLD_EAST_EDGE
              nfold = nfold+1
           endif
@@ -939,7 +941,7 @@
                  'MPP_DEFINE_DOMAINS: the domain could not be crossed when south is folded')
              endif
              if( domain%y(tile)%cyclic )call mpp_error( FATAL, &
-                 'MPP_DEFINE_DOMAINS: an axis cannot be both folded north and cyclic for '//trim(domain%name))
+                 'MPP_DEFINE_DOMAINS: an axis cannot be both folded north and cyclic for '//trim(domain%domain_name))
              domain%fold = domain%fold + FOLD_SOUTH_EDGE
              nfold = nfold+1
           endif
@@ -961,47 +963,47 @@
 
 
              if( domain%y(tile)%cyclic )call mpp_error( FATAL, &
-                'MPP_DEFINE_DOMAINS: an axis cannot be both folded south and cyclic for '//trim(domain%name) )
+                'MPP_DEFINE_DOMAINS: an axis cannot be both folded south and cyclic for '//trim(domain%domain_name) )
              domain%fold = domain%fold + FOLD_NORTH_EDGE
              nfold = nfold+1
           endif
        endif
        if(nfold > 1) call mpp_error(FATAL, &
-           'MPP_DEFINE_DOMAINS2D: number of folded edge is greater than 1 for '//trim(domain%name) )
+           'MPP_DEFINE_DOMAINS2D: number of folded edge is greater than 1 for '//trim(domain%domain_name) )
 
        if(nfold == 1) then
            if( x_offset .NE. 0 .OR. y_offset .NE. 0) call mpp_error(FATAL, &
                'MPP_DEFINE_DOMAINS2D: For the foled_north/folded_south/fold_east/folded_west boundary condition,  '//&
-               'x_cyclic_offset and y_cyclic_offset must be zero for '//trim(domain%name))
+               'x_cyclic_offset and y_cyclic_offset must be zero for '//trim(domain%domain_name))
        endif
        if( BTEST(domain%fold,SOUTH) .OR. BTEST(domain%fold,NORTH) )then
           if( domain%y(tile)%cyclic )call mpp_error( FATAL, &
-              'MPP_DEFINE_DOMAINS: an axis cannot be both folded and cyclic for '//trim(domain%name) )
+              'MPP_DEFINE_DOMAINS: an axis cannot be both folded and cyclic for '//trim(domain%domain_name) )
           if( modulo(domain%x(tile)%global%size,2).NE.0 ) &
                call mpp_error( FATAL, 'MPP_DEFINE_DOMAINS: number of points in X must be even ' // &
-                  'when there is a fold in Y for '//trim(domain%name) )
+                  'when there is a fold in Y for '//trim(domain%domain_name) )
           !check if folded domain boundaries line up in X: compute domains lining up is a sufficient
           !condition for symmetry
           n = ndivx - 1
           do i = 0,n/2
              if( domain%x(tile)%list(i)%compute%size.NE.domain%x(tile)%list(n-i)%compute%size ) &
                   call mpp_error( FATAL, 'MPP_DEFINE_DOMAINS: Folded domain boundaries ' // &
-                                         'must line up (mirror-symmetric extents) for '//trim(domain%name) )
+                                         'must line up (mirror-symmetric extents) for '//trim(domain%domain_name) )
           end do
        end if
        if( BTEST(domain%fold,WEST) .OR. BTEST(domain%fold,EAST) )then
           if( domain%x(tile)%cyclic )call mpp_error( FATAL, &
-             'MPP_DEFINE_DOMAINS: an axis cannot be both folded and cyclic for '//trim(domain%name) )
+             'MPP_DEFINE_DOMAINS: an axis cannot be both folded and cyclic for '//trim(domain%domain_name) )
           if( modulo(domain%y(tile)%global%size,2).NE.0 ) &
                call mpp_error( FATAL, 'MPP_DEFINE_DOMAINS: number of points in Y must be even '//&
-                   'when there is a fold in X for '//trim(domain%name) )
+                   'when there is a fold in X for '//trim(domain%domain_name) )
           !check if folded domain boundaries line up in Y: compute domains lining up is a sufficient
           !condition for symmetry
           n = ndivy - 1
           do i = 0,n/2
              if( domain%y(tile)%list(i)%compute%size.NE.domain%y(tile)%list(n-i)%compute%size ) &
                   call mpp_error( FATAL, 'MPP_DEFINE_DOMAINS: Folded domain boundaries must '//&
-                        'line up (mirror-symmetric extents) for '//trim(domain%name) )
+                        'line up (mirror-symmetric extents) for '//trim(domain%domain_name) )
           end do
        end if
 
@@ -1063,10 +1065,10 @@
           call compute_overlaps(domain, NORTH,  domain%update_N, domain%check_N,      0, jshift, x_offset, y_offset, &
                                 domain%whalo, domain%ehalo, domain%shalo, domain%nhalo)
        endif
-       call check_overlap_pe_order(domain, domain%update_T, trim(domain%name)//" update_T in mpp_define_domains")
-       call check_overlap_pe_order(domain, domain%update_C, trim(domain%name)//" update_C in mpp_define_domains")
-       call check_overlap_pe_order(domain, domain%update_E, trim(domain%name)//" update_E in mpp_define_domains")
-       call check_overlap_pe_order(domain, domain%update_N, trim(domain%name)//" update_N in mpp_define_domains")
+       call check_overlap_pe_order(domain, domain%update_T, trim(domain%domain_name)//" update_T in mpp_define_domains")
+       call check_overlap_pe_order(domain, domain%update_C, trim(domain%domain_name)//" update_C in mpp_define_domains")
+       call check_overlap_pe_order(domain, domain%update_E, trim(domain%domain_name)//" update_E in mpp_define_domains")
+       call check_overlap_pe_order(domain, domain%update_N, trim(domain%domain_name)//" update_N in mpp_define_domains")
 
 
        !--- when ncontacts is nonzero, set_check_overlap will be called in mpp_define
@@ -1170,7 +1172,7 @@ subroutine check_message_size(domain, update, send, recv, position)
 
   do m = 0, nlist-1
      if(msg1(m) .NE. msg2(m)) then
-        print*, "My pe = ", mpp_pe(), ",domain name =", trim(domain%name), ",at position=",position,",from pe=", &
+        print*, "My pe = ", mpp_pe(), ",domain name =", trim(domain%domain_name), ",at position=",position,",from pe=", &
              domain%list(m)%pe, ":send size = ", msg1(m), ", recv size = ", msg2(m)
         call mpp_error(FATAL, "mpp_define_domains2D: mismatch on send and recv size")
      endif
@@ -1528,10 +1530,10 @@ end subroutine check_message_size
           end if
        end do
     end do
-    call check_overlap_pe_order(domain, domain%update_T, trim(domain%name)//" update_T in mpp_define_mosaic")
-    call check_overlap_pe_order(domain, domain%update_C, trim(domain%name)//" update_C in mpp_define_mosaic")
-    call check_overlap_pe_order(domain, domain%update_E, trim(domain%name)//" update_E in mpp_define_mosaic")
-    call check_overlap_pe_order(domain, domain%update_N, trim(domain%name)//" update_N in mpp_define_mosaic")
+    call check_overlap_pe_order(domain, domain%update_T, trim(domain%domain_name)//" update_T in mpp_define_mosaic")
+    call check_overlap_pe_order(domain, domain%update_C, trim(domain%domain_name)//" update_C in mpp_define_mosaic")
+    call check_overlap_pe_order(domain, domain%update_E, trim(domain%domain_name)//" update_E in mpp_define_mosaic")
+    call check_overlap_pe_order(domain, domain%update_N, trim(domain%domain_name)//" update_N in mpp_define_mosaic")
 
     !--- set the overlapping for boundary check if domain is symmetry
     if(debug_update_level .NE. NO_CHECK) then
@@ -1547,9 +1549,9 @@ end subroutine check_message_size
        call set_bound_overlap( domain, CORNER )
        call set_bound_overlap( domain, EAST   )
        call set_bound_overlap( domain, NORTH  )
-       call check_overlap_pe_order(domain, domain%bound_C, trim(domain%name)//" bound_C")
-       call check_overlap_pe_order(domain, domain%bound_E, trim(domain%name)//" bound_E")
-       call check_overlap_pe_order(domain, domain%bound_N, trim(domain%name)//" bound_N")
+       call check_overlap_pe_order(domain, domain%bound_C, trim(domain%domain_name)//" bound_C")
+       call check_overlap_pe_order(domain, domain%bound_E, trim(domain%domain_name)//" bound_E")
+       call check_overlap_pe_order(domain, domain%bound_N, trim(domain%domain_name)//" bound_N")
     end if
 
     !--- check the send and recv size are matching.
@@ -1648,7 +1650,7 @@ end subroutine check_message_size
     folded_north = BTEST(domain%fold,NORTH)
     if( BTEST(domain%fold,SOUTH) .OR. BTEST(domain%fold,EAST) .OR. BTEST(domain%fold,WEST) ) then
        call mpp_error(FATAL,"mpp_domains_define.inc(compute_overlaps): folded south, east or west boundary condition "&
-            &//"is not supported, please use other version of compute_overlaps for "//trim(domain%name))
+            &//"is not supported, please use other version of compute_overlaps for "//trim(domain%domain_name))
     endif
 
     nsend = 0
@@ -3078,16 +3080,16 @@ end subroutine check_message_size
 
     if(.NOT. BTEST(domain%fold,SOUTH)) then
        call mpp_error(FATAL, "mpp_domains_define.inc(compute_overlaps_fold_south): "//&
-            "boundary condition in y-direction should be folded-south for "//trim(domain%name))
+            "boundary condition in y-direction should be folded-south for "//trim(domain%domain_name))
     endif
     if(.NOT. domain%x(tMe)%cyclic) then
        call mpp_error(FATAL, "mpp_domains_define.inc(compute_overlaps_fold_south): "//&
-            "boundary condition in x-direction should be cyclic for "//trim(domain%name))
+            "boundary condition in x-direction should be cyclic for "//trim(domain%domain_name))
     endif
 
     if(.not. domain%symmetry) then
        call mpp_error(FATAL, "mpp_domains_define.inc(compute_overlaps_fold_south): "//&
-            "when south boundary is folded, the domain must be symmetry for "//trim(domain%name))
+            "when south boundary is folded, the domain must be symmetry for "//trim(domain%domain_name))
     endif
 
     nsend = 0
@@ -3718,16 +3720,16 @@ end subroutine check_message_size
 
     if(.NOT. BTEST(domain%fold,WEST)) then
        call mpp_error(FATAL, "mpp_domains_define.inc(compute_overlaps_fold_west): "//&
-            "boundary condition in y-direction should be folded-west for "//trim(domain%name))
+            "boundary condition in y-direction should be folded-west for "//trim(domain%domain_name))
     endif
     if(.NOT. domain%y(tMe)%cyclic) then
        call mpp_error(FATAL, "mpp_domains_define.inc(compute_overlaps_fold_west): "//&
-            "boundary condition in y-direction should be cyclic for "//trim(domain%name))
+            "boundary condition in y-direction should be cyclic for "//trim(domain%domain_name))
     endif
 
     if(.not. domain%symmetry) then
        call mpp_error(FATAL, "mpp_domains_define.inc(compute_overlaps_fold_west): "//&
-            "when west boundary is folded, the domain must be symmetry for "//trim(domain%name))
+            "when west boundary is folded, the domain must be symmetry for "//trim(domain%domain_name))
     endif
 
     nsend = 0
@@ -4340,15 +4342,15 @@ end subroutine check_message_size
 
     if(.NOT. BTEST(domain%fold,EAST)) then
        call mpp_error(FATAL, "mpp_domains_define.inc(compute_overlaps_fold_east): "//&
-            "boundary condition in y-direction should be folded-east for "//trim(domain%name))
+            "boundary condition in y-direction should be folded-east for "//trim(domain%domain_name))
     endif
     if(.NOT. domain%y(tMe)%cyclic) then
        call mpp_error(FATAL, "mpp_domains_define.inc(compute_overlaps_fold_east): "//&
-            "boundary condition in y-direction should be cyclic for "//trim(domain%name))
+            "boundary condition in y-direction should be cyclic for "//trim(domain%domain_name))
     endif
     if(.not. domain%symmetry) then
        call mpp_error(FATAL, "mpp_domains_define.inc(compute_overlaps_fold_east): "//&
-            "when east boundary is folded, the domain must be symmetry for "//trim(domain%name))
+            "when east boundary is folded, the domain must be symmetry for "//trim(domain%domain_name))
     endif
 
     nsend = 0
@@ -5034,7 +5036,7 @@ end subroutine check_message_size
     do m = 1, nsend_in
        ptrIn  => overlap_in%send(m)
        if(ptrIn%count .LE. 0) call mpp_error(FATAL, "mpp_domains_define.inc(set_overlaps):"// &
-                              " number of overlap for send should be a positive number for"//trim(domain%name) )
+                              " number of overlap for send should be a positive number for"//trim(domain%domain_name) )
        do n = 1, ptrIn%count
           dir = ptrIn%dir(n)
           rotation = ptrIn%rotation(n)
@@ -8142,10 +8144,10 @@ end subroutine expand_check_overlap_list
 
 
 !###############################################################################
-subroutine check_overlap_pe_order(domain, overlap, name)
+subroutine check_overlap_pe_order(domain, overlap, domain_name)
   type(domain2d),    intent(in) :: domain
   type(overlapSpec), intent(in) :: overlap
-  character(len=*),  intent(in) :: name
+  character(len=*),  intent(in) :: domain_name
   integer                       :: m
   integer                       :: pe1, pe2
 
@@ -8160,17 +8162,17 @@ subroutine check_overlap_pe_order(domain, overlap, name)
      pe2 = overlap%send(m)%pe
      !-- when p1 == domain%pe, pe2 could be any value except domain%pe
      if( pe2 == domain%pe ) then
-        print*, trim(name)//" at pe = ", domain%pe, ": send pe is ", pe1, pe2
+        print*, trim(domain_name)//" at pe = ", domain%pe, ": send pe is ", pe1, pe2
         call mpp_error(FATAL, &
              "mpp_domains_define.inc(check_overlap_pe_order): send pe2 can not equal to domain%pe")
      else if( (pe1 > domain%pe .AND. pe2 > domain%pe) .OR. (pe1 < domain%pe .AND. pe2 < domain%pe)) then
         if( pe2 < pe1 ) then
-           print*, trim(name)//" at pe = ", domain%pe, ": send pe is ", pe1, pe2
+           print*, trim(domain_name)//" at pe = ", domain%pe, ": send pe is ", pe1, pe2
            call mpp_error(FATAL, &
              "mpp_domains_define.inc(check_overlap_pe_order): pe is not in right order for send 1")
         endif
      else if ( pe2 > domain%pe .AND. pe1 < domain%pe ) then
-        print*, trim(name)//" at pe = ", domain%pe, ": send pe is ", pe1, pe2
+        print*, trim(domain_name)//" at pe = ", domain%pe, ": send pe is ", pe1, pe2
         call mpp_error(FATAL, &
              "mpp_domains_define.inc(check_overlap_pe_order): pe is not in right order for send 2")
      endif
@@ -8182,17 +8184,17 @@ subroutine check_overlap_pe_order(domain, overlap, name)
      pe2 = overlap%recv(m)%pe
      !-- when p1 == domain%pe, pe2 could be any value except domain%pe
      if( pe2 == domain%pe ) then
-        print*, trim(name)//" at pe = ", domain%pe, ": recv pe is ", pe1, pe2
+        print*, trim(domain_name)//" at pe = ", domain%pe, ": recv pe is ", pe1, pe2
         call mpp_error(FATAL, &
              "mpp_domains_define.inc(check_overlap_pe_order): recv pe2 can not equal to domain%pe")
      else if( (pe1 > domain%pe .AND. pe2 > domain%pe) .OR. (pe1 < domain%pe .AND. pe2 < domain%pe)) then
         if( pe2 > pe1 ) then
-           print*, trim(name)//" at pe = ", domain%pe, ": recv pe is ", pe1, pe2
+           print*, trim(domain_name)//" at pe = ", domain%pe, ": recv pe is ", pe1, pe2
            call mpp_error(FATAL, &
              "mpp_domains_define.inc(check_overlap_pe_order): pe is not in right order for recv 1")
         endif
      else if ( pe2 < domain%pe .AND. pe1 > domain%pe ) then
-        print*, trim(name)//" at pe = ", domain%pe, ": recv pe is ", pe1, pe2
+        print*, trim(domain_name)//" at pe = ", domain%pe, ": recv pe is ", pe1, pe2
         call mpp_error(FATAL, &
              "mpp_domains_define.inc(check_overlap_pe_order): pe is not in right order for recv 2")
      endif

--- a/mpp/include/mpp_domains_define.inc
+++ b/mpp/include/mpp_domains_define.inc
@@ -714,10 +714,10 @@
     !--- x_cyclic_offset and y_cyclic_offset should no larger than the global grid size.
     if(abs(x_offset) > jeg-jsg+1) call mpp_error(FATAL, &
          'MPP_DEFINE_DOMAINS2D: absolute value of x_cyclic_offset is greater than jeg-jsg+1 for '// &
-	 & trim(domain%domain_name))
+         & trim(domain%domain_name))
     if(abs(y_offset) > ieg-isg+1) call mpp_error(FATAL, &
          'MPP_DEFINE_DOMAINS2D: absolute value of y_cyclic_offset is greater than ieg-isg+1 for '// &
-	 & trim(domain%domain_name))
+         & trim(domain%domain_name))
 
     !--- when there is more than one tile on one processor, all the tile will limited on this processor
     if( tile > 1 .AND. size(pes(:)) > 1) call mpp_error(FATAL, &
@@ -1172,7 +1172,7 @@ subroutine check_message_size(domain, update, send, recv, position)
 
   do m = 0, nlist-1
      if(msg1(m) .NE. msg2(m)) then
-        print*, "My pe = ", mpp_pe(), ",domain name =", trim(domain%domain_name), ",at position=",position,",from pe=", &
+        print*, "My pe = ", mpp_pe(), ",domain name =", trim(domain%domain_name), ",at position=",position,",from pe=",&
              domain%list(m)%pe, ":send size = ", msg1(m), ", recv size = ", msg2(m)
         call mpp_error(FATAL, "mpp_define_domains2D: mismatch on send and recv size")
      endif

--- a/mpp/include/mpp_domains_util.inc
+++ b/mpp/include/mpp_domains_util.inc
@@ -1423,7 +1423,7 @@ end subroutine mpp_get_tile_compute_domains
      type(domain2d),    intent(in) :: domain
      character(len=NAME_LENGTH)    :: mpp_get_domain_name
 
-     mpp_get_domain_name = domain%name
+     mpp_get_domain_name = domain%domain_name
 
   end function mpp_get_domain_name
 
@@ -1780,7 +1780,7 @@ end subroutine mpp_get_tile_compute_domains
      domain_out%initialized    = domain_in%initialized
      domain_out%tile_root_pe   = domain_in%tile_root_pe
      domain_out%io_layout      = domain_in%io_layout
-     domain_out%name           = domain_in%name
+     domain_out%domain_name    = domain_in%domain_name
 
      ntiles = size(domain_in%x(:))
      allocate(domain_out%x(ntiles), domain_out%y(ntiles), domain_out%tile_id(ntiles) )

--- a/mpp/include/mpp_util.inc
+++ b/mpp/include/mpp_util.inc
@@ -435,8 +435,8 @@ end function rarray_to_char
 
     if( .NOT.module_is_initialized )call mpp_error( FATAL, 'MPP_DECLARE_PELIST: You must first call mpp_init.' )
     i = get_peset(pelist)
-    write( peset(i)%name,'(a,i2.2)' ) 'PElist', i !default name
-    if( PRESENT(name) )peset(i)%name = name
+    write( peset(i)%pelist_name,'(a,i2.2)' ) 'PElist', i !default name
+    if( PRESENT(name) )peset(i)%pelist_name = name
     return
   end subroutine mpp_declare_pelist
 
@@ -481,9 +481,9 @@ end function rarray_to_char
   !#####################################################################
   function mpp_get_current_pelist_name()
    ! Simply return the current pelist name
-   character(len=len(peset(current_peset_num)%name)) :: mpp_get_current_pelist_name
+   character(len=len(peset(current_peset_num)%pelist_name)) :: mpp_get_current_pelist_name
 
-   mpp_get_current_pelist_name = peset(current_peset_num)%name
+   mpp_get_current_pelist_name = peset(current_peset_num)%pelist_name
   end function mpp_get_current_pelist_name
 
   !#####################################################################
@@ -497,7 +497,7 @@ end function rarray_to_char
     if( size(pelist(:)).NE.size(peset(current_peset_num)%list(:)) ) &
          call mpp_error( FATAL, 'MPP_GET_CURRENT_PELIST: size(pelist) is wrong.' )
     pelist(:) = peset(current_peset_num)%list(:)
-    if( PRESENT(name) )name = peset(current_peset_num)%name
+    if( PRESENT(name) )name = peset(current_peset_num)%pelist_name
 #ifdef use_libMPI
     if( PRESENT(commID) )commID = peset(current_peset_num)%id
 #endif
@@ -618,13 +618,13 @@ end function rarray_to_char
   end subroutine mpp_clock_set_grain
 
   !#####################################################################
-  subroutine clock_init( id, name, flags, grain )
+  subroutine clock_init( id, clock_name, flags, grain )
     integer,           intent(in) :: id
-    character(len=*),  intent(in) :: name
+    character(len=*),  intent(in) :: clock_name
     integer, intent(in), optional :: flags, grain
     integer                       :: i
 
-    clocks(id)%name = name
+    clocks(id)%clock_name = clock_name
     clocks(id)%hits = 0
     clocks(id)%tick = 0
     clocks(id)%total_ticks = 0
@@ -639,22 +639,22 @@ end function rarray_to_char
     if( PRESENT(grain) )clocks(id)%grain = grain
     if( clocks(id)%detailed )then
        allocate( clocks(id)%events(MAX_EVENT_TYPES) )
-       clocks(id)%events(EVENT_ALLREDUCE)%name = 'ALLREDUCE'
-       clocks(id)%events(EVENT_BROADCAST)%name = 'BROADCAST'
-       clocks(id)%events(EVENT_RECV)%name = 'RECV'
-       clocks(id)%events(EVENT_SEND)%name = 'SEND'
-       clocks(id)%events(EVENT_WAIT)%name = 'WAIT'
+       clocks(id)%events(EVENT_ALLREDUCE)%event_name = 'ALLREDUCE'
+       clocks(id)%events(EVENT_BROADCAST)%event_name = 'BROADCAST'
+       clocks(id)%events(EVENT_RECV)%event_name = 'RECV'
+       clocks(id)%events(EVENT_SEND)%event_name = 'SEND'
+       clocks(id)%events(EVENT_WAIT)%event_name = 'WAIT'
        do i=1,MAX_EVENT_TYPES
           clocks(id)%events(i)%ticks(:) = 0
           clocks(id)%events(i)%bytes(:) = 0
           clocks(id)%events(i)%calls = 0
        end do
-       clock_summary(id)%name = name
-       clock_summary(id)%event(EVENT_ALLREDUCE)%name = 'ALLREDUCE'
-       clock_summary(id)%event(EVENT_BROADCAST)%name = 'BROADCAST'
-       clock_summary(id)%event(EVENT_RECV)%name = 'RECV'
-       clock_summary(id)%event(EVENT_SEND)%name = 'SEND'
-       clock_summary(id)%event(EVENT_WAIT)%name = 'WAIT'
+       clock_summary(id)%struct_name = clock_name
+       clock_summary(id)%event(EVENT_ALLREDUCE)%summary_name = 'ALLREDUCE'
+       clock_summary(id)%event(EVENT_BROADCAST)%summary_name = 'BROADCAST'
+       clock_summary(id)%event(EVENT_RECV)%summary_name = 'RECV'
+       clock_summary(id)%event(EVENT_SEND)%summary_name = 'SEND'
+       clock_summary(id)%event(EVENT_WAIT)%summary_name = 'WAIT'
        do i=1,MAX_EVENT_TYPES
           clock_summary(id)%event(i)%msg_size_sums(:) = 0.0
           clock_summary(id)%event(i)%msg_time_sums(:) = 0.0
@@ -669,9 +669,9 @@ end function rarray_to_char
 
   !#####################################################################
   !> Return an ID for a new or existing clock
-  function mpp_clock_id( name, flags, grain )
+  function mpp_clock_id( clock_name, flags, grain )
     integer                       :: mpp_clock_id
-    character(len=*),  intent(in) :: name
+    character(len=*),  intent(in) :: clock_name
     integer, intent(in), optional :: flags, grain
 
     if( .NOT.module_is_initialized )call mpp_error( FATAL, 'MPP_CLOCK_ID: You must first call mpp_init.')
@@ -690,9 +690,9 @@ end function rarray_to_char
 
     if( clock_num.EQ.0 )then  !first
        clock_num = mpp_clock_id
-       call clock_init(mpp_clock_id,name,flags)
+       call clock_init(mpp_clock_id,clock_name,flags)
     else
-       FIND_CLOCK: do while( trim(name).NE.trim(clocks(mpp_clock_id)%name) )
+       FIND_CLOCK: do while( trim(clock_name).NE.trim(clocks(mpp_clock_id)%clock_name) )
           mpp_clock_id = mpp_clock_id + 1
           if( mpp_clock_id.GT.clock_num )then
              if( mpp_clock_id.GT.MAX_CLOCKS )then
@@ -700,7 +700,7 @@ end function rarray_to_char
                       'check your clock id request or increase MAX_CLOCKS.')
              else               !new clock: initialize
                 clock_num = mpp_clock_id
-                call clock_init(mpp_clock_id,name,flags,grain)
+                call clock_init(mpp_clock_id,clock_name,flags,grain)
                 exit FIND_CLOCK
              end if
           end if
@@ -722,7 +722,7 @@ end function rarray_to_char
     if( clocks(id)%peset_num.NE.current_peset_num ) &
          call mpp_error( FATAL, 'MPP_CLOCK_BEGIN: cannot change pelist context of a clock.' )
     if( clocks(id)%is_on) call mpp_error(FATAL, 'MPP_CLOCK_BEGIN: mpp_clock_begin is called again '// &
-                'before calling mpp_clock_end for the clock '//trim(clocks(id)%name) )
+                'before calling mpp_clock_end for the clock '//trim(clocks(id)%clock_name) )
     if( clocks(id)%sync_on_begin .OR. sync_all_clocks )then
        !do an untimed sync at the beginning of the clock
        !this puts all PEs in the current pelist on par, so that measurements begin together
@@ -755,7 +755,7 @@ end function rarray_to_char
     if( id.LT.0 .OR. id.GT.clock_num )call mpp_error( FATAL, 'MPP_CLOCK_BEGIN: invalid id.' )
 !$OMP MASTER
     if( .NOT. clocks(id)%is_on) call mpp_error(FATAL, 'MPP_CLOCK_END: mpp_clock_end is called '// &
-                'before calling mpp_clock_begin for the clock '//trim(clocks(id)%name) )
+                'before calling mpp_clock_begin for the clock '//trim(clocks(id)%clock_name) )
 
     call SYSTEM_CLOCK(end_tick)
     if( clocks(id)%peset_num.NE.current_peset_num ) &
@@ -812,7 +812,7 @@ end function rarray_to_char
 
     if( n.EQ.MAX_EVENTS )call mpp_error( WARNING, &
          'MPP_CLOCK: events exceed MAX_EVENTS, ignore detailed profiling data for clock '// &
-         & trim(clocks(current_clock)%name) )
+         & trim(clocks(current_clock)%clock_name) )
     if( n.GT.MAX_EVENTS )return
 
     clocks(current_clock)%events(event_id)%calls = n
@@ -871,7 +871,7 @@ end function rarray_to_char
 
        if( .NOT.clocks(ct)%detailed )cycle
        write(SD_UNIT,*) &
-            clock_summary(ct)%name(1:15),' Communication Data for PE ',pe
+            clock_summary(ct)%struct_name(1:15),' Communication Data for PE ',pe
 
        write(SD_UNIT,*) ' '
        write(SD_UNIT,*) ' '
@@ -886,7 +886,7 @@ end function rarray_to_char
           total_data = clock_summary(ct)%event(k)%total_data
           total_calls = int(clock_summary(ct)%event(k)%total_cnts)
 
-          write(SD_UNIT,1000) clock_summary(ct)%event(k)%name(1:9) // ':'
+          write(SD_UNIT,1000) clock_summary(ct)%event(k)%summary_name(1:9) // ':'
 
           write(SD_UNIT,1001) 'Total Data: ',total_data*1.0e-6, &
                'MB; Total Time: ', total_time, &
@@ -933,7 +933,7 @@ end function rarray_to_char
           total_time_all = total_time_all + total_time
           total_calls = int(clock_summary(ct)%event(MAX_EVENT_TYPES)%total_cnts)
 
-          write(SD_UNIT,1000) clock_summary(ct)%event(MAX_EVENT_TYPES)%name(1:9) // ':'
+          write(SD_UNIT,1000) clock_summary(ct)%event(MAX_EVENT_TYPES)%summary_name(1:9) // ':'
 
           write(SD_UNIT,1004) 'Total Calls: ',total_calls,'; Total Time: ', &
                total_time,'secs'
@@ -942,7 +942,7 @@ end function rarray_to_char
 
        write(SD_UNIT,*) ' '
        write(SD_UNIT,1005) 'Total communication time spent for ' // &
-            clock_summary(ct)%name(1:9) // ': ',total_time_all,'secs'
+            clock_summary(ct)%struct_name(1:9) // ': ',total_time_all,'secs'
        write(SD_UNIT,*) ' '
        write(SD_UNIT,*) ' '
        write(SD_UNIT,*) ' '
@@ -1078,7 +1078,7 @@ end function rarray_to_char
         peset_old(n)%count      = peset(n)%count
         peset_old(n)%id         = peset(n)%id
         peset_old(n)%group      = peset(n)%group
-        peset_old(n)%name       = peset(n)%name
+        peset_old(n)%pelist_name= peset(n)%pelist_name
         peset_old(n)%start      = peset(n)%start
         peset_old(n)%log2stride = peset(n)%log2stride
 
@@ -1098,12 +1098,12 @@ end function rarray_to_char
      peset(:)%group = -1
      peset(:)%start = -1
      peset(:)%log2stride = -1
-     peset(:)%name  = " "
+     peset(:)%pelist_name  = " "
      do n = 0, old_peset_max
         peset(n)%count      = peset_old(n)%count
         peset(n)%id         = peset_old(n)%id
         peset(n)%group      = peset_old(n)%group
-        peset(n)%name       = peset_old(n)%name
+        peset(n)%pelist_name= peset_old(n)%pelist_name
         peset(n)%start      = peset_old(n)%start
         peset(n)%log2stride = peset_old(n)%log2stride
 
@@ -1195,7 +1195,7 @@ end function rarray_to_char
     integer :: i
     integer, dimension(2) :: lines_and_length
     logical :: file_exist
-    character(len=len(peset(current_peset_num)%name)) :: pelist_name
+    character(len=len(peset(current_peset_num)%pelist_name)) :: pelist_name
     character(len=128) :: filename
 
 ! check the status of input_nml_file

--- a/mpp/mpp.F90
+++ b/mpp/mpp.F90
@@ -229,7 +229,7 @@ private
   !> @ingroup mpp_mod
   type :: communicator
      private
-     character(len=32) :: name
+     character(len=32) :: pelist_name
      integer, pointer  :: list(:) =>NULL()
      integer           :: count
      integer           :: start, log2stride !< dummy variables when libMPI is defined.
@@ -240,7 +240,7 @@ private
   !> @ingroup mpp_mod
   type :: event
      private
-     character(len=16)                         :: name
+     character(len=16)                         :: event_name
      integer(i8_kind), dimension(MAX_EVENTS)   :: ticks, bytes
      integer                                   :: calls
   end type event
@@ -249,7 +249,7 @@ private
   !> @ingroup mpp_mod
   type :: clock
      private
-     character(len=32)    :: name
+     character(len=32)    :: clock_name
      integer(i8_kind)     :: hits
      integer(i8_kind)     :: tick
      integer(i8_kind)     :: total_ticks
@@ -265,7 +265,7 @@ private
   !> @ingroup mpp_mod
   type :: Clock_Data_Summary
      private
-     character(len=16)  :: name
+     character(len=16)  :: summary_name
      real(r8_kind)      :: msg_size_sums(MAX_BINS)
      real(r8_kind)      :: msg_time_sums(MAX_BINS)
      real(r8_kind)      :: total_data
@@ -278,7 +278,7 @@ private
   !> @ingroup mpp_mod
   type :: Summary_Struct
      private
-     character(len=16)         :: name
+     character(len=16)         :: struct_name
      type (Clock_Data_Summary) :: event(MAX_EVENT_TYPES)
   end type Summary_Struct
 

--- a/mpp/mpp_domains.F90
+++ b/mpp/mpp_domains.F90
@@ -365,7 +365,7 @@ module mpp_domains_mod
   !> @ingroup mpp_domains_mod
   TYPE :: domain2D
      private
-     character(len=NAME_LENGTH)  :: name='unnamed' !< name of the domain, default is "unspecified"
+     character(len=NAME_LENGTH)  :: domain_name='unnamed' !< name of the domain, default is "unspecified"
      integer(i8_kind)            :: id
      integer                     :: pe             !< PE to which this domain is assigned
      integer                     :: fold
@@ -450,7 +450,7 @@ module mpp_domains_mod
   !> @brief domain with nested fine and course tiles
   !> @ingroup mpp_domains_mod
   type :: nest_domain_type
-     character(len=NAME_LENGTH)     :: name
+     character(len=NAME_LENGTH)     :: domain_name
      integer                        :: num_level
      integer,               pointer :: nest_level(:) => NULL() !< Added for moving nest functionality
      type(nest_level_type), pointer :: nest(:) => NULL()

--- a/mpp/mpp_pset.F90
+++ b/mpp/mpp_pset.F90
@@ -81,7 +81,7 @@ module mpp_pset_mod
      integer(POINTER_KIND) :: p_stack
      integer :: lstack, maxstack, hiWM !current stack length, max, hiWM
      integer :: commID
-     character(len=32) :: name
+     character(len=32) :: pelist_name
      logical :: initialized=.FALSE.
   end type mpp_pset_type
 !public types

--- a/test_fms/coupler/test_atmos_ocean_fluxes.F90
+++ b/test_fms/coupler/test_atmos_ocean_fluxes.F90
@@ -111,7 +111,7 @@ contains
 
     !> set flux fields
     do i=1, num_bcs
-       coupler_index(i)=aof_set_coupler_flux(name=flux_name(i), &
+       coupler_index(i)=aof_set_coupler_flux(flux_name=flux_name(i), &
                                              flux_type=flux_type(i), &
                                              implementation=impl(i), &
                                              atm_tr_index=atm_tr_index(i), &
@@ -161,9 +161,9 @@ contains
 
     do i=1, num_bcs
        !> check fluxes name
-       call check_answers(flux_name(i), gas_fluxes%FMS_TEST_BC_TYPE_(i)%name, 'gas_fluxes flux name')
-       call check_answers(flux_name(i), gas_fields_atm%FMS_TEST_BC_TYPE_(i)%name, 'gas_fields_atms flux name')
-       call check_answers(flux_name(i), gas_fields_ice%FMS_TEST_BC_TYPE_(i)%name, 'gas_fields_ice flux name')
+       call check_answers(flux_name(i), gas_fluxes%FMS_TEST_BC_TYPE_(i)%field_name, 'gas_fluxes flux name')
+       call check_answers(flux_name(i), gas_fields_atm%FMS_TEST_BC_TYPE_(i)%field_name, 'gas_fields_atms flux name')
+       call check_answers(flux_name(i), gas_fields_ice%FMS_TEST_BC_TYPE_(i)%field_name, 'gas_fields_ice flux name')
 
        !> check implementation
        call check_answers(impl(i), gas_fluxes%FMS_TEST_BC_TYPE_(i)%implementation, 'gas_fluxes impl')

--- a/test_fms/coupler/test_coupler_types.F90
+++ b/test_fms/coupler/test_coupler_types.F90
@@ -197,8 +197,8 @@ id_z  = diag_axis_init('z',  nzs,  'point_Z', 'z', long_name='point_Z')
 time_t = set_date(1, 1, 1)
 do i=1, num_bc
   do j=1, num_fields
-    bc_2d_new%FMS_TEST_BC_TYPE_(i)%field(j)%name = "bc"//string(i)//"_var2d_"//string(j)
-    bc_3d_new%FMS_TEST_BC_TYPE_(i)%field(j)%name = "bc"//string(i)//"_var3d_"//string(j)
+    bc_2d_new%FMS_TEST_BC_TYPE_(i)%field(j)%diag_name = "bc"//string(i)//"_var2d_"//string(j)
+    bc_3d_new%FMS_TEST_BC_TYPE_(i)%field(j)%diag_name = "bc"//string(i)//"_var3d_"//string(j)
     bc_2d_new%FMS_TEST_BC_TYPE_(i)%field(j)%long_name = "bc"//string(i)//"_variable_2d_"//string(j)//"_min"
     bc_3d_new%FMS_TEST_BC_TYPE_(i)%field(j)%long_name = "bc"//string(i)//"_variable_3d_"//string(j)//"_min"
   enddo

--- a/test_fms/coupler/test_coupler_utils.inc
+++ b/test_fms/coupler/test_coupler_utils.inc
@@ -46,7 +46,7 @@ subroutine set_up_1d_coupler_type(bc_type, data_grid)
 
       do j = 1, nfields
          write(field_num,'(i1)') j
-         bc_type%FMS_TEST_BC_TYPE_(i)%field(j)%name="var_"//field_num
+         bc_type%FMS_TEST_BC_TYPE_(i)%field(j)%diag_name="var_"//field_num
          allocate(bc_type%FMS_TEST_BC_TYPE_(i)%field(j)%values(data_grid(1):data_grid(2)))
          bc_type%FMS_TEST_BC_TYPE_(i)%field(j)%values = real(j, kind=FMS_CP_TEST_KIND_)
       end do
@@ -98,7 +98,7 @@ subroutine set_up_2d_coupler_type(bc_type, data_grid, appendix, to_read)
 
       do j = 1, nfields
          write(field_num,'(i1)') j
-         bc_type%FMS_TEST_BC_TYPE_(i)%field(j)%name="var_"//field_num
+         bc_type%FMS_TEST_BC_TYPE_(i)%field(j)%diag_name="var_"//field_num
          allocate(bc_type%FMS_TEST_BC_TYPE_(i)%field(j)%values(data_grid(1):data_grid(2), data_grid(3):data_grid(4)))
          if (to_read) then
              bc_type%FMS_TEST_BC_TYPE_(i)%field(j)%values = real(999., kind=FMS_CP_TEST_KIND_)
@@ -140,7 +140,7 @@ subroutine compare_2d_answers(bc_type_read, bc_type)
              sum(bc_type_read%FMS_TEST_BC_TYPE_(i)%field(j)%values)) then
              call mpp_error(FATAL, "test_coupler_2d: Answers do not match for: " &
                             & //trim(bc_type%FMS_TEST_BC_TYPE_(i)%ice_restart_file)&
-                            & //" var: "//trim(bc_type%FMS_TEST_BC_TYPE_(i)%field(j)%name))
+                            & //" var: "//trim(bc_type%FMS_TEST_BC_TYPE_(i)%field(j)%diag_name))
          endif
       end do
    end do
@@ -149,13 +149,13 @@ subroutine compare_2d_answers(bc_type_read, bc_type)
    if (sum(bc_type_read%FMS_TEST_BC_TYPE_(3)%field(1)%values) .ne. &
        sum(bc_type_read%FMS_TEST_BC_TYPE_(1)%field(1)%values)) then
        call mpp_error(FATAL, "test_coupler_2d: Answers do not match for var: "// &
-                              trim(bc_type_read%FMS_TEST_BC_TYPE_(3)%field(1)%name))
+                              trim(bc_type_read%FMS_TEST_BC_TYPE_(3)%field(1)%diag_name))
    endif
 
    if (sum(bc_type_read%FMS_TEST_BC_TYPE_(3)%field(2)%values) .ne. &
        sum(bc_type_read%FMS_TEST_BC_TYPE_(1)%field(2)%values)) then
        call mpp_error(FATAL, "test_coupler_2d: Answers do not match for var: "// &
-                              trim(bc_type_read%FMS_TEST_BC_TYPE_(3)%field(2)%name))
+                              trim(bc_type_read%FMS_TEST_BC_TYPE_(3)%field(2)%diag_name))
    endif
 
 
@@ -209,7 +209,7 @@ subroutine set_up_3d_coupler_type(bc_type, data_grid, appendix, to_read)
 
       do j = 1, nfields
          write(field_num,'(i1)') j
-         bc_type%FMS_TEST_BC_TYPE_(i)%field(j)%name="var_"//field_num
+         bc_type%FMS_TEST_BC_TYPE_(i)%field(j)%diag_name="var_"//field_num
          allocate(bc_type%FMS_TEST_BC_TYPE_(i)%field(j)%values(data_grid(1):data_grid(2), data_grid(3):data_grid(4), &
                                                                data_grid(5)))
 
@@ -253,7 +253,7 @@ subroutine compare_3d_answers(bc_type_read, bc_type)
              sum(bc_type_read%FMS_TEST_BC_TYPE_(i)%field(j)%values)) then
              call mpp_error(FATAL, "test_coupler_3d: Answers do not match for: "// &
                             & trim(bc_type%FMS_TEST_BC_TYPE_(i)%ice_restart_file) &
-                            & //" var: "//trim(bc_type%FMS_TEST_BC_TYPE_(i)%field(j)%name))
+                            & //" var: "//trim(bc_type%FMS_TEST_BC_TYPE_(i)%field(j)%diag_name))
          endif
       end do
    end do
@@ -262,13 +262,13 @@ subroutine compare_3d_answers(bc_type_read, bc_type)
    if (sum(bc_type_read%FMS_TEST_BC_TYPE_(3)%field(1)%values) .ne. &
        sum(bc_type_read%FMS_TEST_BC_TYPE_(1)%field(1)%values)) then
        call mpp_error(FATAL, "test_coupler_3d: Answers do not match for var: "// &
-                      & trim(bc_type_read%FMS_TEST_BC_TYPE_(3)%field(1)%name))
+                      & trim(bc_type_read%FMS_TEST_BC_TYPE_(3)%field(1)%diag_name))
    endif
 
    if (sum(bc_type_read%FMS_TEST_BC_TYPE_(3)%field(2)%values) .ne. &
        sum(bc_type_read%FMS_TEST_BC_TYPE_(1)%field(2)%values)) then
        call mpp_error(FATAL, "test_coupler_3d: Answers do not match for var: "// &
-                      & trim(bc_type_read%FMS_TEST_BC_TYPE_(3)%field(2)%name))
+                      & trim(bc_type_read%FMS_TEST_BC_TYPE_(3)%field(2)%diag_name))
    endif
 
 

--- a/time_interp/include/time_interp_external2.inc
+++ b/time_interp/include/time_interp_external2.inc
@@ -105,7 +105,7 @@
         else
             if(.not. present(is_in) .or. .not. present(ie_in) .or. .not. present(js_in) .or. .not. present(je_in))then
                 call mpp_error(FATAL, 'time_interp_external: is_in, ie_in, js_in and je_in must be present ' // &
-                                    'when numwindows > 1, field='//trim(loaded_fields(index)%name))
+                                    'when numwindows > 1, field='//trim(loaded_fields(index)%field_name))
             endif
             nxw = ie_in - is_in + 1
             nyw = je_in - js_in + 1
@@ -120,7 +120,7 @@
 
         if (nx < nxw .or. ny < nyw .or. nz < loaded_fields(index)%siz(3)) then
             write(message1,'(i6,2i5)') nx,ny,nz
-            call mpp_error(FATAL,'field '//trim(loaded_fields(index)%name)// &
+            call mpp_error(FATAL,'field '//trim(loaded_fields(index)%field_name)// &
                         ' Array size mismatch in time_interp_external. Array "data" is too small. shape(data)=' &
                         //message1)
         endif
@@ -128,7 +128,7 @@
             if (size(mask_out,1) /= nx .or. size(mask_out,2) /= ny .or. size(mask_out,3) /= nz) then
             write(message1,'(i6,2i5)') nx,ny,nz
             write(message2,'(i6,2i5)') size(mask_out,1),size(mask_out,2),size(mask_out,3)
-            call mpp_error(FATAL,'field '//trim(loaded_fields(index)%name)// &
+            call mpp_error(FATAL,'field '//trim(loaded_fields(index)%field_name)// &
                                  ' array size mismatch in time_interp_external.'// &
                                  ' Shape of array "mask_out" does not match that of array "data".'// &
                                  ' shape(data)='//message1//' shape(mask_out)='//message2)
@@ -164,7 +164,7 @@
                 if(err_msg .NE. '') then
                     filename = trim(loaded_fields(index)%fileobj%path)
                     call mpp_error(FATAL,"time_interp_external 1: "//trim(err_msg)//&
-                             ",file="//trim(filename)//",field="//trim(loaded_fields(index)%name) )
+                             ",file="//trim(filename)//",field="//trim(loaded_fields(index)%field_name) )
                 endif
             ! using time_interp_list
             else
@@ -177,7 +177,7 @@
                 if(err_msg .NE. '') then
                     filename = trim(loaded_fields(index)%fileobj%path)
                     call mpp_error(FATAL,"time_interp_external 2: "//trim(err_msg)//&
-                                   ",file="//trim(filename)//",field="//trim(loaded_fields(index)%name) )
+                                   ",file="//trim(filename)//",field="//trim(loaded_fields(index)%field_name) )
                 endif
             endif
             w1 = 1.0_kindl -w2
@@ -263,7 +263,7 @@
           if(err_msg .NE. '') then
              filename = trim(loaded_fields(index)%fileobj%path)
              call mpp_error(FATAL,"time_interp_external 3:"//trim(err_msg)//&
-                    ",file="//trim(filename)//",field="//trim(loaded_fields(index)%name) )
+                    ",file="//trim(filename)//",field="//trim(loaded_fields(index)%field_name) )
           endif
         else
           if(loaded_fields(index)%modulo_time) then
@@ -275,7 +275,7 @@
           if(err_msg .NE. '') then
              filename = trim(loaded_fields(index)%fileobj%path)
              call mpp_error(FATAL,"time_interp_external 4:"//trim(err_msg)// &
-                    ",file="//trim(filename)//",field="//trim(loaded_fields(index)%name) )
+                    ",file="//trim(filename)//",field="//trim(loaded_fields(index)%field_name) )
           endif
         endif
          w1 = 1.0_kindl-w2

--- a/time_interp/time_interp_external2.F90
+++ b/time_interp/time_interp_external2.F90
@@ -94,7 +94,7 @@ module time_interp_external2_mod
   !> @ingroup time_interp_external2_mod
   type, private :: ext_fieldtype
         type(FmsNetcdfFile_t), pointer :: fileobj=>NULL() !< keep unit open when not reading all records
-        character(len=128) :: name, units
+        character(len=128) :: field_name, units
         integer :: siz(4), ndim
         character(len=32) :: axisname(4)
         type(domain2d) :: domain
@@ -442,7 +442,7 @@ module time_interp_external2_mod
 
       init_external_field = num_fields
       loaded_fields(num_fields)%fileobj => fileobj
-      loaded_fields(num_fields)%name = trim(fieldname)
+      loaded_fields(num_fields)%field_name = trim(fieldname)
       loaded_fields(num_fields)%units = trim(fld_units)
       loaded_fields(num_fields)%isc = 1
       loaded_fields(num_fields)%iec = 1
@@ -778,13 +778,13 @@ subroutine load_record(field, rec, interp, is_in, ie_in, js_in, je_in, window_id
      field%ibuf(ib) = rec
      field%need_compute(ib,:) = .true.
 
-     if (debug_this_module) write(outunit,*) 'reading record without domain for field ',trim(field%name)
+     if (debug_this_module) write(outunit,*) 'reading record without domain for field ',trim(field%field_name)
      start = 1; nread = 1
      start(1) = field%is_src; nread(1) = field%ie_src - field%is_src + 1
      start(2) = field%js_src; nread(2) = field%je_src - field%js_src + 1
      start(3) = 1;            nread(3) = size(field%src_data,3)
      start(field%tdim) = rec; nread(field%tdim) = 1
-     call read_data(field%fileobj,field%name,field%src_data(:,:,:,ib:ib),corner=start,edge_lengths=nread)
+     call read_data(field%fileobj,field%field_name,field%src_data(:,:,:,ib:ib),corner=start,edge_lengths=nread)
   endif
 !$OMP END CRITICAL
   isw=field%isc;iew=field%iec
@@ -899,11 +899,11 @@ subroutine load_record_0d(field, rec)
      ib = field%nbuf
      field%ibuf(ib) = rec
 
-     if (debug_this_module) write(outunit,*) 'reading record without domain for field ',trim(field%name)
+     if (debug_this_module) write(outunit,*) 'reading record without domain for field ',trim(field%field_name)
      start = 1; nread = 1
      start(3) = 1;            nread(3) = size(field%src_data,3)
      start(field%tdim) = rec; nread(field%tdim) = 1
-     call read_data(field%fileobj,field%name,field%src_data(:,:,:,ib),corner=start,edge_lengths=nread)
+     call read_data(field%fileobj,field%field_name,field%src_data(:,:,:,ib),corner=start,edge_lengths=nread)
      if ( field%region_type .NE. NO_REGION ) then
         call mpp_error(FATAL, "time_interp_external: region_type should be NO_REGION when field is scalar")
      endif
@@ -995,7 +995,7 @@ subroutine realloc_fields(n)
   allocate(ptr(n))
   do i=1,size(ptr)
      ptr(i)%fileobj => NULL()
-     ptr(i)%name=''
+     ptr(i)%field_name=''
      ptr(i)%units=''
      ptr(i)%siz=-1
      ptr(i)%ndim=-1


### PR DESCRIPTION
**Description**
`name`  is a specifier in fortran. In FMS, `name` is used as a variable name often. This PR suggests changes to these variable names, and does not include any directories/modules that are either no longer used and/or deprecated and avoids changes to variables that are declared as optional in functions and subroutines.

Fixes # 1328

**How Has This Been Tested?**
autotools with gcc/12.3.0, netcdf/4.9.2, mpich/4.1.2, hdf5/1.14.3, libyaml/0.2.5

**Checklist:**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] `make distcheck` passes

