### PR TITLE
dmUpdate: fixes for gcc

### DIFF
--- a/diag_manager/fms_diag_file_object.F90
+++ b/diag_manager/fms_diag_file_object.F90
@@ -34,7 +34,7 @@ use diag_data_mod, only: DIAG_NULL, NO_DOMAIN, max_axes, SUB_REGIONAL, get_base_
                          get_base_year, get_base_month, get_base_day, get_base_hour, get_base_minute, &
                          get_base_second, time_unit_list, time_average, time_rms, time_max, time_min, time_sum, &
                          time_diurnal, time_power, time_none, avg_name, no_units, pack_size_str, &
-                         middle_time, begin_time, end_time, MAX_STR_LEN, index_gridtype, latlon_gridtype
+                         middle_time, begin_time, end_time, MAX_STR_LEN, index_gridtype, latlon_gridtype, null_gridtype
 use time_manager_mod, only: time_type, operator(>), operator(/=), operator(==), get_date, get_calendar_type, &
                             VALID_CALENDAR_TYPES, operator(>=), date_to_string, &
                             OPERATOR(/), OPERATOR(+), operator(<)
@@ -364,6 +364,7 @@ subroutine set_file_time_ops(this, VarYaml, is_static)
   class(fmsDiagFile_type),      intent(inout) :: this      !< The file object
   type (diagYamlFilesVar_type), intent(in)    :: VarYaml   !< The variable's yaml file
   logical,                      intent(in)    :: is_static !< Flag indicating if variable is static
+  integer, allocatable :: var_reduct !< temp to hold enumerated reduction type 
 
   !< Go away if the file is static
   if (this%is_static) return
@@ -375,7 +376,8 @@ subroutine set_file_time_ops(this, VarYaml, is_static)
                             " has variables that are time averaged and instantaneous")
     endif
   else
-    select case (VarYaml%get_var_reduction())
+    var_reduct = VarYaml%get_var_reduction()
+    select case (var_reduct)
       case (time_average, time_rms, time_max, time_min, time_sum, time_diurnal, time_power)
         this%time_ops = .true.
     end select
@@ -514,24 +516,28 @@ pure function get_file_unlimdim (this) result(res)
 end function get_file_unlimdim
 
 !> \brief Returns a copy of file_sub_region from the yaml object
-!! \return Copy of file_sub_region
+!! \return Pointer to file_sub_region
 function get_file_sub_region (obj) result(res)
- class(fmsDiagFile_type), intent(in) :: obj !< The file object
- type(subRegion_type) :: res
-  res = obj%diag_yaml_file%get_file_sub_region()
+ class(fmsDiagFile_type), target, intent(in) :: obj !< The file object
+ type(subRegion_type), pointer :: res
+  res => obj%diag_yaml_file%get_file_sub_region()
 end function get_file_sub_region
 
 !< @brief Query for the subregion grid type (latlon or index)
-!! @return subregion grid type
+!! @return Pointer to subregion grid type
 function get_file_sub_region_grid_type(this) &
   result(res)
   class(fmsDiagFile_type), intent(in) :: this !< Diag file object
   integer :: res
 
-  type(subRegion_type) :: subregion !< Subregion type
+  type(subRegion_type), pointer :: subregion !< Subregion type
 
-  subregion = this%diag_yaml_file%get_file_sub_region()
-  res = subregion%grid_type
+  if(this%diag_yaml_file%has_file_sub_region()) then
+    subregion => this%diag_yaml_file%get_file_sub_region()
+    res = subregion%grid_type
+  else
+    res = null_gridtype
+  endif
 end function get_file_sub_region_grid_type
 
 !> \brief Returns a copy of file_new_file_freq from the yaml object
@@ -718,7 +724,7 @@ end subroutine set_domain_from_axis
 subroutine set_file_domain(this, domain, type_of_domain)
   class(fmsDiagFile_type), intent(inout)       :: this            !< The file object
   integer,                 INTENT(in)          :: type_of_domain !< fileobj_type to use
-  CLASS(diagDomain_t),     INTENT(in), target  :: domain         !< Domain
+  CLASS(diagDomain_t),     INTENT(in), pointer :: domain         !< Domain
 
   if (type_of_domain .ne. this%type_of_domain) then
   !! If the current type_of_domain in the file obj is not the same as the variable calling this subroutine

