### PR TITLE
Modern_diag_manager :: multiple_send_data calls option

### DIFF
--- a/diag_manager/Makefile.am
+++ b/diag_manager/Makefile.am
@@ -56,7 +56,10 @@ libdiag_manager_la_SOURCES = \
   include/fms_diag_fieldbuff_update.fh \
   include/fms_diag_reduction_methods.inc \
   include/fms_diag_reduction_methods_r4.fh \
-  include/fms_diag_reduction_methods_r8.fh
+  include/fms_diag_reduction_methods_r8.fh \
+  include/fms_diag_input_buffer.inc \
+  include/fms_diag_input_buffer_r4.fh \
+  include/fms_diag_input_buffer_r8.fh
 
 # Some mods are dependant on other mods in this dir.
 diag_data_mod.$(FC_MODEXT): fms_diag_bbox_mod.$(FC_MODEXT)
@@ -124,7 +127,10 @@ MODFILES = \
   include/fms_diag_fieldbuff_update.inc \
   include/fms_diag_fieldbuff_update.fh \
   include/fms_diag_reduction_methods_r4.fh \
-  include/fms_diag_reduction_methods_r8.fh
+  include/fms_diag_reduction_methods_r8.fh \
+  include/fms_diag_input_buffer.inc \
+  include/fms_diag_input_buffer_r4.fh \
+  include/fms_diag_input_buffer_r8.fh
 
 nodist_include_HEADERS = $(MODFILES)
 BUILT_SOURCES = $(MODFILES)

--- a/diag_manager/diag_manager.F90
+++ b/diag_manager/diag_manager.F90
@@ -383,7 +383,7 @@ CONTAINS
   !! @return field index for subsequent call to send_data.
   INTEGER FUNCTION register_diag_field_scalar(module_name, field_name, init_time, &
        & long_name, units, missing_value, range, standard_name, do_not_log, err_msg,&
-       & area, volume, realm)
+       & area, volume, realm, multiple_send_data)
     CHARACTER(len=*),           INTENT(in) :: module_name   !< Module where the field comes from
     CHARACTER(len=*),           INTENT(in) :: field_name    !< Name of the field
     TYPE(time_type),  OPTIONAL, INTENT(in) :: init_time     !< Time to start writing data from
@@ -397,6 +397,8 @@ CONTAINS
     INTEGER,          OPTIONAL, INTENT(in) :: area          !< Id of the area field
     INTEGER,          OPTIONAL, INTENT(in) :: volume        !< Id of the volume field
     CHARACTER(len=*), OPTIONAL, INTENT(in) :: realm         !< String to set as the modeling_realm attribute
+    LOGICAL,          OPTIONAL, INTENT(in) :: multiple_send_data !< .True. if send data is called, multiple times
+                                                                 !! for the same time
 
     ! Fatal error if range is present and its extent is not 2.
     IF ( PRESENT(range) ) THEN
@@ -418,7 +420,8 @@ CONTAINS
       register_diag_field_scalar = fms_diag_object%fms_register_diag_field_scalar( &
       & module_name, field_name, init_time, long_name=long_name, units=units, &
       & missing_value=missing_value, var_range=range, standard_name=standard_name, &
-      & do_not_log=do_not_log, err_msg=err_msg, area=area, volume=volume, realm=realm)
+      & do_not_log=do_not_log, err_msg=err_msg, area=area, volume=volume, realm=realm, &
+      multiple_send_data=multiple_send_data)
     else
       register_diag_field_scalar = register_diag_field_scalar_old(module_name, field_name, init_time, &
       & long_name=long_name, units=units, missing_value=missing_value, range=range, standard_name=standard_name, &
@@ -430,7 +433,7 @@ CONTAINS
   !> @return field index for subsequent call to send_data.
   INTEGER FUNCTION register_diag_field_array(module_name, field_name, axes, init_time, &
        & long_name, units, missing_value, range, mask_variant, standard_name, verbose,&
-       & do_not_log, err_msg, interp_method, tile_count, area, volume, realm)
+       & do_not_log, err_msg, interp_method, tile_count, area, volume, realm, multiple_send_data)
     CHARACTER(len=*),           INTENT(in) :: module_name   !< Module where the field comes from
     CHARACTER(len=*),           INTENT(in) :: field_name    !< Name of the field
     INTEGER,                    INTENT(in) :: axes(:)       !< Ids corresponding to the variable axis
@@ -452,6 +455,8 @@ CONTAINS
     INTEGER,          OPTIONAL, INTENT(in) :: area          !< Id of the area field
     INTEGER,          OPTIONAL, INTENT(in) :: volume        !< Id of the volume field
     CHARACTER(len=*), OPTIONAL, INTENT(in) :: realm         !< String to set as the modeling_realm attribute
+    LOGICAL,          OPTIONAL, INTENT(in) :: multiple_send_data !< .True. if send data is called, multiple times
+                                                                 !! for the same time
 
     if (use_modern_diag) then
       if( do_diag_field_log) then
@@ -467,7 +472,8 @@ CONTAINS
        & module_name, field_name, axes, init_time, long_name=long_name, &
        & units=units, missing_value=missing_value, var_range=range, mask_variant=mask_variant, &
        & standard_name=standard_name, verbose=verbose, do_not_log=do_not_log, err_msg=err_msg, &
