### PR TITLE
Fix to finish the reduction methods at the right time

### DIFF
--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -233,23 +233,9 @@ CALL MPP_ERROR(FATAL,"You can not use the modern diag manager without compiling 
   file_ids = get_diag_files_id(diag_field_indices)
   call fieldptr%set_file_ids(file_ids)
 
-!> Initialize buffer_ids of this field with the diag_field_indices(diag_field_indices)
-!! of the sorted variable list
-  fieldptr%buffer_ids = get_diag_field_ids(diag_field_indices)
-  do i = 1, size(fieldptr%buffer_ids)
-    bufferptr => this%FMS_diag_output_buffers(fieldptr%buffer_ids(i))
-    call bufferptr%set_field_id(this%registered_variables)
-    call bufferptr%set_yaml_id(fieldptr%buffer_ids(i))
-    ! check if diurnal reduction for this buffer and if so set the diurnal sample size
-    yamlfptr => diag_yaml%diag_fields(fieldptr%buffer_ids(i))
-    if( yamlfptr%get_var_reduction() .eq. time_diurnal) then
-      call bufferptr%set_diurnal_sample_size(yamlfptr%get_n_diurnal())
-    endif
-    call bufferptr%init_buffer_time(init_time)
-  enddo
-
 !> Allocate and initialize member buffer_allocated of this field
   fieldptr%buffer_allocated = .false.
+  fieldptr%buffer_ids = get_diag_field_ids(diag_field_indices)
 
 !> Register the data for the field
   call fieldptr%register(modname, varname, diag_field_indices, this%diag_axis, &
@@ -298,6 +284,22 @@ CALL MPP_ERROR(FATAL,"You can not use the modern diag manager without compiling 
      call fileptr%set_file_time_ops (fieldptr%diag_field(i), fieldptr%is_static())
     enddo
   endif
+
+  !> Initialize buffer_ids of this field with the diag_field_indices(diag_field_indices)
+!! of the sorted variable list
+  do i = 1, size(fieldptr%buffer_ids)
+    bufferptr => this%FMS_diag_output_buffers(fieldptr%buffer_ids(i))
+    call bufferptr%set_field_id(this%registered_variables)
+    call bufferptr%set_yaml_id(fieldptr%buffer_ids(i))
+    ! check if diurnal reduction for this buffer and if so set the diurnal sample size
+    yamlfptr => diag_yaml%diag_fields(fieldptr%buffer_ids(i))
+    if( yamlfptr%get_var_reduction() .eq. time_diurnal) then
+      call bufferptr%set_diurnal_sample_size(yamlfptr%get_n_diurnal())
+    endif
+    call bufferptr%init_buffer_time(init_time)
+    call bufferptr%set_next_output(this%FMS_diag_files(file_ids(i))%get_next_output())
+  enddo
+
   nullify (fileptr)
   nullify (fieldptr)
   deallocate(diag_field_indices)
@@ -750,7 +752,7 @@ subroutine fms_diag_do_io(this, is_end_of_run)
   logical :: file_is_opened_this_time_step !< True if the file was opened in this time_step
                                            !! If true the metadata will need to be written
   logical :: force_write !< force the last write if at end of run
-  logical :: is_writing !< true if we are writing the actual field data (metadata is always written)
+  logical :: finish_writing !< true if finished writing for all the fields
   logical :: has_mask !< whether we have a mask
   logical, parameter :: DEBUG_REDUCT = .false. !< enables debugging output
   class(*), allocatable :: missing_val !< netcdf missing value for a given field
@@ -775,22 +777,23 @@ subroutine fms_diag_do_io(this, is_end_of_run)
       call diag_file%write_time_metadata()
       call diag_file%write_field_metadata(this%FMS_diag_fields, this%diag_axis)
       call diag_file%write_axis_data(this%diag_axis)
+      call diag_file%increase_unlim_dimension_level()
     endif
 
-    is_writing = diag_file%is_time_to_write(model_time)
+    finish_writing = diag_file%is_time_to_write(model_time)
 
     ! finish reduction method if its time to write
-    buff_reduct: if (is_writing) then
-      buff_ids = diag_file%FMS_diag_file%get_buffer_ids()
-      ! loop through the buffers and finish reduction if needed
-      buff_loop: do ibuff=1, SIZE(buff_ids)
-        diag_buff => this%FMS_diag_output_buffers(buff_ids(ibuff))
-        field_yaml => diag_yaml%diag_fields(diag_buff%get_yaml_id())
-        diag_field => this%FMS_diag_fields(diag_buff%get_field_id())
+    buff_ids = diag_file%FMS_diag_file%get_buffer_ids()
+    ! loop through the buffers and finish reduction if needed
+    buff_loop: do ibuff=1, SIZE(buff_ids)
+      diag_buff => this%FMS_diag_output_buffers(buff_ids(ibuff))
+      field_yaml => diag_yaml%diag_fields(diag_buff%get_yaml_id())
+      diag_field => this%FMS_diag_fields(diag_buff%get_field_id())
 
-        ! Go away if there is no data to write
-        if (.not. diag_buff%is_there_data_to_write()) cycle
+      ! Go away if there is no data to write
+      if (.not. diag_buff%is_there_data_to_write()) cycle
 
+      if ( diag_buff%is_time_to_finish_reduction()) then
         ! sets missing value
         mval = diag_field%find_missing_value(missing_val)
         ! time_average and greater values all involve averaging so need to be "finished" before written
@@ -801,22 +804,22 @@ subroutine fms_diag_do_io(this, is_end_of_run)
             if(has_mask) has_mask = diag_field%get_mask_variant()
             error_string = diag_buff%diag_reduction_done_wrapper( &
                                     field_yaml%get_var_reduction(), &
-                                    mval, has_mask)
+                                   mval, has_mask)
           endif
         endif
-        !endif
-        nullify(diag_buff)
-        nullify(field_yaml)
-      enddo buff_loop
-      deallocate(buff_ids)
-    endif buff_reduct
+        call diag_file%write_field_data(diag_field, diag_buff)
+        call diag_buff%set_next_output(diag_file%get_next_next_output())
+      endif
+      nullify(diag_buff)
+      nullify(field_yaml)
+    enddo buff_loop
+    deallocate(buff_ids)
 
-    if (is_writing) then
-      call diag_file%increase_unlim_dimension_level()
+    if (finish_writing) then
       call diag_file%write_time_data()
-      call diag_file%write_field_data(this%FMS_diag_fields, this%FMS_diag_output_buffers)
       call diag_file%update_next_write(model_time)
       call diag_file%update_current_new_file_freq_index(model_time)
+      call diag_file%increase_unlim_dimension_level()
       if (diag_file%is_time_to_close_file(model_time)) call diag_file%close_diag_file()
     else if (force_write) then
       if (diag_file%get_unlim_dimension_level() .eq. 0) then
@@ -970,6 +973,7 @@ function fms_diag_do_reduction(this, field_data, diag_field_id, oor_mask, weight
 
     !< Determine the reduction method for the buffer
     reduction_method = field_yaml_ptr%get_var_reduction()
+    if (present(time)) new_time = buffer_ptr%update_buffer_time(time)
     select case(reduction_method)
     case (time_none)
       error_msg = buffer_ptr%do_time_none_wrapper(field_data, oor_mask, field_ptr%get_mask_variant(), &
@@ -996,21 +1000,18 @@ function fms_diag_do_reduction(this, field_data, diag_field_id, oor_mask, weight
         return
       endif
     case (time_average)
-      new_time = buffer_ptr%update_buffer_time(time)
       error_msg = buffer_ptr%do_time_sum_wrapper(field_data, oor_mask, field_ptr%get_mask_variant(), &
         bounds_in, bounds_out, missing_value, new_time)
       if (trim(error_msg) .ne. "") then
         return
       endif
     case (time_power)
-      new_time = buffer_ptr%update_buffer_time(time)
       error_msg = buffer_ptr%do_time_sum_wrapper(field_data, oor_mask, field_ptr%get_mask_variant(), &
         bounds_in, bounds_out, missing_value, new_time, pow_value=field_yaml_ptr%get_pow_value())
       if (trim(error_msg) .ne. "") then
         return
       endif
     case (time_rms)
-      new_time = buffer_ptr%update_buffer_time(time)
       error_msg = buffer_ptr%do_time_sum_wrapper(field_data, oor_mask, field_ptr%get_mask_variant(), &
         bounds_in, bounds_out, missing_value, new_time, pow_value = 2)
       if (trim(error_msg) .ne. "") then

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -795,7 +795,7 @@ subroutine fms_diag_do_io(this, end_time)
       ! Go away if there is no data to write
       if (.not. diag_buff%is_there_data_to_write()) cycle
 
-      if ( diag_buff%is_time_to_finish_reduction()) then
+      if ( diag_buff%is_time_to_finish_reduction(end_time)) then
         ! sets missing value
         mval = diag_field%find_missing_value(missing_val)
         ! time_average and greater values all involve averaging so need to be "finished" before written
@@ -824,10 +824,7 @@ subroutine fms_diag_do_io(this, end_time)
       call diag_file%increase_unlim_dimension_level()
       if (diag_file%is_time_to_close_file(model_time)) call diag_file%close_diag_file()
     else if (force_write) then
-      if (diag_file%get_unlim_dimension_level() .eq. 0) then
-        call diag_file%increase_unlim_dimension_level()
-        call diag_file%write_time_data()
-      endif
+      call diag_file%write_time_data()
       call diag_file%close_diag_file()
     endif
   enddo

--- a/diag_manager/fms_diag_output_buffer.F90
+++ b/diag_manager/fms_diag_output_buffer.F90
@@ -819,14 +819,19 @@ end function
 
 !> @brief Determine if it is time to finish the reduction method
 !! @return .true. if it is time to finish the reduction method
-function is_time_to_finish_reduction(this) &
+function is_time_to_finish_reduction(this, end_time) &
   result(res)
   class(fmsDiagOutputBuffer_type), intent(inout) :: this        !< Buffer object
+  type(time_type), optional,       intent(in)    :: end_time    !< The time at the end of the run
 
   logical :: res
 
   res = .false.
   if (this%time >= this%next_output) res = .true.
+
+  if (present(end_time)) then
+    if (end_time >= this%next_output) res = .true.
+  endif
 end function is_time_to_finish_reduction
 
 !> @brief Sets send_data_called to .true.

--- a/diag_manager/fms_diag_output_buffer.F90
+++ b/diag_manager/fms_diag_output_buffer.F90
@@ -27,7 +27,7 @@ module fms_diag_output_buffer_mod
 #ifdef use_yaml
 use platform_mod
 use iso_c_binding
-use time_manager_mod, only: time_type, operator(==), operator(>=), get_ticks_per_second, get_time, operator(>), date_to_string
+use time_manager_mod, only: time_type, operator(==), operator(>=), get_ticks_per_second, get_time, operator(>)
 use constants_mod, only: SECONDS_PER_DAY
 use mpp_mod, only: mpp_error, FATAL, NOTE, mpp_pe, mpp_root_pe
 use diag_data_mod, only: DIAG_NULL, DIAG_NOT_REGISTERED, i4, i8, r4, r8, get_base_time, MIN_VALUE, MAX_VALUE, EMPTY, &


### PR DESCRIPTION
**Description**
- Adds `next_output` to the output buffer object and subroutines to determine when to finish the reduction and to set it (this is used with the `time`)
- Adds logic to `diag_manager_end` so that it can do one last write if it is time to to
- Refactors `write_field_data` to take in one field/buffer instead of an array
- Adds getters for `next_output` and `next_next_output`

Fixes # (issue)

**How Has This Been Tested?**
Before this update, there were answers changes such as
```
19790101.aerosol_daily_cmip.tile1.nc
DIFFER : VARIABLE : loadoa : POSITION : [0,0,0] : VALUES : 8.4246e-07 <> 8.24577e-07
DIFFER : VARIABLE : loadsoa : POSITION : [0,0,0] : VALUES : 2.4235e-07 <> 2.21925e-07
DIFFER : VARIABLE : loadso4 : POSITION : [0,0,0] : VALUES : 1.51636e-06 <> 1.54552e-06
DIFFER : VARIABLE : loadpoa : POSITION : [0,0,0] : VALUES : 6.0011e-07 <> 6.02652e-07
```

With this update they know reproduce. 
This was tested with one year long AM4 experiments.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

