### PR TITLE
CI: mom6 tests on PR's

### DIFF
--- a/.github/workflows/Dockerfile.gnu
+++ b/.github/workflows/Dockerfile.gnu
@@ -55,7 +55,7 @@ COPY --from=builder /opt/deps/ /opt/deps/
 # need to be on the dev boxes if building
 COPY ./fms_test_input /home/unit_tests_input
 
-RUN dnf install -y autoconf make automake m4 libtool pkg-config zip diffutils
+RUN dnf install -y autoconf make automake m4 libtool pkg-config zip
 
 ENV FC="mpifort"
 ENV CC="mpicc"

--- a/.github/workflows/Dockerfile.gnu
+++ b/.github/workflows/Dockerfile.gnu
@@ -55,7 +55,7 @@ COPY --from=builder /opt/deps/ /opt/deps/
 # need to be on the dev boxes if building
 COPY ./fms_test_input /home/unit_tests_input
 
-RUN dnf install -y autoconf make automake m4 libtool pkg-config zip
+RUN dnf install -y autoconf make automake m4 libtool pkg-config zip diffutils
 
 ENV FC="mpifort"
 ENV CC="mpicc"

--- a/.github/workflows/github_mom_gnu.yml
+++ b/.github/workflows/github_mom_gnu.yml
@@ -27,6 +27,6 @@ jobs:
         cd .testing
         make -j
       env:
-        FMS_BRANCH: $GITHUB_SHA
+        FMS_COMMIT: $GITHUB_SHA
     - name: Run MOM tests
       run: make -j test

--- a/.github/workflows/github_mom_gnu.yml
+++ b/.github/workflows/github_mom_gnu.yml
@@ -27,8 +27,6 @@ jobs:
       with:
         path: .testing/deps/fms/src
     - name: Build FMS and MOM test suite
-      run: |
-        cd .testing
-        make -j
+      run: make -C .testing -j
     - name: Run MOM tests
-      run: make -j test
+      run: make -C .testing -j test

--- a/.github/workflows/github_mom_gnu.yml
+++ b/.github/workflows/github_mom_gnu.yml
@@ -27,6 +27,6 @@ jobs:
         cd .testing
         make -j
       env:
-        FMS_COMMIT: ${{ github.sha }}
+        FMS_COMMIT: ${{ github.ref }}
     - name: Run MOM tests
       run: make -j test

--- a/.github/workflows/github_mom_gnu.yml
+++ b/.github/workflows/github_mom_gnu.yml
@@ -27,6 +27,6 @@ jobs:
         cd .testing
         make -j
       env:
-        FMS_COMMIT: $GITHUB_SHA
+        FMS_COMMIT: ${{ GITHUB_SHA }}
     - name: Run MOM tests
       run: make -j test

--- a/.github/workflows/github_mom_gnu.yml
+++ b/.github/workflows/github_mom_gnu.yml
@@ -1,0 +1,27 @@
+# 'main' required ci, does a distcheck (builds, tests, check install)
+# image created off dockerfile in repo, compile/link flags are set there
+name: Build libFMS test with autotools
+
+on: [push, pull_request]
+
+# cancel running jobs if theres a newer push
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: noaagfdl/fms-ci-rocky-gnu:12.3.0
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        repository: 'NOAA-GFDL/MOM6'
+    - name: Build FMS and MOM test suite with makedep
+      run: |
+        cd .testing
+        make -j
+    - name: Run the tests
+      run: make -j test

--- a/.github/workflows/github_mom_gnu.yml
+++ b/.github/workflows/github_mom_gnu.yml
@@ -28,7 +28,5 @@ jobs:
         path: .testing/deps/fms/src
     - name: Build FMS and MOM test suite
       run: make -C .testing -j
-    - name: Install diff for testing
-      run: dnf install -y diffutils
     - name: Run MOM tests
       run: make -C .testing -j test

--- a/.github/workflows/github_mom_gnu.yml
+++ b/.github/workflows/github_mom_gnu.yml
@@ -28,5 +28,6 @@ jobs:
         make -j
       env:
         FMS_COMMIT: ${{ github.ref }}
+        FMS_URL: ${{ github.repositoryUrl }}
     - name: Run MOM tests
       run: make -j test

--- a/.github/workflows/github_mom_gnu.yml
+++ b/.github/workflows/github_mom_gnu.yml
@@ -25,9 +25,6 @@ jobs:
     - name: Build FMS and MOM test suite
       run: |
         cd .testing
-        FMS_COMMIT="${GITHUB_SHA}" FMS_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" make -j
-      env:
-        FMS_COMMIT: ${{ github.ref }}
-        FMS_URL: ${}}
+        FMS_COMMIT="${GITHUB_REF}" FMS_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" make -j
     - name: Run MOM tests
       run: make -j test

