### PR TITLE
dmUpdate: Fix so that filenames are not saved in lowercase

### DIFF
--- a/diag_manager/fms_diag_yaml.F90
+++ b/diag_manager/fms_diag_yaml.F90
@@ -414,8 +414,7 @@ subroutine diag_yaml_object_init(diag_subset_output)
     call fill_in_diag_files(diag_yaml_id, diag_file_ids(i), diag_yaml%diag_files(file_count))
 
     !> Save the file name in the file_list
-    !! The diag_table is not case sensitive (so we are saving it as lowercase)
-    file_list%file_name(file_count) = lowercase(trim(diag_yaml%diag_files(file_count)%file_fname)//c_null_char)
+    file_list%file_name(file_count) = trim(diag_yaml%diag_files(file_count)%file_fname)//c_null_char
     file_list%diag_file_indices(file_count) = file_count
 
     nvars = 0


### PR DESCRIPTION
**Description**
Removes the lowercase when saving the filenames into the sorted list of files.  This sorted list is used to find the file_ids of the variables when the variable is registered using a binary search (for performance). The filename should be saved as it is saved in the yaml object.

Without this change, we are getting errors such as
/gpfs/f5/gfdl_f/scratch/Niki.Zadeh/FMS2024.01-beta1_mom6_20231130_ymal_1/OM4p5_CORE2_IAF_COBALT4.0_abio_csf_mle200/ncrc5.intel23-pr
od/stdout/run/OM4p5_CORE2_IAF_COBALT4.0_abio_csf_mle200_1x1m0d_1057x1o1.o134750073

It is still needed for the variables: https://github.com/NOAA-GFDL/FMS/pull/1176#discussion_r1173911530

Fixes # (issue)

**How Has This Been Tested?**
CI

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

