### PR TITLE
Update CMakeLists.txt: fix problems with missing linker information for OpenMP C library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -395,7 +395,7 @@ foreach(kind ${kinds})
                                          MPI::MPI_Fortran)
 
   if(OpenMP_Fortran_FOUND)
-    target_link_libraries(${libTgt} PRIVATE OpenMP::OpenMP_Fortran)
+    target_link_libraries(${libTgt} PRIVATE OpenMP::OpenMP_C OpenMP::OpenMP_Fortran)
   endif()
 
   add_library(FMS::${libTgt} ALIAS ${libTgt})


### PR DESCRIPTION
**Description**

The FMS library (as a cmake target) is not finding its OpenMP dependencies correctly. This is only a problem on macOS when using clang (LLVM or native Apple) in conjunction with gfortran, since they have different namespaces and symbols in the LLVM `libomp` library and the GNU `libgomp` library. Basically, this means that developers on macOS need to add `-DCMAKE_SHARED_LINKER_FLAGS="${llvm_openmp_ROOT}/lib/libomp.dylib"` for dynamic library builds, or `-DCMAKE_EXE_LINKER_FLAGS="${llvm_openmp_ROOT}/lib/libomp.dylib"` for static executables (like the UFS Weather Model). More information is in this spack-stack issue: https://github.com/JCSDA/spack-stack/issues/923

This PR "fixes" / is working towards https://github.com/JCSDA/spack-stack/issues/923. It still needs to find it's way into a new tag that is then added to spack and deployed via spack-stack.

**How Has This Been Tested?**

I tested the PR below on my macOS as follows: installed fms with the change below via spack-stack, loaded the module and the remaining (unmodified) modules to build the ufs-weather-model, and built the model without using the `DCMAKE_EXE_LINKER_FLAGS` option above - it worked.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~ (not necessary?)
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] My changes generate no new warnings
- [ ] ~~Any dependent changes have been merged and published in downstream modules~~
- [ ] ~~New check tests, if applicable, are included~~
- [x] `make distcheck` passes