-       & interp_method=interp_method, tile_count=tile_count, area=area, volume=volume, realm=realm)
+       & interp_method=interp_method, tile_count=tile_count, area=area, volume=volume, realm=realm, &
+       multiple_send_data=multiple_send_data)
     else
       register_diag_field_array = register_diag_field_array_old(module_name, field_name, axes, init_time, &
        & long_name=long_name, units=units, missing_value=missing_value, range=range, mask_variant=mask_variant, &

--- a/diag_manager/fms_diag_field_object.F90
+++ b/diag_manager/fms_diag_field_object.F90
@@ -95,6 +95,7 @@ type fmsDiagField_type
      procedure :: setID => set_diag_id
      procedure :: set_type => set_vartype
      procedure :: set_data_buffer => set_data_buffer
+     procedure :: prepare_data_buffer
      procedure :: set_data_buffer_is_allocated
      procedure :: set_send_data_time
      procedure :: get_send_data_time
@@ -438,6 +439,16 @@ function get_send_data_time(this) &
 
   rslt = this%input_data_buffer%get_send_data_time()
 end function get_send_data_time
+
+subroutine prepare_data_buffer(this)
+  class (fmsDiagField_type) , intent(inout):: this                !< The field object
+
+  if (.not. this%multiple_send_data) return
+  if (this%mask_variant) return
+
+  call this%input_data_buffer%prepare_input_buffer_object()
+
+end subroutine
 
 !> @brief Adds the input data to the buffered data.
 subroutine set_data_buffer (this, input_data, mask, weight, is, js, ks, ie, je, ke)

--- a/diag_manager/fms_diag_field_object.F90
+++ b/diag_manager/fms_diag_field_object.F90
@@ -1878,15 +1878,17 @@ function check_for_slices(field, diag_axis, var_size) &
   logical :: rslt
   integer :: i !< For do loops
 
-  rslt = .false.
-  if (field%has_axis_ids()) then
-    rslt = .true.
+  if (.not. field%has_axis_ids()) then
+    rslt = .false.
     return
   endif
   do i = 1, size(field%axis_ids)
     select type (axis_obj => diag_axis(field%axis_ids(i))%axis)
     type is (fmsDiagFullAxis_type)
-      if (axis_obj%axis_length() .ne. var_size(i)) return
+      if (axis_obj%axis_length() .ne. var_size(i)) then
+        rslt = .true.
+        return
+      endif
     end select
   enddo
 end function

--- a/diag_manager/fms_diag_field_object.F90
+++ b/diag_manager/fms_diag_field_object.F90
@@ -169,6 +169,7 @@ type fmsDiagField_type
      procedure :: get_dimnames
      procedure :: get_var_skind
      procedure :: get_longname_to_write
+     procedure :: get_multiple_send_data
      procedure :: write_field_metadata
      procedure :: write_coordinate_attribute
      procedure :: get_math_needs_to_be_done
@@ -1071,6 +1072,13 @@ result(rslt)
   end select
 
 end function get_var_skind
+
+pure function get_multiple_send_data(this) &
+result(rslt)
+  class (fmsDiagField_type),   intent(in) :: this       !< diag field
+  logical :: rslt
+  rslt = this%multiple_send_data
+end function get_multiple_send_data
 
 !> @brief Determine the long name to write for the field
 !! @return Long name to write

--- a/diag_manager/fms_diag_field_object.F90
+++ b/diag_manager/fms_diag_field_object.F90
@@ -96,6 +96,7 @@ type fmsDiagField_type
      procedure :: set_type => set_vartype
      procedure :: set_data_buffer => set_data_buffer
      procedure :: prepare_data_buffer
+     procedure :: init_data_buffer
      procedure :: set_data_buffer_is_allocated
      procedure :: set_send_data_time
      procedure :: get_send_data_time
@@ -450,6 +451,17 @@ subroutine prepare_data_buffer(this)
 
 end subroutine
 
+subroutine init_data_buffer(this)
+  class (fmsDiagField_type) , intent(inout):: this                !< The field object
+
+  if (.not. this%multiple_send_data) return
+  if (this%mask_variant) return
+
+  call this%input_data_buffer%init_input_buffer_object()
+
+end subroutine
+
+
 !> @brief Adds the input data to the buffered data.
 subroutine set_data_buffer (this, input_data, mask, weight, is, js, ks, ie, je, ke)
   class (fmsDiagField_type) , intent(inout):: this                !< The field object
@@ -487,7 +499,7 @@ logical function allocate_data_buffer(this, input_data, diag_axis)
   err_msg = ""
 
   allocate(this%input_data_buffer)
-  err_msg = this%input_data_buffer%init(input_data, this%axis_ids, diag_axis)
+  err_msg = this%input_data_buffer%allocate_input_buffer_object(input_data, this%axis_ids, diag_axis)
   if (trim(err_msg) .ne. "") then
     call mpp_error(FATAL, "Field:"//trim(this%varname)//" -"//trim(err_msg))
     return

--- a/diag_manager/fms_diag_field_object.F90
+++ b/diag_manager/fms_diag_field_object.F90
@@ -195,6 +195,7 @@ public :: fms_diag_fields_object_init
 public :: null_ob
 public :: fms_diag_field_object_end
 public :: get_default_missing_value
+public :: check_for_slices
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
  CONTAINS
@@ -1843,5 +1844,28 @@ subroutine generate_associated_files_att(this, att, start_time)
   att = trim(att)//" "//trim(field_name)//": "//trim(file_name)//".nc"
 end subroutine generate_associated_files_att
 
+!> @brief Determines if the compute domain has been divide further into slices (i.e openmp blocks)
+!! @return .True. if the compute domain has been divided furter into slices
+function check_for_slices(field, diag_axis, var_size) &
+  result(rslt)
+  type(fmsDiagField_type),                 intent(in) :: field        !< Field object
+  type(fmsDiagAxisContainer_type), target, intent(in) :: diag_axis(:) !< Array of diag axis
+  integer,                                 intent(in) :: var_size(:)  !< The size of the buffer pass into send_data
+
+  logical :: rslt
+  integer :: i !< For do loops
+
+  rslt = .false.
+  if (field%has_axis_ids()) then
+    rslt = .true.
+    return
+  endif
+  do i = 1, size(field%axis_ids)
+    select type (axis_obj => diag_axis(field%axis_ids(i))%axis)
+    type is (fmsDiagFullAxis_type)
+      if (axis_obj%axis_length() .ne. var_size(i)) return
+    end select
+  enddo
+end function
 #endif
 end module fms_diag_field_object_mod

--- a/diag_manager/fms_diag_file_object.F90
+++ b/diag_manager/fms_diag_file_object.F90
@@ -1399,7 +1399,8 @@ subroutine write_time_data(this)
   fms2io_fileobj => diag_file%fms2io_fileobj
 
   !< If data has not been written for the current unlimited dimension
-  !! ignore this
+  !! ignore this. The diag_file%unlim_dimension_level .ne. 1 is there to ensure
+  !! that at least one time level is written (this is needed for the combiner)
   if (.not. diag_file%data_has_been_written .and. diag_file%unlim_dimension_level .ne. 1) return
 
   if (diag_file%time_ops) then

--- a/diag_manager/fms_diag_file_object.F90
+++ b/diag_manager/fms_diag_file_object.F90
@@ -1400,7 +1400,7 @@ subroutine write_time_data(this)
 
   !< If data has not been written for the current unlimited dimension
   !! ignore this
-  if (.not. diag_file%data_has_been_written) return
+  if (.not. diag_file%data_has_been_written .and. diag_file%unlim_dimension_level .ne. 1) return
 
   if (diag_file%time_ops) then
     middle_time = (diag_file%last_output+diag_file%next_output)/2

--- a/diag_manager/fms_diag_input_buffer.F90
+++ b/diag_manager/fms_diag_input_buffer.F90
@@ -53,6 +53,7 @@ module fms_diag_input_buffer_mod
     procedure :: init => init_input_buffer_object
     procedure :: set_input_buffer_object
     procedure :: update_input_buffer_object
+    procedure :: prepare_input_buffer_object
     procedure :: set_send_data_time
     procedure :: get_send_data_time
     procedure :: is_initialized
@@ -177,6 +178,17 @@ module fms_diag_input_buffer_mod
     endif
 
   end function update_input_buffer_object
+
+  subroutine prepare_input_buffer_object(this)
+    class(fmsDiagInputBuffer_t), intent(inout) :: this                !< input buffer object
+
+    select type (input_data => this%buffer)
+    type is (real(kind=r4_kind))
+      input_data = input_data / this%counter
+    type is (real(kind=r8_kind))
+      input_data = input_data / this%counter
+    end select
+  end subroutine prepare_input_buffer_object
 
   subroutine sum_data_buffer_wrapper(mask, data_out, data_in, counter, var_is_masked)
     logical,  intent(in)    :: mask(:,:,:,:)

--- a/diag_manager/fms_diag_input_buffer.F90
+++ b/diag_manager/fms_diag_input_buffer.F90
@@ -233,6 +233,7 @@ module fms_diag_input_buffer_mod
 
     character(len=128) :: err_msg
 
+    err_msg = ""
     select type(data_out)
     type is (real(kind=r8_kind))
       select type (data_in)
@@ -260,6 +261,7 @@ module fms_diag_input_buffer_mod
 
     character(len=128) :: err_msg
 
+    err_msg = ""
     select type(data_out)
     type is (real(kind=r8_kind))
       select type (data_in)

--- a/diag_manager/fms_diag_input_buffer.F90
+++ b/diag_manager/fms_diag_input_buffer.F90
@@ -224,7 +224,7 @@ module fms_diag_input_buffer_mod
   !! @return Error message (if an error occurs)
   function sum_data_buffer_wrapper(mask, data_out, data_in, counter, var_is_masked) &
     result(err_msg)
-  
+
     logical,  intent(in)    :: mask(:,:,:,:)     !< Mask passed into send_data
     class(*), intent(inout) :: data_out(:,:,:,:) !< Data currently saved in the input_data_buffer
     class(*), intent(in)    :: data_in(:,:,:,:)  !< Data passed into send_data
@@ -259,7 +259,7 @@ module fms_diag_input_buffer_mod
     class(*), intent(in)    :: data_in(:,:,:,:)  !< Data passed in to send_data
 
     character(len=128) :: err_msg
-  
+
     select type(data_out)
     type is (real(kind=r8_kind))
       select type (data_in)

--- a/diag_manager/fms_diag_input_buffer.F90
+++ b/diag_manager/fms_diag_input_buffer.F90
@@ -50,7 +50,8 @@ module fms_diag_input_buffer_mod
     contains
     procedure :: get_buffer
     procedure :: get_weight
-    procedure :: init => init_input_buffer_object
+    procedure :: allocate_input_buffer_object
+    procedure :: init_input_buffer_object
     procedure :: set_input_buffer_object
     procedure :: update_input_buffer_object
     procedure :: prepare_input_buffer_object
@@ -86,7 +87,7 @@ module fms_diag_input_buffer_mod
 
   !> @brief Initiliazes an input data buffer
   !! @return Error message if something went wrong
-  function init_input_buffer_object(this, input_data, axis_ids, diag_axis) &
+  function allocate_input_buffer_object(this, input_data, axis_ids, diag_axis) &
     result(err_msg)
     class(fmsDiagInputBuffer_t),         intent(out)   :: this                !< input buffer object
     class(*),                            intent(in)    :: input_data(:,:,:,:) !< input data
@@ -118,12 +119,16 @@ module fms_diag_input_buffer_mod
     select type (input_data)
     type is (real(r4_kind))
       allocate(real(kind=r4_kind) :: this%buffer(length(1), length(2), length(3), length(4)))
+      this%buffer = 0.0_r4_kind
     type is (real(r8_kind))
       allocate(real(kind=r8_kind) :: this%buffer(length(1), length(2), length(3), length(4)))
+      this%buffer = 0.0_r8_kind
     type is (integer(i4_kind))
       allocate(integer(kind=i4_kind) :: this%buffer(length(1), length(2), length(3), length(4)))
+      this%buffer = 0_i4_kind
     type is (integer(i8_kind))
       allocate(integer(kind=i4_kind) :: this%buffer(length(1), length(2), length(3), length(4)))
+      this%buffer = 0_i8_kind
     class default
       err_msg = "The data input is not one of the supported types."&
         "Only r4, r8, i4, and i8 types are supported."
@@ -132,7 +137,20 @@ module fms_diag_input_buffer_mod
     this%weight = 1.0_r8_kind
     this%initialized = .true.
     this%counter = 0
-  end function init_input_buffer_object
+  end function allocate_input_buffer_object
+
+  subroutine init_input_buffer_object(this)
+    class(fmsDiagInputBuffer_t), intent(inout) :: this                !< input buffer object
+
+    select type(buffer=>this%buffer)
+    type is (real(kind=r8_kind))
+      buffer = 0.0_r8_kind
+    type is (real(kind=r4_kind))
+      buffer = 0.0_r4_kind
+    end select
+
+    this%counter = 0
+  end subroutine init_input_buffer_object
 
   !> @brief Sets the time send data was called last
   subroutine set_send_data_time(this, time)

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -626,6 +626,11 @@ CALL MPP_ERROR(FATAL,"You can not use the modern diag manager without compiling 
       shape(field_data))
   endif
 
+  !< If send data is called multiple times, buffer the data
+  !! This is so that the other reduction methods work and just averaging
+  if (this%FMS_diag_fields(diag_field_id)%get_multiple_send_data()) &
+    buffer_the_data = .true.
+
   !If this is true, buffer data
   main_if: if (buffer_the_data) then
 !> Only 1 thread allocates the output buffer and sets set_math_needs_to_be_done

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -176,7 +176,8 @@ end subroutine fms_diag_object_end
 integer function fms_register_diag_field_obj &
        (this, modname, varname, axes, init_time, &
        longname, units, missing_value, varRange, mask_variant, standname, &
-       do_not_log, err_msg, interp_method, tile_count, area, volume, realm, static)
+       do_not_log, err_msg, interp_method, tile_count, area, volume, realm, static, &
+       multiple_send_data)
 
  class(fmsDiagObject_type),TARGET,INTENT(inout):: this       !< Diaj_obj to fill
  CHARACTER(len=*),               INTENT(in)    :: modname               !< The module name
@@ -201,6 +202,9 @@ integer function fms_register_diag_field_obj &
  CHARACTER(len=*), OPTIONAL,     INTENT(in)    :: realm                 !< String to set as the value to the
                                                                         !! modeling_realm attribute
  LOGICAL,          OPTIONAL,     INTENT(in)    :: static                !< True if the variable is static
+ LOGICAL,          OPTIONAL,     INTENT(in)    :: multiple_send_data    !< .True. if send data is called, multiple
+                                                                        !! times for the same time
+
 #ifdef use_yaml
 
  class (fmsDiagFile_type), pointer :: fileptr !< Pointer to the diag_file
@@ -244,7 +248,7 @@ CALL MPP_ERROR(FATAL,"You can not use the modern diag manager without compiling 
        axes=axes, longname=longname, units=units, missing_value=missing_value, varRange= varRange, &
        mask_variant= mask_variant, standname=standname, do_not_log=do_not_log, err_msg=err_msg, &
        interp_method=interp_method, tile_count=tile_count, area=area, volume=volume, realm=realm, &
-       static=static)
+       static=static, multiple_send_data=multiple_send_data)
 
 !> Add the axis information, initial time, and field IDs to the files
   if (present(axes) .and. present(init_time)) then
