### PR TITLE
add root pe number to diag_field_log filename

### DIFF
--- a/diag_manager/diag_manager.F90
+++ b/diag_manager/diag_manager.F90
@@ -240,6 +240,7 @@ use platform_mod
   USE fms_diag_outfield_mod, ONLY: fmsDiagOutfieldIndex_type, fmsDiagOutfield_type
   USE fms_diag_fieldbuff_update_mod, ONLY: fieldbuff_update, fieldbuff_copy_missvals, &
    & fieldbuff_copy_fieldvals
+  USE fms_string_utils_mod, ONLY: string
 
   USE netcdf, ONLY: NF90_INT, NF90_FLOAT, NF90_CHAR
 
@@ -3926,7 +3927,7 @@ CONTAINS
 
     ! open diag field log file
     IF ( do_diag_field_log.AND.mpp_pe().EQ.mpp_root_pe() ) THEN
-      open(newunit=diag_log_unit, file='diag_field_log.out', action='WRITE')
+      open(newunit=diag_log_unit, file='diag_field_log.out.'//string(mpp_pe()), action='WRITE')
       WRITE (diag_log_unit,'(777a)') &
            & 'Module',         FIELD_LOG_SEPARATOR, 'Field',     FIELD_LOG_SEPARATOR, &
            & 'Long Name',      FIELD_LOG_SEPARATOR, 'Units',     FIELD_LOG_SEPARATOR, &


### PR DESCRIPTION
**Description**
adds the root pe number to the filename of the the diag_field_log.out. When running SPEAR it seems like mom was writing from a different root pe and overwriting the file, so this avoids that by writing out distinct filenames.
Fixes #1496 

**How Has This Been Tested?**
tested with the spear regressions, intel23-classic

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

