### PR TITLE
Modern_diag_manager:: 0 days freq, mix_snapshot_average_fields deprecation

### DIFF
--- a/diag_manager/diag_manager.F90
+++ b/diag_manager/diag_manager.F90
@@ -1769,10 +1769,6 @@ END FUNCTION register_static_field
             & SIZE(field,1), SIZE(field,2), SIZE(field,3), status
        IF ( fms_error_handler('diag_manager_mod::send_data_3d', err_msg_local, err_msg) ) RETURN
     END IF
-    if (use_modern_diag) then !> Set up array lengths for remapping
-
-
-    endif
     SELECT TYPE (field)
     TYPE IS (real(kind=r4_kind))
        field_out = field

--- a/diag_manager/diag_manager.F90
+++ b/diag_manager/diag_manager.F90
@@ -1769,6 +1769,10 @@ END FUNCTION register_static_field
             & SIZE(field,1), SIZE(field,2), SIZE(field,3), status
        IF ( fms_error_handler('diag_manager_mod::send_data_3d', err_msg_local, err_msg) ) RETURN
     END IF
+    if (use_modern_diag) then !> Set up array lengths for remapping
+
+
+    endif
     SELECT TYPE (field)
     TYPE IS (real(kind=r4_kind))
        field_out = field
@@ -4169,11 +4173,15 @@ END FUNCTION register_static_field
     END IF
 
     IF ( mix_snapshot_average_fields ) THEN
-       IF ( mpp_pe() == mpp_root_pe() ) THEN
+       IF ( .not. use_modern_diag ) THEN
           CALL error_mesg('diag_manager_mod::diag_manager_init', 'Setting diag_manager_nml variable '//&
                & 'mix_snapshot_average_fields = .TRUE. will cause ERRORS in the time coordinates '//&
                & 'of all time averaged fields.  Strongly recommend setting mix_snapshot_average_fields '//&
-               & '= .FALSE.', WARNING)
+               & '= .FALSE.', NOTE)
+       ELSE
+          CALL error_mesg('diag_manager_mod::diag_manager_init', 'mix_snapshot_average_fields = .TRUE. is not '//&
+               & 'supported if use_modern_diag = .TRUE. Please set mix_snapshot_average_fields '//&
+               & 'to .FALSE. and put instantaneous and averaged fields in seperate files!', FATAL)
        END IF
     END IF
     ALLOCATE(output_fields(max_output_fields))

--- a/diag_manager/fms_diag_file_object.F90
+++ b/diag_manager/fms_diag_file_object.F90
@@ -94,7 +94,8 @@ type :: fmsDiagFile_type
   integer :: number_of_axis !< Number of axis in the file
   integer, dimension(:), allocatable :: buffer_ids !< array of buffer ids associated with the file
   integer :: number_of_buffers !< Number of buffers that have been added to the file
-  logical, allocatable :: time_ops !< .True. if file contains variables that are time_min, time_max, time_average or time_sum
+  logical, allocatable :: time_ops !< .True. if file contains variables that are time_min, time_max, time_average,
+                                   !! or time_sum
   integer :: unlim_dimension_level !< The unlimited dimension level currently being written
   logical :: data_has_been_written !< .True. if data has been written for the current unlimited dimension level
   logical :: is_static !< .True. if the frequency is -1

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -807,6 +807,7 @@ subroutine fms_diag_do_io(this, end_time)
   real(r8_kind) :: mval !< r8 copy of missing value
   character(len=128) :: error_string !< outputted error string from reducti
   logical :: unlim_dim_was_increased !< .True. if the unlimited dimension index was increased for any of the buffers
+  logical :: do_not_write !< .True. only if this is not a new time step and you are writting at every time step
 
   force_write = .false.
 
@@ -836,7 +837,7 @@ subroutine fms_diag_do_io(this, end_time)
       call diag_file%write_axis_data(this%diag_axis)
     endif
 
-    finish_writing = diag_file%is_time_to_write(model_time, this%FMS_diag_output_buffers)
+    finish_writing = diag_file%is_time_to_write(model_time, this%FMS_diag_output_buffers, do_not_write)
     unlim_dim_was_increased = .false.
 
     ! finish reduction method if its time to write
@@ -850,7 +851,7 @@ subroutine fms_diag_do_io(this, end_time)
       ! Go away if there is no data to write
       if (.not. diag_buff%is_there_data_to_write()) cycle
 
-      if ( diag_buff%is_time_to_finish_reduction(end_time)) then
+      if ( diag_buff%is_time_to_finish_reduction(end_time) .and. .not. do_not_write) then
         ! sets missing value
         mval = diag_field%find_missing_value(missing_val)
         ! time_average and greater values all involve averaging so need to be "finished" before written

--- a/diag_manager/fms_diag_output_buffer.F90
+++ b/diag_manager/fms_diag_output_buffer.F90
@@ -67,6 +67,7 @@ type :: fmsDiagOutputBuffer_type
   type(time_type)       :: next_output        !< The next time to output the data
 
   contains
+  procedure :: get_buffer_name
   procedure :: add_axis_ids
   procedure :: get_axis_ids
   procedure :: set_field_id
@@ -76,6 +77,7 @@ type :: fmsDiagOutputBuffer_type
   procedure :: init_buffer_time
   procedure :: set_next_output
   procedure :: update_buffer_time
+  procedure :: get_buffer_time
   procedure :: is_there_data_to_write
   procedure :: is_time_to_finish_reduction
   procedure :: set_send_data_called
@@ -301,6 +303,17 @@ subroutine initialize_buffer (this, reduction_method, field_name)
 
 end subroutine initialize_buffer
 
+!> @brief Get the name of the field for the output buffer
+!! @return Name of the field for the output buffer
+function get_buffer_name(this) &
+  result(rslt)
+  class(fmsDiagOutputBuffer_type), intent(in) :: this        !< Buffer object
+
+  character(len=:), allocatable :: rslt
+
+  rslt = diag_yaml%diag_fields(this%yaml_id)%get_var_outname()
+end function get_buffer_name
+
 !> @brief Adds the axis ids to the buffer object
 subroutine add_axis_ids(this, axis_ids)
   class(fmsDiagOutputBuffer_type), intent(inout) :: this        !< Buffer object
@@ -399,6 +412,16 @@ subroutine update_buffer_time(this, time)
     this%time = time
   endif
 end subroutine update_buffer_time
+
+!> @brief Get the buffer_time from a output buffer object
+!! @return The buffer time
+function get_buffer_time(this) &
+  result(rslt)
+  class(fmsDiagOutputBuffer_type), intent(in) :: this        !< Buffer object
+  type(time_type) :: rslt
+
+  rslt = this%time
+end function get_buffer_time
 
 !> @brief Determine if finished with math
 !! @return this%done_with_math

--- a/test_fms/diag_manager/Makefile.am
+++ b/test_fms/diag_manager/Makefile.am
@@ -33,9 +33,10 @@ check_PROGRAMS = test_diag_manager test_diag_manager_time \
  test_flexible_time test_diag_update_buffer test_reduction_methods check_time_none \
  check_time_min check_time_max check_time_sum check_time_avg test_diag_diurnal check_time_diurnal \
  check_time_pow check_time_rms check_subregional test_cell_measures test_var_masks \
- check_var_masks test_multiple_send_data test_diag_out_yaml
+ check_var_masks test_multiple_send_data test_diag_out_yaml test_output_every_freq
 
 # This is the source code for the test.
+test_output_every_freq_SOURCES = test_output_every_freq.F90
 test_diag_manager_SOURCES = test_diag_manager.F90
 test_diag_manager_time_SOURCES = test_diag_manager_time.F90
 test_diag_update_buffer_SOURCES= test_diag_update_buffer.F90
@@ -68,14 +69,15 @@ SH_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
 # Run the test.
 TESTS = test_diag_manager2.sh test_time_none.sh test_time_min.sh test_time_max.sh test_time_sum.sh \
         test_time_avg.sh test_time_pow.sh test_time_rms.sh test_time_diurnal.sh test_cell_measures.sh \
