### PR TITLE
fix for mpp stdlog test fails with intel ci

### DIFF
--- a/test_fms/mpp/test_stdlog.F90
+++ b/test_fms/mpp/test_stdlog.F90
@@ -83,7 +83,7 @@ program test_stdlog
     do i=1, 7
       read(u_num_warn, '(A)') line
       if (trim(line) == '') cycle
-      !! if we're testing with the old io enabled, we'll some additional output we can skip
+      !! if we're testing with the old io enabled, we'll have some additional output we can skip
       if (trim(line) == 'NOTE from PE     0: MPP_IO_SET_STACK_SIZE: stack size set to     131072.') cycle
       if(trim(line) .ne. trim(ref_line(ref_num))) call mpp_error(FATAL, "warnfile output does not match reference data"&
                                                                 //"reference line:"//ref_line(ref_num) &
@@ -94,3 +94,4 @@ program test_stdlog
   end subroutine check_write
 
 end program test_stdlog
+

--- a/test_fms/mpp/test_stdlog.F90
+++ b/test_fms/mpp/test_stdlog.F90
@@ -83,6 +83,8 @@ program test_stdlog
     do i=1, 7
       read(u_num_warn, '(A)') line
       if (trim(line) == '') cycle
+      !! if we're testing with the old io enabled, we'll some additional output we can skip
+      if (trim(line) == 'NOTE from PE     0: MPP_IO_SET_STACK_SIZE: stack size set to     131072.') cycle
       if(trim(line) .ne. trim(ref_line(ref_num))) call mpp_error(FATAL, "warnfile output does not match reference data"&
                                                                 //"reference line:"//ref_line(ref_num) &
                                                                 //"output line:"//line)


### PR DESCRIPTION
**Description**
This PR updates a test that was recently added to check the warning log since it was running into an error during the intel ci. This was due to the intel ci using the deprecated io flag, which prints an additional note during initialization and was breaking the test.

**How Has This Been Tested?**
make distcheck on amd box with oneapi 24.1

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

