### PR TITLE
change compiler check and string indices for gcc

### DIFF
--- a/fms2_io/include/register_global_attribute.inc
+++ b/fms2_io/include/register_global_attribute.inc
@@ -41,7 +41,7 @@ subroutine register_global_attribute_0d(fileobj, &
                 err = nf90_put_att(fileobj%ncid, &
                                    nf90_global, &
                                    trim(attribute_name), &
-                                   trim(attribute_value(1:str_len)))
+                                   trim(attribute_value))
             type is (integer(kind=i4_kind))
                 err = nf90_put_att(fileobj%ncid, &
                                    nf90_global, &

--- a/fms2_io/include/register_variable_attribute.inc
+++ b/fms2_io/include/register_variable_attribute.inc
@@ -53,7 +53,7 @@ subroutine register_variable_attribute_0d(fileobj, variable_name, attribute_name
       type is (character(len=*))
         if (.not. present(str_len)) call error("Need to include str length:"//trim(append_error_msg))
         err = nf90_put_att(fileobj%ncid, varid, trim(attribute_name), &
-                           trim(attribute_value(1:str_len)))
+                           trim(attribute_value))
       type is (integer(kind=i4_kind))
         err = nf90_put_att(fileobj%ncid, varid, trim(attribute_name), &
                            attribute_value)

--- a/m4/gx_compiler_bug_checks.m4
+++ b/m4/gx_compiler_bug_checks.m4
@@ -59,7 +59,7 @@ AC_COMPILE_IFELSE([[      subroutine test_sub(ctype)
 
         select type(ctype)
           type is (character(len=*))
-            ctype(:) = ""
+            ctype = ""
         end select
       end subroutine test_sub]],
      [gx_cv_class_char_array_bug_check=no])


### PR DESCRIPTION
**Description**
some small changes for the newest gcc

this gets the code passing the configure check and compiling successfully.

We may just want to get rid of the m4 i modified, so making this a draft for now.

Fixes #1527 

**How Has This Been Tested?**
draft 

**Checklist:**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] `make distcheck` passes