--- a/.github/workflows/github_mom_gnu.yml
+++ b/.github/workflows/github_mom_gnu.yml
@@ -27,6 +27,6 @@ jobs:
         cd .testing
         make -j
       env:
-        FMS_COMMIT: ${{ GITHUB_SHA }}
+        FMS_COMMIT: ${{ github.sha }}
     - name: Run MOM tests
       run: make -j test

--- a/.github/workflows/github_mom_gnu.yml
+++ b/.github/workflows/github_mom_gnu.yml
@@ -28,5 +28,7 @@ jobs:
         path: .testing/deps/fms/src
     - name: Build FMS and MOM test suite
       run: make -C .testing -j
+    - name: Install diff for testing
+      run: dnf install -y diffutils
     - name: Run MOM tests
       run: make -C .testing -j test

--- a/.github/workflows/github_mom_gnu.yml
+++ b/.github/workflows/github_mom_gnu.yml
@@ -1,8 +1,7 @@
-# 'main' required ci, does a distcheck (builds, tests, check install)
-# image created off dockerfile in repo, compile/link flags are set there
-name: Build libFMS test with autotools
+name: Run MOM6 test suite
 
-on: [push, pull_request]
+# runs on PR's or when manually triggered
+on: [workflow_dispatch, pull_request]
 
 # cancel running jobs if theres a newer push
 concurrency:
@@ -15,13 +14,17 @@ jobs:
     container:
       image: noaagfdl/fms-ci-rocky-gnu:12.3.0
     steps:
+    # clone mom6
     - name: Checkout code
       uses: actions/checkout@v4
       with:
         repository: 'NOAA-GFDL/MOM6'
+        submodules: recursive
     - name: Build FMS and MOM test suite with makedep
       run: |
         cd .testing
         make -j
+      env:
+        FMS_BRANCH: $GITHUB_SHA
     - name: Run the tests
       run: make -j test

--- a/.github/workflows/github_mom_gnu.yml
+++ b/.github/workflows/github_mom_gnu.yml
@@ -22,9 +22,13 @@ jobs:
       with:
         repository: 'NOAA-GFDL/MOM6'
         submodules: recursive
+    - name: Checkout FMS into MOM build
+      uses: actions/checkout@v4
+      with:
+        path: .testing/deps/fms/src
     - name: Build FMS and MOM test suite
       run: |
         cd .testing
-        FMS_COMMIT="${GITHUB_REF}" FMS_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" make -j
+        make -j
     - name: Run MOM tests
       run: make -j test

--- a/.github/workflows/github_mom_gnu.yml
+++ b/.github/workflows/github_mom_gnu.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/noaa-gfdl/fms/fms-ci-rocky-gnu:12.3.0
+      image: ghcr.io/noaa-gfdl/fms/fms-ci-rocky-gnu:13.2.0
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}

--- a/.github/workflows/github_mom_gnu.yml
+++ b/.github/workflows/github_mom_gnu.yml
@@ -12,19 +12,21 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: noaagfdl/fms-ci-rocky-gnu:12.3.0
+      image: ghcr.io/noaa-gfdl/fms/fms-ci-rocky-gnu:12.3.0
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.github_token }}
     steps:
-    # clone mom6
-    - name: Checkout code
+    - name: Checkout MOM6 repository
       uses: actions/checkout@v4
       with:
         repository: 'NOAA-GFDL/MOM6'
         submodules: recursive
-    - name: Build FMS and MOM test suite with makedep
+    - name: Build FMS and MOM test suite
       run: |
         cd .testing
         make -j
       env:
         FMS_BRANCH: $GITHUB_SHA
-    - name: Run the tests
+    - name: Run MOM tests
       run: make -j test

--- a/.github/workflows/github_mom_gnu.yml
+++ b/.github/workflows/github_mom_gnu.yml
@@ -25,9 +25,9 @@ jobs:
     - name: Build FMS and MOM test suite
       run: |
         cd .testing
-        make -j
+        FMS_COMMIT="${GITHUB_SHA}" FMS_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" make -j
       env:
         FMS_COMMIT: ${{ github.ref }}
-        FMS_URL: ${{ github.repositoryUrl }}
+        FMS_URL: ${}}
     - name: Run MOM tests
       run: make -j test


### PR DESCRIPTION
**Description**
Adds a workflow to run the mom6 unit tests on any incoming pull requests. Pulls from the default noaa-gfdl/mom6 branch (which is `dev/gfdl`).

**How Has This Been Tested?**
CI

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

