### PR TITLE
Add cray mod output check and unused newunit macro to configure script

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -278,6 +278,9 @@ rm -f test.nc
 # Check if we need a flag to not capitalize module output (needed with cray compiler)
 GX_FC_MOD_CASE_FLAG([FCFLAGS="$FCFLAGS $FC_MOD_CASE_FLAG"])
 
+# Check if new unit is supported
+GX_FC_08_OPEN_NEWUNIT([], [AC_MSG_ERROR([Compiler support for use of newunit argument is required to build FMS])])
+
 # Check if Fortran compiler has the Class, Character array assign bug
 GX_FC_CLASS_CHAR_ARRAY_BUG_CHECK()
 

--- a/configure.ac
+++ b/configure.ac
@@ -254,12 +254,10 @@ if test "$enable_code_coverage" = yes; then
 fi
 AM_CONDITIONAL(COV, [test "$enable_code_coverage" = yes])
 
-
 # Require netCDF
 GX_FC_CHECK_MOD([netcdf], [], [], [AC_MSG_ERROR([Can't find the netCDF Fortran module.  Set CPPFLAGS/FCFLAGS])])
 GX_FORTRAN_SEARCH_LIBS([nf90_create], [netcdff], [use netcdf], [iret = nf90_create('foo.nc', 1, ncid)], [],
   [AC_MSG_ERROR([Can't find the netCDF Fortran library.  Set LDFLAGS/LIBS])])
-
 
 # Check if we get a floating point exception with netcdf
 # this will only get triggered if you have FPE traps enabled via FCFLAGS
@@ -275,7 +273,7 @@ if test $hdf5_fpe_bug = yes; then
 NetCDF must be built with a HDF5 version other than 1.14.3 to support floating point exception traps.])
 fi
 
-rm test.nc
+rm -f test.nc
 
 # Check if we need a flag to not capitalize module output (needed with cray compiler)
 GX_FC_MOD_CASE_FLAG([FCFLAGS="$FCFLAGS $FC_MOD_CASE_FLAG"])

--- a/configure.ac
+++ b/configure.ac
@@ -254,10 +254,12 @@ if test "$enable_code_coverage" = yes; then
 fi
 AM_CONDITIONAL(COV, [test "$enable_code_coverage" = yes])
 
+
 # Require netCDF
 GX_FC_CHECK_MOD([netcdf], [], [], [AC_MSG_ERROR([Can't find the netCDF Fortran module.  Set CPPFLAGS/FCFLAGS])])
 GX_FORTRAN_SEARCH_LIBS([nf90_create], [netcdff], [use netcdf], [iret = nf90_create('foo.nc', 1, ncid)], [],
   [AC_MSG_ERROR([Can't find the netCDF Fortran library.  Set LDFLAGS/LIBS])])
+
 
 # Check if we get a floating point exception with netcdf
 # this will only get triggered if you have FPE traps enabled via FCFLAGS
@@ -273,6 +275,10 @@ if test $hdf5_fpe_bug = yes; then
 NetCDF must be built with a HDF5 version other than 1.14.3 to support floating point exception traps.])
 fi
 
+rm test.nc
+
+# Check if we need a flag to not capitalize module output (needed with cray compiler)
+GX_FC_MOD_CASE_FLAG([FCFLAGS="$FCFLAGS $FC_MOD_CASE_FLAG"])
 
 # Check if Fortran compiler has the Class, Character array assign bug
 GX_FC_CLASS_CHAR_ARRAY_BUG_CHECK()

--- a/m4/gx_fortran_options.m4
+++ b/m4/gx_fortran_options.m4
@@ -430,16 +430,16 @@ end module foo]],
                   AC_MSG_ERROR(["Failed to compile test module with -c"]))
 
 # if output .mod file is capitalized, add the flag and check that it works
-if test -f "FOO.mod"; then
+if test -f "FOO.${FC_MODEXT}"; then
   FCFLAGS="$gx_mod_case_flag_FCFLAGS_save -c -ef"
   AC_COMPILE_IFELSE([[module foo
                     end module mod]],
     [])
-  if test -f "foo.mod"; then
+  if test -f "foo.${FC_MODEXT}"; then
     gx_cv_fc_mod_case_flag="-ef"
   fi
 else
-  gx_cv_fc_mod_case_flag=
+  gx_cv_fc_mod_case_flag=no
 fi
 
 rm -f conftest.err conftest.$ac_objext conftest.$ac_ext
@@ -448,14 +448,12 @@ FCFLAGS=$gx_mod_case_flag_FCFLAGS_save
 
 if test "x$gx_cv_fc_mod_case_flag" = "xunknown"; then
   m4_default([$2],
-              [AC_MSG_ERROR([No working flag found to disable .mod filename capitalization])])
-elif test "x$gx_cv_fc_mod_case_flag" != "x"; then
-  AC_DEFINE([NEEDS_MOD_OUTPUT_CASE_FLAG], 1,
-            [Define to 1 if your Fortran compiler requires a flag to match case of module names])
+              [AC_MSG_ERROR([No working flag found to disable module filename capitalization])])
+elif test "x$gx_cv_fc_mod_case_flag" != "xno"; then
   FC_MOD_CASE_FLAG=$gx_cv_fc_mod_case_flag
+  AC_SUBST([FC_MOD_CASE_FLAG])
   $1
 fi
 AC_LANG_POP([Fortran])
-AC_SUBST([FC_MOD_CASE_FLAG])
 ])
 

--- a/m4/gx_fortran_options.m4
+++ b/m4/gx_fortran_options.m4
@@ -27,6 +27,7 @@
 #   GX_FC_CRAY_POINTER_FLAG([ACTION-IF-SUCCESS], [ACTION-IF-FAILURE = FAILURE])
 #   GX_FC_INTERNAL_FILE_NML()
 #   GX_FC_CHECK_MOD(module-name, [only], [action-if-found], [action-if-not-found])
+#   GX_FC_MOD_OUTPUT_CASE([ACTION-IF-SUCCESS], [ACTION-IF-FAILURE])
 #
 # DESCRIPTION
 #
@@ -405,3 +406,56 @@ AC_DEFUN([_GX_FORTRAN_PP_SRCEXT_POP], [
 AS_VAR_SET_IF([_gx_fortran_pp_srcext_save], [ac_ext=${_gx_fortran_pp_srcext_save}], [ac_ext="f"])
 unset _gx_fortran_pp_srcext_save
 ])# _GX_FORTRAN_PP_SRCEXT_POP
+
+
+# GX_FC_MOD_CASE_FLAG([ACTION-IF-SUCCESS], [ACTION-IF-FAILURE])
+# -----------------------------------------------------------------------------
+# Checks if the output .mod files are in uppercase by default.
+# This has only been seen with cray compiler. A flag is required to disable the uppercase output
+# and instead follow the case of the module name as written in the source file.
+#
+# Sets the variable FC_MOD_CASE_FLAG to hold the flag that disables the behavior.
+#
+AC_DEFUN([GX_FC_MOD_CASE_FLAG],[
+AC_LANG_PUSH([Fortran])
+AC_FC_SRCEXT(F90)
+AC_CACHE_CHECK([if Fortran flag needed for module output case], [gx_cv_fc_mod_case_flag],[
+gx_cv_fc_mod_case_flag="unknown"
+gx_mod_case_flag_FCFLAGS_save=$FCFLAGS
+
+FCFLAGS="$gx_mod_case_flag_FCFLAGS_save -c"
+AC_COMPILE_IFELSE([[module foo
+end module foo]],
+                  [],
+                  AC_MSG_ERROR(["Failed to compile test module with -c"]))
+
+# if output .mod file is capitalized, add the flag and check that it works
+if test -f "FOO.mod"; then
+  FCFLAGS="$gx_mod_case_flag_FCFLAGS_save -c -ef"
+  AC_COMPILE_IFELSE([[module foo
+                    end module mod]],
+    [])
+  if test -f "foo.mod"; then
+    gx_cv_fc_mod_case_flag="-ef"
+  fi
+else
+  gx_cv_fc_mod_case_flag="notneeded"
+fi
+
+rm -f conftest.err conftest.$ac_objext conftest.$ac_ext
+FCFLAGS=$gx_mod_case_flag_FCFLAGS_save
+])
+
+if test "x$gx_cv_fc_mod_case_flag" = "xunknown"; then
+  m4_default([$2],
+              [AC_MSG_ERROR([No working flag found to disable .mod filename capitalization])])
+elif test "x$gx_cv_fc_mod_case_flag" != "notneeded"; then
+  AC_DEFINE([NEEDS_MOD_OUTPUT_CASE_FLAG], 1,
+            [Define to 1 if your Fortran compiler requires a flag to match case of module names])
+  FC_MOD_CASE_FLAG=$gx_cv_fc_mod_case_flag
+  $1
+fi
+AC_LANG_POP([Fortran])
+AC_SUBST([FC_MOD_CASE_FLAG])
+])
+

--- a/m4/gx_fortran_options.m4
+++ b/m4/gx_fortran_options.m4
@@ -439,7 +439,7 @@ if test -f "FOO.mod"; then
     gx_cv_fc_mod_case_flag="-ef"
   fi
 else
-  gx_cv_fc_mod_case_flag="notneeded"
+  gx_cv_fc_mod_case_flag=
 fi
 
 rm -f conftest.err conftest.$ac_objext conftest.$ac_ext
@@ -449,7 +449,7 @@ FCFLAGS=$gx_mod_case_flag_FCFLAGS_save
 if test "x$gx_cv_fc_mod_case_flag" = "xunknown"; then
   m4_default([$2],
               [AC_MSG_ERROR([No working flag found to disable .mod filename capitalization])])
-elif test "x$gx_cv_fc_mod_case_flag" != "notneeded"; then
+elif test "x$gx_cv_fc_mod_case_flag" != "x"; then
   AC_DEFINE([NEEDS_MOD_OUTPUT_CASE_FLAG], 1,
             [Define to 1 if your Fortran compiler requires a flag to match case of module names])
   FC_MOD_CASE_FLAG=$gx_cv_fc_mod_case_flag


### PR DESCRIPTION
**Description**
@J-Lentz found that the cray compiler capitalizes .mod files by default which causes some issues with the build. This PR adds a m4 macro to check if that behavior is happening and if so adds a flag `-ef` to disable it.

There was also an unused m4 file that checks for if a compiler supports newunit in open calls, from what i can see in the history it seems like it may have just accidentally never been added to the `configure.ac` file at the time it was added to the repo. This adds the call so it can actually run as well and also adds a line to remove a leftover file from one of the checks.

**How Has This Been Tested?**
tested with intel, gcc, and the cray compiler on gaea and also with intel and gcc on the amd box

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

