### PR TITLE
limit max parallel intel CI jobs to 1 to avoid running out of storage

### DIFF
--- a/.github/workflows/github_autotools_intel.yml
+++ b/.github/workflows/github_autotools_intel.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         io-flag: ["--disable-deprecated-io", "--enable-deprecated-io"]
     container:
-      image: intel/oneapi-hpckit:2023.1.0-devel-ubuntu20.04
+      image: intel/hpckit:2024.0.1-devel-ubuntu20.04
       env:
         CC: mpiicc
         FC: mpiifort

--- a/.github/workflows/github_autotools_intel.yml
+++ b/.github/workflows/github_autotools_intel.yml
@@ -9,9 +9,9 @@ jobs:
   intel-autotools:
     runs-on: ubuntu-latest
     strategy:
+      max-parallel: 1
       matrix:
         io-flag: ["--disable-deprecated-io", "--enable-deprecated-io"]
-        max-parallel: 1
     container:
       image: intel/oneapi-hpckit:2023.1.0-devel-ubuntu20.04
       env:

--- a/.github/workflows/github_autotools_intel.yml
+++ b/.github/workflows/github_autotools_intel.yml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       matrix:
         io-flag: ["--disable-deprecated-io", "--enable-deprecated-io"]
+        max-parallel: 1
     container:
       image: intel/oneapi-hpckit:2023.1.0-devel-ubuntu20.04
       env:


### PR DESCRIPTION
**Description**
This is a small fix to help with storage limit issues that occasionally pop up in the intel CI due to the size of the intel images it has to pull in. Instead of running both jobs (with and without the old io) it'll run one at a time.

**How Has This Been Tested?**
CI

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