@@ -313,7 +317,7 @@ end function fms_register_diag_field_obj
 !! in the diag_table.yaml
 INTEGER FUNCTION fms_register_diag_field_scalar(this,module_name, field_name, init_time, &
        & long_name, units, missing_value, var_range, standard_name, do_not_log, err_msg,&
-       & area, volume, realm)
+       & area, volume, realm, multiple_send_data)
     class(fmsDiagObject_type),TARGET,INTENT(inout):: this       !< Diaj_obj to fill
     CHARACTER(len=*),           INTENT(in) :: module_name   !< Module where the field comes from
     CHARACTER(len=*),           INTENT(in) :: field_name    !< Name of the field
@@ -328,6 +332,9 @@ INTEGER FUNCTION fms_register_diag_field_scalar(this,module_name, field_name, in
     INTEGER,          OPTIONAL, INTENT(in) :: area          !< Id of the area field
     INTEGER,          OPTIONAL, INTENT(in) :: volume        !< Id of the volume field
     CHARACTER(len=*), OPTIONAL, INTENT(in) :: realm         !< String to set as the modeling_realm attribute
+    LOGICAL,          OPTIONAL, INTENT(in) :: multiple_send_data !< .True. if send data is called, multiple times
+                                                                 !! for the same time
+
 #ifndef use_yaml
 fms_register_diag_field_scalar=DIAG_FIELD_NOT_FOUND
 CALL MPP_ERROR(FATAL,"You can not use the modern diag manager without compiling with -Duse_yaml")
@@ -336,7 +343,7 @@ CALL MPP_ERROR(FATAL,"You can not use the modern diag manager without compiling 
       & module_name, field_name, init_time=init_time, &
       & longname=long_name, units=units, missing_value=missing_value, varrange=var_range, &
       & standname=standard_name, do_not_log=do_not_log, err_msg=err_msg, &
-      & area=area, volume=volume, realm=realm)
+      & area=area, volume=volume, realm=realm, multiple_send_data=multiple_send_data)
 #endif
 end function fms_register_diag_field_scalar
 
