### PR TITLE
Workaround for Cray compiler bug involving `NULL()` intrinsic

### DIFF
--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -224,6 +224,7 @@ integer function fms_register_diag_field_obj &
  integer, allocatable :: file_ids(:) !< The file IDs for this variable
  integer :: i !< For do loops
  integer, allocatable :: diag_field_indices(:) !< indices where the field was found in the yaml
+ class(diagDomain_t), pointer :: null_ptr => NULL() !< Workaround for a Cray compiler bug
 #endif
 #ifndef use_yaml
 fms_register_diag_field_obj = DIAG_FIELD_NOT_FOUND
@@ -267,7 +268,7 @@ CALL MPP_ERROR(FATAL,"You can not use the modern diag manager without compiling 
      call fileptr%add_field_and_yaml_id(fieldptr%get_id(), diag_field_indices(i))
      call fileptr%add_buffer_id(fieldptr%buffer_ids(i))
      if(fieldptr%get_type_of_domain() .eq. NO_DOMAIN) then
-       call fileptr%set_file_domain(NULL(), fieldptr%get_type_of_domain())
+       call fileptr%set_file_domain(null_ptr, fieldptr%get_type_of_domain())
      else
        call fileptr%set_file_domain(fieldptr%get_domain(), fieldptr%get_type_of_domain())
      endif
@@ -284,7 +285,7 @@ CALL MPP_ERROR(FATAL,"You can not use the modern diag manager without compiling 
      call fileptr%add_buffer_id(fieldptr%buffer_ids(i))
      call fileptr%init_diurnal_axis(this%diag_axis, this%registered_axis, diag_field_indices(i))
      if(fieldptr%get_type_of_domain() .eq. NO_DOMAIN) then
-       call fileptr%set_file_domain(NULL(), fieldptr%get_type_of_domain())
+       call fileptr%set_file_domain(null_ptr, fieldptr%get_type_of_domain())
      else
        call fileptr%set_file_domain(fieldptr%get_domain(), fieldptr%get_type_of_domain())
      endif

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -224,7 +224,7 @@ integer function fms_register_diag_field_obj &
  integer, allocatable :: file_ids(:) !< The file IDs for this variable
  integer :: i !< For do loops
  integer, allocatable :: diag_field_indices(:) !< indices where the field was found in the yaml
- class(diagDomain_t), pointer :: null_ptr => NULL() !< Workaround for a Cray compiler bug
+ class(diagDomain_t), pointer :: null_diag_domain => NULL() !< Workaround for a Cray bug which will be fixed in CCE 19
 #endif
 #ifndef use_yaml
 fms_register_diag_field_obj = DIAG_FIELD_NOT_FOUND
@@ -268,7 +268,7 @@ CALL MPP_ERROR(FATAL,"You can not use the modern diag manager without compiling 
      call fileptr%add_field_and_yaml_id(fieldptr%get_id(), diag_field_indices(i))
      call fileptr%add_buffer_id(fieldptr%buffer_ids(i))
      if(fieldptr%get_type_of_domain() .eq. NO_DOMAIN) then
-       call fileptr%set_file_domain(null_ptr, fieldptr%get_type_of_domain())
+       call fileptr%set_file_domain(null_diag_domain, fieldptr%get_type_of_domain())
      else
        call fileptr%set_file_domain(fieldptr%get_domain(), fieldptr%get_type_of_domain())
      endif
@@ -285,7 +285,7 @@ CALL MPP_ERROR(FATAL,"You can not use the modern diag manager without compiling 
      call fileptr%add_buffer_id(fieldptr%buffer_ids(i))
      call fileptr%init_diurnal_axis(this%diag_axis, this%registered_axis, diag_field_indices(i))
      if(fieldptr%get_type_of_domain() .eq. NO_DOMAIN) then
-       call fileptr%set_file_domain(null_ptr, fieldptr%get_type_of_domain())
+       call fileptr%set_file_domain(null_diag_domain, fieldptr%get_type_of_domain())
      else
        call fileptr%set_file_domain(fieldptr%get_domain(), fieldptr%get_type_of_domain())
      endif


### PR DESCRIPTION
**Description**
The Cray compiler contains a bug where the `NULL()` intrinsic fails to produce a pointer of the correct type when it is passed directly to a subroutine expecting a pointer to a derived type.

This PR implements a workaround where `NULL()` is assigned to a variable which is passed to the subroutine, rather than calling `NULL()` directly as a subroutine argument.

**How Has This Been Tested?**
Builds with Cray compiler 15.0.1 on C5.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes