### PR TITLE
Fix for when there are multiple subregional diagnostics in the same file

### DIFF
--- a/diag_manager/diag_data.F90
+++ b/diag_manager/diag_data.F90
@@ -127,6 +127,8 @@ use platform_mod
   INTEGER, PARAMETER :: middle_time = 2 !< Use the middle of the time average bounds
   INTEGER, PARAMETER :: end_time    = 3 !< Use the end of the time average bounds
   INTEGER, PARAMETER :: MAX_STR_LEN = 255 !< Max length for a string
+  INTEGER, PARAMETER :: is_x_axis = 1 !< integer indicating that it is a x axis
+  INTEGER, PARAMETER :: is_y_axis = 2 !< integer indicating that it is a y axis
   !> @}
 
   !> @brief Contains the coordinates of the local domain to output.

--- a/diag_manager/fms_diag_axis_object.F90
+++ b/diag_manager/fms_diag_axis_object.F90
@@ -1092,6 +1092,8 @@ module fms_diag_axis_object_mod
 
     write_on_this_pe = .false.
     need_to_define_axis = .true.
+    parent_axis_ids = diag_null
+
     !< Get the rectangular coordinates of the subRegion
     !! If the subRegion is not rectangular, the points outside of the subRegion will be masked
     !! out later
@@ -1179,10 +1181,11 @@ module fms_diag_axis_object_mod
     !< If it made it to this point, the current PE is in the subRegion!
     write_on_this_pe = .true.
 
-    do i = 1, size(axis_ids)
-      select type (parent_axis => diag_axis(axis_ids(i))%axis)
+    do i = 1, size(parent_axis_ids)
+      if (parent_axis_ids(i) .eq. diag_null) cycle
+      select type (parent_axis => diag_axis(parent_axis_ids(i))%axis)
       type is (fmsDiagFullAxis_type)
