### PR TITLE
dmUpdate: fix nvhpc compile error

### DIFF
--- a/diag_manager/diag_data.F90
+++ b/diag_manager/diag_data.F90
@@ -573,19 +573,34 @@ CONTAINS
     select type (att_value)
     type is (integer(kind=i4_kind))
       allocate(integer(kind=i4_kind) :: this%att_value(natt))
-      this%att_value = att_value
+      select type(aval => this%att_value)
+        type is (integer(kind=i4_kind))
+          aval = att_value
+      end select
     type is (integer(kind=i8_kind))
       allocate(integer(kind=i8_kind) :: this%att_value(natt))
-      this%att_value = att_value
+      select type(aval => this%att_value)
+        type is (integer(kind=i8_kind))
+          aval = att_value
+      end select
     type is (real(kind=r4_kind))
       allocate(real(kind=r4_kind) :: this%att_value(natt))
-      this%att_value = att_value
+      select type(aval => this%att_value)
+        type is (real(kind=r4_kind))
+          aval = att_value
+      end select
     type is (real(kind=r8_kind))
       allocate(real(kind=r8_kind) :: this%att_value(natt))
-      this%att_value = att_value
+      select type(aval => this%att_value)
+        type is (real(kind=r8_kind))
+          aval = att_value
+      end select
     type is (character(len=*))
       allocate(character(len=len(att_value)) :: this%att_value(natt))
-      this%att_value = att_value
+      select type(aval => this%att_value)
+        type is (character(len=*))
+          aval = att_value
+      end select
     end select
   end subroutine fms_add_attribute
 

--- a/diag_manager/diag_data.F90
+++ b/diag_manager/diag_data.F90
@@ -573,28 +573,16 @@ CONTAINS
     select type (att_value)
     type is (integer(kind=i4_kind))
       allocate(integer(kind=i4_kind) :: this%att_value(natt))
-      select type(aval => this%att_value)
-        type is (integer(kind=i4_kind))
-          aval = att_value
-      end select
+      aval = att_value
     type is (integer(kind=i8_kind))
       allocate(integer(kind=i8_kind) :: this%att_value(natt))
-      select type(aval => this%att_value)
-        type is (integer(kind=i8_kind))
-          aval = att_value
-      end select
+      aval = att_value
     type is (real(kind=r4_kind))
       allocate(real(kind=r4_kind) :: this%att_value(natt))
-      select type(aval => this%att_value)
-        type is (real(kind=r4_kind))
-          aval = att_value
-      end select
+      aval = att_value
     type is (real(kind=r8_kind))
       allocate(real(kind=r8_kind) :: this%att_value(natt))
-      select type(aval => this%att_value)
-        type is (real(kind=r8_kind))
-          aval = att_value
-      end select
+      aval = att_value
     type is (character(len=*))
       allocate(character(len=len(att_value)) :: this%att_value(natt))
       select type(aval => this%att_value)

--- a/diag_manager/diag_data.F90
+++ b/diag_manager/diag_data.F90
@@ -573,16 +573,16 @@ CONTAINS
     select type (att_value)
     type is (integer(kind=i4_kind))
       allocate(integer(kind=i4_kind) :: this%att_value(natt))
-      aval = att_value
+      this%att_value = att_value
     type is (integer(kind=i8_kind))
       allocate(integer(kind=i8_kind) :: this%att_value(natt))
-      aval = att_value
+      this%att_value = att_value
     type is (real(kind=r4_kind))
       allocate(real(kind=r4_kind) :: this%att_value(natt))
-      aval = att_value
+      this%att_value = att_value
     type is (real(kind=r8_kind))
       allocate(real(kind=r8_kind) :: this%att_value(natt))
-      aval = att_value
+      this%att_value = att_value
     type is (character(len=*))
       allocate(character(len=len(att_value)) :: this%att_value(natt))
       select type(aval => this%att_value)