--- a/diag_manager/fms_diag_file_object.F90
+++ b/diag_manager/fms_diag_file_object.F90
@@ -364,7 +364,7 @@ subroutine set_file_time_ops(this, VarYaml, is_static)
   class(fmsDiagFile_type),      intent(inout) :: this      !< The file object
   type (diagYamlFilesVar_type), intent(in)    :: VarYaml   !< The variable's yaml file
   logical,                      intent(in)    :: is_static !< Flag indicating if variable is static
-  integer, allocatable :: var_reduct !< temp to hold enumerated reduction type 
+  integer, allocatable :: var_reduct !< temp to hold enumerated reduction type
 
   !< Go away if the file is static
   if (this%is_static) return

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -258,10 +258,10 @@ CALL MPP_ERROR(FATAL,"You can not use the modern diag manager without compiling 
      call fileptr%add_field_and_yaml_id(fieldptr%get_id(), diag_field_indices(i))
      call fileptr%add_buffer_id(fieldptr%buffer_ids(i))
      if(fieldptr%get_type_of_domain() .eq. NO_DOMAIN) then
-      call fileptr%set_file_domain(NULL(), fieldptr%get_type_of_domain()) ! fails here
-    else
-      call fileptr%set_file_domain(fieldptr%get_domain(), fieldptr%get_type_of_domain()) ! fails here
-    endif
+       call fileptr%set_file_domain(NULL(), fieldptr%get_type_of_domain()) ! fails here
+     else
+       call fileptr%set_file_domain(fieldptr%get_domain(), fieldptr%get_type_of_domain()) ! fails here
+     endif
      call fileptr%init_diurnal_axis(this%diag_axis, this%registered_axis, diag_field_indices(i))
      call fileptr%add_axes(axes, this%diag_axis, this%registered_axis, diag_field_indices(i), &
        fieldptr%buffer_ids(i), this%FMS_diag_output_buffers)
@@ -275,10 +275,10 @@ CALL MPP_ERROR(FATAL,"You can not use the modern diag manager without compiling 
      call fileptr%add_buffer_id(fieldptr%buffer_ids(i))
      call fileptr%init_diurnal_axis(this%diag_axis, this%registered_axis, diag_field_indices(i))
      if(fieldptr%get_type_of_domain() .eq. NO_DOMAIN) then
-      call fileptr%set_file_domain(NULL(), fieldptr%get_type_of_domain()) ! fails here
-    else
-      call fileptr%set_file_domain(fieldptr%get_domain(), fieldptr%get_type_of_domain()) ! fails here
-    endif
+       call fileptr%set_file_domain(NULL(), fieldptr%get_type_of_domain()) ! fails here
+     else
+       call fileptr%set_file_domain(fieldptr%get_domain(), fieldptr%get_type_of_domain()) ! fails here
+     endif
      call fileptr%add_axes(axes, this%diag_axis, this%registered_axis, diag_field_indices(i), &
        fieldptr%buffer_ids(i), this%FMS_diag_output_buffers)
      call fileptr%set_file_time_ops (fieldptr%diag_field(i), fieldptr%is_static())

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -22,7 +22,7 @@ use diag_data_mod,  only: diag_null, diag_not_found, diag_not_registered, diag_r
                          &DIAG_FIELD_NOT_FOUND, diag_not_registered, max_axes, TWO_D_DOMAIN, &
                          &get_base_time, NULL_AXIS_ID, get_var_type, diag_not_registered, &
                          &time_none, time_max, time_min, time_sum, time_average, time_diurnal, &
-                         &time_power, time_rms, r8
+                         &time_power, time_rms, r8, NO_DOMAIN
 
   USE time_manager_mod, ONLY: set_time, set_date, get_time, time_type, OPERATOR(>=), OPERATOR(>),&
        & OPERATOR(<), OPERATOR(==), OPERATOR(/=), OPERATOR(/), OPERATOR(+), ASSIGNMENT(=), get_date, &
@@ -257,7 +257,11 @@ CALL MPP_ERROR(FATAL,"You can not use the modern diag manager without compiling 
      fileptr => this%FMS_diag_files(file_ids(i))%FMS_diag_file
      call fileptr%add_field_and_yaml_id(fieldptr%get_id(), diag_field_indices(i))
      call fileptr%add_buffer_id(fieldptr%buffer_ids(i))
-     call fileptr%set_file_domain(fieldptr%get_domain(), fieldptr%get_type_of_domain())
+     if(fieldptr%get_type_of_domain() .eq. NO_DOMAIN) then
+      call fileptr%set_file_domain(NULL(), fieldptr%get_type_of_domain()) ! fails here
+    else
+      call fileptr%set_file_domain(fieldptr%get_domain(), fieldptr%get_type_of_domain()) ! fails here
+    endif
      call fileptr%init_diurnal_axis(this%diag_axis, this%registered_axis, diag_field_indices(i))
      call fileptr%add_axes(axes, this%diag_axis, this%registered_axis, diag_field_indices(i), &
        fieldptr%buffer_ids(i), this%FMS_diag_output_buffers)
@@ -270,7 +274,11 @@ CALL MPP_ERROR(FATAL,"You can not use the modern diag manager without compiling 
      call fileptr%add_field_and_yaml_id(fieldptr%get_id(), diag_field_indices(i))
      call fileptr%add_buffer_id(fieldptr%buffer_ids(i))
      call fileptr%init_diurnal_axis(this%diag_axis, this%registered_axis, diag_field_indices(i))
-     call fileptr%set_file_domain(fieldptr%get_domain(), fieldptr%get_type_of_domain())
+     if(fieldptr%get_type_of_domain() .eq. NO_DOMAIN) then
+      call fileptr%set_file_domain(NULL(), fieldptr%get_type_of_domain()) ! fails here
+    else
+      call fileptr%set_file_domain(fieldptr%get_domain(), fieldptr%get_type_of_domain()) ! fails here
+    endif
      call fileptr%add_axes(axes, this%diag_axis, this%registered_axis, diag_field_indices(i), &
        fieldptr%buffer_ids(i), this%FMS_diag_output_buffers)
      call fileptr%set_file_time_ops (fieldptr%diag_field(i), fieldptr%is_static())

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -258,9 +258,9 @@ CALL MPP_ERROR(FATAL,"You can not use the modern diag manager without compiling 
      call fileptr%add_field_and_yaml_id(fieldptr%get_id(), diag_field_indices(i))
      call fileptr%add_buffer_id(fieldptr%buffer_ids(i))
      if(fieldptr%get_type_of_domain() .eq. NO_DOMAIN) then
-       call fileptr%set_file_domain(NULL(), fieldptr%get_type_of_domain()) ! fails here
+       call fileptr%set_file_domain(NULL(), fieldptr%get_type_of_domain())
      else
-       call fileptr%set_file_domain(fieldptr%get_domain(), fieldptr%get_type_of_domain()) ! fails here
+       call fileptr%set_file_domain(fieldptr%get_domain(), fieldptr%get_type_of_domain())
      endif
      call fileptr%init_diurnal_axis(this%diag_axis, this%registered_axis, diag_field_indices(i))
      call fileptr%add_axes(axes, this%diag_axis, this%registered_axis, diag_field_indices(i), &
@@ -275,9 +275,9 @@ CALL MPP_ERROR(FATAL,"You can not use the modern diag manager without compiling 
      call fileptr%add_buffer_id(fieldptr%buffer_ids(i))
      call fileptr%init_diurnal_axis(this%diag_axis, this%registered_axis, diag_field_indices(i))
      if(fieldptr%get_type_of_domain() .eq. NO_DOMAIN) then
-       call fileptr%set_file_domain(NULL(), fieldptr%get_type_of_domain()) ! fails here
+       call fileptr%set_file_domain(NULL(), fieldptr%get_type_of_domain())
      else
-       call fileptr%set_file_domain(fieldptr%get_domain(), fieldptr%get_type_of_domain()) ! fails here
+       call fileptr%set_file_domain(fieldptr%get_domain(), fieldptr%get_type_of_domain())
      endif
      call fileptr%add_axes(axes, this%diag_axis, this%registered_axis, diag_field_indices(i), &
        fieldptr%buffer_ids(i), this%FMS_diag_output_buffers)

--- a/diag_manager/fms_diag_yaml.F90
+++ b/diag_manager/fms_diag_yaml.F90
@@ -954,9 +954,9 @@ end function get_file_unlimdim
 !! @return file_sub_region of a diag_yaml_file_obj
 function get_file_sub_region (this) &
 result (res)
- class (diagYamlFiles_type), intent(in) :: this !< The object being inquiried
- type(subRegion_type) :: res !< What is returned
-  res = this%file_sub_region
+ class (diagYamlFiles_type), target, intent(in) :: this !< The object being inquiried
+ type(subRegion_type), pointer :: res !< What is returned
+  res => this%file_sub_region
 end function get_file_sub_region
 !> @brief Inquiry for diag_files_obj%file_new_file_freq
 !! @return file_new_file_freq of a diag_yaml_file_obj

--- a/diag_manager/fms_diag_yaml.F90
+++ b/diag_manager/fms_diag_yaml.F90
@@ -261,9 +261,9 @@ contains
 !! @return a copy of the diag_yaml module variable
 function get_diag_yaml_obj() &
 result(res)
-  type (diagYamlObject_type) :: res
+  type (diagYamlObject_type), pointer :: res
 
-  res= diag_yaml
+  res => diag_yaml
 end function get_diag_yaml_obj
 
 !> @brief get the basedate of a diag_yaml type
@@ -1476,7 +1476,7 @@ subroutine dump_diag_yaml_obj( filename )
   character(len=*), optional, intent(in)        :: filename !< optional name of logfile to write to, otherwise
                                                             !! prints to stdout
   type(diagyamlfilesvar_type), allocatable      :: fields(:)
-  type(diagyamlfiles_type), allocatable         :: files(:)
+  type(diagyamlfiles_type), pointer :: files(:)
   integer                                       :: i, unit_num
   if( present(filename)) then
     open(newunit=unit_num, file=trim(filename), action='WRITE')
@@ -1490,8 +1490,7 @@ subroutine dump_diag_yaml_obj( filename )
     if( diag_yaml%has_diag_basedate()) write(unit_num, *) 'basedate array:', diag_yaml%diag_basedate
     write(unit_num, *) 'FILES'
     allocate(fields(SIZE(diag_yaml%get_diag_fields())))
-    allocate(files(SIZE(diag_yaml%get_diag_files())))
-    files = diag_yaml%get_diag_files()
+    files => diag_yaml%diag_files 
     fields = diag_yaml%get_diag_fields()
     do i=1, SIZE(files)
       write(unit_num, *) 'File: ', files(i)%get_file_fname()
@@ -1528,7 +1527,8 @@ subroutine dump_diag_yaml_obj( filename )
       if(fields(i)%has_pow_value()) write(unit_num, *) 'pow_value:', fields(i)%get_pow_value()
       if(fields(i)%has_var_attributes()) write(unit_num, *) 'is_var_attributes:', fields(i)%is_var_attributes()
     enddo
-    deallocate(files, fields)
+    deallocate(fields)
+    nullify(files)
     if( present(filename)) then
       close(unit_num)
     endif

--- a/test_fms/diag_manager/test_diag_ocean.F90
+++ b/test_fms/diag_manager/test_diag_ocean.F90
@@ -31,8 +31,8 @@ use platform_mod
 
 implicit none
 
-type(diagYamlObject_type) :: my_yaml !< diagYamlObject obtained from diag_yaml_object_init
-type(diagYamlFiles_type), allocatable, dimension (:) :: diag_files !< Files from the diag_yaml
+type(diagYamlObject_type), pointer :: my_yaml !< diagYamlObject obtained from diag_yaml_object_init
+type(diagYamlFiles_type), pointer, dimension (:) :: diag_files !< Files from the diag_yaml
 type(diagYamlFilesVar_type), allocatable, dimension(:) :: diag_fields !< Fields from the diag_yaml
 character(len=10), allocatable :: file_names(:) !< The expected names of the files
 character(len=10), allocatable :: var_names(:) !< The expected names of the variables
@@ -69,8 +69,8 @@ endif
 
 call diag_manager_init(diag_model_subset=diag_subset)
 
-my_yaml = get_diag_yaml_obj()
-diag_files = my_yaml%get_diag_files()
+my_yaml => get_diag_yaml_obj()
+diag_files => my_yaml%diag_files
 if (size(diag_files) .ne. nfiles) call mpp_error(FATAL, "The number of files should be "//string(nfiles))
 
 do i = 1, nfiles
@@ -88,7 +88,7 @@ do i = 1, nvariables
       &trim(var_names(i))//" not "//diag_fields(i)%get_var_varname())
 end do
 
-deallocate(diag_files)
+nullify(diag_files)
 deallocate(diag_fields)
 deallocate(file_names)
 deallocate(var_names)


### PR DESCRIPTION
**Description**
Fixes failures in a bunch of unit tests when compiling with gcc and runtime checks enabled.

The majority of these fixes are related to derived type assignments. There seems to be a compiler bug that breaks assignments with certain derived types (in this case its diagYamlFiles_type and diagYamlObject_type), so the workaround is to just point to the objects instead of doing a full copy.

**How Has This Been Tested?**
Tested on amd box with gcc 13 + `-g -O0 -fbacktrace -fcheck=all`
and also with oneapi

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