-        call define_new_axis(diag_axis, parent_axis, naxis, axis_ids(i), &
+        call define_new_axis(diag_axis, parent_axis, naxis, parent_axis_ids(i), &
           starting_index(i), ending_index(i), compute_idx_2(i,:))
      end select
     enddo

--- a/diag_manager/fms_diag_axis_object.F90
+++ b/diag_manager/fms_diag_axis_object.F90
@@ -1085,10 +1085,10 @@ module fms_diag_axis_object_mod
 
     if (.not. write_on_this_pe) return
 
-    select type(corners=> subRegion%corners(:,is_x_or_y))
+    select type(corners=> subRegion%corners)
     type is (integer(kind=i4_kind))
-      global_idx(1) = minval(corners)
-      global_idx(2) = maxval(corners)
+      global_idx(1) = minval(corners(:,is_x_or_y))
+      global_idx(2) = maxval(corners(:,is_x_or_y))
     end select
 
     !< If it made it to this point, the current PE is in the subRegion!
@@ -1435,12 +1435,12 @@ module fms_diag_axis_object_mod
 
   end subroutine
 
-  !> @brief Determine if the parent_axis is the parent of axis_id
-  !! @return .True. if the parent_axis is the parent of axis_id
+  !> @brief Determine if the diag_axis(parent_axis_id) is the parent of diag_axis(axis_id)
+  !! @return .True. if diag_axis(parent_axis_id) is the parent of diag_axis(axis_id)
   function is_parent_axis(axis_id, parent_axis_id, diag_axis) &
     result(rslt)
-    integer, intent(in) :: axis_id
-    integer, intent(in) :: parent_axis_id
+    integer, intent(in) :: axis_id        !< Axis id to check
+    integer, intent(in) :: parent_axis_id !< Axis id of the parent to check
     class(fmsDiagAxisContainer_type), target, intent(in) :: diag_axis(:)    !< Array of diag_axis objects
 
     logical :: rslt

--- a/diag_manager/fms_diag_axis_object.F90
+++ b/diag_manager/fms_diag_axis_object.F90
@@ -1091,6 +1091,7 @@ module fms_diag_axis_object_mod
     integer :: compute_idx_2(2, 2)    !< Starting and ending indices of the compute domain for the "x" and "y" direction
 
     write_on_this_pe = .false.
+    need_to_define_axis = .true.
     !< Get the rectangular coordinates of the subRegion
     !! If the subRegion is not rectangular, the points outside of the subRegion will be masked
     !! out later
@@ -1178,10 +1179,10 @@ module fms_diag_axis_object_mod
     !< If it made it to this point, the current PE is in the subRegion!
     write_on_this_pe = .true.
 
-    do i = 1, size(parent_axis_ids)
-      select type (parent_axis => diag_axis(parent_axis_ids(i))%axis)
+    do i = 1, size(axis_ids)
+      select type (parent_axis => diag_axis(axis_ids(i))%axis)
       type is (fmsDiagFullAxis_type)
-        call define_new_axis(diag_axis, parent_axis, naxis, parent_axis_ids(i), &
+        call define_new_axis(diag_axis, parent_axis, naxis, axis_ids(i), &
           starting_index(i), ending_index(i), compute_idx_2(i,:))
      end select
     enddo

--- a/diag_manager/fms_diag_axis_object.F90
+++ b/diag_manager/fms_diag_axis_object.F90
@@ -52,7 +52,7 @@ module fms_diag_axis_object_mod
           & get_domain_and_domain_type, diagDomain_t, &
           & DIAGDOMAIN2D_T, fmsDiagSubAxis_type, fmsDiagAxisContainer_type, fmsDiagFullAxis_type, DIAGDOMAINUG_T
   public :: define_new_axis, define_subaxis, parse_compress_att, get_axis_id_from_name, define_diurnal_axis, &
-          & fmsDiagDiurnalAxis_type, create_new_z_subaxis
+          & fmsDiagDiurnalAxis_type, create_new_z_subaxis, is_parent_axis
 
   !> @}
 
@@ -1405,6 +1405,24 @@ module fms_diag_axis_object_mod
     enddo
 
   end subroutine
+
+  !> @brief Determine if the parent_axis is the parent of axis_id
+  !! @return .True. if the parent_axis is the parent of axis_id
+  function is_parent_axis(axis_id, parent_axis_id, diag_axis) &
+    result(rslt)
+    integer, intent(in) :: axis_id
+    integer, intent(in) :: parent_axis_id
+    class(fmsDiagAxisContainer_type), target, intent(in) :: diag_axis(:)    !< Array of diag_axis objects
+
+    logical :: rslt
+
+    rslt = .false.
+    select type(axis => diag_axis(axis_id)%axis)
+    type is (fmsDiagSubAxis_type)
+      if (axis%parent_axis_id .eq. parent_axis_id) rslt = .true.
+    end select
+  end function is_parent_axis
+
 #endif
 end module fms_diag_axis_object_mod
 !> @}

--- a/diag_manager/fms_diag_file_object.F90
+++ b/diag_manager/fms_diag_file_object.F90
@@ -34,7 +34,7 @@ use diag_data_mod, only: DIAG_NULL, NO_DOMAIN, max_axes, SUB_REGIONAL, get_base_
                          get_base_year, get_base_month, get_base_day, get_base_hour, get_base_minute, &
                          get_base_second, time_unit_list, time_average, time_rms, time_max, time_min, time_sum, &
                          time_diurnal, time_power, time_none, avg_name, no_units, pack_size_str, &
-                         middle_time, begin_time, end_time, MAX_STR_LEN
+                         middle_time, begin_time, end_time, MAX_STR_LEN, index_gridtype, latlon_gridtype
 use time_manager_mod, only: time_type, operator(>), operator(/=), operator(==), get_date, get_calendar_type, &
                             VALID_CALENDAR_TYPES, operator(>=), date_to_string, &
                             OPERATOR(/), OPERATOR(+), operator(<)
