### PR TITLE
modern_diag_manager:: Fixes for empty files and non registered fields

### DIFF
--- a/diag_manager/fms_diag_file_object.F90
+++ b/diag_manager/fms_diag_file_object.F90
@@ -1370,6 +1370,7 @@ logical function is_time_to_write(this, time_step, output_buffers)
           call mpp_error(FATAL, this%FMS_diag_file%get_file_fname()//&
             ": diag_manager_mod: You skipped a time_step. Be sure that diag_send_complete is called at every "//&
             "time_step needed by the file.")
+        is_time_to_write =.false.
       endif
     endif
   else

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -825,7 +825,7 @@ subroutine fms_diag_do_io(this, end_time)
       call diag_file%increase_unlim_dimension_level()
     endif
 
-    finish_writing = diag_file%is_time_to_write(model_time)
+    finish_writing = diag_file%is_time_to_write(model_time, this%FMS_diag_output_buffers)
 
     ! finish reduction method if its time to write
     buff_ids = diag_file%FMS_diag_file%get_buffer_ids()
@@ -863,10 +863,11 @@ subroutine fms_diag_do_io(this, end_time)
       call diag_file%update_next_write(model_time)
       call diag_file%update_current_new_file_freq_index(model_time)
       call diag_file%increase_unlim_dimension_level()
-      if (diag_file%is_time_to_close_file(model_time)) call diag_file%close_diag_file()
+      if (diag_file%is_time_to_close_file(model_time)) call diag_file%close_diag_file(this%FMS_diag_output_buffers, &
+        diag_fields = this%FMS_diag_fields)
     else if (force_write) then
       call diag_file%write_time_data()
-      call diag_file%close_diag_file()
+      call diag_file%close_diag_file(this%FMS_diag_output_buffers, diag_fields = this%FMS_diag_fields)
     endif
   enddo
 #endif

--- a/diag_manager/fms_diag_output_buffer.F90
+++ b/diag_manager/fms_diag_output_buffer.F90
@@ -61,7 +61,7 @@ type :: fmsDiagOutputBuffer_type
                                                     !! ie. diurnal24 = sample size of 24
   integer               :: diurnal_section= -1 !< the diurnal section (ie 5th index) calculated from the current model
                                               !! time and sample size if using a diurnal reduction
-  logical               :: send_data_called   !< .True. if send_data has been called
+  logical, allocatable  :: send_data_called   !< .True. if send_data has been called
   type(time_type)       :: time               !< The last time the data was received
   type(time_type)       :: next_output        !< The next time to output the data
 
@@ -830,7 +830,11 @@ function is_there_data_to_write(this) &
 
   logical :: res
 
-  res = this%send_data_called
+  if (allocated(this%send_data_called)) then
+    res = this%send_data_called
+  else
+    res = .false.
+  endif
 end function
 
 !> @brief Determine if it is time to finish the reduction method

--- a/diag_manager/fms_diag_output_buffer.F90
+++ b/diag_manager/fms_diag_output_buffer.F90
@@ -826,7 +826,7 @@ end subroutine get_remapped_diurnal_data
 !! @return .true. if there is data to write
 function is_there_data_to_write(this) &
   result(res)
-  class(fmsDiagOutputBuffer_type), intent(inout) :: this        !< Buffer object
+  class(fmsDiagOutputBuffer_type), intent(in) :: this        !< Buffer object
 
   logical :: res
 

--- a/diag_manager/fms_diag_yaml.F90
+++ b/diag_manager/fms_diag_yaml.F90
@@ -37,7 +37,7 @@ use diag_data_mod,   only: DIAG_NULL, DIAG_OCEAN, DIAG_ALL, DIAG_OTHER, set_base
                            middle_time, begin_time, end_time, MAX_STR_LEN
 use yaml_parser_mod, only: open_and_parse_file, get_value_from_key, get_num_blocks, get_nkeys, &
                            get_block_ids, get_key_value, get_key_ids, get_key_name
-use mpp_mod,         only: mpp_error, FATAL, mpp_pe, mpp_root_pe, stdout
+use mpp_mod,         only: mpp_error, FATAL, NOTE, mpp_pe, mpp_root_pe, stdout
 use, intrinsic :: iso_c_binding, only : c_ptr, c_null_char
 use fms_string_utils_mod, only: fms_array_to_pointer, fms_find_my_string, fms_sort_this, fms_find_unique, string
 use platform_mod, only: r4_kind, i4_kind
@@ -356,6 +356,7 @@ subroutine diag_yaml_object_init(diag_subset_output)
   integer              :: file_count       !! The current number of files added to the diag_yaml obj
   logical              :: write_file       !< Flag indicating if the user wants the file to be written
   logical              :: write_var        !< Flag indicating if the user wants the variable to be written
+  character(len=:), allocatable :: filename!< Diag file name (for error messages)
 
   if (diag_yaml_module_initialized) return
 
