### PR TITLE
Use Cray-compatible syntax for multi-line string literals

### DIFF
--- a/diag_manager/diag_data.F90
+++ b/diag_manager/diag_data.F90
@@ -611,8 +611,8 @@ CONTAINS
     type is (character(len=*))
       var_type = string
     class default
-      call mpp_error(FATAL, "get_var_type:: The variable does not have a supported type. "&
-                           &"The supported types are r4, r8, i4, i8 and string.")
+      call mpp_error(FATAL, "get_var_type:: The variable does not have a supported type. &
+                            &The supported types are r4, r8, i4, i8 and string.")
     end select
   end function get_var_type
 

--- a/diag_manager/fms_diag_axis_object.F90
+++ b/diag_manager/fms_diag_axis_object.F90
@@ -1033,8 +1033,8 @@ module fms_diag_axis_object_mod
     select case (domain_position)
     case (CENTER, NORTH, EAST)
     case default
-        call mpp_error(FATAL, "diag_axit_init: Invalid domain_positon. "&
-                             "The acceptable values are NORTH, EAST, CENTER")
+        call mpp_error(FATAL, "diag_axit_init: Invalid domain_positon. &
+                              &The acceptable values are NORTH, EAST, CENTER")
     end select
   end subroutine check_if_valid_domain_position
 
@@ -1045,8 +1045,8 @@ module fms_diag_axis_object_mod
     select case(direction)
     case(-1, 0, 1)
     case default
-      call mpp_error(FATAL, "diag_axit_init: Invalid direction. "&
-                             "The acceptable values are-1 0 1")
+      call mpp_error(FATAL, "diag_axit_init: Invalid direction. &
+                            &The acceptable values are-1 0 1")
     end select
   end subroutine check_if_valid_direction
 

--- a/diag_manager/fms_diag_field_object.F90
+++ b/diag_manager/fms_diag_field_object.F90
@@ -383,18 +383,18 @@ subroutine fms_register_diag_field_obj &
 
   if (present(area)) then
     if (area < 0) call mpp_error("fms_register_diag_field_obj", &
-                     "The area id passed with field_name"//trim(varname)//" has not been registered."&
-                     "Check that there is a register_diag_field call for the AREA measure and that is in the"&
-                     "diag_table.yaml", FATAL)
+                     "The area id passed with field_name"//trim(varname)//" has not been registered. &
+                     &Check that there is a register_diag_field call for the AREA measure and that is in the &
+                     &diag_table.yaml", FATAL)
     allocate(this%area)
     this%area = area
   endif
 
   if (present(volume)) then
     if (volume < 0) call mpp_error("fms_register_diag_field_obj", &
-                     "The volume id passed with field_name"//trim(varname)//" has not been registered."&
-                     "Check that there is a register_diag_field call for the VOLUME measure and that is in the"&
-                     "diag_table.yaml", FATAL)
+                     "The volume id passed with field_name"//trim(varname)//" has not been registered. &
+                     &Check that there is a register_diag_field call for the VOLUME measure and that is in the &
+                     &diag_table.yaml", FATAL)
     allocate(this%volume)
     this%volume = volume
   endif
@@ -1610,9 +1610,9 @@ subroutine add_area_volume(this, area, volume)
     if (area > 0) then
       this%area = area
     else
-      call mpp_error(FATAL, "diag_field_add_cell_measures: the area id is not valid. "&
-                           &"Verify that the area_id passed in to the field:"//this%varname//&
-                           &" is valid and that the field is registered and in the diag_table.yaml")
+      call mpp_error(FATAL, "diag_field_add_cell_measures: the area id is not valid. &
+                            &Verify that the area_id passed in to the field:"//this%varname// &
+                            " is valid and that the field is registered and in the diag_table.yaml")
     endif
   endif
 
@@ -1620,9 +1620,9 @@ subroutine add_area_volume(this, area, volume)
     if (volume > 0) then
       this%volume = volume
     else
-      call mpp_error(FATAL, "diag_field_add_cell_measures: the volume id is not valid. "&
-                           &"Verify that the volume_id passed in to the field:"//this%varname//&
-                           &" is valid and that the field is registered and in the diag_table.yaml")
+      call mpp_error(FATAL, "diag_field_add_cell_measures: the volume id is not valid. &
+                            &Verify that the volume_id passed in to the field:"//this%varname// &
+                            " is valid and that the field is registered and in the diag_table.yaml")
     endif
   endif
 

--- a/diag_manager/fms_diag_file_object.F90
+++ b/diag_manager/fms_diag_file_object.F90
@@ -1018,8 +1018,8 @@ subroutine add_start_time(this, start_time)
     !! this%start_time was already updated so make sure it is the same for the current variable
     !! or error out
     if (this%start_time .ne. start_time)&
-      call mpp_error(FATAL, "The variables associated with the file:"//this%get_file_fname()//" have"&
-      &" different start_time")
+      call mpp_error(FATAL, "The variables associated with the file:"//this%get_file_fname()//" have &
+                            &different start_time")
   else
     !> If the this%start_time is equal to the diag_init_time,
     !! simply update it with the start_time and set up the *_output variables

--- a/diag_manager/fms_diag_input_buffer.F90
+++ b/diag_manager/fms_diag_input_buffer.F90
@@ -133,8 +133,8 @@ module fms_diag_input_buffer_mod
       allocate(integer(kind=i4_kind) :: this%buffer(length(1), length(2), length(3), length(4)))
       this%buffer = 0_i8_kind
     class default
-      err_msg = "The data input is not one of the supported types."&
-        "Only r4, r8, i4, and i8 types are supported."
+      err_msg = "The data input is not one of the supported types. &
+                &Only r4, r8, i4, and i8 types are supported."
     end select
 
     this%weight = 1.0_r8_kind

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -511,8 +511,8 @@ CALL MPP_ERROR(FATAL,"You can not use the modern diag manager without compiling 
   type is (fmsDiagFullAxis_type)
     if(present(edges)) then
       if (edges < 0 .or. edges > this%registered_axis) &
-        call mpp_error(FATAL, "diag_axit_init: The edge axis has not been defined. "&
-                               "Call diag_axis_init for the edge axis first")
+        call mpp_error(FATAL, "diag_axit_init: The edge axis has not been defined. &
+                              &Call diag_axis_init for the edge axis first")
       select type (edges_axis => this%diag_axis(edges)%axis)
       type is (fmsDiagFullAxis_type)
         edges_name = edges_axis%get_axis_name()

--- a/diag_manager/fms_diag_yaml.F90
+++ b/diag_manager/fms_diag_yaml.F90
@@ -936,8 +936,8 @@ result(time_units_int)
     time_units_int = DIAG_YEARS
   case default
     time_units_int =DIAG_NULL
-    call mpp_error(FATAL, trim(error_msg)//" is not valid. Acceptable values are "&
-                   "seconds, minutes, hours, days, months, years")
+    call mpp_error(FATAL, trim(error_msg)//" is not valid. Acceptable values are &
+                          &seconds, minutes, hours, days, months, years")
   end select
 end function set_valid_time_units
 

--- a/fms2_io/netcdf_io.F90
+++ b/fms2_io/netcdf_io.F90
@@ -1090,8 +1090,8 @@ subroutine netcdf_save_restart(fileobj, unlim_dim_level)
   integer :: i
 
   if (.not. fileobj%is_restart) then
-    call error("write_restart:: file "//trim(fileobj%path)//" is not a restart file."&
-              &" Be sure the file was opened with is_restart=.true.")
+    call error("write_restart:: file "//trim(fileobj%path)//" is not a restart file. &
+               &Be sure the file was opened with is_restart=.true.")
   endif
   do i = 1, fileobj%num_restart_vars
     if (associated(fileobj%restart_vars(i)%data0d)) then
@@ -1132,8 +1132,8 @@ subroutine netcdf_restore_state(fileobj, unlim_dim_level)
   integer :: i
 
   if (.not. fileobj%is_restart) then
-    call error("read_restart:: file "//trim(fileobj%path)//" is not a restart file."&
-              &" Be sure the file was opened with is_restart=.true.")
+    call error("read_restart:: file "//trim(fileobj%path)//" is not a restart file. &
+               &Be sure the file was opened with is_restart=.true.")
   endif
   do i = 1, fileobj%num_restart_vars
     if (associated(fileobj%restart_vars(i)%data0d)) then
@@ -1283,8 +1283,8 @@ subroutine get_dimension_names(fileobj, names, broadcast)
     ndims = get_num_dimensions(fileobj, broadcast=.false.)
     if (ndims .gt. 0) then
       if (size(names) .ne. ndims) then
-        call error("'names' has to be the same size of the number of dimensions."&
-                   &" Check your get_dimension_names call for file "//trim(fileobj%path))
+        call error("'names' has to be the same size of the number of dimensions. &
+                   &Check your get_dimension_names call for file "//trim(fileobj%path))
       endif
     else
       call error("get_dimension_names: the file "//trim(fileobj%path)//" does not have any dimensions")
@@ -1304,8 +1304,8 @@ subroutine get_dimension_names(fileobj, names, broadcast)
   if (.not. fileobj%is_root) then
     if (ndims .gt. 0) then
       if (size(names) .ne. ndims) then
-        call error("'names' has to be the same size of the number of dimensions."&
-                   &" Check your get_dimension_names call for file "//trim(fileobj%path))
+        call error("'names' has to be the same size of the number of dimensions. &
+                   &Check your get_dimension_names call for file "//trim(fileobj%path))
       endif
     else
       call error("get_dimension_names: the file "//trim(fileobj%path)//" does not have any dimensions")
@@ -1507,8 +1507,8 @@ subroutine get_variable_names(fileobj, names, broadcast)
     nvars = get_num_variables(fileobj, broadcast=.false.)
     if (nvars .gt. 0) then
       if (size(names) .ne. nvars) then
-        call error("'names' has to be the same size of the number of variables."&
-                   &" Check your get_variable_names call for file "//trim(fileobj%path))
+        call error("'names' has to be the same size of the number of variables. &
+                   &Check your get_variable_names call for file "//trim(fileobj%path))
       endif
     else
       call error("get_variable_names: the file "//trim(fileobj%path)//" does not have any variables")
@@ -1528,8 +1528,8 @@ subroutine get_variable_names(fileobj, names, broadcast)
   if (.not. fileobj%is_root) then
     if (nvars .gt. 0) then
       if (size(names) .ne. nvars) then
-        call error("'names' has to be the same size of the number of variables."&
-                   &" Check your get_variable_names call for file "//trim(fileobj%path))
+        call error("'names' has to be the same size of the number of variables. &
+                   &Check your get_variable_names call for file "//trim(fileobj%path))
       endif
     else
       call error("get_variable_names: the file "//trim(fileobj%path)//" does not have any variables")
@@ -1641,9 +1641,9 @@ subroutine get_variable_dimension_names(fileobj, variable_name, dim_names, &
     call check_netcdf_code(err, append_error_msg)
     if (ndims .gt. 0) then
       if (size(dim_names) .ne. ndims) then
-        call error("'names' has to be the same size of the number of dimensions for the variable."&
-                   &" Check your get_variable_dimension_names call for file "//trim(fileobj%path)//&
-                   &" and variable:"//trim(variable_name))
+        call error("'names' has to be the same size of the number of dimensions for the variable. &
+                   &Check your get_variable_dimension_names call for file "//trim(fileobj%path)// &
+                   " and variable:"//trim(variable_name))
       endif
     else
       call error("get_variable_dimension_names: the variable: "//trim(variable_name)//" in file: "//trim(fileobj%path)&
@@ -1664,9 +1664,9 @@ subroutine get_variable_dimension_names(fileobj, variable_name, dim_names, &
   if (.not. fileobj%is_root) then
     if (ndims .gt. 0) then
       if (size(dim_names) .ne. ndims) then
-        call error("'names' has to be the same size of the number of dimensions for the variable."&
-                   &" Check your get_variable_dimension_names call for file "//trim(fileobj%path)//&
-                   &" and variable:"//trim(variable_name))
+        call error("'names' has to be the same size of the number of dimensions for the variable. &
+                   & Check your get_variable_dimension_names call for file "//trim(fileobj%path)// &
+                   " and variable:"//trim(variable_name))
       endif
     else
       call error("get_variable_dimension_names: the variable: "//trim(variable_name)//" in file: "//trim(fileobj%path)&
@@ -1707,9 +1707,9 @@ subroutine get_variable_size(fileobj, variable_name, dim_sizes, broadcast)
     call check_netcdf_code(err, append_error_msg)
     if (ndims .gt. 0) then
       if (size(dim_sizes) .ne. ndims) then
-        call error("'dim_sizes' has to be the same size of the number of dimensions for the variable."&
-                   &" Check your get_variable_size call for file "//trim(fileobj%path)//&
-                   &" and variable:"//trim(variable_name))
+        call error("'dim_sizes' has to be the same size of the number of dimensions for the variable. &
+                   &Check your get_variable_size call for file "//trim(fileobj%path)// &
+                   " and variable:"//trim(variable_name))
       endif
     else
       call error("get_variable_size: the variable: "//trim(variable_name)//" in file: "//trim(fileobj%path)//&
@@ -1729,9 +1729,9 @@ subroutine get_variable_size(fileobj, variable_name, dim_sizes, broadcast)
   if (.not. fileobj%is_root) then
     if (ndims .gt. 0) then
       if (size(dim_sizes) .ne. ndims) then
-        call error("'dim_sizes' has to be the same size of the number of dimensions for the variable."&
-                   &" Check your get_variable_size call for file "//trim(fileobj%path)//&
-                   &" and variable:"//trim(variable_name))
+        call error("'dim_sizes' has to be the same size of the number of dimensions for the variable. &
+                   &Check your get_variable_size call for file "//trim(fileobj%path)// &
+                   " and variable:"//trim(variable_name))
       endif
     else
       call error("get_variable_size: the variable: "//trim(variable_name)//" in file: "//trim(fileobj%path)//&
@@ -2227,8 +2227,8 @@ function is_registered_to_restart(fileobj, variable_name) &
   integer :: i
 
   if (.not. fileobj%is_restart) then
-    call error("file "//trim(fileobj%path)//" is not a restart file. "&
-              //"Add is_restart=.true. to your open_file call")
+    call error("file "//trim(fileobj%path)//" is not a restart file. &
+               &Add is_restart=.true. to your open_file call")
   endif
   is_registered = .false.
   do i = 1, fileobj%num_restart_vars
@@ -2320,8 +2320,8 @@ subroutine write_restart_bc(fileobj, unlim_dim_level)
   integer :: i !< No description
 
   if (.not. fileobj%is_restart) then
-    call error("file "//trim(fileobj%path)//" is not a restart file. "&
-               &"Add is_restart=.true. to your open_file call")
+    call error("file "//trim(fileobj%path)//" is not a restart file. &
+               &Add is_restart=.true. to your open_file call")
   endif
 
  !> Loop through the variables, root pe gathers the data from the other pes and writes out the checksum.


### PR DESCRIPTION
**Description**
The Cray compiler does not support C-style concatenation of string literals, and therefore, the following results in a syntax error:

```
print "(A)", "Hello " &
             &"world"
```

All occurrences of the above syntax have therefore been changed to:

```
print "(A)", "Hello &
             &world"
```

**How Has This Been Tested?**
* Fixes the relevant syntax errors with Cray compiler version 15.0.1 on Gaea
* Builds with Intel compiler version 2024.1.0 on the AMD box

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes