### PR TITLE
Modern_diag_manager:: Fix for when two+ empty files

### DIFF
--- a/diag_manager/fms_diag_yaml.F90
+++ b/diag_manager/fms_diag_yaml.F90
@@ -415,6 +415,7 @@ subroutine diag_yaml_object_init(diag_subset_output)
         else
           call diag_get_value_from_key(diag_yaml_id, diag_file_ids(i), "file_name", filename)
           call mpp_error(NOTE, "diag_manager_mod:: the file:"//trim(filename)//" has no variables defined. Ignoring!")
+          if (allocated(filename)) deallocate(filename)
           ignore(i) = .True.
         endif
     endif
@@ -1735,7 +1736,7 @@ subroutine fms_diag_yaml_out()
           tmpstr1 = ''; tmpstr1 = string(varptr%n_diurnal)
           call fms_f2c_string(vals3(key3_i)%val9, tmpstr1)
         endif
-        
+
         if( varptr%pow_value .gt. 0) then
           tmpstr1 = ''; tmpstr1 = string(varptr%pow_value)
           call fms_f2c_string(vals3(key3_i)%val10, tmpstr1)

--- a/test_fms/diag_manager/test_time_none.sh
+++ b/test_fms/diag_manager/test_time_none.sh
@@ -189,6 +189,24 @@ cat <<_EOF > diag_table.yaml
 title: test_none
 base_date: 2 1 1 0 0 0
 diag_files:
+- file_name: test_empty_file
+  time_units: hours
+  unlimdim: time
+  freq: 6 hours
+- file_name: test_empty_file2
+  time_units: hours
+  unlimdim: time
+  freq: 6 hours
+_EOF
+
+my_test_count=`expr $my_test_count + 1`
+test_expect_success "Testing diag manager that defined 2 diag file with no variables (test $my_test_count)" '
+  mpirun -n 6 ../test_reduction_methods
+'
+cat <<_EOF > diag_table.yaml
+title: test_none
+base_date: 2 1 1 0 0 0
+diag_files:
 - file_name: test_unregistered_data
   time_units: hours
   unlimdim: time


### PR DESCRIPTION
**Description**
Adds a deallocate statement to prevent crashes when using a diag_table.yaml with two empty files
Adds a test (it fails without the code update)

Fixes #1502 

**How Has This Been Tested?**
CI

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