@@ -42,8 +42,9 @@ use fms_diag_time_utils_mod, only: diag_time_inc, get_time_string, get_date_dif
 use fms_diag_yaml_mod, only: diag_yaml, diagYamlObject_type, diagYamlFiles_type, subRegion_type, diagYamlFilesVar_type
 use fms_diag_axis_object_mod, only: diagDomain_t, get_domain_and_domain_type, fmsDiagAxis_type, &
                                     fmsDiagAxisContainer_type, DIAGDOMAIN2D_T, DIAGDOMAINUG_T, &
-                                    fmsDiagFullAxis_type, define_subaxis, define_diurnal_axis, &
-                                    fmsDiagDiurnalAxis_type, create_new_z_subaxis, is_parent_axis
+                                    fmsDiagFullAxis_type, define_diurnal_axis, &
+                                    fmsDiagDiurnalAxis_type, create_new_z_subaxis, is_parent_axis, &
+                                    define_new_subaxis_latlon, define_new_subaxis_index, fmsDiagSubAxis_type
 use fms_diag_field_object_mod, only: fmsDiagField_type
 use fms_diag_output_buffer_mod, only: fmsDiagOutputBuffer_type
 use mpp_mod, only: mpp_get_current_pelist, mpp_npes, mpp_root_pe, mpp_pe, mpp_error, FATAL, stdout, &
@@ -107,6 +108,10 @@ type :: fmsDiagFile_type
   procedure, public :: set_domain_from_axis
   procedure, public :: set_file_domain
   procedure, public :: add_axes
+  procedure, public :: add_new_axis
+  procedure, public :: update_write_on_this_pe
+  procedure, public :: does_axis_exist
+  procedure, public :: define_new_subaxis
   procedure, public :: add_start_time
   procedure, public :: set_file_time_ops
   procedure, public :: has_field_ids
@@ -122,6 +127,7 @@ type :: fmsDiagFile_type
  procedure, public :: get_file_timeunit
  procedure, public :: get_file_unlimdim
  procedure, public :: get_file_sub_region
+ procedure, public :: get_file_sub_region_grid_type
  procedure, public :: get_file_new_file_freq
  procedure, public :: get_filename_time
  procedure, public :: get_file_new_file_freq_units
@@ -508,6 +514,19 @@ function get_file_sub_region (obj) result(res)
   res = obj%diag_yaml_file%get_file_sub_region()
 end function get_file_sub_region
 
+!< @brief Query for the subregion grid type (latlon or index)
+!! @return subregion grid type
+function get_file_sub_region_grid_type(this) &
+  result(res)
+  class(fmsDiagFile_type), intent(in) :: this !< Diag file object
+  integer :: res
+
+  type(subRegion_type) :: subregion !< Subregion type
+
+  subregion = this%diag_yaml_file%get_file_sub_region()
+  res = subregion%grid_type
+end function get_file_sub_region_grid_type
+
 !> \brief Returns a copy of file_new_file_freq from the yaml object
 !! \return Copy of file_new_file_freq
 pure function get_file_new_file_freq (this) result(res)
