### PR TITLE
Add CMake config to support building shared libraries

### DIFF
--- a/CMAKE_INSTRUCTIONS.md
+++ b/CMAKE_INSTRUCTIONS.md
@@ -50,17 +50,18 @@ make install
 ```
 
 ### User configurable options:
-By default, FMS is built without `OpenMP` and in `single precision (r4)`
+By default, FMS is built without `OpenMP`, in `single precision (r4)` and delivered in static library files.
 
 The 64BIT and 32BIT precision options will build distinct libraries when enabled with the given default
 real size, libfms_r4 or libfms_r8.
 
 The following build options are available:
 ```
--DOPENMP   "Build FMS with OpenMP support"        DEFAULT: OFF
--D32BIT    "Build 32-bit (r4) FMS library"        DEFAULT: ON
--D64BIT    "Build 64-bit (r8) FMS library"        DEFAULT: OFF
--DFPIC     "Build with position independent code" DEFAULT: OFF
+-DOPENMP      "Build FMS with OpenMP support"        DEFAULT: OFF
+-D32BIT       "Build 32-bit (r4) FMS library"        DEFAULT: ON
+-D64BIT       "Build 64-bit (r8) FMS library"        DEFAULT: OFF
+-DFPIC        "Build with position independent code" DEFAULT: OFF
+-DSHARED_LIBS "Build shared/dynamic libraries"       DEFAULT: OFF
 
 -DCONSTANTS             "Build with <X> constants parameter definitions"     DEFAULT:GFDL  OPTIONS:GFS|GEOS|GFDL
 -DINTERNAL_FILE_NML     "Enable compiler definition -DINTERNAL_FILE_NML"     DEFAULT: ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,10 +52,11 @@ endif()
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 # Build options
-option(OPENMP "Build FMS with OpenMP support"        OFF)
-option(32BIT  "Build 32-bit (r4) FMS library"         ON)
-option(64BIT  "Build 64-bit (r8) FMS library"        OFF)
-option(FPIC   "Build with position independent code" OFF)
+option(OPENMP      "Build FMS with OpenMP support"        OFF)
+option(32BIT       "Build 32-bit (r4) FMS library"         ON)
+option(64BIT       "Build 64-bit (r8) FMS library"        OFF)
+option(FPIC        "Build with position independent code" OFF)
+option(SHARED_LIBS "Build shared/dynamic libraries"       OFF)
 
 # Options for compiler definitions
 option(INTERNAL_FILE_NML     "Enable compiler definition -DINTERNAL_FILE_NML"      ON)
@@ -360,8 +361,15 @@ foreach(kind ${kinds})
   endif()
 
   # FMS (C + Fortran)
-  add_library(${libTgt} STATIC $<TARGET_OBJECTS:${libTgt}_c>
-                               $<TARGET_OBJECTS:${libTgt}_f>)
+  if (SHARED_LIBS)
+      message(STATUS "Shared library target: ${libTgt}")
+      add_library(${libTgt} SHARED $<TARGET_OBJECTS:${libTgt}_c>
+                                   $<TARGET_OBJECTS:${libTgt}_f>)
+  else ()
+      message(STATUS "Static library target: ${libTgt}")
+      add_library(${libTgt} STATIC $<TARGET_OBJECTS:${libTgt}_c>
+                                   $<TARGET_OBJECTS:${libTgt}_f>)
+  endif ()
 
   target_include_directories(${libTgt} PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
@@ -397,7 +405,8 @@ foreach(kind ${kinds})
   target_compile_definitions(${libTgt} PRIVATE "${fms_defs}")
   target_compile_definitions(${libTgt} PRIVATE "${${kind}_defs}")
 
-  target_link_libraries(${libTgt} PUBLIC NetCDF::NetCDF_Fortran
+  target_link_libraries(${libTgt} PUBLIC NetCDF::NetCDF_C
+                                         NetCDF::NetCDF_Fortran
                                          MPI::MPI_Fortran)
 
   if(OpenMP_Fortran_FOUND)


### PR DESCRIPTION
**Description**

This PR adds CMake configuration to optionally build shared libraries. Building static libraries remains the default action.

Fixes #1558

**How Has This Been Tested?**

I tested these changes on my Mac laptop. I verified that static libraries build by default and by using the cmake command line option `-DSHARED_LIBS` that shared libraries were build instead.

JEDI is currently using FMS 2023.04 and I tested these changes (relative to the 2023.04 version of CMakeLists.txt) and verified that FV3-GFS built successfully with either static or shared FMS libraries, and indeed the issue with the static libraries is fixed by using shared libraries instead.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] `make distcheck` passes


