### PR TITLE
Fix for inefficient iceberg restarts

### DIFF
--- a/fms2_io/netcdf_io.F90
+++ b/fms2_io/netcdf_io.F90
@@ -798,16 +798,9 @@ subroutine register_unlimited_compressed_axis(fileobj, dimension_name, dimension
   !Gather all local dimension lengths on the I/O root pe.
   allocate(npes_start(size(fileobj%pelist)))
   allocate(npes_count(size(fileobj%pelist)))
-  do i = 1, size(fileobj%pelist)
-    if (fileobj%pelist(i) .eq. mpp_pe()) then
-      npes_count(i) = dimension_length
-    else
-      call mpp_recv(npes_count(i), fileobj%pelist(i), block=.false.)
-      call mpp_send(dimension_length, fileobj%pelist(i))
-    endif
-  enddo
-  call mpp_sync_self(check=event_recv)
-  call mpp_sync_self(check=event_send)
+
+  call mpp_gather((/dimension_length/),npes_count,pelist=fileobj%pelist)
+
   npes_start(1) = 1
   do i = 1, size(fileobj%pelist)-1
      npes_start(i+1) = npes_start(i) + npes_count(i)


### PR DESCRIPTION
Changed registration of axes during iceberg restarts so that dimension lengths from each PE are gathered to only the I/O root PE, replacing the original approach of gathering to all PEs. The original approach was inefficient enough to stall runs with a large number of PEs until they timed out, and this PR fixes this issue.

**How Has This Been Tested?**
intel-classic/2022.0.2. Confirmed that the restart files produced with/without this commit are identical

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

