### PR TITLE
Fix parallel make builds

### DIFF
--- a/.github/workflows/github_autotools_gnu.yml
+++ b/.github/workflows/github_autotools_gnu.yml
@@ -37,8 +37,8 @@ jobs:
       if: ${{ matrix.conf-flag == '--disable-setting-flags' }}
       run: ./configure ${DISTCHECK_CONFIGURE_FLAGS} FCFLAGS="-fdefault-real-8 -fdefault-double-8 -fcray-pointer -ffree-line-length-none -I/usr/include $FCFLAGS" || cat config.log
     - name: Build the library
-      run: make distcheck
+      run: make -j distcheck
       if: ${{ matrix.conf-flag != '--with-mpi=no' }}
     - name: Build the library (without test suite for serial build)
-      run: make
+      run: make -j
       if: ${{ matrix.conf-flag == '--with-mpi=no' }}

--- a/.github/workflows/github_autotools_intel.yml
+++ b/.github/workflows/github_autotools_intel.yml
@@ -57,6 +57,6 @@ jobs:
     - name: Configure
       run: autoreconf -if ./configure.ac && ./configure --with-yaml
     - name: Compile
-      run: make -j || make
+      run: make -j
     - name: Run test suite
       run: make check LD_LIBRARY_PATH="/libs/lib:$LD_LIBRARY_PATH" TEST_VERBOSE=1

--- a/Makefile.am
+++ b/Makefile.am
@@ -68,7 +68,7 @@ SUBDIRS = \
   tracer_manager \
   sat_vapor_pres \
   random_numbers \
-  . \
+  global \
   libFMS \
   test_fms \
   ${DOCS}