@@ -345,7 +352,8 @@ end function fms_register_diag_field_scalar
 !! in the diag_table.yaml
 INTEGER FUNCTION fms_register_diag_field_array(this, module_name, field_name, axes, init_time, &
        & long_name, units, missing_value, var_range, mask_variant, standard_name, verbose,&
-       & do_not_log, err_msg, interp_method, tile_count, area, volume, realm)
+       & do_not_log, err_msg, interp_method, tile_count, area, volume, realm, &
+       & multiple_send_data)
     class(fmsDiagObject_type),TARGET,INTENT(inout):: this       !< Diaj_obj to fill
     CHARACTER(len=*),           INTENT(in) :: module_name   !< Module where the field comes from
     CHARACTER(len=*),           INTENT(in) :: field_name    !< Name of the field
@@ -368,6 +376,9 @@ INTEGER FUNCTION fms_register_diag_field_array(this, module_name, field_name, ax
     INTEGER,          OPTIONAL, INTENT(in) :: area          !< Id of the area field
     INTEGER,          OPTIONAL, INTENT(in) :: volume        !< Id of the volume field
     CHARACTER(len=*), OPTIONAL, INTENT(in) :: realm         !< String to set as the modeling_realm attribute
+    LOGICAL,          OPTIONAL, INTENT(in) :: multiple_send_data !< .True. if send data is called, multiple times
+                                                                 !! for the same time
+
 
 #ifndef use_yaml
 fms_register_diag_field_array=DIAG_FIELD_NOT_FOUND
@@ -377,7 +388,8 @@ CALL MPP_ERROR(FATAL,"You can not use the modern diag manager without compiling 
       & module_name, field_name, init_time=init_time, &
       & axes=axes, longname=long_name, units=units, missing_value=missing_value, varrange=var_range, &
       & mask_variant=mask_variant, standname=standard_name, do_not_log=do_not_log, err_msg=err_msg, &
-      & interp_method=interp_method, tile_count=tile_count, area=area, volume=volume, realm=realm)
+      & interp_method=interp_method, tile_count=tile_count, area=area, volume=volume, realm=realm, &
+      & multiple_send_data=multiple_send_data)
 #endif
 end function fms_register_diag_field_array
 

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -732,6 +732,7 @@ subroutine do_buffer_math(this)
     doing_math: if (size(file_ids) .ge. 1 .and. math) then
       ! Check if buffer alloc'd
       has_input_buff: if (diag_field%has_input_data_buffer()) then
+        call diag_field%prepare_data_buffer()
         input_data_buffer => diag_field%get_data_buffer()
         ! reset bounds, allocate output buffer, and update it with reduction
         call bounds%reset_bounds_from_array_4D(input_data_buffer)

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -740,6 +740,7 @@ subroutine do_buffer_math(this)
         error_string = this%fms_diag_do_reduction(input_data_buffer, ifield, &
                               diag_field%get_mask(), diag_field%get_weight(), &
                               bounds, .False., Time=diag_field%get_send_data_time())