--- a/exchange/xgrid.F90
+++ b/exchange/xgrid.F90
@@ -1542,7 +1542,8 @@ subroutine setup_xmap(xmap, grid_ids, grid_domains, grid_file, atm_grid, lnd_ug_
   integer                                      :: lnd_ug_id, l
   integer,                         allocatable :: grid_index(:)
   type(FmsNetcdfFile_t)                        :: gridfileobj, mosaicfileobj, fileobj
-  type(grid_type), allocatable, target         :: grids_tmp(:)
+  type(grid_type), allocatable, target         :: grids_tmp(:) !< added for nvhpc workaround, stores xmap's
+                                                               !! grid_type array so we can safely point to it
 
   call mpp_clock_begin(id_setup_xmap)
 
@@ -1597,8 +1598,7 @@ subroutine setup_xmap(xmap, grid_ids, grid_domains, grid_file, atm_grid, lnd_ug_
   call mpp_clock_begin(id_load_xgrid)
 
   ! nvhpc compiler workaround
-  ! saves grid array as an allocatable
-  ! this lets us use a normal assignment instead of a pointer assignment in the loop to avoid a compiler error
+  ! saves grid array as an allocatable and points to that to avoid error from pointing to xmap%grids in loop
   grids_tmp = xmap%grids
 
   grid1 => xmap%grids(1)

--- a/exchange/xgrid.F90
+++ b/exchange/xgrid.F90
@@ -1514,7 +1514,7 @@ end subroutine get_ocean_model_area_elements
 !> @brief Sets up exchange grid connectivity using grid specification file and
 !!      processor domain decomposition.
 subroutine setup_xmap(xmap, grid_ids, grid_domains, grid_file, atm_grid, lnd_ug_domain)
-  type (xmap_type),                        intent(inout) :: xmap
+  type(xmap_type), allocatable,            intent(inout) :: xmap
   character(len=3), dimension(:),            intent(in ) :: grid_ids
   type(Domain2d),   dimension(:),            intent(in ) :: grid_domains
   character(len=*),                          intent(in ) :: grid_file
@@ -1524,7 +1524,8 @@ subroutine setup_xmap(xmap, grid_ids, grid_domains, grid_file, atm_grid, lnd_ug_
   integer :: g, p, i
   integer :: nxgrid_file, i1, i2, i3, tile1, tile2, j
   integer :: nxc, nyc, out_unit
-  type (grid_type), pointer, save              :: grid =>NULL(), grid1 =>NULL()
+  type(grid_type), pointer :: grid => NULL()!< pointer to loop through grid_type's in list
+  type(grid_type), pointer, save :: grid1 => NULL() !< saved pointer to the first grid in the list
   real(r8_kind), dimension(3)                  :: xxx
   real(r8_kind), dimension(:,:),   allocatable :: check_data
   real(r8_kind), dimension(:,:,:), allocatable :: check_data_3D
@@ -1593,9 +1594,14 @@ subroutine setup_xmap(xmap, grid_ids, grid_domains, grid_file, atm_grid, lnd_ug_
   endif
 
   call mpp_clock_begin(id_load_xgrid)
-  do g=1,size(grid_ids(:))
-     grid => xmap%grids(g)
-     if (g==1) grid1 => xmap%grids(g)
+
+  ! save the first grid in the array
+  grid1 => xmap%grids(1)
+
+  do g=1, size(grid_ids(:))
+
+     grid = xmap%grids(g)
+
      grid%id     = grid_ids    (g)
      grid%domain = grid_domains(g)
      grid%on_this_pe = mpp_domain_is_initialized(grid_domains(g))

--- a/exchange/xgrid.F90
+++ b/exchange/xgrid.F90
@@ -1514,7 +1514,7 @@ end subroutine get_ocean_model_area_elements
 !> @brief Sets up exchange grid connectivity using grid specification file and
 !!      processor domain decomposition.
 subroutine setup_xmap(xmap, grid_ids, grid_domains, grid_file, atm_grid, lnd_ug_domain)
-  type(xmap_type), allocatable,            intent(inout) :: xmap
+  type(xmap_type),                         intent(inout) :: xmap
   character(len=3), dimension(:),            intent(in ) :: grid_ids
   type(Domain2d),   dimension(:),            intent(in ) :: grid_domains
   character(len=*),                          intent(in ) :: grid_file
@@ -1542,6 +1542,7 @@ subroutine setup_xmap(xmap, grid_ids, grid_domains, grid_file, atm_grid, lnd_ug_
   integer                                      :: lnd_ug_id, l
   integer,                         allocatable :: grid_index(:)
   type(FmsNetcdfFile_t)                        :: gridfileobj, mosaicfileobj, fileobj
+  type(xmap_type), allocatable, save           :: xmap_tmp
 
   call mpp_clock_begin(id_setup_xmap)
 
@@ -1595,12 +1596,16 @@ subroutine setup_xmap(xmap, grid_ids, grid_domains, grid_file, atm_grid, lnd_ug_
 
   call mpp_clock_begin(id_load_xgrid)
 
-  ! save the first grid in the array
+  ! nvhpc compiler workaround
+  ! saves passed in xmap as an allocatable
+  ! this lets us use a normal assignment instead of a pointer assignment in the loop to avoid a compiler error
+  xmap_tmp = xmap
+
   grid1 => xmap%grids(1)
 
   do g=1, size(grid_ids(:))
 
-     grid = xmap%grids(g)
+     grid = xmap_tmp%grids(g)
 
      grid%id     = grid_ids    (g)
      grid%domain = grid_domains(g)


### PR DESCRIPTION
**Description**
Fixes a nvidia compilation error coming from the diag_manager updates. I missed this one in PR #1463 because i was only using autotools. Interestingly this error seems to only happen with mkmf, even if i use the same target flags for autotools.

Just adds a nested select type for when assigning a class(*) field to a character variable.

**How Has This Been Tested?**
mkmf on gaea with nvhpc/22.3, autotools build on amd with nvhpc/23.11

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