@@ -735,8 +754,14 @@ subroutine add_axes(this, axis_ids, diag_axis, naxis, yaml_id, buffer_id, output
   logical              :: is_cube_sphere   !< Flag indicating if the file's domain is a cubesphere
   logical              :: axis_found       !< Flag indicating that the axis was already to the file obj
   integer, allocatable :: var_axis_ids(:)  !< Array of the variable's axis ids
+  integer              :: x_y_axis_id(2)   !< Ids of the x and y axis
+  integer              :: x_or_y           !< integer indicating if the axis is x or y
+  logical              :: is_x_or_y        !< flag indicating if the axis is x or y
+  integer              :: subregion_gridtype !< The type of the subregion (latlon or index)
+  logical              :: write_on_this_pe !< Flag indicating if the current pe is in the subregion
 
   is_cube_sphere = .false.
+  subregion_gridtype = this%get_file_sub_region_grid_type()
 
   field_yaml => diag_yaml%get_diag_field_from_id(yaml_id)
   !< Created a copy here, because if the variable has a z subaxis var_axis_ids will be modified in
@@ -752,70 +777,165 @@ subroutine add_axes(this, axis_ids, diag_axis, naxis, yaml_id, buffer_id, output
 
   select type(this)
   type is (subRegionalFile_type)
-    subaxis_not_defined: if (.not. this%is_subaxis_defined) then
+    subaxis_defined: if (this%is_subaxis_defined) then
       if (associated(this%domain)) then
         if (this%domain%get_ntiles() .eq. 6) is_cube_sphere = .true.
       endif
 
-      call define_subaxis(diag_axis, var_axis_ids, naxis, this%get_file_sub_region(), &
-        is_cube_sphere, this%write_on_this_pe)
-      this%is_subaxis_defined = .true.
-
-      !> add the axis to the list of axis in the file
-      if (this%write_on_this_pe) then
-        do i = 1, size(var_axis_ids)
-          this%number_of_axis = this%number_of_axis + 1 !< This is the current number of axis in the file
-          this%axis_ids(this%number_of_axis) = diag_axis(var_axis_ids(i))%axis%get_subaxes_id()
-
-          !< Change the variable axis ids to the subaxis that was just created
-          var_axis_ids(i) = this%axis_ids(this%number_of_axis)
-        enddo
-      else
-        this%axis_ids = diag_null
-      endif
-    else
-      !The subaxis has already being defined, update var_axis_ids with the subaxis id
       do i = 1, size(var_axis_ids)
-        axis_found = .false.
-        do j = 1, this%number_of_axis
-          if (this%axis_ids(j) .eq. var_axis_ids(i)) then
-            axis_found = .true.
-            cycle
-          else
-            if (is_parent_axis(this%axis_ids(j), var_axis_ids(i), diag_axis)) then
-              var_axis_ids(i) = this%axis_ids(j)
+        select type (parent_axis => diag_axis(var_axis_ids(i))%axis)
+        type is (fmsDiagFullAxis_type)
+          axis_found = .false.
+          is_x_or_y = parent_axis%is_x_or_y_axis()
+          do j = 1, this%number_of_axis
+            if (is_x_or_y) then
+              if(is_parent_axis(this%axis_ids(j), var_axis_ids(i), diag_axis)) then
+                axis_found = .true.
+                var_axis_ids(i) = this%axis_ids(j) !Set the var_axis_id to the sub axis_id
+                cycle
+              endif
+            elseif (var_axis_ids(i) .eq. this%axis_ids(j)) then
               axis_found = .true.
             endif
+          enddo
+
+          if (.not. axis_found) then
+            if (is_x_or_y) then
+              if (subregion_gridtype .eq. latlon_gridtype .and. is_cube_sphere) &
+                call mpp_error(FATAL, "If using the cube sphere and defining the subregion with latlon "//&
+                "the variable need to have the same x and y axis. Please check the variables in the file "//&
+                trim(this%get_file_fname())//" or use indices to define the subregion.")
+
+              select case (subregion_gridtype)
+              case (index_gridtype)
+                call define_new_subaxis_index(parent_axis, this%get_file_sub_region(), diag_axis, naxis, &
+                  i, write_on_this_pe)
+              case (latlon_gridtype)
+                call define_new_subaxis_latlon(diag_axis, var_axis_ids(i:i), naxis, this%get_file_sub_region(), &
+                  .false., write_on_this_pe)
+              end select
+              call this%add_new_axis(naxis)
+              var_axis_ids(i) = naxis
+            else
+              call this%add_new_axis(var_axis_ids(i))
+            endif
           endif
-        enddo
-        if (.not. axis_found) then
-          this%number_of_axis = this%number_of_axis + 1
-          this%axis_ids(this%number_of_axis) = var_axis_ids(j)
-        endif
+        type is (fmsDiagSubAxis_type)
+          axis_found = this%does_axis_exist(var_axis_ids(i))
+          if (.not. axis_found) call this%add_new_axis(var_axis_ids(i))
+        end select
       enddo
-    endif subaxis_not_defined
+    else
+      x_y_axis_id = diag_null
+      do i = 1, size(var_axis_ids)
+        select type (parent_axis => diag_axis(var_axis_ids(i))%axis)
+        type is (fmsDiagFullAxis_type)
+          if (.not. parent_axis%is_x_or_y_axis(x_or_y)) then
+            axis_found = this%does_axis_exist(var_axis_ids(i))
+            if (.not. axis_found) call this%add_new_axis(var_axis_ids(i))
+          else
+            x_y_axis_id(x_or_y) = var_axis_ids(i)
+          endif
+        type is (fmsDiagSubAxis_type)
+          axis_found = this%does_axis_exist(var_axis_ids(i))
+          if (.not. axis_found) call this%add_new_axis(var_axis_ids(i))
+        end select
+      enddo
+
+      call this%define_new_subaxis(var_axis_ids, x_y_axis_id, is_cube_sphere, diag_axis, naxis)
+      this%is_subaxis_defined = .true.
+    endif subaxis_defined
   type is (fmsDiagFile_type)
     do i = 1, size(var_axis_ids)
-      axis_found = .false.
-      do j = 1, this%number_of_axis
-        !> Check if the axis already exists, move on
-        if (var_axis_ids(i) .eq. this%axis_ids(j)) then
-          axis_found = .true.
-          cycle
-        endif
-      enddo
-
-      if (.not. axis_found) then
-        !> If the axis does not exist add it to the list
-        this%number_of_axis = this%number_of_axis + 1
-        this%axis_ids(this%number_of_axis) = var_axis_ids(i)
-      endif
+      axis_found = this%does_axis_exist(var_axis_ids(i))
+      if (.not. axis_found) call this%add_new_axis(var_axis_ids(i))
     enddo
   end select
-
   !> Add the axis to the buffer object
   call output_buffers(buffer_id)%add_axis_ids(var_axis_ids)
 end subroutine add_axes
+
+!> @brief Adds a new axis the list of axis in the diag file object
+subroutine add_new_axis(this, var_axis_id)
+  class(fmsDiagFile_type),                 intent(inout) :: this        !< The file object
+  integer,                                 intent(in)    :: var_axis_id !< Axis id of the variable
+
+  this%number_of_axis = this%number_of_axis + 1
+  this%axis_ids(this%number_of_axis) = var_axis_id
+end subroutine add_new_axis
+
+!> @brief This updates write on this pe
+subroutine update_write_on_this_pe(this, write_on_this_pe)
+  class(fmsDiagFile_type),                 intent(inout) :: this             !< The file object
+  logical,                                 intent(in)    :: write_on_this_pe !< .True. if the current PE is in
+                                                                             !! subregion
+
+  select type (this)
+  type is (subRegionalFile_type)
+    if (.not. this%write_on_this_pe) this%write_on_this_pe = write_on_this_pe
+  end select
+end subroutine update_write_on_this_pe
+
+!< @brief Determine if an axis is already in the list of axis for a diag file
+!! @return .True. if the axis is already in the list of axis for a diag file
+function does_axis_exist(this, var_axis_id) &
+  result(rslt)
+  class(fmsDiagFile_type), intent(inout) :: this         !< The file object
+  integer,                 intent(in)    :: var_axis_id  !< Variable axis id to check
+
+  logical :: rslt
+  integer :: j !< For do loops
+
+  rslt = .false.
+  do j = 1, this%number_of_axis
+    !> Check if the axis already exists, move on
+    if (var_axis_id .eq. this%axis_ids(j)) then
+      rslt = .true.
+      return
+    endif
+  enddo
+end function
+
+!> @brief Define a new sub axis
+subroutine define_new_subaxis(this, var_axis_ids, x_y_axis_id, is_cube_sphere, diag_axis, naxis)
+  class(fmsDiagFile_type),                 intent(inout) :: this              !< The file object
+  integer,                                 INTENT(inout) :: var_axis_ids(:)   !< Original variable axis ids
+  integer,                                 INTENT(in)    :: x_y_axis_id(:)    !< The ids of the x and y axis
+  logical,                                 intent(in)    :: is_cube_sphere    !< .True. if the axis is in the cubesphere
+  integer,                                 intent(inout) :: naxis             !< Number of axis current registered
+  class(fmsDiagAxisContainer_type),        intent(inout) :: diag_axis(:)      !< Diag_axis object
+
+  logical :: write_on_this_pe !< .True. if the current PE is in the subregion
+  integer :: i, j             !< For do loop
+
+  select case (this%get_file_sub_region_grid_type())
+  case(latlon_gridtype)
+    call define_new_subaxis_latlon(diag_axis, x_y_axis_id, naxis, this%get_file_sub_region(), is_cube_sphere, &
+      write_on_this_pe)
+    call this%update_write_on_this_pe(write_on_this_pe)
+    if (.not. write_on_this_pe) return
+    call this%add_new_axis(naxis)
+    call this%add_new_axis(naxis-1)
+    do j = 1, size(var_axis_ids)
+      if (x_y_axis_id(1) .eq. var_axis_ids(j)) var_axis_ids(j) = naxis - 1
+      if (x_y_axis_id(2) .eq. var_axis_ids(j)) var_axis_ids(j) = naxis
+    enddo
+  case (index_gridtype)
+    do i = 1, size(x_y_axis_id)
+      select type (parent_axis => diag_axis(x_y_axis_id(i))%axis)
+      type is (fmsDiagFullAxis_type)
+        call define_new_subaxis_index(parent_axis, this%get_file_sub_region(), diag_axis, naxis, i, &
+          write_on_this_pe)
+        call this%update_write_on_this_pe(write_on_this_pe)
+        if (.not. write_on_this_pe) return
+        call this%add_new_axis(naxis)
+        do j = 1, size(var_axis_ids)
+          if (x_y_axis_id(i) .eq. var_axis_ids(j)) var_axis_ids(j) = naxis
+        enddo
+      end select
+    enddo
+  end select
+end subroutine define_new_subaxis
 
 !> @brief adds the start time to the fileobj
 !! @note This should be called from the register field calls. It can be called multiple times (one for each variable)

--- a/diag_manager/fms_diag_file_object.F90
+++ b/diag_manager/fms_diag_file_object.F90
@@ -779,12 +779,11 @@ subroutine add_axes(this, axis_ids, diag_axis, naxis, yaml_id, buffer_id, output
 
   select type(this)
   type is (subRegionalFile_type)
+    if (associated(this%domain)) then
+      if (this%domain%get_ntiles() .eq. 6) is_cube_sphere = .true.
+    endif
     if (.not. this%get_write_on_this_pe()) return
     subaxis_defined: if (this%is_subaxis_defined) then
-      if (associated(this%domain)) then
-        if (this%domain%get_ntiles() .eq. 6) is_cube_sphere = .true.
-      endif
-
       do i = 1, size(var_axis_ids)
         select type (parent_axis => diag_axis(var_axis_ids(i))%axis)
         type is (fmsDiagFullAxis_type)

--- a/diag_manager/fms_diag_file_object.F90
+++ b/diag_manager/fms_diag_file_object.F90
@@ -765,6 +765,7 @@ subroutine add_axes(this, axis_ids, diag_axis, naxis, yaml_id, buffer_id, output
   subregion_gridtype = this%get_file_sub_region_grid_type()
 
   field_yaml => diag_yaml%get_diag_field_from_id(yaml_id)
+
   !< Created a copy here, because if the variable has a z subaxis var_axis_ids will be modified in
   !! `create_new_z_subaxis` to contain the id of the new z subaxis instead of the parent axis,
   !! which will be added to the the list of axis in the file object (axis_ids is intent(in),
@@ -778,6 +779,7 @@ subroutine add_axes(this, axis_ids, diag_axis, naxis, yaml_id, buffer_id, output
 
   select type(this)
   type is (subRegionalFile_type)
+    if (.not. this%get_write_on_this_pe()) return
     subaxis_defined: if (this%is_subaxis_defined) then
       if (associated(this%domain)) then
         if (this%domain%get_ntiles() .eq. 6) is_cube_sphere = .true.

--- a/test_fms/diag_manager/check_time_none.F90
+++ b/test_fms/diag_manager/check_time_none.F90
@@ -20,7 +20,7 @@
 !> @brief  Checks the output file after running test_reduction_methods using the "none" reduction method
 program check_time_none
   use fms_mod,           only: fms_init, fms_end, string
-  use fms2_io_mod,       only: FmsNetcdfFile_t, read_data, close_file, open_file
+  use fms2_io_mod,       only: FmsNetcdfFile_t, read_data, close_file, open_file, get_dimension_size
   use mpp_mod,           only: mpp_npes, mpp_error, FATAL, mpp_pe, input_nml_file
   use platform_mod,      only: r4_kind, r8_kind
   use testing_utils,     only: allocate_buffer, test_normal, test_openmp, test_halos, no_mask, logical_mask, real_mask
@@ -37,6 +37,7 @@ program check_time_none
   integer                            :: nw                 !< Number of points in the 4th dimension
   integer                            :: i                  !< For looping
   integer                            :: io_status          !< Io status after reading the namelist
+  integer                            :: dim_size           !< dimension size as read from the file
   logical                            :: use_mask           !< .true. if using masks
 
   integer :: test_case = test_normal !< Indicates which test case to run
@@ -67,6 +68,23 @@ program check_time_none
 
   if (.not. open_file(fileobj2, "test_none_regional.nc.0005", "read")) &
     call mpp_error(FATAL, "unable to open test_none_regional.nc.0005")
+
+  print *, "Checking the dimensions of the subaxis"
+  ! This is only done for the "none" reduction because the logic that determines the subaxis
+  ! size is independent of the reduction method
+  call get_dimension_size(fileobj1, "x_sub01", dim_size)
+  if (dim_size .ne. 4) call mpp_error(FATAL, "x_sub01 is not the correct size!")
+  call get_dimension_size(fileobj1, "y_sub01", dim_size)
+  if (dim_size .ne. 3) call mpp_error(FATAL, "y_sub01 is not the correct size!")
+  call get_dimension_size(fileobj1, "z_sub01", dim_size)
+  if (dim_size .ne. 2) call mpp_error(FATAL, "z_sub01 is not the correct size!")
+
+  call get_dimension_size(fileobj2, "x_sub01", dim_size)
+  if (dim_size .ne. 4) call mpp_error(FATAL, "x_sub01 is not the correct size!")
+  call get_dimension_size(fileobj2, "y_sub01", dim_size)
+  if (dim_size .ne. 1) call mpp_error(FATAL, "y_sub01 is not the correct size!")
+  call get_dimension_size(fileobj2, "z_sub01", dim_size)
+  if (dim_size .ne. 2) call mpp_error(FATAL, "z_sub01 is not the correct size!")
 
   cdata_out = allocate_buffer(1, nx, 1, ny, nz, nw)
 


### PR DESCRIPTION
**Description**
Fix for when there are multiple subregional diagnostics in the same file. The `var_axis_ids` was not updated with the subaxis id and that was leading to errors such as:
```
FATAL from PE    81: NetCDF: Invalid dimension ID or name: netcdf_add_variable: file:19480101.ocean_Drake_Passage.nc.0081 variable:uo
```

Fixes # (issue)

**How Has This Been Tested?**
CI

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