@@ -77,19 +77,6 @@ include_HEADERS = include/file_version.h include/fms_platform.h
 
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = FMS.pc
-
-## Build libFMS module
-AM_CPPFLAGS = -I${top_srcdir}/include
-AM_FCFLAGS = $(FC_MODINC). $(FC_MODOUT)$(MODDIR)
-
-noinst_LTLIBRARIES = libFMS_mod.la
-libFMS_mod_la_SOURCES = libFMS.F90
-
-fms.$(FC_MODEXT): .mods/*_mod.$(FC_MODEXT)
-
-nodist_include_HEADERS = .mods/fms.$(FC_MODEXT)
-
-include $(top_srcdir)/mkmods.mk
 
 # Prepare CMake files for installation.  This is to help
 # packages build using CMake to more easily use the libFMS

--- a/astronomy/Makefile.am
+++ b/astronomy/Makefile.am
@@ -36,11 +36,6 @@ libastronomy_la_SOURCES = \
     include/astronomy_r8.fh \
     include/astronomy.inc
 
-astronomy.$(FC_MODEXT): \
-include/astronomy_r4.fh \
-include/astronomy_r8.fh \
-include/astronomy.inc
-
 BUILT_SOURCES = astronomy_mod.$(FC_MODEXT)
 nodist_include_HEADERS = astronomy_mod.$(FC_MODEXT)
 

--- a/axis_utils/Makefile.am
+++ b/axis_utils/Makefile.am
@@ -36,11 +36,6 @@ libaxis_utils_la_SOURCES = \
   include/axis_utils2_r8.fh \
   include/axis_utils2.inc
 
-axis_utils2.$(FC_MODEXT) : \
-include/axis_utils2_r4.fh \
-include/axis_utils2_r8.fh \
-include/axis_utils2.inc
-
 # Mod file depends on its o file, is built and then installed.
 nodist_include_HEADERS = axis_utils_mod.$(FC_MODEXT) axis_utils2_mod.$(FC_MODEXT)
 BUILT_SOURCES = axis_utils_mod.$(FC_MODEXT) axis_utils2_mod.$(FC_MODEXT)

--- a/column_diagnostics/Makefile.am
+++ b/column_diagnostics/Makefile.am
@@ -35,11 +35,6 @@ include/column_diagnostics.inc \
 include/column_diagnostics_r4.fh \
 include/column_diagnostics_r8.fh
 
-column_diagnostics.$(FC_MOD_EXT):\
-include/column_diagnostics.inc \
-include/column_diagnostics_r4.fh \
-include/column_diagnostics_r8.fh
-
 BUILT_SOURCES = column_diagnostics_mod.$(FC_MODEXT)
 nodist_include_HEADERS = column_diagnostics_mod.$(FC_MODEXT)
 

--- a/configure.ac
+++ b/configure.ac
@@ -468,6 +468,7 @@ AC_CONFIG_FILES([
   docs/Makefile
   parser/Makefile
   string_utils/Makefile
+  global/Makefile
   test_fms/test-lib.sh
   test_fms/intel_coverage.sh
   test_fms/Makefile

--- a/constants/Makefile.am
+++ b/constants/Makefile.am
@@ -37,7 +37,6 @@ libconstants_la_SOURCES = \
   geos_constants.fh \
   constants.F90
 
-FMSconstants.$(FC_MODEXT): gfdl_constants.fh gfs_constants.fh geos_constants.fh
 constants_mod.$(FC_MODEXT): fmsconstants.$(FC_MODEXT)
 
 # Mod files are built and then installed as headers

--- a/constants4/Makefile.am
+++ b/constants4/Makefile.am
@@ -37,7 +37,6 @@ libconstants4_la_SOURCES = \
   geos_constantsR4.fh \
   constantsr4.F90
 
-fmsconstantsr4.$(FC_MODEXT): gfdl_constantsR4.fh gfs_constantsR4.fh geos_constantsR4.fh
 constantsr4_mod.$(FC_MODEXT): fmsconstantsr4.$(FC_MODEXT)
 
 # Mod files are built and then installed as headers

--- a/diag_integral/Makefile.am
+++ b/diag_integral/Makefile.am
@@ -35,11 +35,6 @@ libdiag_integral_la_SOURCES = diag_integral.F90\
 															include/diag_integral_r4.fh\
 															include/diag_integral_r8.fh
 
-diag_integral_mod.$(FC_MODEXT): include/diag_integral.inc\
-																include/diag_integral_r4.fh\
-																include/diag_integral_r8.fh
-
-
 nodist_include_HEADERS = diag_integral_mod.$(FC_MODEXT)
 BUILT_SOURCES = diag_integral_mod.$(FC_MODEXT)
 

--- a/diag_manager/Makefile.am
+++ b/diag_manager/Makefile.am
@@ -42,28 +42,22 @@ libdiag_manager_la_SOURCES = \
   fms_diag_outfield.F90 \
   fms_diag_elem_weight_procs.F90 \
   fms_diag_fieldbuff_update.F90 \
-		fms_diag_bbox.F90 \
+  fms_diag_bbox.F90 \
   include/fms_diag_fieldbuff_update.inc \
   include/fms_diag_fieldbuff_update.fh
 
 # Some mods are dependant on other mods in this dir.
 diag_data_mod.$(FC_MODEXT): fms_diag_bbox_mod.$(FC_MODEXT)
 diag_axis_mod.$(FC_MODEXT): diag_data_mod.$(FC_MODEXT)
-diag_output_mod.$(FC_MODEXT): diag_axis_mod.$(FC_MODEXT) diag_data_mod.$(FC_MODEXT)
-diag_util_mod.$(FC_MODEXT): diag_data_mod.$(FC_MODEXT) diag_axis_mod.$(FC_MODEXT) diag_output_mod.$(FC_MODEXT) \
-                  diag_grid_mod.$(FC_MODEXT) fms_diag_bbox_mod.$(FC_MODEXT)
-diag_table_mod.$(FC_MODEXT): diag_data_mod.$(FC_MODEXT) diag_util_mod.$(FC_MODEXT)
+diag_output_mod.$(FC_MODEXT): diag_axis_mod.$(FC_MODEXT)
+diag_util_mod.$(FC_MODEXT): diag_data_mod.$(FC_MODEXT) diag_output_mod.$(FC_MODEXT) diag_grid_mod.$(FC_MODEXT)
+diag_table_mod.$(FC_MODEXT): diag_util_mod.$(FC_MODEXT)
 fms_diag_axis_object_mod.$(FC_MODEXT): diag_data_mod.$(FC_MODEXT) fms_diag_time_utils_mod.$(FC_MODEXT)
 fms_diag_time_reduction_mod.$(FC_MODEXT): diag_data_mod.$(FC_MODEXT)
 fms_diag_elem_weight_procs_mod.$(FC_MODEXT): diag_data_mod.$(FC_MODEXT)
-fms_diag_outfield_mod.$(FC_MODEXT): diag_data_mod.$(FC_MODEXT) fms_diag_elem_weight_procs_mod.$(FC_MODEXT)
-fms_diag_fieldbuff_update_mod.$(FC_MODEXT): diag_data_mod.$(FC_MODEXT) diag_util_mod.$(FC_MODEXT) \
-                  fms_diag_outfield_mod.$(FC_MODEXT) fms_diag_elem_weight_procs_mod.$(FC_MODEXT) \
-                  fms_diag_bbox_mod.$(FC_MODEXT)
-diag_manager_mod.$(FC_MODEXT): diag_axis_mod.$(FC_MODEXT) diag_data_mod.$(FC_MODEXT) diag_util_mod.$(FC_MODEXT) \
-                  diag_output_mod.$(FC_MODEXT) diag_grid_mod.$(FC_MODEXT) diag_table_mod.$(FC_MODEXT) \
-                  fms_diag_time_reduction_mod.$(FC_MODEXT) fms_diag_outfield_mod.$(FC_MODEXT) \
-                  fms_diag_fieldbuff_update_mod.$(FC_MODEXT)
+fms_diag_outfield_mod.$(FC_MODEXT): fms_diag_elem_weight_procs_mod.$(FC_MODEXT)
+fms_diag_fieldbuff_update_mod.$(FC_MODEXT): diag_util_mod.$(FC_MODEXT) fms_diag_outfield_mod.$(FC_MODEXT) fms_diag_elem_weight_procs_mod.$(FC_MODEXT) fms_diag_bbox_mod.$(FC_MODEXT)
+diag_manager_mod.$(FC_MODEXT): diag_axis_mod.$(FC_MODEXT) diag_table_mod.$(FC_MODEXT) fms_diag_time_reduction_mod.$(FC_MODEXT) fms_diag_fieldbuff_update_mod.$(FC_MODEXT)
 
 
 # Mod files are built and then installed as headers.

--- a/drifters/Makefile.am
+++ b/drifters/Makefile.am
@@ -46,8 +46,7 @@ libdrifters_la_SOURCES = drifters.F90 \
   drifters_set_field.fh \
   fms_switches.h
 
-drifters_mod.$(FC_MODEXT): drifters_core_mod.$(FC_MODEXT) drifters_input_mod.$(FC_MODEXT) drifters_io_mod.$(FC_MODEXT) \
-                  drifters_comm_mod.$(FC_MODEXT) cloud_interpolator_mod.$(FC_MODEXT)
+drifters_mod.$(FC_MODEXT): drifters_input_mod.$(FC_MODEXT) drifters_io_mod.$(FC_MODEXT) drifters_comm_mod.$(FC_MODEXT) cloud_interpolator_mod.$(FC_MODEXT)
 drifters_comm_mod.$(FC_MODEXT): drifters_core_mod.$(FC_MODEXT)
 
 # Mod files are built and then installed as headers.

--- a/field_manager/Makefile.am
+++ b/field_manager/Makefile.am
@@ -42,10 +42,9 @@ libfield_manager_la_SOURCES = \
 	include/fm_util_r4.fh \
 	include/fm_util_r8.fh
 
-field_manager_mod.$(FC_MODEXT): parse.inc fm_yaml_mod.$(FC_MODEXT) \
-	include/field_manager.inc include/field_manager_r4.fh include/field_manager_r8.fh
-fm_util_mod.$(FC_MODEXT): field_manager_mod.$(FC_MODEXT) \
-	include/fm_util.inc include/fm_util_r4.fh include/fm_util_r8.fh
+field_manager_mod.$(FC_MODEXT): fm_yaml_mod.$(FC_MODEXT)
+
+fm_util_mod.$(FC_MODEXT): field_manager_mod.$(FC_MODEXT)
 
 # Mod files are built and then installed as headers.
 MODFILES = \

--- a/fms/Makefile.am
+++ b/fms/Makefile.am
@@ -51,25 +51,8 @@ libfms_la_SOURCES = \
   fms_io_unstructured_save_restart.inc \
   read_data_3d.inc
 
-fms_mod.$(FC_MODEXT): fms_io_mod.$(FC_MODEXT) \
-  fms.F90 \
-  include/fms.inc \
-  include/fms_r4.fh \
-  include/fms_r8.fh
+fms_mod.$(FC_MODEXT): fms_io_mod.$(FC_MODEXT)
 
-fms_io_mod.$(FC_MODEXT): fms_io_unstructured_field_exist.inc \
-  fms_io_unstructured_get_file_name.inc \
-  fms_io_unstructured_register_restart_axis.inc \
-  fms_io_unstructured_setup_one_field.inc read_data_4d.inc \
-  fms_io_unstructured_file_unit.inc \
-  fms_io_unstructured_get_file_unit.inc \
-  fms_io_unstructured_register_restart_field.inc \
-  read_data_2d.inc \
-  write_data.inc \
-  fms_io_unstructured_get_field_size.inc \
-  fms_io_unstructured_read.inc \
-  fms_io_unstructured_save_restart.inc \
-  read_data_3d.inc
 
 # Mod files are built and then installed as headers.
 MODFILES = \

--- a/fms2_io/Makefile.am
+++ b/fms2_io/Makefile.am
@@ -58,22 +58,15 @@ libfms2_io_la_SOURCES = \
   include/unpack_data.inc
 
 # Some mods are dependant on other mods in this dir.
-fms2_io_mod.$(FC_MODEXT): fms_io_utils_mod.$(FC_MODEXT) netcdf_io_mod.$(FC_MODEXT) fms_netcdf_domain_io_mod.$(FC_MODEXT) \
-                 fms_netcdf_unstructured_domain_io_mod.$(FC_MODEXT) blackboxio.$(FC_MODEXT)
-fms_io_utils_mod.$(FC_MODEXT): include/array_utils.inc include/array_utils_char.inc \
-                      include/get_data_type_string.inc
-netcdf_io_mod.$(FC_MODEXT): fms_io_utils_mod.$(FC_MODEXT) include/netcdf_add_restart_variable.inc include/netcdf_read_data.inc \
-                   include/netcdf_write_data.inc include/register_global_attribute.inc \
-                   include/register_variable_attribute.inc include/get_global_attribute.inc \
-                   include/get_variable_attribute.inc include/compressed_write.inc include/compressed_read.inc \
-                   include/gather_data_bc.inc include/scatter_data_bc.inc include/unpack_data.inc
-fms_netcdf_domain_io_mod.$(FC_MODEXT): fms_io_utils_mod.$(FC_MODEXT) netcdf_io_mod.$(FC_MODEXT) include/register_domain_restart_variable.inc \
-                              include/domain_read.inc include/domain_write.inc include/compute_global_checksum.inc
-fms_netcdf_unstructured_domain_io_mod.$(FC_MODEXT): fms_io_utils_mod.$(FC_MODEXT) netcdf_io_mod.$(FC_MODEXT) \
-                                           include/register_unstructured_domain_restart_variable.inc \
-                                           include/unstructured_domain_read.inc include/unstructured_domain_write.inc
-blackboxio.$(FC_MODEXT): fms_io_utils_mod.$(FC_MODEXT) netcdf_io_mod.$(FC_MODEXT) fms_netcdf_domain_io_mod.$(FC_MODEXT) \
-                fms_netcdf_unstructured_domain_io_mod.$(FC_MODEXT)
+fms2_io_mod.$(FC_MODEXT): netcdf_io_mod.$(FC_MODEXT) fms_netcdf_domain_io_mod.$(FC_MODEXT) fms_netcdf_unstructured_domain_io_mod.$(FC_MODEXT) blackboxio.$(FC_MODEXT)
+
+netcdf_io_mod.$(FC_MODEXT): fms_io_utils_mod.$(FC_MODEXT)
+
+fms_netcdf_domain_io_mod.$(FC_MODEXT): netcdf_io_mod.$(FC_MODEXT)
+
+fms_netcdf_unstructured_domain_io_mod.$(FC_MODEXT): netcdf_io_mod.$(FC_MODEXT)
+
+blackboxio.$(FC_MODEXT): fms_netcdf_domain_io_mod.$(FC_MODEXT) fms_netcdf_unstructured_domain_io_mod.$(FC_MODEXT)
 
 # Mod files are built and then installed as headers.
 MODFILES = \

--- a/global/Makefile.am
+++ b/global/Makefile.am
@@ -17,37 +17,23 @@
 #* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
 #***********************************************************************
 
-# This is an automake file for the topography directory of the FMS
+# This is an automake file for the global directory of the FMS
 # package.
+#
+# This directory only holds the libFMS.F90 file, which gets compiled into
+# a module just named 'fms'. It is meant to access all public routines/types/variables from
+# the other modules in fms.
 
-# Ed Hartnett 2/22/19
+# Ryan Mulhall 1/19/24
 
-# Include .h and .mod files.
-AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/topography/include
-
+AM_CPPFLAGS = -I${top_srcdir}/include
 AM_FCFLAGS = $(FC_MODINC). $(FC_MODOUT)$(MODDIR)
 
-# Build these uninstalled convenience libraries.
-noinst_LTLIBRARIES = libtopography.la
+noinst_LTLIBRARIES = libfms_global.la
 
-# Each convenience library depends on its source.
-libtopography_la_SOURCES = \
-    topography.F90 \
-    include/topography_r4.fh \
-    include/topography_r8.fh \
-    include/topography.inc \
-    gaussian_topog.F90 \
-    include/gaussian_topog_r4.fh \
-    include/gaussian_topog_r8.fh \
-    include/gaussian_topog.inc
+libfms_global_la_SOURCES = fms_global.F90
 
-topography_mod.$(FC_MODEXT): gaussian_topog_mod.$(FC_MODEXT)
-
-# Mod files are built and then installed as headers.
-MODFILES = \
-  gaussian_topog_mod.$(FC_MODEXT) \
-  topography_mod.$(FC_MODEXT)
-nodist_include_HEADERS = $(MODFILES)
-BUILT_SOURCES = $(MODFILES)
+BUILT_SOURCES = fms_global_mod.$(FC_MODEXT)
+nodist_include_HEADERS = fms_global_mod.$(FC_MODEXT)
 
 include $(top_srcdir)/mkmods.mk

--- a/global/fms_global.F90
+++ b/global/fms_global.F90
@@ -62,7 +62,7 @@
 
 !> @addtogroup FMS
 !> @{
-module fms
+module fms_global_mod
 
   !> import each FMS module's public routines/functions, interfaces, and variables
   !! done explicitly to avoid including any unwanted/depracated routines/modules
@@ -841,6 +841,6 @@ module fms
   character(len=*), parameter, public :: version_FMS = version
   private :: version
 
-end module fms
+end module fms_global_mod
 !> @}
 ! close documentation grouping

--- a/horiz_interp/Makefile.am
+++ b/horiz_interp/Makefile.am
@@ -61,9 +61,8 @@ horiz_interp_bicubic_mod.$(FC_MODEXT): horiz_interp_type_mod.$(FC_MODEXT)
 horiz_interp_bilinear_mod.$(FC_MODEXT): horiz_interp_type_mod.$(FC_MODEXT)
 horiz_interp_conserve_mod.$(FC_MODEXT): horiz_interp_type_mod.$(FC_MODEXT)
 horiz_interp_spherical_mod.$(FC_MODEXT): horiz_interp_type_mod.$(FC_MODEXT)
-horiz_interp_mod.$(FC_MODEXT): horiz_interp_bicubic_mod.$(FC_MODEXT) horiz_interp_type_mod.$(FC_MODEXT) \
-                      horiz_interp_bilinear_mod.$(FC_MODEXT) horiz_interp_conserve_mod.$(FC_MODEXT) \
-                      horiz_interp_spherical_mod.$(FC_MODEXT)
+
+horiz_interp_mod.$(FC_MODEXT): horiz_interp_conserve_mod.$(FC_MODEXT) horiz_interp_spherical_mod.$(FC_MODEXT) horiz_interp_bicubic_mod.$(FC_MODEXT) horiz_interp_bilinear_mod.$(FC_MODEXT)
 
 # Mod files are built and then installed as headers.
 MODFILES = \

--- a/libFMS/Makefile.am
+++ b/libFMS/Makefile.am
@@ -64,7 +64,7 @@ libFMS_la_LIBADD += $(top_builddir)/diag_integral/libdiag_integral.la
 libFMS_la_LIBADD += $(top_builddir)/sat_vapor_pres/libsat_vapor_pres.la
 libFMS_la_LIBADD += $(top_builddir)/parser/libparser.la
 libFMS_la_LIBADD += $(top_builddir)/string_utils/libstring_utils.la
-libFMS_la_LIBADD += $(top_builddir)/libFMS_mod.la
+libFMS_la_LIBADD += $(top_builddir)/global/libfms_global.la
 
 libFMS_la_SOURCES =
 nodist_EXTRA_libFMS_la_SOURCES = dummy.f90

--- a/mkmods.mk
+++ b/mkmods.mk
@@ -1,6 +1,6 @@
 # Ensure the $(MODDIR) exists
 
-SUFFIXES = .$(FC_MODEXT) _mod.$(FC_MODEXT)
+SUFFIXES = *.$(FC_MODEXT) _mod.$(FC_MODEXT)
 .F90.$(FC_MODEXT) .F90_mod.$(FC_MODEXT) .f90.$(FC_MODEXT) .f90_mod.$(FC_MODEXT):
 	test -d $(MODDIR) || mkdir -p $(MODDIR)
 	$(PPFCCOMPILE) -c $<

--- a/monin_obukhov/Makefile.am
+++ b/monin_obukhov/Makefile.am
@@ -37,16 +37,7 @@ libmonin_obukhov_la_SOURCES = \
         include/monin_obukhov_inter_r8.fh \
         include/monin_obukhov_inter.inc
 
-monin_obukhov_inter.$(FC_MODEXT): \
-        include/monin_obukhov_inter_r4.fh \
-        include/monin_obukhov_inter_r8.fh \
-        include/monin_obukhov_inter.inc
-
-monin_obukhov_mod.$(FC_MODEXT): \
-        monin_obukhov_inter.$(FC_MODEXT) \
-        include/monin_obukhov_r4.fh \
-        include/monin_obukhov_r8.fh \
-        include/monin_obukhov.inc
+monin_obukhov_mod.$(FC_MODEXT): monin_obukhov_inter.$(FC_MODEXT)
 
 # Mod files are built and then installed as headers.
 MODFILES = \

--- a/mosaic2/Makefile.am
+++ b/mosaic2/Makefile.am
@@ -37,8 +37,7 @@ include/mosaic2_r4.fh  include/mosaic2_r8.fh  include/mosaic2.inc \
 include/grid2_r4.fh  include/grid2_r8.fh include/grid2.inc
 
 # Some mods are dependant on other mods in this dir.
-grid2_mod.$(FC_MODEXT): mosaic2_mod.$(FC_MODEXT) include/grid2_r4.fh include/grid2_r8.fh include/grid2.inc
-mosaic2_mod.$(FC_MODEXT): include/mosaic2_r4.fh include/mosaic2_r8.fh include/mosaic2.inc
+grid2_mod.$(FC_MODEXT): mosaic2_mod.$(FC_MODEXT)
 
 MODFILES = \
 	mosaic2_mod.$(FC_MODEXT) \

--- a/mpp/Makefile.am
+++ b/mpp/Makefile.am
@@ -128,111 +128,12 @@ libmpp_la_SOURCES = \
   include/mpp_write_unlimited_axis.fh \
   include/system_clock.fh
 
-mpp_mod.$(FC_MODEXT): \
-  mpp_parameter_mod.$(FC_MODEXT) \
-  mpp_data_mod.$(FC_MODEXT) \
-  include/mpp_util.inc \
-  include/mpp_error_a_a.fh \
-  include/mpp_error_a_s.fh \
-  include/mpp_error_s_a.fh \
-  include/mpp_error_s_s.fh \
-  include/mpp_util_mpi.inc \
-  include/mpp_util_nocomm.inc \
-  include/mpp_comm.inc \
-  include/mpp_chksum.fh \
-  include/mpp_chksum_int.fh \
-  include/mpp_chksum_scalar.fh \
-  include/mpp_comm_mpi.inc \
-  include/mpp_alltoall_mpi.fh \
-  include/mpp_reduce_mpi.fh \
-  include/mpp_sum_mpi.fh \
-  include/mpp_sum.inc \
-  include/mpp_sum_mpi_ad.fh \
-  include/mpp_sum_ad.inc \
-  include/mpp_transmit_mpi.fh \
-  include/mpp_transmit.inc \
-  include/mpp_type_mpi.fh \
-  include/mpp_comm_nocomm.inc \
-  include/mpp_alltoall_nocomm.fh \
-  include/mpp_reduce_nocomm.fh \
-  include/mpp_sum_nocomm.fh \
-  include/mpp_sum_nocomm_ad.fh \
-  include/mpp_transmit_nocomm.fh \
-  include/mpp_type_nocomm.fh \
-  include/mpp_gather.fh \
-  include/mpp_scatter.fh \
-  include/system_clock.fh
-mpp_data_mod.$(FC_MODEXT): \
-  mpp_parameter_mod.$(FC_MODEXT) \
-  include/mpp_data_mpi.inc \
-  include/mpp_data_nocomm.inc
-mpp_utilities_mod.$(FC_MODEXT): \
-  mpp_mod.$(FC_MODEXT) \
-  mpp_efp_mod.$(FC_MODEXT)
-mpp_domains_mod.$(FC_MODEXT): \
-  mpp_data_mod.$(FC_MODEXT) \
-  mpp_parameter_mod.$(FC_MODEXT) \
-  mpp_mod.$(FC_MODEXT) \
-  mpp_memutils_mod.$(FC_MODEXT) \
-  mpp_efp_mod.$(FC_MODEXT) \
-  include/mpp_define_nest_domains.inc \
-  include/mpp_domains_util.inc \
-  include/mpp_domains_comm.inc \
-  include/mpp_domains_define.inc \
-  include/mpp_domains_misc.inc \
-  include/mpp_do_check.fh \
-  include/mpp_do_checkV.fh \
-  include/mpp_do_get_boundary.fh \
-  include/mpp_do_get_boundary_ad.fh \
-  include/mpp_do_redistribute.fh \
-  include/mpp_do_update.fh \
-  include/mpp_do_updateV.fh \
-  include/mpp_do_updateV_ad.fh \
-  include/mpp_do_updateV_nonblock.fh \
-  include/mpp_do_update_ad.fh \
-  include/mpp_do_update_nest.fh \
-  include/mpp_do_update_nonblock.fh \
-  include/mpp_get_boundary.fh \
-  include/mpp_get_boundary_ad.fh \
-  include/mpp_group_update.fh \
-  include/group_update_pack.inc \
-  include/group_update_unpack.inc \
-  include/mpp_update_domains2D.fh \
-  include/mpp_update_domains2D_ad.fh \
-  include/mpp_update_domains2D_nonblock.fh \
-  include/mpp_update_nest_domains.fh \
-  include/mpp_domains_reduce.inc \
-  include/mpp_do_global_field.fh \
-  include/mpp_do_global_field_ad.fh \
-  include/mpp_global_field.fh \
-  include/mpp_global_field_ad.fh \
-  include/mpp_global_reduce.fh \
-  include/mpp_global_sum.fh \
-  include/mpp_global_sum_ad.fh \
-  include/mpp_global_sum_tl.fh \
-  include/mpp_unstruct_domain.inc \
-  include/mpp_global_field_ug.fh \
-  include/mpp_unstruct_pass_data.fh
-mpp_io_mod.$(FC_MODEXT): \
-  mpp_parameter_mod.$(FC_MODEXT) \
-  mpp_mod.$(FC_MODEXT) \
-  mpp_domains_mod.$(FC_MODEXT) \
-  include/mpp_io_util.inc \
-  include/mpp_io_misc.inc \
-  include/mpp_io_connect.inc \
-  include/mpp_io_read.inc \
-  include/mpp_read_2Ddecomp.fh \
-  include/mpp_read_compressed.fh \
-  include/mpp_read_distributed_ascii.inc \
-  include/mpp_read_distributed_ascii.fh \
-  include/mpp_io_write.inc \
-  include/mpp_write.fh \
-  include/mpp_write_2Ddecomp.fh \
-  include/mpp_write_compressed.fh \
-  include/mpp_write_unlimited_axis.fh \
-  include/mpp_io_unstructured_write.inc \
-  include/mpp_io_unstructured_read.inc
-mpp_efp_mod.$(FC_MODEXT): mpp_parameter_mod.$(FC_MODEXT) mpp_mod.$(FC_MODEXT)
+mpp_mod.$(FC_MODEXT): mpp_data_mod.$(FC_MODEXT)
+mpp_data_mod.$(FC_MODEXT): mpp_parameter_mod.$(FC_MODEXT)
+mpp_utilities_mod.$(FC_MODEXT): mpp_mod.$(FC_MODEXT) mpp_efp_mod.$(FC_MODEXT)
+mpp_domains_mod.$(FC_MODEXT): mpp_memutils_mod.$(FC_MODEXT) mpp_efp_mod.$(FC_MODEXT)
+mpp_io_mod.$(FC_MODEXT): mpp_mod.$(FC_MODEXT) mpp_domains_mod.$(FC_MODEXT)
+mpp_efp_mod.$(FC_MODEXT): mpp_mod.$(FC_MODEXT)
 mpp_memutils_mod.$(FC_MODEXT): mpp_mod.$(FC_MODEXT)
 mpp_pset_mod.$(FC_MODEXT): mpp_mod.$(FC_MODEXT)
 

--- a/sat_vapor_pres/Makefile.am
+++ b/sat_vapor_pres/Makefile.am
@@ -41,15 +41,7 @@ libsat_vapor_pres_la_SOURCES = \
 	include/sat_vapor_pres_k.inc
 
 # Some mods are dependant on other mods in this dir.
-sat_vapor_pres_mod.$(FC_MODEXT): \
-	sat_vapor_pres_k_mod.$(FC_MODEXT) \
-	include/sat_vapor_pres_r4.fh \
-	include/sat_vapor_pres_r8.fh \
-	include/sat_vapor_pres.inc
-sat_vapor_pres_k_mod.$(FC_MODEXT): \
-	include/sat_vapor_pres_k_r4.fh \
-	include/sat_vapor_pres_k_r8.fh \
-	include/sat_vapor_pres_k.inc
+sat_vapor_pres_mod.$(FC_MODEXT): sat_vapor_pres_k_mod.$(FC_MODEXT)
 
 # Mod files are built and then installed as headers.
 MODFILES = \

--- a/tridiagonal/Makefile.am
+++ b/tridiagonal/Makefile.am
@@ -35,8 +35,6 @@ libtridiagonal_la_SOURCES = tridiagonal.F90           \
                             include/tridiagonal_r4.fh \
                             include/tridiagonal_r8.fh
 
-# Mod file depends on its o file, is built and then installed.
-tridiagonal.lo: tridiagonal_mod.$(FC_MODEXT)
 
 BUILT_SOURCES = tridiagonal_mod.$(FC_MODEXT)
 nodist_include_HEADERS = tridiagonal_mod.$(FC_MODEXT)


### PR DESCRIPTION
**Description**
fixes for parallel make's with autotools (`make -j`). Also cleans up any targets pointing to include files since they aren't needed. draft for now since this will need to be updated for the diag_manager updates.

Fixes # (issue)

**How Has This Been Tested?**
make -j on the amd box.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

