### PR TITLE
fix typo in pe variable name

### DIFF
--- a/mpp/include/mpp_util.inc
+++ b/mpp/include/mpp_util.inc
@@ -122,11 +122,10 @@
 
   !> Opens the warning log file, called during mpp_init
   subroutine mpp_init_warninglog()
-  integer :: p
   logical :: exist
   character(len=11) :: this_pe
   if( pe.EQ.root_pe )then
-    write(this_pe,'(a,i6.6,a)') '.',p,'.out'
+    write(this_pe,'(a,i6.6,a)') '.',pe,'.out'
     inquire( file=trim(warnfile)//this_pe, exist=exist )
     if(exist)then
       open(newunit=warn_unit, file=trim(warnfile)//this_pe, status='REPLACE' )


### PR DESCRIPTION
**Description**
fixes a typo where the `pe` should have been used instead of the `p` variable for the warning log routine. This caused failures with debug mode due to the uninitialized value being used.

**How Has This Been Tested?**
aquaplanet regressions with intel23-classic and debug flags

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

