### PR TITLE
Fix data_override for the 0d test case and a test for it

### DIFF
--- a/data_override/include/data_override.inc
+++ b/data_override/include/data_override.inc
@@ -69,9 +69,9 @@ type data_type
    logical            :: multifile = .false.
    character(len=512) :: prev_file_name   !< name of netCDF data file for previous segment
    character(len=512) :: next_file_name   !< name of netCDF data file for next segment
-   type(time_type), dimension(:), pointer :: time_records => NULL()
-   type(time_type), dimension(:), pointer :: time_prev_records => NULL()
-   type(time_type), dimension(:), pointer :: time_next_records => NULL()
+   type(time_type), dimension(:), allocatable :: time_records
+   type(time_type), dimension(:), allocatable :: time_prev_records
+   type(time_type), dimension(:), allocatable :: time_next_records
 end type data_type
 
 !> Private type for holding various data fields for performing data overrides
@@ -900,13 +900,17 @@ subroutine DATA_OVERRIDE_0D_(gridname,fieldname_code,data_out,time,override,data
 
   !10 do time interp to get data in compute_domain
 
-  first_record = data_table(index1)%time_records(1)
-  last_record = data_table(index1)%time_records(dims(4))
-
   ! if using consecutive files, allow to perform time interpolation between the last record of previous
   ! file and first record of current file OR between the last record of current file and first record of
   ! next file hence "bridging" over files.
   if_multi2: if (multifile) then
+    dims = get_external_field_size(id_time)
+    if (.not. allocated(data_table(index1)%time_records)) allocate(data_table(index1)%time_records(dims(4)))
+    call get_time_axis(id_time,data_table(index1)%time_records)
+
+    first_record = data_table(index1)%time_records(1)
+    last_record = data_table(index1)%time_records(dims(4))
+
     if_time2: if (time<first_record) then
       if (id_time_prev<0) call mpp_error(FATAL,'data_override:previous file needed with multifile')
       prev_dims = get_external_field_size(id_time_prev)
@@ -1438,7 +1442,7 @@ subroutine DATA_OVERRIDE_3D_(gridname,fieldname_code,return_data,time,override,d
 
 
   dims = get_external_field_size(id_time)
-  if (.not. associated(data_table(index1)%time_records)) allocate(data_table(index1)%time_records(dims(4)))
+  if (.not. allocated(data_table(index1)%time_records)) allocate(data_table(index1)%time_records(dims(4)))
   call get_time_axis(id_time,data_table(index1)%time_records)
 
   first_record = data_table(index1)%time_records(1)

--- a/test_fms/data_override/Makefile.am
+++ b/test_fms/data_override/Makefile.am
@@ -72,10 +72,12 @@ TESTS_ENVIRONMENT= test_input_path="@TEST_INPUT_PATH@" \
 
 # Run the test program.
 
-TESTS = test_data_override2.sh test_data_override_init.sh test_data_override2_mono.sh test_data_override2_ongrid.sh
+TESTS = test_data_override2.sh test_data_override_init.sh test_data_override2_mono.sh test_data_override2_ongrid.sh \
+        test_data_override2_scalar.sh
 
 # Include these files with the distribution.
-EXTRA_DIST = test_data_override2.sh test_data_override_init.sh test_data_override2_mono.sh test_data_override2_ongrid.sh
+EXTRA_DIST = test_data_override2.sh test_data_override_init.sh test_data_override2_mono.sh test_data_override2_ongrid.sh \
+             test_data_override2_scalar.sh
 
 # Clean up
 CLEANFILES = input.nml *.nc* *.out diag_table data_table data_table.yaml INPUT/* *.dpi *.spi *.dyn *.spl *-files/*

--- a/test_fms/data_override/test_data_override2_scalar.sh
+++ b/test_fms/data_override/test_data_override2_scalar.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+
+#***********************************************************************
+#*                   GNU Lesser General Public License
+#*
+#* This file is part of the GFDL Flexible Modeling System (FMS).
+#*
+#* FMS is free software: you can redistribute it and/or modify it under
+#* the terms of the GNU Lesser General Public License as published by
+#* the Free Software Foundation, either version 3 of the License, or (at
+#* your option) any later version.
+#*
+#* FMS is distributed in the hope that it will be useful, but WITHOUT
+#* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+#* for more details.
+#*
+#* You should have received a copy of the GNU Lesser General Public
+#* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
+#***********************************************************************
+#
+# Copyright (c) 2019-2021 Ed Hartnett, Uriel Ramirez, Seth Underwood
+
+# Set common test settings.
+. ../test-lib.sh
+
+output_dir
+rm -rf data_table data_table.yaml input.nml input_base.nml
+
+if [ ! -z $parser_skip ]; then
+  cat <<_EOF > input.nml
+&data_override_nml
+use_data_table_yaml=.False.
+/
+&test_data_override_ongrid_nml
+  test_case = 3
+/
+_EOF
+  printf '"OCN", "co2", "co2", "./INPUT/scalar.nc", "none" ,  1.0' | cat > data_table
+else
+cat <<_EOF > input.nml
+&data_override_nml
+use_data_table_yaml=.True.
+/
+&test_data_override_ongrid_nml
+  test_case = 3
+/
+_EOF
+cat <<_EOF > data_table.yaml
+data_table:
+ - gridname          : OCN
+   fieldname_code    : co2
+   fieldname_file    : co2
+   file_name         : INPUT/scalar.nc
+   interpol_method   : none
+   factor            : 1.0
+_EOF
+fi
+
+[ ! -d "INPUT" ] && mkdir -p "INPUT"
+for KIND in r4 r8
+do
+rm -rf INPUT/*
+test_expect_success "data_override scalar field (${KIND})" '
+  mpirun -n 6 ../test_data_override_ongrid_${KIND}
+'
+
+done
+rm -rf INPUT *.nc # remove any leftover files to reduce size
+
+test_done


### PR DESCRIPTION
**Description**
- Fixes issue with data_override_0d where the code attempted to use a variable without allocating it first
- Replaces pointers with allocatables

Fixes #1490 

**How Has This Been Tested?**
CI included added test
1day run for ESM4p2_longamip_J

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