+        call diag_field%init_data_buffer()
         if (trim(error_string) .ne. "") call mpp_error(FATAL, "Field:"//trim(diag_field%get_varname()//&
                                                        " -"//trim(error_string)))
       else

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -649,9 +649,8 @@ CALL MPP_ERROR(FATAL,"You can not use the modern diag manager without compiling 
     call this%FMS_diag_fields(diag_field_id)%set_data_buffer_is_allocated(.TRUE.)
     call this%FMS_diag_fields(diag_field_id)%set_math_needs_to_be_done(.TRUE.)
 !$omp end critical
-    call this%FMS_diag_fields(diag_field_id)%set_data_buffer(field_data, field_weight, &
+    call this%FMS_diag_fields(diag_field_id)%set_data_buffer(field_data, oor_mask, field_weight, &
                                                              is, js, ks, ie, je, ke)
-    call this%FMS_diag_fields(diag_field_id)%set_mask(oor_mask, field_info, is, js, ks, ie, je, ke)
     fms_diag_accept_data = .TRUE.
     return
   else

--- a/diag_manager/fms_diag_output_buffer.F90
+++ b/diag_manager/fms_diag_output_buffer.F90
@@ -372,23 +372,14 @@ subroutine set_next_output(this, time, is_static)
 end subroutine set_next_output
 
 !> @brief Update the buffer time if it is a new time
-!! @return .true. if the buffer was updated
-function update_buffer_time(this, time) &
-  result(res)
+subroutine update_buffer_time(this, time)
   class(fmsDiagOutputBuffer_type), intent(inout) :: this        !< Buffer object
   type(time_type),                 intent(in)    :: time        !< Current model time
 
-  logical :: res
-
   if (time > this%time) then
     this%time = time
-    res = .true.
-  else
-    res = .false.
-    !< If this is the first time send_data has been called
-    if (.not. this%send_data_called) res = .true.
   endif
-end function
+end subroutine update_buffer_time
 
 !> @brief Determine if finished with math
 !! @return this%done_with_math
@@ -659,7 +650,7 @@ end function do_time_max_wrapper
 !> @brief Does the time_sum reduction method on the buffer object
 !! @return Error message if the math was not successful
 function do_time_sum_wrapper(this, field_data, mask, is_masked, mask_variant, bounds_in, bounds_out, missing_value, &
-                             increase_counter, pow_value) &
+                             pow_value) &
   result(err_msg)
   class(fmsDiagOutputBuffer_type), intent(inout) :: this                !< buffer object to write
   class(*),                        intent(in)    :: field_data(:,:,:,:) !< Buffer data for current time
@@ -669,8 +660,6 @@ function do_time_sum_wrapper(this, field_data, mask, is_masked, mask_variant, bo
   logical,                         intent(in)    :: is_masked           !< .True. if the field has a mask
   logical,                         intent(in)    :: mask_variant        !< .True. if the mask changes over time
   real(kind=r8_kind),              intent(in)    :: missing_value       !< Missing_value for data points that are masked
-  logical,                         intent(in)    :: increase_counter    !< .True. if data has not been received for
-                                                                        !! time, so the counter needs to be increased
   integer, optional,               intent(in)    :: pow_value           !< power value, will calculate field_data^pow
                                                                         !! before adding to buffer should only be
                                                                         !! present if using pow reduction method
@@ -683,7 +672,7 @@ function do_time_sum_wrapper(this, field_data, mask, is_masked, mask_variant, bo
       select type (field_data)
       type is (real(kind=r8_kind))
         call do_time_sum_update(output_buffer, this%weight_sum, field_data, mask, is_masked, mask_variant, &
-                                bounds_in, bounds_out, missing_value, increase_counter, this%diurnal_section, &
+                                bounds_in, bounds_out, missing_value, this%diurnal_section, &
                                 pow=pow_value)
       class default
         err_msg="do_time_sum_wrapper::the output buffer and the buffer send in are not of the same type (r8_kind)"
@@ -692,7 +681,7 @@ function do_time_sum_wrapper(this, field_data, mask, is_masked, mask_variant, bo
       select type (field_data)
       type is (real(kind=r4_kind))
         call do_time_sum_update(output_buffer, this%weight_sum, field_data, mask, is_masked, mask_variant, &
-                                bounds_in, bounds_out, real(missing_value, kind=r4_kind), increase_counter, &
+                                bounds_in, bounds_out, real(missing_value, kind=r4_kind), &
                                 this%diurnal_section, pow=pow_value)
       class default
         err_msg="do_time_sum_wrapper::the output buffer and the buffer send in are not of the same type (r4_kind)"

--- a/diag_manager/include/fms_diag_input_buffer.inc
+++ b/diag_manager/include/fms_diag_input_buffer.inc
@@ -44,7 +44,7 @@ subroutine SUM_DATA_BUFFER_(mask, data_out, data_in, counter, var_is_masked)
   logical,  intent(in)    :: mask(:,:,:,:)
   real(FMS_TRM_KIND_), intent(inout) :: data_out(:,:,:,:)
   real(FMS_TRM_KIND_), intent(in)    :: data_in(:,:,:,:)
-  integer,  intent(inout)    :: counter
+  integer,  intent(inout)    :: counter(:,:,:,:)
   logical,  intent(in)    :: var_is_masked
 
   if (var_is_masked) then

--- a/diag_manager/include/fms_diag_input_buffer.inc
+++ b/diag_manager/include/fms_diag_input_buffer.inc
@@ -17,13 +17,14 @@
 !* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
 !***********************************************************************
 
+!> @brief Appends the input_data_buffer and the mask (only when the mask is set to .True.)
 subroutine APPEND_DATA_BUFFER_(mask_out, mask_in, data_out, data_in)
-  logical, intent(inout) :: mask_out(:,:,:,:)
-  logical, intent(in)    :: mask_in(:,:,:,:)
-  real(FMS_TRM_KIND_), intent(inout) :: data_out(:,:,:,:)
-  real(FMS_TRM_KIND_), intent(in) :: data_in(:,:,:,:)
+  logical,             intent(inout) :: mask_out(:,:,:,:) !< Mask currently in the input_data_buffer
+  logical,             intent(in)    :: mask_in(:,:,:,:)  !< Mask passed in to send_data
+  real(FMS_TRM_KIND_), intent(inout) :: data_out(:,:,:,:) !< Data currently in the input_data_buffer
+  real(FMS_TRM_KIND_), intent(in)    :: data_in(:,:,:,:)  !< Data passed in to send_data
 
-  integer :: i, j, k, l
+  integer :: i, j, k, l !< For looping through the input_data_buffer
 
   do l = 1, size(data_out, 4)
     do k = 1, size(data_out, 3)
@@ -38,14 +39,15 @@ subroutine APPEND_DATA_BUFFER_(mask_out, mask_in, data_out, data_in)
     enddo
   enddo
 
-end subroutine
+end subroutine APPEND_DATA_BUFFER_
 
+!> @brief Sums the data in the input_data_buffer
 subroutine SUM_DATA_BUFFER_(mask, data_out, data_in, counter, var_is_masked)
-  logical,  intent(in)    :: mask(:,:,:,:)
-  real(FMS_TRM_KIND_), intent(inout) :: data_out(:,:,:,:)
-  real(FMS_TRM_KIND_), intent(in)    :: data_in(:,:,:,:)
-  integer,  intent(inout)    :: counter(:,:,:,:)
-  logical,  intent(in)    :: var_is_masked
+  logical,             intent(in)    :: mask(:,:,:,:)     !< Mask passed into send_data
+  real(FMS_TRM_KIND_), intent(inout) :: data_out(:,:,:,:) !< Data currently saved in the input_data_buffer
+  real(FMS_TRM_KIND_), intent(in)    :: data_in(:,:,:,:)  !< Data passed into send_data
+  integer,             intent(inout) :: counter(:,:,:,:)  !< Number of times data has been summed
+  logical,             intent(in)    :: var_is_masked     !< .True. if the variable is masked
 
   if (var_is_masked) then
     where (mask)

--- a/diag_manager/include/fms_diag_input_buffer.inc
+++ b/diag_manager/include/fms_diag_input_buffer.inc
@@ -1,0 +1,59 @@
+!***********************************************************************
+!*                   GNU Lesser General Public License
+!*
+!* This file is part of the GFDL Flexible Modeling System (FMS).
+!*
+!* FMS is free software: you can redistribute it and/or modify it under
+!* the terms of the GNU Lesser General Public License as published by
+!* the Free Software Foundation, either version 3 of the License, or (at
+!* your option) any later version.
+!*
+!* FMS is distributed in the hope that it will be useful, but WITHOUT
+!* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+!* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+!* for more details.
+!*
+!* You should have received a copy of the GNU Lesser General Public
+!* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
+!***********************************************************************
+
+subroutine APPEND_DATA_BUFFER_(mask_out, mask_in, data_out, data_in)
+  logical, intent(inout) :: mask_out(:,:,:,:)
+  logical, intent(in)    :: mask_in(:,:,:,:)
+  real(FMS_TRM_KIND_), intent(inout) :: data_out(:,:,:,:)
+  real(FMS_TRM_KIND_), intent(in) :: data_in(:,:,:,:)
+
+  integer :: i, j, k, l
+
+  do l = 1, size(data_out, 4)
+    do k = 1, size(data_out, 3)
+      do j = 1, size(data_out, 2)
+        do i = 1, size(data_out, 1)
+          if (mask_in(i,j,k,l)) then
+            mask_out(i,j,k,l) = .True.
+            data_out(i,j,k,l) = data_in(i,j,k,l)
+          endif
+        enddo
+      enddo
+    enddo
+  enddo
+
+end subroutine
+
+subroutine SUM_DATA_BUFFER_(mask, data_out, data_in, counter, var_is_masked)
+  logical,  intent(in)    :: mask(:,:,:,:)
+  real(FMS_TRM_KIND_), intent(inout) :: data_out(:,:,:,:)
+  real(FMS_TRM_KIND_), intent(in)    :: data_in(:,:,:,:)
+  integer,  intent(inout)    :: counter
+  logical,  intent(in)    :: var_is_masked
+
+  if (var_is_masked) then
+    where (mask)
+      data_out = data_out + data_in
+    endwhere
+  else
+    data_out = data_out + data_in
+  endif
+
+  counter = counter + 1
+end subroutine SUM_DATA_BUFFER_

--- a/diag_manager/include/fms_diag_input_buffer_r4.fh
+++ b/diag_manager/include/fms_diag_input_buffer_r4.fh
@@ -1,0 +1,38 @@
+!***********************************************************************
+!*                   GNU Lesser General Public License
+!*
+!* This file is part of the GFDL Flexible Modeling System (FMS).
+!*
+!* FMS is free software: you can redistribute it and/or modify it under
+!* the terms of the GNU Lesser General Public License as published by
+!* the Free Software Foundation, either version 3 of the License, or (at
+!* your option) any later version.
+!*
+!* FMS is distributed in the hope that it will be useful, but WITHOUT
+!* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+!* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+!* for more details.
+!*
+!* You should have received a copy of the GNU Lesser General Public
+!* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
+!***********************************************************************
+!> @file
+!> @brief Imports the input buffer routines from other include files used
+!! in @ref diag_manager_mod
+
+!> @addtogroup diag_manager_mod
+!> @{
+
+#undef FMS_TRM_KIND_
+#define FMS_TRM_KIND_ r4_kind
+
+#undef APPEND_DATA_BUFFER_
+#define APPEND_DATA_BUFFER_ append_data_buffer_r4
+
+#undef SUM_DATA_BUFFER_
+#define SUM_DATA_BUFFER_ sum_data_buffer_r4
+
+#include "fms_diag_input_buffer.inc"
+
+!> @}
+! close documentation grouping

--- a/diag_manager/include/fms_diag_input_buffer_r8.fh
+++ b/diag_manager/include/fms_diag_input_buffer_r8.fh
@@ -1,0 +1,38 @@
+!***********************************************************************
+!*                   GNU Lesser General Public License
+!*
+!* This file is part of the GFDL Flexible Modeling System (FMS).
+!*
+!* FMS is free software: you can redistribute it and/or modify it under
+!* the terms of the GNU Lesser General Public License as published by
+!* the Free Software Foundation, either version 3 of the License, or (at
+!* your option) any later version.
+!*
+!* FMS is distributed in the hope that it will be useful, but WITHOUT
+!* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+!* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+!* for more details.
+!*
+!* You should have received a copy of the GNU Lesser General Public
+!* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
+!***********************************************************************
+!> @file
+!> @brief Imports the input buffer routines from other include files used
+!! in @ref diag_manager_mod
+
+!> @addtogroup diag_manager_mod
+!> @{
+
+#undef FMS_TRM_KIND_
+#define FMS_TRM_KIND_ r8_kind
+
+#undef APPEND_DATA_BUFFER_
+#define APPEND_DATA_BUFFER_ append_data_buffer_r8
+
+#undef SUM_DATA_BUFFER_
+#define SUM_DATA_BUFFER_ sum_data_buffer_r8
+
+#include "fms_diag_input_buffer.inc"
+
+!> @}
+! close documentation grouping

--- a/diag_manager/include/fms_diag_reduction_methods.inc
+++ b/diag_manager/include/fms_diag_reduction_methods.inc
@@ -215,7 +215,7 @@ end subroutine DO_TIME_MAX_
 !!
 !! Where l are the indices passed in through the bounds_in/out
 subroutine DO_TIME_SUM_UPDATE_(data_out, weight_sum, data_in, mask, is_masked, mask_variant, bounds_in, bounds_out, &
-                               missing_value, increase_counter, diurnal_section, weight, pow)
+                               missing_value, diurnal_section, weight, pow)
   real(FMS_TRM_KIND_),       intent(inout) :: data_out(:,:,:,:,:) !< output data
   real(r8_kind),             intent(inout) :: weight_sum(:,:,:,:) !< Sum of weights from the output buffer object
   real(FMS_TRM_KIND_),       intent(in)    :: data_in(:,:,:,:)    !< data to update the buffer with
@@ -227,8 +227,6 @@ subroutine DO_TIME_SUM_UPDATE_(data_out, weight_sum, data_in, mask, is_masked, m
   type(fmsDiagIbounds_type), intent(in)    :: bounds_out          !< indices indicating the correct portion
                                                                   !! of the output buffer
   real(FMS_TRM_KIND_),       intent(in)    :: missing_value       !< Missing_value for data points that are masked
-  logical,                   intent(in)    :: increase_counter    !< .True. if data has not been received for
-                                                                  !! time, so the counter needs to be increased
   integer, intent(in)                      :: diurnal_section !< the diurnal "section" if doing a diurnal reduction
                                                               !! indicates which index to add data on 5th axis
                                                               !! if not doing a diurnal reduction, this should always =1
@@ -242,24 +240,17 @@ subroutine DO_TIME_SUM_UPDATE_(data_out, weight_sum, data_in, mask, is_masked, m
   integer :: is_out, ie_out, js_out, je_out, ks_out, ke_out !< Starting and ending indices of each dimention for
                                                             !! the output buffer
   integer :: i, j, k, l !< For looping
-  real(FMS_TRM_KIND_) :: counter_local !< counter to increase the counter by
   real(FMS_TRM_KIND_) :: weight_scale !< local copy of optional weight
   integer :: pow_loc !> local copy of optional pow value (set if using pow reduction)
   integer, parameter  :: kindl = FMS_TRM_KIND_ !< real kind size as set by macro
   integer :: diurnal !< diurnal index to indicate which daily section is updated
                      !! will be 1 unless using a diurnal reduction
 
-  ! The counter and the weight are stored in different variables to avoid having
-  ! to do a if (increase_counter) inside a do loop
   if(present(weight)) then
-    counter_local = weight
     weight_scale = weight
   else
-    counter_local = 1.0_kindl
     weight_scale = 1.0_kindl
   endif
-
-  if (.not. increase_counter) counter_local = 0.0_kindl
 
   if(present(pow)) then
     pow_loc = pow
@@ -302,13 +293,13 @@ subroutine DO_TIME_SUM_UPDATE_(data_out, weight_sum, data_in, mask, is_masked, m
                      + (data_in(is_in +i, js_in + j, ks_in + k, :) * weight_scale) ** pow_loc
               !Increase the weight sum for the grid point that was not masked
               weight_sum(is_out + i, js_out + j, ks_out + k, :) = &
-                weight_sum(is_out + i, js_out + j, ks_out + k, :) + counter_local
+                weight_sum(is_out + i, js_out + j, ks_out + k, :) + weight_scale
             endwhere
           enddo
         enddo
       enddo
     else
-      weight_sum = weight_sum + counter_local
+      weight_sum = weight_sum + weight_scale
       do k = 0, ke_out - ks_out
         do j = 0, je_out - js_out
           do i = 0, ie_out - is_out
@@ -324,7 +315,7 @@ subroutine DO_TIME_SUM_UPDATE_(data_out, weight_sum, data_in, mask, is_masked, m
       enddo
     endif
   else
-    weight_sum = weight_sum + counter_local
+    weight_sum = weight_sum + weight_scale
     ! doesn't need to loop through l if no mask, just sums the 1d slices
     do k = 0, ke_out - ks_out
       do j = 0, je_out - js_out

--- a/test_fms/diag_manager/Makefile.am
+++ b/test_fms/diag_manager/Makefile.am
@@ -33,7 +33,7 @@ check_PROGRAMS = test_diag_manager test_diag_manager_time \
  test_flexible_time test_diag_update_buffer test_reduction_methods check_time_none \
  check_time_min check_time_max check_time_sum check_time_avg test_diag_diurnal check_time_diurnal \
  check_time_pow check_time_rms check_subregional test_cell_measures test_var_masks \
- check_var_masks
+ check_var_masks test_multiple_send_data
 
 # This is the source code for the test.
 test_diag_manager_SOURCES = test_diag_manager.F90
@@ -58,6 +58,7 @@ test_cell_measures_SOURCES = test_cell_measures.F90
 check_subregional_SOURCES = check_subregional.F90
 test_var_masks_SOURCES = test_var_masks.F90
 check_var_masks_SOURCES = check_var_masks.F90
+test_multiple_send_data_SOURCES = test_multiple_send_data.F90
 
 TEST_EXTENSIONS = .sh
 SH_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
@@ -66,14 +67,14 @@ SH_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
 # Run the test.
 TESTS = test_diag_manager2.sh test_time_none.sh test_time_min.sh test_time_max.sh test_time_sum.sh \
         test_time_avg.sh test_time_pow.sh test_time_rms.sh test_time_diurnal.sh test_cell_measures.sh \
-        test_subregional.sh test_var_masks.sh
+        test_subregional.sh test_var_masks.sh test_multiple_send_data.sh
 
 testing_utils.mod: testing_utils.$(OBJEXT)
 
 # Copy over other needed files to the srcdir
 EXTRA_DIST = test_diag_manager2.sh check_crashes.sh test_time_none.sh test_time_min.sh test_time_max.sh \
              test_time_sum.sh test_time_avg.sh test_time_pow.sh test_time_rms.sh test_time_diurnal.sh \
-             test_cell_measures.sh test_subregional.sh test_var_masks.sh
+             test_cell_measures.sh test_subregional.sh test_var_masks.sh test_multiple_send_data.sh
 
 if USING_YAML
 skipflag=""

--- a/test_fms/diag_manager/test_multiple_send_data.F90
+++ b/test_fms/diag_manager/test_multiple_send_data.F90
@@ -1,0 +1,144 @@
+!***********************************************************************
+!*                   GNU Lesser General Public License
+!*
+!* This file is part of the GFDL Flexible Modeling System (FMS).
+!*
+!* FMS is free software: you can redistribute it and/or modify it under
+!* the terms of the GNU Lesser General Public License as published by
+!* the Free Software Foundation, either version 3 of the License, or (at
+!* your option) any later version.
+!*
+!* FMS is distributed in the hope that it will be useful, but WITHOUT
+!* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+!* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+!* for more details.
+!*
+!* You should have received a copy of the GNU Lesser General Public
+!* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
+!***********************************************************************
+
+!> @brief  This programs tests fields that call send_data multiple times
+program test_multiple_send_data
+  use fms_mod, only: fms_init, fms_end
+  use diag_manager_mod
+  use mpp_mod
+  use mpp_domains_mod
+  use platform_mod,     only: r8_kind, r4_kind
+  use time_manager_mod, only: time_type, set_calendar_type, set_date, JULIAN, set_time, OPERATOR(+)
+  use fms2_io_mod
+  use fms_diag_yaml_mod
+
+  implicit none
+
+  type(time_type)                    :: Time             !< Time of the simulation
+  type(time_type)                    :: Time_step        !< Time_step of the simulation
+  integer                            :: nx               !< Number of x points
+  integer                            :: ny               !< Number of y points
+  integer                            :: nz               !< Number of z points
+  integer                            :: id_x             !< Axis id for the x dimension
+  integer                            :: id_y             !< Axis id for the y dimension
+  integer                            :: id_var1          !< Field id for 1st variable
+  integer                            :: id_var2          !< Field id for 2nd variable
+  logical                            :: used             !< Dummy argument to send_data
+  real,                  allocatable :: x(:)             !< X axis data
+  real,                  allocatable :: y(:)             !< Y axis_data
+  real,                  allocatable :: var1_data(:,:)   !< Data for variable 1
+  logical,               allocatable :: var1_mask(:,:)   !< Mask for variable 1
+  integer                            :: i                !< For do loops
+
+  call fms_init
+  call set_calendar_type(JULIAN)
+  call diag_manager_init
+
+  nx = 360
+  ny = 180
+
+  allocate(x(nx), y(ny))
+  allocate(var1_data(nx,ny), var1_mask(nx,ny))
+  do i=1,nx
+    x(i) = i
+  enddo
+  do i=1,ny
+    y(i) = -91 + i
+  enddo
+
+  Time = set_date(2,1,1,0,0,0)
+  Time_step = set_time (3600,0) !< 1 hour
+
+  id_x  = diag_axis_init('x',  x,  'point_E', 'x', long_name='point_E')
+  id_y  = diag_axis_init('y',  y,  'point_N', 'y', long_name='point_N')
+
+  ! id_var1 is using diag manager similarly to how the `rv_ice` and `rv_T` in the river code
+  id_var1 = register_diag_field  ('atmos', 'ua', (/id_x, id_y/), Time, missing_value=-999., mask_variant=.True., &
+    multiple_send_data=.True.)
+
+  ! id_var2 is using diag manager similarly to way it is used in the vert_diff module code
+  id_var2 = register_diag_field  ('atmos', 'va', (/id_x, id_y/), Time, missing_value=-999., &
+    multiple_send_data=.True.)
+
+  call diag_manager_set_time_end(set_date(2,1,2,0,0,0))
+  do i = 1, 24
+    Time = Time + Time_step
+
+    var1_data = real(i)
+
+    var1_mask = .False.
+    ! Only count the data for the (:,1) section of the grid on this send_data call
+    var1_mask(:,1) = .True.
+    used = send_data(id_var1, var1_data, Time, mask=var1_mask)
+
+    var1_mask = .False.
+    ! Only count the data for the (:,2:) section of the grid on this send_data call
+    var1_mask(:,2:) = .True.
+    used = send_data(id_var1, var1_data, Time, mask=var1_mask)
+
+    used = send_data(id_var2, var1_data, Time)
+    used = send_data(id_var2, var1_data, Time)
+    call diag_send_complete(Time_step)
+  enddo
+
+  call diag_manager_end(Time)
+  call check_answers()
+  call fms_end
+
+  contains
+    subroutine check_answers()
+      type(FmsNetcdfFile_t) :: fileobj
+      integer                            :: ntimes
+      integer                            :: nx
+      integer                            :: ny
+      real,   allocatable                :: vardata(:,:)
+      real                               :: ans_var
+      integer                            :: i, j
+
+      if (.not. open_file(fileobj, "test_multiple_sends.nc", "read")) &
+        call mpp_error(FATAL, "unable to open test_var_masks.nc for reading")
+
+      call get_dimension_size(fileobj, "time", ntimes)
+      if (ntimes .ne. 1) call mpp_error(FATAL, "time is not the correct size!")
+
+      call get_dimension_size(fileobj, "x", nx)
+      if (nx .ne. 360) call mpp_error(FATAL, "x is not the correct size!")
+
+      call get_dimension_size(fileobj, "y", ny)
+      if (ny .ne. 180) call mpp_error(FATAL, "y is not the correct size!")
+
+      allocate(vardata(nx,ny))
+
+      ans_var = 0.
+      do i = 1, 24
+        ans_var = ans_var + real(i)
+      enddo
+      ans_var = ans_var / 24
+
+      call read_data(fileobj, "ua", vardata)
+      if (any(vardata .ne. ans_var)) &
+        call mpp_error(FATAL, "ua is not the expected result")
+
+      call read_data(fileobj, "va", vardata)
+      if (any(vardata .ne. ans_var)) &
+        call mpp_error(FATAL, "va is not the expected result")
+
+      call close_file(fileobj)
+    end subroutine check_answers
+end program test_multiple_send_data

--- a/test_fms/diag_manager/test_multiple_send_data.sh
+++ b/test_fms/diag_manager/test_multiple_send_data.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+
+#***********************************************************************
+#*                   GNU Lesser General Public License
+#*
+#* This file is part of the GFDL Flexible Modeling System (FMS).
+#*
+#* FMS is free software: you can redistribute it and/or modify it under
+#* the terms of the GNU Lesser General Public License as published by
+#* the Free Software Foundation, either version 3 of the License, or (at
+#* your option) any later version.
+#*
+#* FMS is distributed in the hope that it will be useful, but WITHOUT
+#* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+#* for more details.
+#*
+#* You should have received a copy of the GNU Lesser General Public
+#* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
+#***********************************************************************
+
+# Set common test settings.
+. ../test-lib.sh
+
+if [ -z "${skipflag}" ]; then
+# create and enter directory for in/output files
+output_dir
+
+cat <<_EOF > diag_table.yaml
+title: test_multiple_sends
+base_date: 2 1 1 0 0 0
+diag_files:
+- file_name: test_multiple_sends
+  time_units: hours
+  unlimdim: time
+  freq: 1 days
+  varlist:
+  - module: atmos
+    var_name: ua
+    reduction: average
+    kind: r4
+  - module: atmos
+    var_name: va
+    reduction: average
+    kind: r4
+_EOF
+
+# remove any existing files that would result in false passes during checks
+rm -f *.nc
+
+my_test_count=1
+printf "&diag_manager_nml \n use_modern_diag=.true. \n/" | cat > input.nml
+test_expect_success "Running diag_manager with fields that call send_data multiple times for the same time (test $my_test_count)" '
+  mpirun -n 1 ../test_multiple_send_data
+'
+fi
+test_done


### PR DESCRIPTION
**Description**
- Adds an optional variable (`multiple_send_data`) to register_diag_field, which if set to .True. it indicates that send_data is called multiple times for the same time
- If that option is set to .True. the data will be buffered
   - If the field's mask changes over time, the input buffer will be updated only when the mask is set to .True. This will be the case for some of the river diagnostics (https://gitlab.gfdl.noaa.gov/uriel.ramirez/land_lad2/-/blob/multiple_send_data_fix/river/river_physics.F90?ref_type=heads#L161-L166)
   - If the field's mask does not change over time , the input_buffer will be added and a counter will be added. Once the code hits diag_send_complete it will divide the field by the number of times send _data is called). This will be the case for some variable in vert_diff_driver (https://gitlab.gfdl.noaa.gov/fms/atmos_phys/-/commit/e1bf0539060a4b1e9b63f0e3fbfaf65f663c6c08)
- Modifies logic so that the time dimension will be written at least once. This is needed so that the combiner works for when doing regression testing.  

Fixes # (issue)

**How Has This Been Tested?**
CI
AM4 - the river diagnostics and the vert_diff_drivers were changing answers before this update

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

