### PR TITLE
add return_status optional argument to coupler_types_send_data

### DIFF
--- a/coupler/coupler_types.F90
+++ b/coupler/coupler_types.F90
@@ -2944,10 +2944,12 @@ contains
 
 
   !> @brief Write out all diagnostics of elements of a coupler_2d_bc_type
-  !! TODO this should really be a function in order to return the status of send_data call
-  subroutine CT_send_data_2d(var, Time)
+  subroutine CT_send_data_2d(var, Time, return_statuses)
     type(coupler_2d_bc_type), intent(in) :: var  !< BC_type structure with the diagnostics to write
     type(time_type),          intent(in) :: time !< The current model time
+    logical, allocatable, optional, intent(out) :: return_statuses(:,:) !< Return status of send data calls
+                                                          !! first index is index of boundary condition
+                                                          !! second index is field/value within that boundary condition
 
     integer :: m, n
     logical :: used
@@ -2966,18 +2968,33 @@ contains
 
     ! num_bcs .lt. 1 -> loop doesn't run but shouldn't error out
     if(associated(var%bc) .or. var%num_bcs .lt. 1) then
+
+      ! allocate array for returned send data statuses
+      if( present(return_statuses) .and. var%num_bcs .gt. 0) then
+        allocate(return_statuses(var%num_bcs, var%bc(1)%num_fields))
+      endif
+
       do n = 1, var%num_bcs
         do m = 1, var%bc(n)%num_fields
           if (var%bc(n)%field(m)%id_diag > 0) then
             used = send_data(var%bc(n)%field(m)%id_diag, var%bc(n)%field(m)%values, Time)
+            if(allocated(return_statuses)) return_statuses(n,m) = used
           endif
         enddo
       enddo
+
     else if(associated(var%bc_r4)) then
+
+      ! allocate array for returned send data statuses
+      if( present(return_statuses) .and. var%num_bcs .gt. 0) then
+        allocate(return_statuses(var%num_bcs, var%bc_r4(1)%num_fields))
+      endif
+
       do n = 1, var%num_bcs
         do m = 1, var%bc_r4(n)%num_fields
           if (var%bc_r4(n)%field(m)%id_diag > 0) then
             used = send_data(var%bc_r4(n)%field(m)%id_diag, var%bc_r4(n)%field(m)%values, Time)
+            if(allocated(return_statuses)) return_statuses(n,m) = used
           endif
         enddo
       enddo
@@ -2988,10 +3005,12 @@ contains
   end subroutine CT_send_data_2d
 
   !> @brief Write out all diagnostics of elements of a coupler_3d_bc_type
-  !! TODO this should really be a function in order to return the status of send_data call
-  subroutine CT_send_data_3d(var, Time)
+  subroutine CT_send_data_3d(var, Time, return_statuses)
     type(coupler_3d_bc_type), intent(in) :: var  !< BC_type structure with the diagnostics to write
     type(time_type),          intent(in) :: time !< The current model time
+    logical, allocatable, optional, intent(out) :: return_statuses(:,:) !< Return status of send data calls
+                                                          !! first index is index of boundary condition
+                                                          !! second index is field/value within that boundary condition
 
     integer :: m, n
     logical :: used
@@ -3010,18 +3029,32 @@ contains
 
     ! num_bcs .lt. 1 -> loop doesn't run but shouldn't error out
     if(associated(var%bc) .or. var%num_bcs .lt. 1) then
+
+      ! allocate array for returned send data statuses
+      if( present(return_statuses) .and. var%num_bcs .gt. 0) then
+        allocate(return_statuses(var%num_bcs, var%bc(1)%num_fields))
+      endif
+
       do n = 1, var%num_bcs
         do m = 1, var%bc(n)%num_fields
           if (var%bc(n)%field(m)%id_diag > 0) then
             used = send_data(var%bc(n)%field(m)%id_diag, var%bc(n)%field(m)%values, Time)
+            if(allocated(return_statuses)) return_statuses(n,m) = used
           endif
         enddo
       enddo
     else if(associated(var%bc_r4)) then
+
+      ! allocate array for returned send data statuses
+      if( present(return_statuses) .and. var%num_bcs .gt. 0) then
+        allocate(return_statuses(var%num_bcs, var%bc_r4(1)%num_fields))
+      endif
+
       do n = 1, var%num_bcs
         do m = 1, var%bc_r4(n)%num_fields
           if (var%bc_r4(n)%field(m)%id_diag > 0) then
             used = send_data(var%bc_r4(n)%field(m)%id_diag, var%bc_r4(n)%field(m)%values, Time)
+            if(allocated(return_statuses)) return_statuses(n,m) = used
           endif
         enddo
       enddo

--- a/test_fms/coupler/test_atmos_ocean_fluxes.F90
+++ b/test_fms/coupler/test_atmos_ocean_fluxes.F90
@@ -23,7 +23,7 @@
 !! @description This program tests the two main subroutines in atmos_ocean_fluxes.
 program test_atmos_ocean_fluxes
 
-  use fms_mod, only: fms_init
+  use fms_mod, only: fms_init, fms_end
   use coupler_types_mod, only: coupler_1d_bc_type
   use field_manager_mod, only: fm_exists, fm_get_value
   use fm_util_mod, only: fm_util_get_real_array
@@ -81,6 +81,7 @@ program test_atmos_ocean_fluxes
   call test_atmos_ocean_fluxes_init
   !> checking gas_fluxes, gas_fields_atm, and gas_fields_ice have been initialized correctly
   call test_coupler_1d_bc_type
+  call fms_end
 
 contains
   !--------------------------------------

--- a/test_fms/coupler/test_coupler.sh
+++ b/test_fms/coupler/test_coupler.sh
@@ -26,6 +26,7 @@
 # Set common test settings.
 . ../test-lib.sh
 
+rm -f input.nml
 touch input.nml
 
 # diag_table for test
@@ -109,6 +110,25 @@ test_expect_success "coupler types interfaces (r4_kind)" '
 '
 
 test_expect_success "coupler types interfaces (r8_kind)" '
+  mpirun -n 4 ./test_coupler_types_r8
+'
+
+# delete lines from the table to make sure we see the difference in the send_data return status
+sed -i '8,12{d}' diag_table
+sed -i '10,13{d}' diag_table.yaml
+sed -i '18,25{d}' diag_table.yaml
+cat <<_EOF > input.nml
+&test_coupler_types_nml
+   fail_return_status=.true.
+/
+_EOF
+
+
+test_expect_success "coupler types interfaces - check send_data return vals (r4_kind)" '
+  mpirun -n 4 ./test_coupler_types_r4
+'
+
+test_expect_success "coupler types interfaces - check send_data return vals (r8_kind)" '
   mpirun -n 4 ./test_coupler_types_r8
 '
 


### PR DESCRIPTION
**Description**
adds `return_statuses` as an optional argument to `coupler_types_send_data`, along with some modifications to the test to ensure its working properly.

Fixes #1370 

**How Has This Been Tested?**
tested on amd box with oneapi 2024.01

**Checklist:**
- [x My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passed

