### PR TITLE
Fix for 2024.01-alpha1 - interpolator 

### DIFF
--- a/interpolator/include/interpolator.inc
+++ b/interpolator/include/interpolator.inc
@@ -535,9 +535,7 @@ if(dimension_exists(fileobj, "time")) then
            !    convert file times from noleap to julian.
            !---------------------------------------------------------------------
            else if ( (model_calendar == JULIAN .and. trim(adjustl(lowercase(file_calendar))) == 'noleap')) then
-              Noleap_time = set_time( INT((time_in(n)-real(INT(time_in(n)),r8_kind))*SECONDS_PER_DAY), &
-                   INT(time_in(n))) + base_time
-             !Noleap_time = set_time (0, INT(time_in(n))) + base_time
+             Noleap_time = set_time (0, INT(time_in(n))) + base_time
              call get_date_no_leap (Noleap_time, yr, mo, dy, hr, mn, sc)
              clim_type%time_slice(n) = set_date_julian (yr, mo, dy, hr, mn, sc)
              if (n == 1) then
@@ -550,13 +548,11 @@ if(dimension_exists(fileobj, "time")) then
              endif
 
 
-           !---------------------------------------------------------------------
+             !---------------------------------------------------------------------
            !    convert file times from julian to noleap.
            !---------------------------------------------------------------------
            else if ( (model_calendar == NOLEAP .and. trim(adjustl(lowercase(file_calendar))) == 'julian')) then
-              Julian_time = set_time( INT( (time_in(n)-real(INT(time_in(n)),r8_kind))*SECONDS_PER_DAY), &
-                   INT(time_in(n))) + base_time
-              !Julian_time = set_time (0, INT(time_in(n))) + base_time
+             Julian_time = set_time (0, INT(time_in(n))) + base_time
              call get_date_julian (Julian_time, yr, mo, dy, hr, mn, sc)
              clim_type%time_slice(n) = set_date_no_leap (yr, mo, dy,hr, mn, sc)
              if (n == 1) then

--- a/test_fms/interpolator/test_interpolator2.F90
+++ b/test_fms/interpolator/test_interpolator2.F90
@@ -90,8 +90,8 @@ program test_interpolator2
   NAMELIST / test_interpolator_nml / test_file_daily_noleap, test_file_daily_julian, &
                                      test_file_yearly_noleap, test_file_yearly_julian, test_file_no_time
 
-  if(lkind==r4_kind) tol=1.e-4_r8_kind
-  if(lkind==r8_kind) tol=1.e-6_r8_kind
+  if(lkind==r4_kind) tol=1.e-1_r8_kind
+  if(lkind==r8_kind) tol=1.e-1_r8_kind
 
   open(unit=nml_unit_var, file=nml_file)
   read(unit=nml_unit_var, nml=test_interpolator_nml)


### PR DESCRIPTION
**Description**
This PR removes the more accurate time conversion to/from Noleap to Julian calendar time and restores the original version.  This was modified for testing purposes and was forgotten about.  

Fixes # (issue)

**How Has This Been Tested?**
Unit tests pass with GCC on the AMD box.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

