### PR TITLE
fix hdf5 compiler check

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -125,10 +125,10 @@ check-code-coverage: check
 .PHONY: check-code-coverage
 
 clean-local:
-	-rm -rf .mods coverage-data coverage-report
+	-rm -rf .mods coverage-data coverage-report test.nc
 else
 clean-local:
-	-rm -rf .mods
+	-rm -rf .mods test.nc
 endif
 
 install-data-hook:

--- a/configure.ac
+++ b/configure.ac
@@ -265,7 +265,7 @@ AC_MSG_CHECKING([if HDF5 version causes floating point exceptions with set flags
 AC_RUN_IFELSE([AC_LANG_PROGRAM([], [[
       use netcdf
       integer i, j
-      j = nf90_open("test.nc", NC_WRITE, i)
+      j = nf90_create("test.nc", NC_WRITE, i)
 ]])], [hdf5_fpe_bug=no], [hdf5_fpe_bug=yes])
 AC_MSG_RESULT([$hdf5_fpe_bug])
 if test $hdf5_fpe_bug = yes; then

--- a/test_fms/monin_obukhov/test_monin_obukhov2.sh
+++ b/test_fms/monin_obukhov/test_monin_obukhov2.sh
@@ -35,7 +35,7 @@ for p in r4 r8
 do
   cp ${top_srcdir}/test_fms/monin_obukhov/input.${p}.nml input.nml
   test_expect_success "test monin_obukhov_mod (${p})" "mpirun -n 1 ./test_monin_obukhov_${p}"
-  rm input.nml
+  rm -f input.nml
 done
 
 test_done


### PR DESCRIPTION
**Description**
Changes the configure check used to determine if a bug in hdf5 is present. Before it was using nf90_open which wouldn't work on certain systems.

Fixes #1492 

**How Has This Been Tested?**
tested on gaea, amd box, and my laptop

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