@@ -393,13 +394,16 @@ subroutine diag_yaml_object_init(diag_subset_output)
     call get_value_from_key(diag_yaml_id, diag_file_ids(i), "write_file", write_file, is_optional=.true.)
     if(.not. write_file) ignore(i) = .true.
 
+    !< If ignoring the file, ignore the fields in that file too!
     if (.not. ignore(i)) then
-        !< If ignoring the file, ignore the fields in that file too!
-        total_nvars = total_nvars + get_total_num_vars(diag_yaml_id, diag_file_ids(i))
-        if (total_nvars .ne. 0) then
+        nvars = get_total_num_vars(diag_yaml_id, diag_file_ids(i))
+        total_nvars = total_nvars + nvars
+        if (nvars .ne. 0) then
           actual_num_files = actual_num_files + 1
         else
-          ignore(i) = .true.
+          call diag_get_value_from_key(diag_yaml_id, diag_file_ids(i), "file_name", filename)
+          call mpp_error(NOTE, "diag_manager_mod:: the file:"//trim(filename)//" has no variables defined. Ignoring!")
+          ignore(i) = .True.
         endif
     endif
   enddo

--- a/test_fms/diag_manager/test_time_none.sh
+++ b/test_fms/diag_manager/test_time_none.sh
@@ -169,5 +169,40 @@ test_expect_success "Running diag_manager with "none" reduction method with halo
 test_expect_success "Checking answers for the "none" reduction method with halo output with real mask (test $my_test_count)" '
   mpirun -n 1 ../check_time_none
 '
+
+cat <<_EOF > diag_table.yaml
+title: test_avg
+base_date: 2 1 1 0 0 0
+diag_files:
+- file_name: test_empty_file
+  time_units: hours
+  unlimdim: time
+  freq: 6 hours
+_EOF
+
+my_test_count=`expr $my_test_count + 1`
+test_expect_success "Testing diag manager that defined a diag file with no variables (test $my_test_count)" '
+  mpirun -n 6 ../test_reduction_methods
+'
+
+cat <<_EOF > diag_table.yaml
+title: test_avg
+base_date: 2 1 1 0 0 0
+diag_files:
+- file_name: test_unregistered_data
+  time_units: hours
+  unlimdim: time
+  freq: 6 hours
+  varlist:
+  - module: ocn_mod
+    var_name: something_funny
+    reduction: none
+    kind: r4
+_EOF
+
+my_test_count=`expr $my_test_count + 1`
+test_expect_success "Testing diag manager where no variables were registered for a file (test $my_test_count)" '
+  mpirun -n 6 ../test_reduction_methods
+'
 fi
 test_done

--- a/test_fms/diag_manager/test_time_none.sh
+++ b/test_fms/diag_manager/test_time_none.sh
@@ -171,7 +171,7 @@ test_expect_success "Checking answers for the "none" reduction method with halo 
 '
 
 cat <<_EOF > diag_table.yaml
-title: test_avg
+title: test_none
 base_date: 2 1 1 0 0 0
 diag_files:
 - file_name: test_empty_file
@@ -186,7 +186,7 @@ test_expect_success "Testing diag manager that defined a diag file with no varia
 '
 
 cat <<_EOF > diag_table.yaml
-title: test_avg
+title: test_none
 base_date: 2 1 1 0 0 0
 diag_files:
 - file_name: test_unregistered_data
@@ -204,5 +204,25 @@ my_test_count=`expr $my_test_count + 1`
 test_expect_success "Testing diag manager where no variables were registered for a file (test $my_test_count)" '
   mpirun -n 6 ../test_reduction_methods
 '
+
+cat <<_EOF > diag_table.yaml
+title: test_none
+base_date: 2 1 1 0 0 0
+diag_files:
+- file_name: test_send_data_never_called
+  time_units: hours
+  unlimdim: time
+  freq: 6 hours
+  varlist:
+  - module: ocn_mod
+    var_name: IOnASphere
+    reduction: none
+    kind: r4
+_EOF
+
+my_test_count=`expr $my_test_count + 1`
+test_expect_success "Testing diag manager where send data was never called for any fields in a file (test $my_test_count)" '
+  mpirun -n 6 ../test_reduction_methods
+  '
 fi
 test_done


### PR DESCRIPTION
**Description**
1. Updates the code that parses the diag table so that files that don't have any variables get ignored and a NOTE is printed out. Without this change, the model crashes in runs where the base_date is not the same as the model time (i.e the second segment of a run) since the model time will be greater than next_next_output because it wasn't updated since no variables were registered. 
2. Updates the code so that if no variables were registered for the file, it will print out a warning and write out a dummy time dimension. Without this change, the same thing as above will happen.
3. Updates the code so that it prints out a warning if send data was not called for any fields in a file (this wasn't done properly before)
4. Adds a test for these cases

Fixes # (issue)

**How Has This Been Tested?**
CI

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [ ] `make distcheck` passes

