### PR TITLE
dmUpdate: move current_model_time to the field object

### DIFF
--- a/diag_manager/fms_diag_field_object.F90
+++ b/diag_manager/fms_diag_field_object.F90
@@ -1805,16 +1805,16 @@ subroutine generate_associated_files_att(this, att, start_time)
 
   att = trim(att)//" "//trim(field_name)//": "//trim(file_name)//".nc"
 end subroutine generate_associated_files_att
-!> @brief Sets the given time as the current model time for a field 
+!> @brief Sets the given time as the current model time for a field
 subroutine set_current_model_time(this, time)
   class(fmsDiagField_type), intent(inout) :: this    !< Field object to query
   type(time_type), intent(in) :: time !< a time type to represent the current model time
 
-  this%current_model_time = time 
+  this%current_model_time = time
 end subroutine set_current_model_time
 
 !> @brief Gets the current set time for a given field
-!! @return current model time for that field 
+!! @return current model time for that field
 function get_current_model_time(this) &
   result(res)
   class(fmsDiagField_type), intent(in) :: this    !< Field object to query

--- a/diag_manager/fms_diag_file_object.F90
+++ b/diag_manager/fms_diag_file_object.F90
@@ -1053,9 +1053,8 @@ end select
 end function is_file_static
 
 !< @brief Opens the diag_file if it is time to do so
-subroutine open_diag_file(this, time_step, file_is_opened)
+subroutine open_diag_file(this, file_is_opened)
   class(fmsDiagFileContainer_type), intent(inout), target :: this            !< The file object
-  TYPE(time_type),                  intent(in)            :: time_step       !< Current model step time
   logical,                          intent(out)           :: file_is_opened  !< .true. if the file was opened in this
                                                                              !! time
 

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -62,7 +62,6 @@ private
                                                                        !! one for each variable in the diag_table.yaml
   integer, private :: registered_buffers = 0 !< number of registered buffers, per dimension
   class(fmsDiagAxisContainer_type), allocatable :: diag_axis(:) !< Array of diag_axis
-  !type(time_type)  :: global_model_time !< The model time for the whole object
   integer, private :: registered_variables !< Number of registered variables
   integer, private :: registered_axis !< Number of registered axis
   logical, private :: initialized=.false. !< True if the fmsDiagObject is initialized

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -92,7 +92,6 @@ private
     procedure :: fms_diag_field_add_cell_measures
     procedure :: allocate_diag_field_output_buffers
     procedure :: fms_diag_compare_window
-    !procedure :: update_current_model_time
 #ifdef use_yaml
     procedure :: get_diag_buffer
 #endif
@@ -131,7 +130,6 @@ subroutine fms_diag_object_init (this,diag_subset_output)
   this%buffers_initialized =fms_diag_output_buffer_init(this%FMS_diag_output_buffers,SIZE(diag_yaml%get_diag_fields()))
   this%registered_variables = 0
   this%registered_axis = 0
-  !this%global_model_time= get_base_time()
   this%initialized = .true.
 #else
   call mpp_error("fms_diag_object_init",&
@@ -268,7 +266,7 @@ CALL MPP_ERROR(FATAL,"You can not use the modern diag manager without compiling 
      call fileptr%init_diurnal_axis(this%diag_axis, this%registered_axis, diag_field_indices(i))
      call fileptr%add_axes(axes, this%diag_axis, this%registered_axis, diag_field_indices(i), &
        fieldptr%buffer_ids(i), this%FMS_diag_output_buffers)
-       ! update global and field-specific model times
+     ! update field-specific model times
      start_time = get_base_time()
      call fileptr%add_start_time(init_time, start_time)
      call fieldptr%set_current_model_time(start_time)
@@ -290,7 +288,7 @@ CALL MPP_ERROR(FATAL,"You can not use the modern diag manager without compiling 
      fileptr => this%FMS_diag_files(file_ids(i))%FMS_diag_file
      call fileptr%add_field_and_yaml_id(fieldptr%get_id(), diag_field_indices(i))
      call fileptr%add_buffer_id(fieldptr%buffer_ids(i))
-     ! update global and field-specific model times
+     ! update field-specific model times
      start_time = get_base_time()
      call fileptr%add_start_time(init_time, start_time)
      call fieldptr%set_current_model_time(start_time)


### PR DESCRIPTION
**Description**
moves the current_model_time variable from the main diag object to the individual field objects

I'm not too sure if the check under `all fields should have the same time if writing` should be there.

**How Has This Been Tested?**
latest oneapi on amd

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

