### PR TITLE
dmUpdate: move type declaration and change type for nvhpc

### DIFF
--- a/diag_manager/fms_diag_axis_object.F90
+++ b/diag_manager/fms_diag_axis_object.F90
@@ -83,15 +83,9 @@ module fms_diag_axis_object_mod
     type(domainUG) :: DomainUG !< Domain of "U" axis
   end type
 
-  !> @brief Type to hold the diag_axis (either subaxis or a full axis)
-  !> @ingroup diag_axis_object_mod
-  type :: fmsDiagAxisContainer_type
-    class(fmsDiagAxis_type), allocatable :: axis
-  end type
-
   !> @brief Type to hold the diagnostic axis description.
   !> @ingroup diag_axis_object_mod
-  TYPE fmsDiagAxis_type
+  TYPE :: fmsDiagAxis_type
      INTEGER                        , private :: axis_id         !< ID of the axis
 
      contains
@@ -106,6 +100,12 @@ module fms_diag_axis_object_mod
        procedure :: is_unstructured_grid
        procedure :: get_edges_id
   END TYPE fmsDiagAxis_type
+
+  !> @brief Type to hold the diag_axis (either subaxis or a full axis)
+  !> @ingroup diag_axis_object_mod
+  type :: fmsDiagAxisContainer_type
+    class(fmsDiagAxis_type), allocatable :: axis
+  end type
 
   !> @brief Type to hold the subaxis
   !> @ingroup diag_axis_object_mod

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -1176,7 +1176,7 @@ function get_diag_buffer(this, bufferid) &
 result(rslt)
   class(fmsDiagObject_type), intent(in) :: this
   integer, intent(in)                   :: bufferid
-  class(fmsDiagOutputBuffer_type),allocatable:: rslt
+  type(fmsDiagOutputBuffer_type),allocatable:: rslt
   if( (bufferid .gt. UBOUND(this%FMS_diag_output_buffers, 1)) .or. &
       (bufferid .lt. LBOUND(this%FMS_diag_output_buffers, 1))) &
     call mpp_error(FATAL, 'get_diag_bufer: invalid bufferid given')


### PR DESCRIPTION
**Description**
fixes compilation errors related to the diag manager updates when building with nvhpc. Had to move a type declaration to be before any references to it and switch a `class` to a `type`.

I still ran into runtime errors when running the unit testing with nvhpc.

**How Has This Been Tested?**
built with nvhpc on amd box (23.11) and gaea (22.3)

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

