### PR TITLE
dmUpdate: fix uninitialized return value

### DIFF
--- a/diag_manager/fms_diag_field_object.F90
+++ b/diag_manager/fms_diag_field_object.F90
@@ -1884,6 +1884,8 @@ function check_for_slices(field, diag_axis, var_size) &
   logical :: rslt
   integer :: i !< For do loops
 
+  rslt = .false.
+
   if (.not. field%has_axis_ids()) then
     rslt = .false.
     return


### PR DESCRIPTION
**Description**
initializes the return value in `check_for_slices`. This was resulting in failures when run with intel + debug flags.

**How Has This Been Tested?**
tested on gaea with the doubly_periodic model

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

