### PR TITLE
Fms.parallel startup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ option(ENABLE_QUAD_PRECISION "Enable compiler definition -DENABLE_QUAD_PRECISION
 option(GFS_PHYS              "Enable compiler definition -DGFS_PHYS"              OFF)
 option(LARGEFILE             "Enable compiler definition -Duse_LARGEFILE"         OFF)
 option(WITH_YAML             "Enable compiler definition -Duse_yaml"              OFF)
-option(USE_DEPRECATED_IO     "Enable compiler definition -Duse_deprecated_io (compile with fms_io/mpp_io)"   ON)
+option(USE_DEPRECATED_IO     "Enable compiler definition -Duse_deprecated_io (compile with fms_io/mpp_io)"   OFF)
 
 if(32BIT)
   list(APPEND kinds "r4")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ option(ENABLE_QUAD_PRECISION "Enable compiler definition -DENABLE_QUAD_PRECISION
 option(GFS_PHYS              "Enable compiler definition -DGFS_PHYS"              OFF)
 option(LARGEFILE             "Enable compiler definition -Duse_LARGEFILE"         OFF)
 option(WITH_YAML             "Enable compiler definition -Duse_yaml"              OFF)
-option(USE_DEPRECATED_IO     "Enable compiler definition -Duse_deprecated_io (compile with fms_io/mpp_io)"   OFF)
+option(USE_DEPRECATED_IO     "Enable compiler definition -Duse_deprecated_io (compile with fms_io/mpp_io)"   ON)
 
 if(32BIT)
   list(APPEND kinds "r4")

--- a/fms2_io/include/netcdf_read_data.inc
+++ b/fms2_io/include/netcdf_read_data.inc
@@ -354,8 +354,12 @@ subroutine netcdf_read_data_2d(fileobj, variable_name, buf, unlim_dim_level, &
     endif
     c(unlim_dim_index) = unlim_dim_level
   endif
-  if (fileobj%is_root) then
+  if(fileobj%use_collective) then
     varid = get_variable_id(fileobj%ncid, trim(variable_name), msg=append_error_msg)
+    ! NetCDF does not have the ability to specify collective I/O at
+    ! the file basis so we must activate at the variable level
+    err = nf90_var_par_access(fileobj%ncid, varid, nf90_collective)
+    call check_netcdf_code(err, append_error_msg)
     select type(buf)
       type is (integer(kind=i4_kind))
         err = nf90_get_var(fileobj%ncid, varid, buf, start=c, count=e)
@@ -370,20 +374,38 @@ subroutine netcdf_read_data_2d(fileobj, variable_name, buf, unlim_dim_level, &
     end select
     call check_netcdf_code(err, append_error_msg)
     call unpack_data_2d(fileobj, varid, variable_name, buf)
-  endif
-  if (bcast) then
-    select type(buf)
-      type is (integer(kind=i4_kind))
-        call mpp_broadcast(buf, size(buf), fileobj%io_root, pelist=fileobj%pelist)
-      type is (integer(kind=i8_kind))
-        call mpp_broadcast(buf, size(buf), fileobj%io_root, pelist=fileobj%pelist)
-      type is (real(kind=r4_kind))
-        call mpp_broadcast(buf, size(buf), fileobj%io_root, pelist=fileobj%pelist)
-      type is (real(kind=r8_kind))
-        call mpp_broadcast(buf, size(buf), fileobj%io_root, pelist=fileobj%pelist)
-      class default
-        call error("Unsupported variable type: "//trim(append_error_msg))
-    end select
+  else
+    if (fileobj%is_root) then
+      varid = get_variable_id(fileobj%ncid, trim(variable_name), msg=append_error_msg)
+      select type(buf)
+        type is (integer(kind=i4_kind))
+          err = nf90_get_var(fileobj%ncid, varid, buf, start=c, count=e)
+        type is (integer(kind=i8_kind))
+          err = nf90_get_var(fileobj%ncid, varid, buf, start=c, count=e)
+        type is (real(kind=r4_kind))
+          err = nf90_get_var(fileobj%ncid, varid, buf, start=c, count=e)
+        type is (real(kind=r8_kind))
+          err = nf90_get_var(fileobj%ncid, varid, buf, start=c, count=e)
+        class default
+          call error("Unsupported variable type: "//trim(append_error_msg))
+      end select
+      call check_netcdf_code(err, append_error_msg)
+      call unpack_data_2d(fileobj, varid, variable_name, buf)
+    endif
+    if (bcast) then
+      select type(buf)
+        type is (integer(kind=i4_kind))
+          call mpp_broadcast(buf, size(buf), fileobj%io_root, pelist=fileobj%pelist)
+        type is (integer(kind=i8_kind))
+          call mpp_broadcast(buf, size(buf), fileobj%io_root, pelist=fileobj%pelist)
+        type is (real(kind=r4_kind))
+          call mpp_broadcast(buf, size(buf), fileobj%io_root, pelist=fileobj%pelist)
+        type is (real(kind=r8_kind))
+          call mpp_broadcast(buf, size(buf), fileobj%io_root, pelist=fileobj%pelist)
+        class default
+          call error("Unsupported variable type: "//trim(append_error_msg))
+      end select
+    endif
   endif
 end subroutine netcdf_read_data_2d
 
@@ -446,8 +468,12 @@ subroutine netcdf_read_data_3d(fileobj, variable_name, buf, unlim_dim_level, &
     endif
     c(unlim_dim_index) = unlim_dim_level
   endif
-  if (fileobj%is_root) then
+  if(fileobj%use_collective) then
     varid = get_variable_id(fileobj%ncid, trim(variable_name), msg=append_error_msg)
+    ! NetCDF does not have the ability to specify collective I/O at
+    ! the file basis so we must activate at the variable level
+    err = nf90_var_par_access(fileobj%ncid, varid, nf90_collective)
+    call check_netcdf_code(err, append_error_msg)
     select type(buf)
       type is (integer(kind=i4_kind))
         err = nf90_get_var(fileobj%ncid, varid, buf, start=c, count=e)
@@ -462,20 +488,38 @@ subroutine netcdf_read_data_3d(fileobj, variable_name, buf, unlim_dim_level, &
     end select
     call check_netcdf_code(err, append_error_msg)
     call unpack_data_3d(fileobj, varid, variable_name, buf)
-  endif
-  if (bcast) then
-    select type(buf)
-      type is (integer(kind=i4_kind))
-        call mpp_broadcast(buf, size(buf), fileobj%io_root, pelist=fileobj%pelist)
-      type is (integer(kind=i8_kind))
-        call mpp_broadcast(buf, size(buf), fileobj%io_root, pelist=fileobj%pelist)
-      type is (real(kind=r4_kind))
-        call mpp_broadcast(buf, size(buf), fileobj%io_root, pelist=fileobj%pelist)
-      type is (real(kind=r8_kind))
-        call mpp_broadcast(buf, size(buf), fileobj%io_root, pelist=fileobj%pelist)
-      class default
-        call error("Unsupported variable type: "//trim(append_error_msg))
-    end select
+  else
+    if (fileobj%is_root) then
+      varid = get_variable_id(fileobj%ncid, trim(variable_name), msg=append_error_msg)
+      select type(buf)
+        type is (integer(kind=i4_kind))
+          err = nf90_get_var(fileobj%ncid, varid, buf, start=c, count=e)
+        type is (integer(kind=i8_kind))
+          err = nf90_get_var(fileobj%ncid, varid, buf, start=c, count=e)
+        type is (real(kind=r4_kind))
+          err = nf90_get_var(fileobj%ncid, varid, buf, start=c, count=e)
+        type is (real(kind=r8_kind))
+          err = nf90_get_var(fileobj%ncid, varid, buf, start=c, count=e)
+        class default
+          call error("Unsupported variable type: "//trim(append_error_msg))
+      end select
+      call check_netcdf_code(err, append_error_msg)
+      call unpack_data_3d(fileobj, varid, variable_name, buf)
+    endif
+    if (bcast) then
+      select type(buf)
+        type is (integer(kind=i4_kind))
+          call mpp_broadcast(buf, size(buf), fileobj%io_root, pelist=fileobj%pelist)
+        type is (integer(kind=i8_kind))
+          call mpp_broadcast(buf, size(buf), fileobj%io_root, pelist=fileobj%pelist)
+        type is (real(kind=r4_kind))
+          call mpp_broadcast(buf, size(buf), fileobj%io_root, pelist=fileobj%pelist)
+        type is (real(kind=r8_kind))
+          call mpp_broadcast(buf, size(buf), fileobj%io_root, pelist=fileobj%pelist)
+        class default
+          call error("Unsupported variable type: "//trim(append_error_msg))
+      end select
+    endif
   endif
 end subroutine netcdf_read_data_3d
 

--- a/fms2_io/netcdf_io.F90
+++ b/fms2_io/netcdf_io.F90
@@ -567,7 +567,8 @@ function netcdf_file_open(fileobj, path, mode, nc_format, pelist, is_restart, do
 
   integer :: nc_format_param
   integer :: err
-  integer :: IsNetcdf4=-999 !< Query the file for IsNetcdf4 in the event that the open for collective reads fails
+  integer :: netcdf4 !< Query the file for the _IsNetcdf4 global attribute in the event
+                     !! that the open for collective reads fails
   character(len=256) :: buf !< Filename with .res in the filename if it is a restart
   character(len=256) :: buf2 !< Filename with the filename appendix if there is one
   logical :: is_res
@@ -671,9 +672,9 @@ function netcdf_file_open(fileobj, path, mode, nc_format, pelist, is_restart, do
                       comm=fileobj%tile_comm, info=MPP_INFO_NULL)
       if(err /= nf90_noerr) then
         err = nf90_open(trim(fileobj%path), nf90_nowrite, fileobj%ncid)
-        err = nf90_get_att(fileobj%ncid, nf90_global, "_IsNetcdf4", IsNetcdf4)
+        err = nf90_get_att(fileobj%ncid, nf90_global, "_IsNetcdf4", netcdf4)
         err = nf90_close(fileobj%ncid)
-        if(IsNetcdf4 /= 1) then
+        if(netcdf4 /= 1) then
           call mpp_error(NOTE,"netcdf_file_open: Open for collective read failed because the file is not &
                                netCDF-4 format."// &
                               " Falling back to parallel independent for file "// trim(fileobj%path))

--- a/fms2_io/netcdf_io.F90
+++ b/fms2_io/netcdf_io.F90
@@ -32,7 +32,6 @@ use netcdf
 use mpp_mod
 use fms_io_utils_mod
 use platform_mod
-use mpi, only: MPI_COMM_NULL
 implicit none
 private
 
@@ -153,7 +152,7 @@ type, public :: FmsNetcdfFile_t
   logical :: use_collective = .false. !< Flag indicating if we should open the file for collective input
                                       !! this should be set to .true. in the user application if they want
                                       !! collective reads (put before open_file())
-  integer :: TileComm=MPI_COMM_NULL   !< MPI communicator used for collective reads.
+  integer :: TileComm=MPP_COMM_NULL   !< MPI communicator used for collective reads.
                                       !! To be replaced with a real communicator at user request
 
 endtype FmsNetcdfFile_t
@@ -663,18 +662,20 @@ function netcdf_file_open(fileobj, path, mode, nc_format, pelist, is_restart, do
                  &"Check your open_file call, the acceptable values are read, append, write, overwrite")
     endif
     call check_netcdf_code(err, "netcdf_file_open:"//trim(fileobj%path))
-  elseif(fileobj%use_collective .and. (fileobj%TileComm /= MPI_COMM_NULL)) then
+  elseif(fileobj%use_collective .and. (fileobj%TileComm /= MPP_COMM_NULL)) then
     if(string_compare(mode, "read", .true.)) then
       ! Open the file for collective reads if the user requested that treatment in their application.
       ! NetCDF does not have the ability to specify collective I/O at the file basis
       ! so we must activate each variable in netcdf_read_data_2d() and netcdf_read_data_3d()
-      err = nf90_open(trim(fileobj%path), ior(NF90_NOWRITE, NF90_MPIIO), fileobj%ncid, comm=fileobj%TileComm, info=MPP_INFO_NULL)
+      err = nf90_open(trim(fileobj%path), ior(NF90_NOWRITE, NF90_MPIIO), fileobj%ncid, &
+                      comm=fileobj%TileComm, info=MPP_INFO_NULL)
       if(err /= nf90_noerr) then
         err = nf90_open(trim(fileobj%path), nf90_nowrite, fileobj%ncid)
         err = nf90_get_att(fileobj%ncid, nf90_global, "_IsNetcdf4", IsNetcdf4)
         err = nf90_close(fileobj%ncid)
         if(IsNetcdf4 /= 1) then
-          call mpp_error(NOTE,"netcdf_file_open: Open for collective read failed because the file is not netCDF-4 format."// &
+          call mpp_error(NOTE,"netcdf_file_open: Open for collective read failed because the file is not &
+                               netCDF-4 format."// &
                               " Falling back to parallel independent for file "// trim(fileobj%path))
         endif
         err = nf90_open(trim(fileobj%path), nf90_nowrite, fileobj%ncid, chunksize=fms2_ncchksz)
@@ -682,11 +683,13 @@ function netcdf_file_open(fileobj, path, mode, nc_format, pelist, is_restart, do
     elseif (string_compare(mode, "write", .true.)) then
       call mpp_error(FATAL,"netcdf_file_open: Attempt to create a file for collective write"// &
                               " This feature is not implemented"// trim(fileobj%path))
-      !err = nf90_create(trim(fileobj%path), ior(nf90_noclobber, nc_format_param), fileobj%ncid, comm=fileobj%TileComm, info=MPP_INFO_NULL)
+      !err = nf90_create(trim(fileobj%path), ior(nf90_noclobber, nc_format_param), fileobj%ncid, &
+      !                  comm=fileobj%TileComm, info=MPP_INFO_NULL)
     elseif (string_compare(mode,"overwrite",.true.)) then
       call mpp_error(FATAL,"netcdf_file_open: Attempt to create a file for collective overwrite"// &
                               " This feature is not implemented"// trim(fileobj%path))
-      !err = nf90_create(trim(fileobj%path), ior(nf90_clobber, nc_format_param), fileobj%ncid, comm=fileobj%TileComm, info=MPP_INFO_NULL)
+      !err = nf90_create(trim(fileobj%path), ior(nf90_clobber, nc_format_param), fileobj%ncid, &
+      !                  comm=fileobj%TileComm, info=MPP_INFO_NULL)
     else
       call error("unrecognized file mode: '"//trim(mode)//"' for file:"//trim(fileobj%path)//&
                  &"Check your open_file call, the acceptable values are read, append, write, overwrite")

--- a/fms2_io/netcdf_io.F90
+++ b/fms2_io/netcdf_io.F90
@@ -32,6 +32,7 @@ use netcdf
 use mpp_mod
 use fms_io_utils_mod
 use platform_mod
+use mpi, only: MPI_COMM_NULL
 implicit none
 private
 
@@ -149,6 +150,11 @@ type, public :: FmsNetcdfFile_t
   character (len=20) :: time_name
   type(dimension_information) :: bc_dimensions !<information about the current dimensions for regional
                                                !! restart variables
+  logical :: use_collective = .false. !< Flag indicating if we should open the file for collective input
+                                      !! this should be set to .true. in the user application if they want
+                                      !! collective reads (put before open_file())
+  integer :: TileComm=MPI_COMM_NULL   !< MPI communicator used for collective reads.
+                                      !! To be replaced with a real communicator at user request
 
 endtype FmsNetcdfFile_t
 
@@ -562,6 +568,7 @@ function netcdf_file_open(fileobj, path, mode, nc_format, pelist, is_restart, do
 
   integer :: nc_format_param
   integer :: err
+  integer :: IsNetcdf4=-999 !< Query the file for IsNetcdf4 in the event that the open for collective reads fails
   character(len=256) :: buf !< Filename with .res in the filename if it is a restart
   character(len=256) :: buf2 !< Filename with the filename appendix if there is one
   logical :: is_res
@@ -619,30 +626,30 @@ function netcdf_file_open(fileobj, path, mode, nc_format, pelist, is_restart, do
   fileobj%is_root = mpp_pe() .eq. fileobj%io_root
 
   fileobj%is_netcdf4 = .false.
-  !Open the file with netcdf if this rank is the I/O root.
-  if (fileobj%is_root) then
-    if (fms2_ncchksz == -1) call error("netcdf_file_open:: fms2_ncchksz not set, call fms2_io_init")
-    if (fms2_nc_format_param == -1) call error("netcdf_file_open:: fms2_nc_format_param not set, call fms2_io_init")
+  if (fms2_ncchksz == -1) call error("netcdf_file_open:: fms2_ncchksz not set, call fms2_io_init")
+  if (fms2_nc_format_param == -1) call error("netcdf_file_open:: fms2_nc_format_param not set, call fms2_io_init")
 
-    if (present(nc_format)) then
-      if (string_compare(nc_format, "64bit", .true.)) then
-        nc_format_param = nf90_64bit_offset
-      elseif (string_compare(nc_format, "classic", .true.)) then
-        nc_format_param = nf90_classic_model
-      elseif (string_compare(nc_format, "netcdf4", .true.)) then
-        fileobj%is_netcdf4 = .true.
-        nc_format_param = nf90_netcdf4
-      else
-        call error("unrecognized netcdf file format: '"//trim(nc_format)//"' for file:"//trim(fileobj%path)//&
-                   &"Check your open_file call, the acceptable values are 64bit, classic, netcdf4")
-      endif
-      call string_copy(fileobj%nc_format, nc_format)
+  if (present(nc_format)) then
+    if (string_compare(nc_format, "64bit", .true.)) then
+      nc_format_param = nf90_64bit_offset
+    elseif (string_compare(nc_format, "classic", .true.)) then
+      nc_format_param = nf90_classic_model
+    elseif (string_compare(nc_format, "netcdf4", .true.)) then
+      fileobj%is_netcdf4 = .true.
+      nc_format_param = nf90_netcdf4
     else
-      call string_copy(fileobj%nc_format, trim(fms2_nc_format))
-      nc_format_param = fms2_nc_format_param
-      fileobj%is_netcdf4 = fms2_is_netcdf4
+      call error("unrecognized netcdf file format: '"//trim(nc_format)//"' for file:"//trim(fileobj%path)//&
+                 &"Check your open_file call, the acceptable values are 64bit, classic, netcdf4")
     endif
+    call string_copy(fileobj%nc_format, nc_format)
+  else
+    call string_copy(fileobj%nc_format, trim(fms2_nc_format))
+    nc_format_param = fms2_nc_format_param
+    fileobj%is_netcdf4 = fms2_is_netcdf4
+  endif
 
+  !Open the file with netcdf if this rank is the I/O root.
+  if (fileobj%is_root .and. .not.(fileobj%use_collective)) then
     if (string_compare(mode, "read", .true.)) then
       err = nf90_open(trim(fileobj%path), nf90_nowrite, fileobj%ncid, chunksize=fms2_ncchksz)
     elseif (string_compare(mode, "append", .true.)) then
@@ -651,6 +658,35 @@ function netcdf_file_open(fileobj, path, mode, nc_format, pelist, is_restart, do
       err = nf90_create(trim(fileobj%path), ior(nf90_noclobber, nc_format_param), fileobj%ncid, chunksize=fms2_ncchksz)
     elseif (string_compare(mode,"overwrite",.true.)) then
       err = nf90_create(trim(fileobj%path), ior(nf90_clobber, nc_format_param), fileobj%ncid, chunksize=fms2_ncchksz)
+    else
+      call error("unrecognized file mode: '"//trim(mode)//"' for file:"//trim(fileobj%path)//&
+                 &"Check your open_file call, the acceptable values are read, append, write, overwrite")
+    endif
+    call check_netcdf_code(err, "netcdf_file_open:"//trim(fileobj%path))
+  elseif(fileobj%use_collective .and. (fileobj%TileComm /= MPI_COMM_NULL)) then
+    if(string_compare(mode, "read", .true.)) then
+      ! Open the file for collective reads if the user requested that treatment in their application.
+      ! NetCDF does not have the ability to specify collective I/O at the file basis
+      ! so we must activate each variable in netcdf_read_data_2d() and netcdf_read_data_3d()
+      err = nf90_open(trim(fileobj%path), ior(NF90_NOWRITE, NF90_MPIIO), fileobj%ncid, comm=fileobj%TileComm, info=MPP_INFO_NULL)
+      if(err /= nf90_noerr) then
+        err = nf90_open(trim(fileobj%path), nf90_nowrite, fileobj%ncid)
+        err = nf90_get_att(fileobj%ncid, nf90_global, "_IsNetcdf4", IsNetcdf4)
+        err = nf90_close(fileobj%ncid)
+        if(IsNetcdf4 /= 1) then
+          call mpp_error(NOTE,"netcdf_file_open: Open for collective read failed because the file is not netCDF-4 format."// &
+                              " Falling back to parallel independent for file "// trim(fileobj%path))
+        endif
+        err = nf90_open(trim(fileobj%path), nf90_nowrite, fileobj%ncid, chunksize=fms2_ncchksz)
+      endif
+    elseif (string_compare(mode, "write", .true.)) then
+      call mpp_error(FATAL,"netcdf_file_open: Attempt to create a file for collective write"// &
+                              " This feature is not implemented"// trim(fileobj%path))
+      !err = nf90_create(trim(fileobj%path), ior(nf90_noclobber, nc_format_param), fileobj%ncid, comm=fileobj%TileComm, info=MPP_INFO_NULL)
+    elseif (string_compare(mode,"overwrite",.true.)) then
+      call mpp_error(FATAL,"netcdf_file_open: Attempt to create a file for collective overwrite"// &
+                              " This feature is not implemented"// trim(fileobj%path))
+      !err = nf90_create(trim(fileobj%path), ior(nf90_clobber, nc_format_param), fileobj%ncid, comm=fileobj%TileComm, info=MPP_INFO_NULL)
     else
       call error("unrecognized file mode: '"//trim(mode)//"' for file:"//trim(fileobj%path)//&
                  &"Check your open_file call, the acceptable values are read, append, write, overwrite")

--- a/mpp/mpp.F90
+++ b/mpp/mpp.F90
@@ -196,7 +196,7 @@ private
   public :: COMM_TAG_9,  COMM_TAG_10, COMM_TAG_11, COMM_TAG_12
   public :: COMM_TAG_13, COMM_TAG_14, COMM_TAG_15, COMM_TAG_16
   public :: COMM_TAG_17, COMM_TAG_18, COMM_TAG_19, COMM_TAG_20
-  public :: MPP_FILL_INT,MPP_FILL_DOUBLE,MPP_INFO_NULL
+  public :: MPP_FILL_INT,MPP_FILL_DOUBLE,MPP_INFO_NULL,MPP_COMM_NULL
   public :: mpp_init_test_full_init, mpp_init_test_init_true_only, mpp_init_test_peset_allocated
   public :: mpp_init_test_clocks_init, mpp_init_test_datatype_list_init, mpp_init_test_logfile_init
   public :: mpp_init_test_read_namelist, mpp_init_test_etc_unit, mpp_init_test_requests_allocated
@@ -1332,6 +1332,15 @@ private
   integer, parameter ::  MPP_INFO_NULL = MPI_INFO_NULL
 #else
   integer, parameter ::  MPP_INFO_NULL = 469762048
+#endif
+
+!> MPP_COMM_NULL acts as an analagous mpp-macro for MPI_COMM_NULL to share with fms2_io NetCDF4
+!! mpi-io.  The default value for the no-mpi case comes from Intel MPI and MPICH.  OpenMPI sets
+!! a default value of '2'
+#if defined(use_libMPI)
+  integer, parameter ::  MPP_COMM_NULL = MPI_COMM_NULL
+#else
+  integer, parameter ::  MPP_COMM_NULL = 67108864
 #endif
 
 !***********************************************************************


### PR DESCRIPTION
This PR is a replacement for https://github.com/NOAA-GFDL/FMS/pull/1405 which I closed accidentally.

NetCDF-4, using the HDF5 file layout, has the ability to do parallel I/O in two different modes. The two modes are referred to as “independent” while the second mode is referred to as “collective”. The collective mode has been tested with a few NOAA workloads and shown to provide substantial improvement in job startup time while reducing negative impact on the underlying Lustre file system.

This PR does not address parallel I/O via pNetCDF.

This PR adds an option to enable collective reads. The user controls that option via settings in input.nml. The default behavior is unchanged, the user has to activate collective reads using the settings in input.nml.

Fixes # 1322
https://github.com/NOAA-GFDL/FMS/issues/1322

How Has This Been Tested?
I have run a RRFS (regional) case on WCOSS2 with and without collective reads activated. The resulting binary restart files are zero-diff.
I have not yet run a regional HAFS case or the UFS model on a full cube.

The compile time environment used to compile FMS was:
Currently Loaded Modules:
  1) craype-x86-rome     (H)   3) craype-network-ofi (H)   5) PrgEnv-intel/8.3.3   7) intel/19.1.3.304   9) cray-mpich/8.1.19  11) hpc-intel/19.1.3.304   13) hdf5/1.14.1
  2) libfabric/1.11.0.0. (H)   4) envvar/1.0  6) cmake/3.20.2    8) craype/2.7.17  10) hpc/1.2.0  12) hpc-cray-mpich/8.1.19  14) netcdf/4.9.2


**Checklist:**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] `make distcheck` passes