-        test_subregional.sh test_var_masks.sh test_multiple_send_data.sh
+        test_subregional.sh test_var_masks.sh test_multiple_send_data.sh test_output_every_freq.sh
 
 testing_utils.mod: testing_utils.$(OBJEXT)
 
 # Copy over other needed files to the srcdir
 EXTRA_DIST = test_diag_manager2.sh check_crashes.sh test_time_none.sh test_time_min.sh test_time_max.sh \
              test_time_sum.sh test_time_avg.sh test_time_pow.sh test_time_rms.sh test_time_diurnal.sh \
-             test_cell_measures.sh test_subregional.sh test_var_masks.sh test_multiple_send_data.sh
+             test_cell_measures.sh test_subregional.sh test_var_masks.sh test_multiple_send_data.sh \
+             test_output_every_freq.sh
 
 if USING_YAML
 skipflag=""

--- a/test_fms/diag_manager/test_diag_manager2.sh
+++ b/test_fms/diag_manager/test_diag_manager2.sh
@@ -560,13 +560,13 @@ diag_files:
   - module: test_diag_manager_mod
     var_name: sstt
     output_name: sstt
-    reduction: average
+    reduction: none
     kind: r4
     long_name: S S T
   - module: test_diag_manager_mod
     var_name: sstt2
     output_name: sstt2
-    reduction: average
+    reduction: none
     kind: r4
     long_name: S S T
     write_var: false

--- a/test_fms/diag_manager/test_diag_yaml.F90
+++ b/test_fms/diag_manager/test_diag_yaml.F90
@@ -25,7 +25,7 @@ use FMS_mod, only: fms_init, fms_end
 use fms_diag_yaml_mod
 use diag_data_mod, only: DIAG_NULL, DIAG_ALL, get_base_year, get_base_month, get_base_day, get_base_hour, &
                        & get_base_minute, get_base_second, diag_data_init, DIAG_HOURS, DIAG_NULL, DIAG_DAYS, &
-                       & time_average, r4, middle_time, end_time
+                       & time_average, r4, middle_time, end_time, time_none
 use  time_manager_mod, only: set_calendar_type, JULIAN
 use mpp_mod
 use platform_mod
@@ -165,7 +165,7 @@ subroutine compare_diag_fields(res)
 
   call compare_result("var_reduction 1", res(1)%get_var_reduction(), time_average)
   call compare_result("var_reduction 2", res(2)%get_var_reduction(), time_average)
-  call compare_result("var_reduction 3", res(3)%get_var_reduction(), time_average)
+  call compare_result("var_reduction 3", res(3)%get_var_reduction(), time_none)
 
   call compare_result("var_module 1", res(1)%get_var_module(), "test_diag_manager_mod")
   call compare_result("var_module 2", res(2)%get_var_module(), "test_diag_manager_mod")

