### PR TITLE
fix flag in intel ci workflow

### DIFF
--- a/.github/workflows/github_autotools_intel.yml
+++ b/.github/workflows/github_autotools_intel.yml
@@ -17,7 +17,7 @@ jobs:
         CC: mpiicc
         FC: mpiifort
         CFLAGS:  "-I/libs/include"
-        FCFLAGS: "-I/libs/include -g -traceback ${{ matrix.io-flag }}"
+        FCFLAGS: "-I/libs/include -g -traceback"
         LDFLAGS: "-L/libs/lib"
         TEST_VERBOSE: 1
         I_MPI_FABRICS: "shm" # needed for mpi in image
@@ -55,7 +55,7 @@ jobs:
     - name: checkout
       uses: actions/checkout@v4
     - name: Configure
-      run: autoreconf -if ./configure.ac && ./configure --with-yaml
+      run: autoreconf -if ./configure.ac && ./configure --with-yaml ${{ matrix.io-flag }}
     - name: Compile
       run: make -j || make
     - name: Run test suite

--- a/.github/workflows/github_autotools_intel.yml
+++ b/.github/workflows/github_autotools_intel.yml
@@ -55,7 +55,10 @@ jobs:
     - name: checkout
       uses: actions/checkout@v4
     - name: Configure
-      run: autoreconf -if ./configure.ac && ./configure --with-yaml ${{ matrix.io-flag }}
+      run: |
+        autoreconf -if ./configure.ac
+        export LD_LIBRARY_PATH="/libs/lib:$LD_LIBRARY_PATH"
+        ./configure --with-yaml ${{ matrix.io-flag }}
     - name: Compile
       run: make -j || make
     - name: Run test suite


### PR DESCRIPTION
**Description**
This fixes a mistake in one of the flags in the intel CI where it was added as a compiler flag rather than a configure option. 

It seems the storage issues we were encountering went away at some point, but before they went away a hdf5 check in the configure script was added, which started causing failures since the LD_LIBRARY_PATH needed to be set again for the configure script.
 
**How Has This Been Tested?**
CI

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