--- a/test_fms/diag_manager/test_output_every_freq.F90
+++ b/test_fms/diag_manager/test_output_every_freq.F90
@@ -1,0 +1,92 @@
+!***********************************************************************
+!*                   GNU Lesser General Public License
+!*
+!* This file is part of the GFDL Flexible Modeling System (FMS).
+!*
+!* FMS is free software: you can redistribute it and/or modify it under
+!* the terms of the GNU Lesser General Public License as published by
+!* the Free Software Foundation, either version 3 of the License, or (at
+!* your option) any later version.
+!*
+!* FMS is distributed in the hope that it will be useful, but WITHOUT
+!* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+!* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+!* for more details.
+!*
+!* You should have received a copy of the GNU Lesser General Public
+!* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
+!***********************************************************************
+
+!> @brief  This programs tests diag manager when the file frequency is set to 0 days
+program test_output_every_freq
+
+  use fms_mod,          only: fms_init, fms_end, string
+  use diag_manager_mod, only: diag_axis_init, send_data, diag_send_complete, diag_manager_set_time_end, &
+                              register_diag_field, diag_manager_init, diag_manager_end
+  use time_manager_mod, only: time_type, operator(+), JULIAN, set_time, set_calendar_type, set_date
+  use mpp_mod,          only: FATAL, mpp_error
+  use fms2_io_mod,      only: FmsNetcdfFile_t, open_file, close_file, read_data, get_dimension_size
+
+  implicit none
+
+  integer         :: id_var0, id_var1 !< diag field ids
+  logical         :: used             !< for send_data calls
+  integer         :: ntimes = 48      !< Number of time steps
+  real            :: vdata            !< Buffer to store the data
+  type(time_type) :: Time             !< "Model" time
+  type(time_type) :: Time_step        !< Time step for the "simulation"
+  integer         :: i                !< For do loops
+
+  call fms_init
+  call set_calendar_type(JULIAN)
+  call diag_manager_init
+
+  Time = set_date(2,1,1,0,0,0)
+  Time_step = set_time (3600,0) !< 1 hour
+  call diag_manager_set_time_end(set_date(2,1,3,0,0,0))
+
+  id_var0 = register_diag_field  ('ocn_mod', 'var0', Time)
+  id_var1 = register_diag_field  ('ocn_mod', 'var1', Time)
+
+  do i = 1, ntimes
+    Time = Time + Time_step
+    vdata = real(i)
+
+    used = send_data(id_var0, vdata, Time) !< Sending data every hour!
+    if (mod(i,2) .eq. 0) used = send_data(id_var1, vdata, Time) !< Sending data every two hours!
+
+    call diag_send_complete(Time_step)
+  enddo
+
+  call diag_manager_end(Time)
+
+  call check_output()
+  call fms_end
+
+  contains
+
+  !< @brief Check the diag manager output
+  subroutine check_output()
+    type(FmsNetcdfFile_t) :: fileobj     !< Fms2io fileobj
+    integer               :: var_size    !< Size of the variable reading
+    real, allocatable     :: var_data(:) !< Buffer to read variable data to
+    integer               :: j           !< For looping
+
+    if (.not. open_file(fileobj, "test_0days.nc", "read")) &
+      call mpp_error(FATAL, "Error opening file:test_0days.nc to read")
+
+    call get_dimension_size(fileobj, "time", var_size)
+    if (var_size .ne. 48) call mpp_error(FATAL, "The dimension of time in the file:test_0days is not the "//&
+                                                 "correct size!")
+    allocate(var_data(var_size))
+    var_data = -999.99
+
+    call read_data(fileobj, "var0", var_data)
+    do j = 1, var_size
+      if (var_data(j) .ne. real(j)) call mpp_error(FATAL, "The variable data for var1 at time level:"//&
+                                                          string(j)//" is not the correct value!")
+    enddo
+
+    call close_file(fileobj)
+  end subroutine check_output
+end program test_output_every_freq

--- a/test_fms/diag_manager/test_output_every_freq.sh
+++ b/test_fms/diag_manager/test_output_every_freq.sh
@@ -1,0 +1,116 @@
+#!/bin/sh
+
+#***********************************************************************
+#*                   GNU Lesser General Public License
+#*
+#* This file is part of the GFDL Flexible Modeling System (FMS).
+#*
+#* FMS is free software: you can redistribute it and/or modify it under
+#* the terms of the GNU Lesser General Public License as published by
+#* the Free Software Foundation, either version 3 of the License, or (at
+#* your option) any later version.
+#*
+#* FMS is distributed in the hope that it will be useful, but WITHOUT
+#* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+#* for more details.
+#*
+#* You should have received a copy of the GNU Lesser General Public
+#* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
+#***********************************************************************
+
+# Copyright (c) 2019-2020 Ed Hartnett, Seth Underwood
+
+# Set common test settings.
+. ../test-lib.sh
+
+if [ -z "${skipflag}" ]; then
+# create and enter directory for in/output files
+output_dir
+
+cat <<_EOF > diag_table.yaml
+title: test_diag_manager_01
+base_date: 2 1 1 0 0 0
+diag_files:
+- file_name: test_0days
+  time_units: days
+  unlimdim: time
+  freq: 0 days
+  varlist:
+  - module: ocn_mod
+    var_name: var0
+    reduction: none
+    kind: r4
+_EOF
+
+my_test_count=1
+printf "&diag_manager_nml \n use_modern_diag=.true. \n / \n&test_reduction_methods_nml \n test_case = 0 \n/" | cat > input.nml
+test_expect_success "Running diag_manager with 0 days frequency (test $my_test_count)" '
+  mpirun -n 1 ../test_output_every_freq
+'
+
+cat <<_EOF > diag_table.yaml
+title: test_diag_manager_01
+base_date: 2 1 1 0 0 0
+diag_files:
+- file_name: test_0days
+  time_units: days
+  unlimdim: time
+  freq: 0 days
+  varlist:
+  - module: ocn_mod
+    var_name: var0
+    reduction: none
+    kind: r4
+  - module: ocn_mod
+    var_name: var1
+    reduction: none
+    kind: r4
+_EOF
+
+my_test_count=`expr $my_test_count + 1`
+test_expect_failure "Running diag_manager with 0 days frequency and variable are calling send data at different frequencies (test $my_test_count)" '
+  mpirun -n 1 ../test_output_every_freq
+'
+
+cat <<_EOF > diag_table.yaml
+title: test_diag_manager_01
+base_date: 2 1 1 0 0 0
+diag_files:
+- file_name: test_0days
+  time_units: days
+  unlimdim: time
+  freq: 0 days
+  varlist:
+  - module: ocn_mod
+    var_name: var0
+    reduction: average
+    kind: r4
+_EOF
+
+my_test_count=`expr $my_test_count + 1`
+test_expect_failure "Running diag_manager with 0 days frequency but using average reduction method (test $my_test_count)" '
+  mpirun -n 1 ../test_output_every_freq
+'
+
+cat <<_EOF > diag_table.yaml
+title: test_diag_manager_01
+base_date: 2 1 1 0 0 0
+diag_files:
+- file_name: test_0days
+  time_units: days
+  unlimdim: time
+  freq: -1 days
+  varlist:
+  - module: ocn_mod
+    var_name: var0
+    reduction: average
+    kind: r4
+_EOF
+
+my_test_count=`expr $my_test_count + 1`
+test_expect_failure "Running diag_manager with -1 days frequency but using average reduction method (test $my_test_count)" '
+  mpirun -n 1 ../test_output_every_freq
+'
+fi
+test_done

--- a/test_fms/diag_manager/test_time_avg.sh
+++ b/test_fms/diag_manager/test_time_avg.sh
@@ -192,6 +192,39 @@ test_expect_success "Checking answers for the "avg" reduction method with halo o
   mpirun -n 1 ../check_time_avg
 '
 
+my_test_count=`expr $my_test_count + 1`
+printf "&diag_manager_nml \n use_modern_diag=.true. \n mix_snapshot_average_fields = .true. \n /" | cat > input.nml
+test_expect_failure "Running diag_manager with with mix_snapshot_average_fields = .true. (test $my_test_count)" '
+  mpirun -n 6 ../test_reduction_methods
+'
+
+cat <<_EOF > diag_table.yaml
+title: test_avg
+base_date: 2 1 1 0 0 0
+diag_files:
+- file_name:  test_avg
+  time_units: hours
+  unlimdim: time
+  freq: 6 hours
+  varlist:
+  - module: ocn_mod
+    var_name: var0
+    output_name: var0_avg
+    reduction: average
+    kind: r4
+  - module: ocn_mod
+    var_name: var0
+    output_name: var0_none
+    reduction: none
+    kind: r4
+_EOF
+
+my_test_count=`expr $my_test_count + 1`
+printf "&diag_manager_nml \n use_modern_diag=.true. \n /" | cat > input.nml
+test_expect_failure "Running diag_manager with with a file with instantaneous and averaged output (test $my_test_count)" '
+  mpirun -n 6 ../test_reduction_methods
+'
+
 cat <<_EOF > diag_table.yaml
 title: test_avg
 base_date: 2 1 1 0 0 0


### PR DESCRIPTION
**Description**
- Implement the freq=`0 days` capability into the new diag manager
- Crash if you try to have averaged fields when the freq=`-1 days` or `0 days`
- Crash if mix_snapshot_average_fields=.true. for the new diag manager
- Crash if mixing averaged and non-averaged fields in the same file
- Adds tests

Fixes #1498
Fixes #1499 

**How Has This Been Tested?**
CI, including new tests

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

