### PR TITLE
add consistent character lengths for files and paths

### DIFF
--- a/amip_interp/amip_interp.F90
+++ b/amip_interp/amip_interp.F90
@@ -135,10 +135,11 @@ use           fms_mod, only: error_mesg, write_version_number,  &
                              NOTE, mpp_error, fms_error_handler
 
 use     constants_mod, only: TFREEZE, pi
-use      platform_mod, only: r4_kind, r8_kind, i2_kind
+use      platform_mod, only: r4_kind, r8_kind, i2_kind, FMS_PATH_LEN
 use mpp_mod,           only: input_nml_file
 use fms2_io_mod,       only: FmsNetcdfFile_t, fms2_io_file_exists=>file_exists, open_file, close_file, &
                              get_dimension_size, fms2_io_read_data=>read_data
+use netcdf,            only: NF90_MAX_NAME
 
 implicit none
 private
@@ -302,9 +303,8 @@ end type amip_interp_type
 
 !  ---- global unit & date ----
 
-   integer, parameter :: maxc = 128
    integer :: iunit
-   character(len=maxc) :: file_name_sst, file_name_ice
+   character(len=FMS_PATH_LEN) :: file_name_sst, file_name_ice
    type(FmsNetcdfFile_t), target :: fileobj_sst, fileobj_ice
 
    type (date_type) :: Curr_date = date_type( -99, -99, -99 )

--- a/amip_interp/amip_interp.F90
+++ b/amip_interp/amip_interp.F90
@@ -135,7 +135,7 @@ use           fms_mod, only: error_mesg, write_version_number,  &
                              NOTE, mpp_error, fms_error_handler
 
 use     constants_mod, only: TFREEZE, pi
-use      platform_mod, only: r4_kind, r8_kind, i2_kind, FMS_PATH_LEN
+use      platform_mod, only: r4_kind, r8_kind, i2_kind, FMS_FILE_LEN
 use mpp_mod,           only: input_nml_file
 use fms2_io_mod,       only: FmsNetcdfFile_t, fms2_io_file_exists=>file_exists, open_file, close_file, &
                              get_dimension_size, fms2_io_read_data=>read_data
@@ -304,7 +304,7 @@ end type amip_interp_type
 !  ---- global unit & date ----
 
    integer :: iunit
-   character(len=FMS_PATH_LEN) :: file_name_sst, file_name_ice
+   character(len=FMS_FILE_LEN) :: file_name_sst, file_name_ice
    type(FmsNetcdfFile_t), target :: fileobj_sst, fileobj_ice
 
    type (date_type) :: Curr_date = date_type( -99, -99, -99 )

--- a/amip_interp/include/amip_interp.inc
+++ b/amip_interp/include/amip_interp.inc
@@ -46,7 +46,7 @@ subroutine GET_AMIP_SST_ (Time, Interp, sst, err_msg, lon_model, lat_model)
     integer, dimension(:), allocatable :: ryr, rmo, rdy
     character(len=30) :: time_unit
     real(FMS_AMIP_INTERP_KIND_), dimension(:), allocatable :: timeval
-    character(len=FMS_PATH_LEN) :: ncfilename
+    character(len=FMS_FILE_LEN) :: ncfilename
     type(FmsNetcdfFile_t) :: fileobj
     logical :: the_file_exists
 ! end add by JHC
@@ -652,7 +652,7 @@ endif
      integer(I2_KIND) :: idat(mobs,nobs)
      integer :: nrecords, yr, mo, dy, ierr, k
      integer, dimension(:), allocatable :: ryr, rmo, rdy
-     character(len=FMS_PATH_LEN)  :: ncfilename
+     character(len=FMS_FILE_LEN)  :: ncfilename
      character(len=NF90_MAX_NAME) :: ncfieldname
      type(FmsNetcdfFile_t), pointer :: fileobj
      integer, parameter :: lkind = FMS_AMIP_INTERP_KIND_

--- a/amip_interp/include/amip_interp.inc
+++ b/amip_interp/include/amip_interp.inc
@@ -46,7 +46,7 @@ subroutine GET_AMIP_SST_ (Time, Interp, sst, err_msg, lon_model, lat_model)
     integer, dimension(:), allocatable :: ryr, rmo, rdy
     character(len=30) :: time_unit
     real(FMS_AMIP_INTERP_KIND_), dimension(:), allocatable :: timeval
-    character(len=maxc) :: ncfilename
+    character(len=FMS_PATH_LEN) :: ncfilename
     type(FmsNetcdfFile_t) :: fileobj
     logical :: the_file_exists
 ! end add by JHC
@@ -652,7 +652,8 @@ endif
      integer(I2_KIND) :: idat(mobs,nobs)
      integer :: nrecords, yr, mo, dy, ierr, k
      integer, dimension(:), allocatable :: ryr, rmo, rdy
-     character(len=maxc) :: ncfilename, ncfieldname
+     character(len=FMS_PATH_LEN)  :: ncfilename
+     character(len=NF90_MAX_NAME) :: ncfieldname
      type(FmsNetcdfFile_t), pointer :: fileobj
      integer, parameter :: lkind = FMS_AMIP_INTERP_KIND_
 

--- a/column_diagnostics/column_diagnostics.F90
+++ b/column_diagnostics/column_diagnostics.F90
@@ -32,7 +32,7 @@ use time_manager_mod,       only:  time_manager_init, month_name, &
                                    get_date, time_type
 use constants_mod,          only:  constants_init, PI, RADIAN
 use mpp_mod,                only:  input_nml_file
-use platform_mod,           only:  r4_kind, r8_kind
+use platform_mod,           only:  r4_kind, r8_kind, FMS_FILE_LEN
 !-------------------------------------------------------------------
 
 implicit none

--- a/column_diagnostics/include/column_diagnostics.inc
+++ b/column_diagnostics/include/column_diagnostics.inc
@@ -99,7 +99,7 @@ integer, dimension(:), intent(out)   :: diag_units            !< unit number for
       real(FMS_CD_KIND_) ::  ref_lat
       real(FMS_CD_KIND_) ::  current_distance
       character(len=8)   ::  char         !< character string for diaganostic column index
-      character(len=32)  ::  filename     !< filename for output file for diagnostic column
+      character(len=FMS_PATH_LEN)  ::  filename     !< filename for output file for diagnostic column
       logical            ::  allow_ij_input
       logical            ::  open_file
       integer            ::  io

--- a/column_diagnostics/include/column_diagnostics.inc
+++ b/column_diagnostics/include/column_diagnostics.inc
@@ -99,7 +99,7 @@ integer, dimension(:), intent(out)   :: diag_units            !< unit number for
       real(FMS_CD_KIND_) ::  ref_lat
       real(FMS_CD_KIND_) ::  current_distance
       character(len=8)   ::  char         !< character string for diaganostic column index
-      character(len=FMS_PATH_LEN)  ::  filename     !< filename for output file for diagnostic column
+      character(len=FMS_FILE_LEN)  ::  filename     !< filename for output file for diagnostic column
       logical            ::  allow_ij_input
       logical            ::  open_file
       integer            ::  io

--- a/coupler/atmos_ocean_fluxes.F90
+++ b/coupler/atmos_ocean_fluxes.F90
@@ -48,7 +48,7 @@ module  atmos_ocean_fluxes_mod
   use coupler_types_mod, only: ind_runoff
   use coupler_types_mod, only: ind_flux, ind_deltap, ind_kw, ind_flux0
 
-  use field_manager_mod, only: fm_path_name_len, fm_string_len, fm_exists, fm_get_index
+  use field_manager_mod, only: fm_string_len, fm_exists, fm_get_index
   use field_manager_mod, only: fm_new_list, fm_get_current_list, fm_change_list
   use field_manager_mod, only: fm_field_name_len, fm_type_name_len, fm_dump_list
   use field_manager_mod, only: fm_loop_over_list
@@ -63,7 +63,7 @@ module  atmos_ocean_fluxes_mod
   use fm_util_mod,       only: fm_util_get_real_array, fm_util_get_real, fm_util_get_integer
   use fm_util_mod,       only: fm_util_get_logical, fm_util_get_logical_array
   use fms_io_utils_mod,  only: get_data_type_string
-  use platform_mod,      only: r4_kind, r8_kind
+  use platform_mod,      only: r4_kind, r8_kind, FMS_PATH_LEN
 
   implicit none
   private
@@ -135,8 +135,8 @@ contains
     integer                                                 :: length
     integer                                                 :: num_parameters
     integer                                                 :: outunit
-    character(len=fm_path_name_len)                         :: coupler_list
-    character(len=fm_path_name_len)                         :: current_list
+    character(len=FMS_PATH_LEN)                             :: coupler_list
+    character(len=FMS_PATH_LEN)                             :: current_list
     character(len=fm_string_len)                            :: flux_type_test
     character(len=fm_string_len)                            :: implementation_test
     character(len=256)                                      :: error_header

--- a/coupler/atmos_ocean_fluxes.F90
+++ b/coupler/atmos_ocean_fluxes.F90
@@ -135,8 +135,8 @@ contains
     integer                                                 :: length
     integer                                                 :: num_parameters
     integer                                                 :: outunit
-    character(len=FMS_PATH_LEN)                             :: coupler_list
-    character(len=FMS_PATH_LEN)                             :: current_list
+    character(len=FMS_PATH_LEN)                            :: coupler_list
+    character(len=FMS_PATH_LEN)                            :: current_list
     character(len=fm_string_len)                            :: flux_type_test
     character(len=fm_string_len)                            :: implementation_test
     character(len=256)                                      :: error_header

--- a/coupler/coupler_types.F90
+++ b/coupler/coupler_types.F90
@@ -41,7 +41,7 @@ module coupler_types_mod
   use mpp_domains_mod,   only: domain2D, mpp_redistribute
   use mpp_mod,           only: mpp_error, FATAL, mpp_chksum
   use fms_string_utils_mod,  only: string
-  use platform_mod,      only: r4_kind, r8_kind, i8_kind, FMS_PATH_LEN
+  use platform_mod,      only: r4_kind, r8_kind, i8_kind, FMS_FILE_LEN, FMS_PATH_LEN
 
   implicit none
   private
@@ -103,8 +103,8 @@ module coupler_types_mod
     character(len=128)                :: implementation = ' ' !< implementation
     logical, pointer, dimension(:)    :: flag => NULL() !< flag
     integer                           :: atm_tr_index = 0 !< atm_tr_index
-    character(len=FMS_PATH_LEN)       :: ice_restart_file = ' ' !< ice_restart_file
-    character(len=FMS_PATH_LEN)       :: ocean_restart_file = ' ' !< ocean_restart_file
+    character(len=FMS_FILE_LEN)       :: ice_restart_file = ' ' !< ice_restart_file
+    character(len=FMS_FILE_LEN)       :: ocean_restart_file = ' ' !< ocean_restart_file
 #ifdef use_deprecated_io
     type(restart_file_type), pointer  :: rest_type => NULL() !< A pointer to the restart_file_type
                                                              !! that is used for this field.
@@ -146,8 +146,8 @@ module coupler_types_mod
     character(len=128)                :: implementation = ' ' !< implementation
     logical, pointer, dimension(:)    :: flag => NULL() !< flag
     integer                           :: atm_tr_index = 0 !< atm_tr_index
-    character(len=FMS_PATH_LEN)       :: ice_restart_file = ' ' !< ice_restart_file
-    character(len=FMS_PATH_LEN)       :: ocean_restart_file = ' ' !< ocean_restart_file
+    character(len=FMS_FILE_LEN)       :: ice_restart_file = ' ' !< ice_restart_file
+    character(len=FMS_FILE_LEN)       :: ocean_restart_file = ' ' !< ocean_restart_file
 #ifdef use_deprecated_io
     type(restart_file_type), pointer  :: rest_type => NULL() !< A pointer to the restart_file_type
                                                              !! that is used for this field.
@@ -207,8 +207,8 @@ module coupler_types_mod
     real(r8_kind), pointer, dimension(:)       :: param => NULL() !< param
     logical, pointer, dimension(:)    :: flag => NULL() !< flag
     integer                           :: atm_tr_index = 0 !< atm_tr_index
-    character(len=FMS_PATH_LEN)       :: ice_restart_file = ' ' !< ice_restart_file
-    character(len=FMS_PATH_LEN)       :: ocean_restart_file = ' ' !< ocean_restart_file
+    character(len=FMS_FILE_LEN)       :: ice_restart_file = ' ' !< ice_restart_file
+    character(len=FMS_FILE_LEN)       :: ocean_restart_file = ' ' !< ocean_restart_file
 #ifdef use_deprecated_io
     type(restart_file_type), pointer  :: rest_type => NULL() !< A pointer to the restart_file_type
                                                              !! that is used for this field.
@@ -253,8 +253,8 @@ module coupler_types_mod
     real(r8_kind), pointer, dimension(:)       :: param => NULL() !< param
     logical, pointer, dimension(:)    :: flag => NULL() !< flag
     integer                           :: atm_tr_index = 0 !< atm_tr_index
-    character(len=FMS_PATH_LEN)       :: ice_restart_file = ' ' !< ice_restart_file
-    character(len=FMS_PATH_LEN)       :: ocean_restart_file = ' ' !< ocean_restart_file
+    character(len=FMS_FILE_LEN)       :: ice_restart_file = ' ' !< ice_restart_file
+    character(len=FMS_FILE_LEN)       :: ocean_restart_file = ' ' !< ocean_restart_file
 #ifdef use_deprecated_io
     type(restart_file_type), pointer  :: rest_type => NULL() !< A pointer to the restart_file_type
                                                              !! that is used for this field.
@@ -309,8 +309,8 @@ module coupler_types_mod
     real(r8_kind), pointer, dimension(:) :: param => NULL() !< param
     logical, pointer, dimension(:) :: flag => NULL() !< flag
     integer                        :: atm_tr_index = 0 !< atm_tr_index
-    character(len=FMS_PATH_LEN)    :: ice_restart_file = ' ' !< ice_restart_file
-    character(len=FMS_PATH_LEN)    :: ocean_restart_file = ' ' !< ocean_restart_file
+    character(len=FMS_FILE_LEN)    :: ice_restart_file = ' ' !< ice_restart_file
+    character(len=FMS_FILE_LEN)    :: ocean_restart_file = ' ' !< ocean_restart_file
     logical                        :: use_atm_pressure !< use_atm_pressure
     logical                        :: use_10m_wind_speed !< use_10m_wind_speed
     logical                        :: pass_through_ice !< pass_through_ice
@@ -350,8 +350,8 @@ module coupler_types_mod
     real(r8_kind), pointer, dimension(:) :: param => NULL() !< param
     logical, pointer, dimension(:) :: flag => NULL() !< flag
     integer                        :: atm_tr_index = 0 !< atm_tr_index
-    character(len=FMS_PATH_LEN)    :: ice_restart_file = ' ' !< ice_restart_file
-    character(len=FMS_PATH_LEN)    :: ocean_restart_file = ' ' !< ocean_restart_file
+    character(len=FMS_FILE_LEN)    :: ice_restart_file = ' ' !< ice_restart_file
+    character(len=FMS_FILE_LEN)    :: ocean_restart_file = ' ' !< ocean_restart_file
     logical                        :: use_atm_pressure !< use_atm_pressure
     logical                        :: use_10m_wind_speed !< use_10m_wind_speed
     logical                        :: pass_through_ice !< pass_through_ice
@@ -3076,8 +3076,8 @@ contains
     logical,         optional,intent(in)  :: ocean_restart  !< If true, use the ocean restart file name.
     character(len=*),optional,intent(in)  :: directory      !< Directory where to open the file
 
-    character(len=FMS_PATH_LEN), dimension(max(1,var%num_bcs)) :: rest_file_names
-    character(len=FMS_PATH_LEN) :: file_nm
+    character(len=FMS_FILE_LEN), dimension(max(1,var%num_bcs)) :: rest_file_names
+    character(len=FMS_FILE_LEN) :: file_nm
     logical :: ocn_rest
     integer :: f, n, m
 
@@ -3358,8 +3358,8 @@ contains
     logical,         optional,intent(in)  :: ocean_restart  !< If true, use the ocean restart file name.
     character(len=*),optional,intent(in)  :: directory      !< Directory where to open the file
 
-    character(len=FMS_PATH_LEN), dimension(max(1,var%num_bcs)) :: rest_file_names
-    character(len=FMS_PATH_LEN) :: file_nm
+    character(len=FMS_FILE_LEN), dimension(max(1,var%num_bcs)) :: rest_file_names
+    character(len=FMS_FILE_LEN) :: file_nm
     logical :: ocn_rest
     integer :: f, n, m
 

--- a/coupler/coupler_types.F90
+++ b/coupler/coupler_types.F90
@@ -41,7 +41,7 @@ module coupler_types_mod
   use mpp_domains_mod,   only: domain2D, mpp_redistribute
   use mpp_mod,           only: mpp_error, FATAL, mpp_chksum
   use fms_string_utils_mod,  only: string
-  use platform_mod,      only: r4_kind, r8_kind, i8_kind
+  use platform_mod,      only: r4_kind, r8_kind, i8_kind, FMS_PATH_LEN
 
   implicit none
   private
@@ -103,8 +103,8 @@ module coupler_types_mod
     character(len=128)                :: implementation = ' ' !< implementation
     logical, pointer, dimension(:)    :: flag => NULL() !< flag
     integer                           :: atm_tr_index = 0 !< atm_tr_index
-    character(len=128)                :: ice_restart_file = ' ' !< ice_restart_file
-    character(len=128)                :: ocean_restart_file = ' ' !< ocean_restart_file
+    character(len=FMS_PATH_LEN)       :: ice_restart_file = ' ' !< ice_restart_file
+    character(len=FMS_PATH_LEN)       :: ocean_restart_file = ' ' !< ocean_restart_file
 #ifdef use_deprecated_io
     type(restart_file_type), pointer  :: rest_type => NULL() !< A pointer to the restart_file_type
                                                              !! that is used for this field.
@@ -146,8 +146,8 @@ module coupler_types_mod
     character(len=128)                :: implementation = ' ' !< implementation
     logical, pointer, dimension(:)    :: flag => NULL() !< flag
     integer                           :: atm_tr_index = 0 !< atm_tr_index
-    character(len=128)                :: ice_restart_file = ' ' !< ice_restart_file
-    character(len=128)                :: ocean_restart_file = ' ' !< ocean_restart_file
+    character(len=FMS_PATH_LEN)       :: ice_restart_file = ' ' !< ice_restart_file
+    character(len=FMS_PATH_LEN)       :: ocean_restart_file = ' ' !< ocean_restart_file
 #ifdef use_deprecated_io
     type(restart_file_type), pointer  :: rest_type => NULL() !< A pointer to the restart_file_type
                                                              !! that is used for this field.
@@ -207,8 +207,8 @@ module coupler_types_mod
     real(r8_kind), pointer, dimension(:)       :: param => NULL() !< param
     logical, pointer, dimension(:)    :: flag => NULL() !< flag
     integer                           :: atm_tr_index = 0 !< atm_tr_index
-    character(len=128)                :: ice_restart_file = ' ' !< ice_restart_file
-    character(len=128)                :: ocean_restart_file = ' ' !< ocean_restart_file
+    character(len=FMS_PATH_LEN)       :: ice_restart_file = ' ' !< ice_restart_file
+    character(len=FMS_PATH_LEN)       :: ocean_restart_file = ' ' !< ocean_restart_file
 #ifdef use_deprecated_io
     type(restart_file_type), pointer  :: rest_type => NULL() !< A pointer to the restart_file_type
                                                              !! that is used for this field.
@@ -253,8 +253,8 @@ module coupler_types_mod
     real(r8_kind), pointer, dimension(:)       :: param => NULL() !< param
     logical, pointer, dimension(:)    :: flag => NULL() !< flag
     integer                           :: atm_tr_index = 0 !< atm_tr_index
-    character(len=124)                :: ice_restart_file = ' ' !< ice_restart_file
-    character(len=124)                :: ocean_restart_file = ' ' !< ocean_restart_file
+    character(len=FMS_PATH_LEN)       :: ice_restart_file = ' ' !< ice_restart_file
+    character(len=FMS_PATH_LEN)       :: ocean_restart_file = ' ' !< ocean_restart_file
 #ifdef use_deprecated_io
     type(restart_file_type), pointer  :: rest_type => NULL() !< A pointer to the restart_file_type
                                                              !! that is used for this field.
@@ -309,8 +309,8 @@ module coupler_types_mod
     real(r8_kind), pointer, dimension(:) :: param => NULL() !< param
     logical, pointer, dimension(:) :: flag => NULL() !< flag
     integer                        :: atm_tr_index = 0 !< atm_tr_index
-    character(len=128)             :: ice_restart_file = ' ' !< ice_restart_file
-    character(len=128)             :: ocean_restart_file = ' ' !< ocean_restart_file
+    character(len=FMS_PATH_LEN)    :: ice_restart_file = ' ' !< ice_restart_file
+    character(len=FMS_PATH_LEN)    :: ocean_restart_file = ' ' !< ocean_restart_file
     logical                        :: use_atm_pressure !< use_atm_pressure
     logical                        :: use_10m_wind_speed !< use_10m_wind_speed
     logical                        :: pass_through_ice !< pass_through_ice
@@ -350,8 +350,8 @@ module coupler_types_mod
     real(r8_kind), pointer, dimension(:) :: param => NULL() !< param
     logical, pointer, dimension(:) :: flag => NULL() !< flag
     integer                        :: atm_tr_index = 0 !< atm_tr_index
-    character(len=128)             :: ice_restart_file = ' ' !< ice_restart_file
-    character(len=128)             :: ocean_restart_file = ' ' !< ocean_restart_file
+    character(len=FMS_PATH_LEN)    :: ice_restart_file = ' ' !< ice_restart_file
+    character(len=FMS_PATH_LEN)    :: ocean_restart_file = ' ' !< ocean_restart_file
     logical                        :: use_atm_pressure !< use_atm_pressure
     logical                        :: use_10m_wind_speed !< use_10m_wind_speed
     logical                        :: pass_through_ice !< pass_through_ice
@@ -3076,15 +3076,15 @@ contains
     logical,         optional,intent(in)  :: ocean_restart  !< If true, use the ocean restart file name.
     character(len=*),optional,intent(in)  :: directory      !< Directory where to open the file
 
-    character(len=80), dimension(max(1,var%num_bcs)) :: rest_file_names
-    character(len=80) :: file_nm
+    character(len=FMS_PATH_LEN), dimension(max(1,var%num_bcs)) :: rest_file_names
+    character(len=FMS_PATH_LEN) :: file_nm
     logical :: ocn_rest
     integer :: f, n, m
 
     character(len=20), allocatable, dimension(:)             :: dim_names !< Array of dimension names
     character(len=20)                          :: io_type   !< flag indicating io type: "read" "overwrite"
     logical, dimension(max(1,var%num_bcs))     :: file_is_open !< flag indicating if file is open
-    character(len=20)                          :: dir       !< Directory where to open the file
+    character(len=FMS_PATH_LEN)                          :: dir       !< Directory where to open the file
 
     if(var%set .and. var%num_bcs .gt. 0) then
       if(associated(var%bc) .eqv. associated(var%bc_r4)) then
@@ -3358,15 +3358,15 @@ contains
     logical,         optional,intent(in)  :: ocean_restart  !< If true, use the ocean restart file name.
     character(len=*),optional,intent(in)  :: directory      !< Directory where to open the file
 
-    character(len=80), dimension(max(1,var%num_bcs)) :: rest_file_names
-    character(len=80) :: file_nm
+    character(len=FMS_PATH_LEN), dimension(max(1,var%num_bcs)) :: rest_file_names
+    character(len=FMS_PATH_LEN) :: file_nm
     logical :: ocn_rest
     integer :: f, n, m
 
     character(len=20), allocatable, dimension(:) :: dim_names !< Array of dimension names
     character(len=20)                          :: io_type   !< flag indicating io type: "read" "overwrite"
     logical, dimension(max(1,var%num_bcs))     :: file_is_open !< Flag indicating if file is open
-    character(len=20)                          :: dir       !< Directory where to open the file
+    character(len=FMS_PATH_LEN)                :: dir       !< Directory where to open the file
     integer                                    :: nz        !< Length of the z direction of each file
 
     if(var%set .and. var%num_bcs .gt. 0) then

--- a/data_override/get_grid_version.F90
+++ b/data_override/get_grid_version.F90
@@ -24,7 +24,7 @@
 !> @{
 module get_grid_version_mod
 use constants_mod, only: DEG_TO_RAD
-use platform_mod, only: r4_kind, r8_kind
+use platform_mod, only: r4_kind, r8_kind, FMS_PATH_LEN
 use mpp_mod, only : mpp_error,FATAL,NOTE, mpp_min, mpp_max
 use mpp_domains_mod, only : domain2d, operator(.NE.),operator(.EQ.)
 use mpp_domains_mod, only : mpp_get_global_domain, mpp_get_data_domain

--- a/data_override/include/data_override.inc
+++ b/data_override/include/data_override.inc
@@ -48,6 +48,7 @@ use fms2_io_mod,     only : FmsNetcdfFile_t, open_file, close_file, &
                             get_mosaic_tile_file, file_exists
 use get_grid_version_mod, only: get_grid_version_1, get_grid_version_2
 use fms_string_utils_mod, only: string
+use platform_mod
 
 implicit none
 private
@@ -61,14 +62,14 @@ type data_type
    character(len=3)   :: gridname
    character(len=128) :: fieldname_code  !< fieldname used in user's code (model)
    character(len=128) :: fieldname_file  !< fieldname used in the netcdf data file
-   character(len=512) :: file_name       !< name of netCDF data file
+   character(len=FMS_PATH_LEN) :: file_name       !< name of netCDF data file
    character(len=128) :: interpol_method !< interpolation method (default "bilinear")
    real(FMS_DATA_OVERRIDE_KIND_)        :: factor          !< For unit conversion, default=1, see OVERVIEW above
    real(FMS_DATA_OVERRIDE_KIND_)        :: lon_start, lon_end, lat_start, lat_end
    integer            :: region_type
    logical            :: multifile = .false.
-   character(len=512) :: prev_file_name   !< name of netCDF data file for previous segment
-   character(len=512) :: next_file_name   !< name of netCDF data file for next segment
+   character(len=FMS_PATH_LEN) :: prev_file_name   !< name of netCDF data file for previous segment
+   character(len=FMS_PATH_LEN) :: next_file_name   !< name of netCDF data file for next segment
    type(time_type), dimension(:), allocatable :: time_records
    type(time_type), dimension(:), allocatable :: time_prev_records
    type(time_type), dimension(:), allocatable :: time_next_records
@@ -152,7 +153,7 @@ subroutine DATA_OVERRIDE_INIT_IMPL_(Atm_domain_in, Ocean_domain_in, Ice_domain_i
   type (domain2d), intent(in), optional :: Land_domain_in   !> Land domain
   type(domainUG) , intent(in), optional :: Land_domainUG_in !> Land domain, unstructured grid
 
-  character(len=128)    :: grid_file = 'INPUT/grid_spec.nc'
+  character(len=18), parameter    :: grid_file = 'INPUT/grid_spec.nc'
   integer               :: is,ie,js,je,use_get_grid_version
   integer               :: i, iunit, io_status, ierr
   logical               :: atm_on, ocn_on, lnd_on, ice_on, lndUG_on
@@ -786,9 +787,9 @@ subroutine DATA_OVERRIDE_0D_(gridname,fieldname_code,data_out,time,override,data
 
   type(time_type)    :: first_record !< first record of "current" file
   type(time_type)    :: last_record !< last record of "current" file
-  character(len=512) :: filename !< file containing source data
-  character(len=512) :: prevfilename !< file containing previous source data, when using multiple files
-  character(len=512) :: nextfilename !< file containing next source data, when using multiple files
+  character(len=FMS_PATH_LEN) :: filename !< file containing source data
+  character(len=FMS_PATH_LEN) :: prevfilename !< file containing previous source data, when using multiple files
+  character(len=FMS_PATH_LEN) :: nextfilename !< file containing next source data, when using multiple files
   character(len=128) :: fieldname !< fieldname used in the data file
   integer :: index1 !< field index in data_table
   integer            :: dims(4)
@@ -980,12 +981,12 @@ subroutine DATA_OVERRIDE_3D_(gridname,fieldname_code,return_data,time,override,d
   integer,           optional,  intent(in) :: is_in, ie_in, js_in, je_in
   logical, dimension(:,:,:),   allocatable :: mask_out
 
-  character(len=512) :: filename !< file containing source data
-  character(len=512) :: filename2 !< file containing source data
-  character(len=512) :: prevfilename !< file containing source data for previous file
-  character(len=512) :: prevfilename2 !< file containing source data for previous file
-  character(len=512) :: nextfilename !< file containing source data for next file
-  character(len=512) :: nextfilename2 !< file containing source data for next file
+  character(len=FMS_PATH_LEN) :: filename !< file containing source data
+  character(len=FMS_PATH_LEN) :: filename2 !< file containing source data
+  character(len=FMS_PATH_LEN) :: prevfilename !< file containing source data for previous file
+  character(len=FMS_PATH_LEN) :: prevfilename2 !< file containing source data for previous file
+  character(len=FMS_PATH_LEN) :: nextfilename !< file containing source data for next file
+  character(len=FMS_PATH_LEN) :: nextfilename2 !< file containing source data for next file
   character(len=128) :: fieldname !< fieldname used in the data file
   integer            :: i,j
   integer            :: dims(4)

--- a/data_override/include/data_override.inc
+++ b/data_override/include/data_override.inc
@@ -48,7 +48,6 @@ use fms2_io_mod,     only : FmsNetcdfFile_t, open_file, close_file, &
                             get_mosaic_tile_file, file_exists
 use get_grid_version_mod, only: get_grid_version_1, get_grid_version_2
 use fms_string_utils_mod, only: string
-use platform_mod
 
 implicit none
 private

--- a/data_override/include/data_override.inc
+++ b/data_override/include/data_override.inc
@@ -21,7 +21,7 @@
 ! modules. These modules are not intended to be used directly - they should be
 ! used through the data_override_mod API. See data_override.F90 for details.
 
-use platform_mod, only: r4_kind, r8_kind
+use platform_mod, only: r4_kind, r8_kind, FMS_PATH_LEN
 use yaml_parser_mod
 use constants_mod, only: DEG_TO_RAD
 use mpp_mod, only : mpp_error, FATAL, WARNING, NOTE, stdout, stdlog, mpp_max

--- a/data_override/include/get_grid_version.inc
+++ b/data_override/include/get_grid_version.inc
@@ -159,7 +159,7 @@ subroutine GET_GRID_VERSION_2_(fileobj, mod_name, domain, isc, iec, jsc, jec, lo
   integer                   :: isd, ied, jsd, jed
   integer                   :: isg, ieg, jsg, jeg
   integer                   :: isc2, iec2, jsc2, jec2
-  character(len=256)        :: solo_mosaic_file, grid_file
+  character(len=FMS_PATH_LEN) :: solo_mosaic_file, grid_file
   real(lkind), allocatable  :: tmpx(:,:), tmpy(:,:)
   logical                   :: open_solo_mosaic
   type(FmsNetcdfFile_t)     :: mosaicfileobj, tilefileobj

--- a/diag_integral/diag_integral.F90
+++ b/diag_integral/diag_integral.F90
@@ -28,7 +28,7 @@ module diag_integral_mod
 
 !###############################################################################
 
-use platform_mod,     only:  i8_kind
+use platform_mod,     only:  i8_kind, FMS_PATH_LEN
 use time_manager_mod, only:  time_type, get_time, set_time,  &
                              time_manager_init, &
                              operator(+),  operator(-),      &
@@ -135,16 +135,13 @@ private         &
 !-------------------------------------------------------------------------------
 !------ namelist -------
 
-integer, parameter  ::    &
-                      mxch = 64    !< maximum number of characters in
-                                   !! the optional output file name
 real(r8_kind)       ::    &
          output_interval = -1.0_r8_kind !< time interval at which integrals
                                         !! are to be output
 character(len=8)    ::    &
             time_units = 'hours'   !< time units associated with
                                    !! output_interval
-character(len=mxch) ::    &
+character(len=FMS_PATH_LEN) ::    &
                  file_name = ' '   !< optional integrals output file name
 logical             ::    &
            print_header = .true.   !< print a header for the integrals
@@ -1081,14 +1078,14 @@ end function vert_diag_integral
 !> @brief Adds .ens_## to the diag_integral.out file name
 !! @return character array updated_file_name
 function ensemble_file_name(fname) result(updated_file_name)
-     character (len=mxch), intent(inout) :: fname
-     character (len=mxch) :: updated_file_name
+     character (len=*), intent(inout) :: fname
+     character (len=FMS_PATH_LEN) :: updated_file_name
      integer :: ensemble_id_int
      character(len=7) :: ensemble_suffix
      character(len=2) :: ensemble_id_char
      integer :: i
      !> Make sure the file name short enough to handle adding the ensemble number
-     if (len(trim(fname)) > mxch-7) call error_mesg ('diag_integral_mod :: ensemble_file_name',  &
+     if (len(trim(fname)) > FMS_PATH_LEN-7) call error_mesg ('diag_integral_mod :: ensemble_file_name',  &
           trim(fname)//" is too long and can not support adding ens_XX.  Please shorten the "//&
           "file_name in the diag_integral_nml", FATAL)
      !> Get the ensemble ID and convert it to a string
@@ -1107,7 +1104,7 @@ function ensemble_file_name(fname) result(updated_file_name)
      !> Loop through to find the last period
           do i=len(trim(fname)),2,-1
                if (fname(i:i) == ".") then
-                    updated_file_name = fname(1:i-1)//trim(ensemble_suffix)//fname(i:mxch)
+                    updated_file_name = fname(1:i-1)//trim(ensemble_suffix)//fname(i:FMS_PATH_LEN)
                     return
                endif
           enddo

--- a/diag_integral/diag_integral.F90
+++ b/diag_integral/diag_integral.F90
@@ -28,7 +28,7 @@ module diag_integral_mod
 
 !###############################################################################
 
-use platform_mod,     only:  i8_kind, FMS_PATH_LEN
+use platform_mod,     only:  i8_kind, FMS_FILE_LEN
 use time_manager_mod, only:  time_type, get_time, set_time,  &
                              time_manager_init, &
                              operator(+),  operator(-),      &
@@ -141,7 +141,7 @@ real(r8_kind)       ::    &
 character(len=8)    ::    &
             time_units = 'hours'   !< time units associated with
                                    !! output_interval
-character(len=FMS_PATH_LEN) ::    &
+character(len=FMS_FILE_LEN) ::    &
                  file_name = ' '   !< optional integrals output file name
 logical             ::    &
            print_header = .true.   !< print a header for the integrals
@@ -1079,13 +1079,13 @@ end function vert_diag_integral
 !! @return character array updated_file_name
 function ensemble_file_name(fname) result(updated_file_name)
      character (len=*), intent(inout) :: fname
-     character (len=FMS_PATH_LEN) :: updated_file_name
+     character (len=FMS_FILE_LEN) :: updated_file_name
      integer :: ensemble_id_int
      character(len=7) :: ensemble_suffix
      character(len=2) :: ensemble_id_char
      integer :: i
      !> Make sure the file name short enough to handle adding the ensemble number
-     if (len(trim(fname)) > FMS_PATH_LEN-7) call error_mesg ('diag_integral_mod :: ensemble_file_name',  &
+     if (len(trim(fname)) > FMS_FILE_LEN-7) call error_mesg ('diag_integral_mod :: ensemble_file_name',  &
           trim(fname)//" is too long and can not support adding ens_XX.  Please shorten the "//&
           "file_name in the diag_integral_nml", FATAL)
      !> Get the ensemble ID and convert it to a string
@@ -1104,7 +1104,7 @@ function ensemble_file_name(fname) result(updated_file_name)
      !> Loop through to find the last period
           do i=len(trim(fname)),2,-1
                if (fname(i:i) == ".") then
-                    updated_file_name = fname(1:i-1)//trim(ensemble_suffix)//fname(i:FMS_PATH_LEN)
+                    updated_file_name = fname(1:i-1)//trim(ensemble_suffix)//fname(i:len(fname))
                     return
                endif
           enddo

--- a/diag_manager/diag_data.F90
+++ b/diag_manager/diag_data.F90
@@ -180,7 +180,7 @@ use platform_mod
   !> @brief Type to define the diagnostic files that will be written as defined by the diagnostic table.
   !> @ingroup diag_data_mod
   TYPE file_type
-     CHARACTER(len=128) :: name !< Name of the output file.
+     CHARACTER(len=FMS_PATH_LEN) :: name !< Name of the output file.
      CHARACTER(len=128) :: long_name
      INTEGER, DIMENSION(max_fields_per_file) :: fields
      INTEGER :: num_fields

--- a/diag_manager/diag_data.F90
+++ b/diag_manager/diag_data.F90
@@ -180,7 +180,7 @@ use platform_mod
   !> @brief Type to define the diagnostic files that will be written as defined by the diagnostic table.
   !> @ingroup diag_data_mod
   TYPE file_type
-     CHARACTER(len=FMS_PATH_LEN) :: name !< Name of the output file.
+     CHARACTER(len=FMS_FILE_LEN) :: name !< Name of the output file.
      CHARACTER(len=128) :: long_name
      INTEGER, DIMENSION(max_fields_per_file) :: fields
      INTEGER :: num_fields

--- a/diag_manager/diag_manager.F90
+++ b/diag_manager/diag_manager.F90
@@ -1415,7 +1415,7 @@ END FUNCTION register_static_field
     INTEGER :: year, month, day, hour, minute, second
     INTEGER :: n
     CHARACTER(len=25) :: date_prefix
-    CHARACTER(len=256) :: asso_file_name
+    CHARACTER(len=FMS_PATH_LEN) :: asso_file_name
 
     ! Create the date_string
     IF ( prepend_date ) THEN

--- a/diag_manager/diag_manager.F90
+++ b/diag_manager/diag_manager.F90
@@ -1415,7 +1415,7 @@ END FUNCTION register_static_field
     INTEGER :: year, month, day, hour, minute, second
     INTEGER :: n
     CHARACTER(len=25) :: date_prefix
-    CHARACTER(len=FMS_PATH_LEN) :: asso_file_name
+    CHARACTER(len=FMS_FILE_LEN) :: asso_file_name
 
     ! Create the date_string
     IF ( prepend_date ) THEN

--- a/diag_manager/diag_output.F90
+++ b/diag_manager/diag_output.F90
@@ -109,7 +109,7 @@ CONTAINS
     integer, allocatable, dimension(:) :: current_pelist
     integer :: mype  !< The pe you are on
     character(len=9) :: mype_string !< a string to store the pe
-    character(len=FMS_PATH_LEN) :: filename_tile !< Filename with the tile number included
+    character(len=FMS_FILE_LEN) :: filename_tile !< Filename with the tile number included
                                         !! It is needed for subregional diagnostics
 
     !---- initialize mpp_io ----

--- a/diag_manager/diag_output.F90
+++ b/diag_manager/diag_output.F90
@@ -109,7 +109,7 @@ CONTAINS
     integer, allocatable, dimension(:) :: current_pelist
     integer :: mype  !< The pe you are on
     character(len=9) :: mype_string !< a string to store the pe
-    character(len=128) :: filename_tile !< Filename with the tile number included
+    character(len=FMS_PATH_LEN) :: filename_tile !< Filename with the tile number included
                                         !! It is needed for subregional diagnostics
 
     !---- initialize mpp_io ----

--- a/diag_manager/diag_table.F90
+++ b/diag_manager/diag_table.F90
@@ -255,6 +255,7 @@ MODULE diag_table_mod
   USE diag_data_mod, ONLY: global_descriptor, get_base_time, set_base_time, &
                          & DIAG_OTHER, DIAG_OCEAN, DIAG_ALL, coord_type, append_pelist_name, pelist_name
   USE diag_util_mod, ONLY: init_file, check_duplicate_output_fields, init_input_field, init_output_field
+  USE platform_mod, ONLY: FMS_PATH_LEN
 
   IMPLICIT NONE
 
@@ -283,7 +284,7 @@ MODULE diag_table_mod
      INTEGER :: iOutput_freq_units
      INTEGER :: iNew_file_freq_units
      INTEGER :: iFile_duration_units
-     CHARACTER(len=128) :: file_name
+     CHARACTER(len=FMS_PATH_LEN) :: file_name
      CHARACTER(len=10) :: output_freq_units
      CHARACTER(len=10) :: time_units
      CHARACTER(len=128) :: long_name

--- a/diag_manager/diag_table.F90
+++ b/diag_manager/diag_table.F90
@@ -255,7 +255,7 @@ MODULE diag_table_mod
   USE diag_data_mod, ONLY: global_descriptor, get_base_time, set_base_time, &
                          & DIAG_OTHER, DIAG_OCEAN, DIAG_ALL, coord_type, append_pelist_name, pelist_name
   USE diag_util_mod, ONLY: init_file, check_duplicate_output_fields, init_input_field, init_output_field
-  USE platform_mod, ONLY: FMS_PATH_LEN
+  USE platform_mod, ONLY: FMS_FILE_LEN
 
   IMPLICIT NONE
 
@@ -284,7 +284,7 @@ MODULE diag_table_mod
      INTEGER :: iOutput_freq_units
      INTEGER :: iNew_file_freq_units
      INTEGER :: iFile_duration_units
-     CHARACTER(len=FMS_PATH_LEN) :: file_name
+     CHARACTER(len=FMS_FILE_LEN) :: file_name
      CHARACTER(len=10) :: output_freq_units
      CHARACTER(len=10) :: time_units
      CHARACTER(len=128) :: long_name

--- a/diag_manager/diag_util.F90
+++ b/diag_manager/diag_util.F90
@@ -1654,10 +1654,11 @@ END SUBROUTINE check_bounds_are_exact_dynamic
     INTEGER, ALLOCATABLE  :: axesc(:) ! indices if compressed axes associated with the field
     LOGICAL :: time_ops, aux_present, match_aux_name, req_present, match_req_fields
     CHARACTER(len=7) :: avg_name = 'average'
-    CHARACTER(len=128) :: time_units, timeb_units, avg, error_string, filename, aux_name, req_fields, fieldname
+    CHARACTER(len=128) :: time_units, timeb_units, avg, error_string, aux_name, req_fields, fieldname
+    CHARACTER(len=FMS_PATH_LEN) :: filename
     CHARACTER(len=128) :: suffix, base_name
     CHARACTER(len=32) :: time_name, timeb_name,time_longname, timeb_longname, cart_name
-    CHARACTER(len=256) :: fname
+    CHARACTER(len=FMS_PATH_LEN) :: fname
     CHARACTER(len=24) :: start_date
     TYPE(domain1d) :: domain
     TYPE(domain2d) :: domain2

--- a/diag_manager/diag_util.F90
+++ b/diag_manager/diag_util.F90
@@ -1655,10 +1655,10 @@ END SUBROUTINE check_bounds_are_exact_dynamic
     LOGICAL :: time_ops, aux_present, match_aux_name, req_present, match_req_fields
     CHARACTER(len=7) :: avg_name = 'average'
     CHARACTER(len=128) :: time_units, timeb_units, avg, error_string, aux_name, req_fields, fieldname
-    CHARACTER(len=FMS_PATH_LEN) :: filename
+    CHARACTER(len=FMS_FILE_LEN) :: filename
     CHARACTER(len=128) :: suffix, base_name
     CHARACTER(len=32) :: time_name, timeb_name,time_longname, timeb_longname, cart_name
-    CHARACTER(len=FMS_PATH_LEN) :: fname
+    CHARACTER(len=FMS_FILE_LEN) :: fname
     CHARACTER(len=24) :: start_date
     TYPE(domain1d) :: domain
     TYPE(domain2d) :: domain2

--- a/diag_manager/fms_diag_field_object.F90
+++ b/diag_manager/fms_diag_field_object.F90
@@ -1899,7 +1899,7 @@ subroutine generate_associated_files_att(this, att, start_time)
   type(time_type),                   intent(in)            :: start_time !< The start_time for the field's file
 
   character(len=:), allocatable :: field_name !< Name of the area/volume field
-  character(len=FMS_PATH_LEN) :: file_name !< Name of the file the area/volume field is in!
+  character(len=FMS_FILE_LEN) :: file_name !< Name of the file the area/volume field is in!
   character(len=128) :: start_date !< Start date to append to the begining of the filename
 
   integer :: year, month, day, hour, minute, second

--- a/diag_manager/fms_diag_field_object.F90
+++ b/diag_manager/fms_diag_field_object.F90
@@ -1899,7 +1899,7 @@ subroutine generate_associated_files_att(this, att, start_time)
   type(time_type),                   intent(in)            :: start_time !< The start_time for the field's file
 
   character(len=:), allocatable :: field_name !< Name of the area/volume field
-  character(len=MAX_STR_LEN) :: file_name !< Name of the file the area/volume field is in!
+  character(len=FMS_PATH_LEN) :: file_name !< Name of the file the area/volume field is in!
   character(len=128) :: start_date !< Start date to append to the begining of the filename
 
   integer :: year, month, day, hour, minute, second

--- a/diag_manager/fms_diag_file_object.F90
+++ b/diag_manager/fms_diag_file_object.F90
@@ -1115,10 +1115,10 @@ subroutine open_diag_file(this, time_step, file_is_opened)
   class(fmsDiagFile_type), pointer     :: diag_file      !< Diag_file object to open
   class(diagDomain_t),     pointer     :: domain         !< The domain used in the file
   character(len=:),        allocatable :: diag_file_name !< The file name as defined in the yaml
-  character(len=FMS_PATH_LEN)          :: base_name      !< The file name as defined in the yaml
+  character(len=FMS_FILE_LEN)          :: base_name      !< The file name as defined in the yaml
                                                          !! without the wildcard definition
-  character(len=FMS_PATH_LEN)          :: file_name      !< The file name as it will be written to disk
-  character(len=FMS_PATH_LEN)          :: temp_name      !< Temp variable to store the file_name
+  character(len=FMS_FILE_LEN)          :: file_name      !< The file name as it will be written to disk
+  character(len=FMS_FILE_LEN)          :: temp_name      !< Temp variable to store the file_name
   character(len=128)                   :: start_date     !< The start_time as a string that will be added to
                                                          !! the begining of the filename (start_date.filename)
   character(len=128)                   :: suffix         !< The current time as a string that will be added to
@@ -1694,7 +1694,7 @@ subroutine write_field_metadata(this, diag_field, diag_axis)
   logical            :: is_regional   !< Flag indicating if the field is in a regional file
   character(len=255) :: cell_measures !< cell_measures attributes for the field
   logical            :: need_associated_files !< .True. if the 'associated_files' global attribute is needed
-  character(len=FMS_PATH_LEN) :: associated_files !< Associated files attribute to add
+  character(len=FMS_FILE_LEN) :: associated_files !< Associated files attribute to add
 
   is_regional = this%is_regional()
 

--- a/diag_manager/fms_diag_file_object.F90
+++ b/diag_manager/fms_diag_file_object.F90
@@ -50,6 +50,7 @@ use fms_diag_field_object_mod, only: fmsDiagField_type
 use fms_diag_output_buffer_mod, only: fmsDiagOutputBuffer_type
 use mpp_mod, only: mpp_get_current_pelist, mpp_npes, mpp_root_pe, mpp_pe, mpp_error, FATAL, stdout, &
                    uppercase, lowercase, NOTE
+use platform_mod, only: FMS_FILE_LEN 
 
 implicit none
 private

--- a/diag_manager/fms_diag_file_object.F90
+++ b/diag_manager/fms_diag_file_object.F90
@@ -50,7 +50,7 @@ use fms_diag_field_object_mod, only: fmsDiagField_type
 use fms_diag_output_buffer_mod, only: fmsDiagOutputBuffer_type
 use mpp_mod, only: mpp_get_current_pelist, mpp_npes, mpp_root_pe, mpp_pe, mpp_error, FATAL, stdout, &
                    uppercase, lowercase, NOTE
-use platform_mod, only: FMS_FILE_LEN 
+use platform_mod, only: FMS_FILE_LEN
 
 implicit none
 private

--- a/diag_manager/fms_diag_file_object.F90
+++ b/diag_manager/fms_diag_file_object.F90
@@ -1115,10 +1115,10 @@ subroutine open_diag_file(this, time_step, file_is_opened)
   class(fmsDiagFile_type), pointer     :: diag_file      !< Diag_file object to open
   class(diagDomain_t),     pointer     :: domain         !< The domain used in the file
   character(len=:),        allocatable :: diag_file_name !< The file name as defined in the yaml
-  character(len=128)                   :: base_name      !< The file name as defined in the yaml
+  character(len=FMS_PATH_LEN)          :: base_name      !< The file name as defined in the yaml
                                                          !! without the wildcard definition
-  character(len=128)                   :: file_name      !< The file name as it will be written to disk
-  character(len=128)                   :: temp_name      !< Temp variable to store the file_name
+  character(len=FMS_PATH_LEN)          :: file_name      !< The file name as it will be written to disk
+  character(len=FMS_PATH_LEN)          :: temp_name      !< Temp variable to store the file_name
   character(len=128)                   :: start_date     !< The start_time as a string that will be added to
                                                          !! the begining of the filename (start_date.filename)
   character(len=128)                   :: suffix         !< The current time as a string that will be added to
@@ -1694,7 +1694,7 @@ subroutine write_field_metadata(this, diag_field, diag_axis)
   logical            :: is_regional   !< Flag indicating if the field is in a regional file
   character(len=255) :: cell_measures !< cell_measures attributes for the field
   logical            :: need_associated_files !< .True. if the 'associated_files' global attribute is needed
-  character(len=255) :: associated_files !< Associated files attribute to add
+  character(len=FMS_PATH_LEN) :: associated_files !< Associated files attribute to add
 
   is_regional = this%is_regional()
 

--- a/diag_manager/fms_diag_yaml.F90
+++ b/diag_manager/fms_diag_yaml.F90
@@ -43,7 +43,7 @@ use mpp_mod,         only: mpp_error, FATAL, NOTE, mpp_pe, mpp_root_pe, stdout
 use, intrinsic :: iso_c_binding, only : c_ptr, c_null_char
 use fms_string_utils_mod, only: fms_array_to_pointer, fms_find_my_string, fms_sort_this, fms_find_unique, string, &
                                 fms_f2c_string
-use platform_mod, only: r4_kind, i4_kind, r8_kind, i8_kind, FMS_PATH_LEN
+use platform_mod, only: r4_kind, i4_kind, r8_kind, i8_kind, FMS_FILE_LEN
 use fms_mod, only: lowercase
 
 implicit none
@@ -77,7 +77,7 @@ end type
 
 !> @brief type to hold an array of sorted diag_files
 type fileList_type
-  character(len=FMS_PATH_LEN), allocatable :: file_name(:) !< Array of diag_field
+  character(len=FMS_FILE_LEN), allocatable :: file_name(:) !< Array of diag_field
   type(c_ptr), allocatable :: file_pointer(:) !< Array of pointers
   integer, allocatable :: diag_file_indices(:)  !< Index of the file in the diag_file array
 end type
@@ -1525,7 +1525,7 @@ function get_diag_files_id(indices) &
 
   integer :: field_id !< Indices of the field in the diag_yaml field array
   integer :: i !< For do loops
-  character(len=FMS_PATH_LEN) :: filename !< Filename of the field
+  character(len=FMS_FILE_LEN) :: filename !< Filename of the field
   integer, allocatable :: file_indices(:) !< Indices of the file in the sorted variable_list
 
   allocate(file_id(size(indices)))

--- a/diag_manager/fms_diag_yaml.F90
+++ b/diag_manager/fms_diag_yaml.F90
@@ -43,7 +43,7 @@ use mpp_mod,         only: mpp_error, FATAL, NOTE, mpp_pe, mpp_root_pe, stdout
 use, intrinsic :: iso_c_binding, only : c_ptr, c_null_char
 use fms_string_utils_mod, only: fms_array_to_pointer, fms_find_my_string, fms_sort_this, fms_find_unique, string, &
                                 fms_f2c_string
-use platform_mod, only: r4_kind, i4_kind, r8_kind, i8_kind
+use platform_mod, only: r4_kind, i4_kind, r8_kind, i8_kind, FMS_PATH_LEN
 use fms_mod, only: lowercase
 
 implicit none
@@ -77,7 +77,7 @@ end type
 
 !> @brief type to hold an array of sorted diag_files
 type fileList_type
-  character(len=255), allocatable :: file_name(:) !< Array of diag_field
+  character(len=FMS_PATH_LEN), allocatable :: file_name(:) !< Array of diag_field
   type(c_ptr), allocatable :: file_pointer(:) !< Array of pointers
   integer, allocatable :: diag_file_indices(:)  !< Index of the file in the diag_file array
 end type
@@ -1525,7 +1525,7 @@ function get_diag_files_id(indices) &
 
   integer :: field_id !< Indices of the field in the diag_yaml field array
   integer :: i !< For do loops
-  character(len=120) :: filename !< Filename of the field
+  character(len=FMS_PATH_LEN) :: filename !< Filename of the field
   integer, allocatable :: file_indices(:) !< Indices of the file in the sorted variable_list
 
   allocate(file_id(size(indices)))

--- a/drifters/drifters.F90
+++ b/drifters/drifters.F90
@@ -95,6 +95,7 @@ module drifters_mod
                                drifters_comm_gather, drifters_comm_update
 
   use cloud_interpolator_mod, only: cld_ntrp_linear_cell_interp, cld_ntrp_locate_cell, cld_ntrp_get_cell_values
+  use platform_mod,       only: FMS_PATH_LEN
   implicit none
   private
 

--- a/drifters/drifters.F90
+++ b/drifters/drifters.F90
@@ -143,8 +143,8 @@ module drifters_mod
      real, allocatable :: rk4_k4(:,:) !< Runge Kutta coefficients holding
                                       !! intermediate results (positions)
      ! store filenames for convenience
-     character(len=MAX_STR_LEN) :: input_file !< store filenames for convenience
-     character(len=MAX_STR_LEN) :: output_file !< store filenames for convenience
+     character(len=FMS_PATH_LEN) :: input_file !< store filenames for convenience
+     character(len=FMS_PATH_LEN) :: output_file !< store filenames for convenience
      ! Runge Kutta stuff
      integer :: rk4_step !< Runge Kutta stuff
      logical :: rk4_completed !< Runge Kutta stuff

--- a/exchange/xgrid.F90
+++ b/exchange/xgrid.F90
@@ -129,7 +129,7 @@ use gradient_mod,        only: gradient_cubic
 use fms2_io_mod,         only: FmsNetcdfFile_t, open_file, variable_exists, close_file
 use fms2_io_mod,         only: FmsNetcdfDomainFile_t, read_data, get_dimension_size
 use fms2_io_mod,         only: get_variable_units, dimension_exists
-use platform_mod,        only: r8_kind, i8_kind, FMS_PATH_LEN
+use platform_mod,        only: r8_kind, i8_kind, FMS_FILE_LEN
 
 implicit none
 private
@@ -1530,11 +1530,12 @@ subroutine setup_xmap(xmap, grid_ids, grid_domains, grid_file, atm_grid, lnd_ug_
   real(r8_kind), dimension(:,:),   allocatable :: check_data
   real(r8_kind), dimension(:,:,:), allocatable :: check_data_3D
   real(r8_kind),                   allocatable :: tmp_2d(:,:), tmp_3d(:,:,:)
-  character(len=FMS_PATH_LEN)                  :: xgrid_file, xgrid_name
-  character(len=256)                           :: tile_file, mosaic_file, xgrid_dimname
-  character(len=256)                           :: mosaic1, mosaic2, contact
+  character(len=FMS_FILE_LEN)                  :: xgrid_file, xgrid_name
+  character(len=FMS_FILE_LEN)                  :: tile_file, mosaic_file
+  character(len=256)                           :: mosaic1, mosaic2, contact, xgrid_dimname
   character(len=256)                           :: tile1_name, tile2_name
-  character(len=256),              allocatable :: tile1_list(:), tile2_list(:), xgrid_filelist(:)
+  character(len=256),              allocatable :: tile1_list(:), tile2_list(:)
+  character(len=FMS_FILE_LEN), allocatable     :: xgrid_filelist(:)
   integer                                      :: npes, npes2
   integer,                         allocatable :: pelist(:)
   type(domain2d), save                         :: domain2

--- a/exchange/xgrid.F90
+++ b/exchange/xgrid.F90
@@ -129,7 +129,7 @@ use gradient_mod,        only: gradient_cubic
 use fms2_io_mod,         only: FmsNetcdfFile_t, open_file, variable_exists, close_file
 use fms2_io_mod,         only: FmsNetcdfDomainFile_t, read_data, get_dimension_size
 use fms2_io_mod,         only: get_variable_units, dimension_exists
-use platform_mod,        only: r8_kind, i8_kind
+use platform_mod,        only: r8_kind, i8_kind, FMS_PATH_LEN
 
 implicit none
 private
@@ -1530,8 +1530,8 @@ subroutine setup_xmap(xmap, grid_ids, grid_domains, grid_file, atm_grid, lnd_ug_
   real(r8_kind), dimension(:,:),   allocatable :: check_data
   real(r8_kind), dimension(:,:,:), allocatable :: check_data_3D
   real(r8_kind),                   allocatable :: tmp_2d(:,:), tmp_3d(:,:,:)
-  character(len=256)                           :: xgrid_file, xgrid_name, xgrid_dimname
-  character(len=256)                           :: tile_file, mosaic_file
+  character(len=FMS_PATH_LEN)                  :: xgrid_file, xgrid_name
+  character(len=256)                           :: tile_file, mosaic_file, xgrid_dimname
   character(len=256)                           :: mosaic1, mosaic2, contact
   character(len=256)                           :: tile1_name, tile2_name
   character(len=256),              allocatable :: tile1_list(:), tile2_list(:), xgrid_filelist(:)

--- a/field_manager/field_manager.F90
+++ b/field_manager/field_manager.F90
@@ -590,14 +590,14 @@ end subroutine field_manager_init
 !> @brief Routine to read and parse the field table yaml
 subroutine read_field_table_yaml(nfields, table_name)
 integer,                      intent(out), optional :: nfields    !< number of fields
-character(len=fm_string_len), intent(in),  optional :: table_name !< Name of the field table, default
+character(len=FMS_PATH_LEN),  intent(in),  optional :: table_name !< Name of the field table file, default is 'field_table.yaml'
 
-character(len=fm_string_len)    :: tbl_name !< field_table yaml file
+character(len=FMS_PATH_LEN)     :: tbl_name !< field_table yaml file
 character(len=fm_string_len)    :: method_control !< field_table yaml file
 integer                         :: h, i, j, k, l, m !< dummy integer buffer
 type (fmTable_t)                :: my_table !< the field table
 integer                         :: model !< model assocaited with the current field
-character(len=FMS_PATH_LEN) :: list_name !< field_manager list name
+character(len=FMS_PATH_LEN)     :: list_name !< field_manager list name
 character(len=fm_string_len)    :: subparamvalue !< subparam value to be used when defining new name
 character(len=fm_string_len)    :: fm_yaml_null !< useful hack when OG subparam does not contain an equals sign
 integer                         :: current_field !< field index within loop

--- a/field_manager/field_manager.F90
+++ b/field_manager/field_manager.F90
@@ -191,7 +191,7 @@ use    fms_mod, only : lowercase,   &
                        write_version_number, &
                        check_nml_error
 use fms2_io_mod, only: file_exists
-use platform_mod, only: r4_kind, r8_kind, FMS_PATH_LEN
+use platform_mod, only: r4_kind, r8_kind, FMS_PATH_LEN, FMS_FILE_LEN
 #ifdef use_yaml
 use fm_yaml_mod
 #endif
@@ -590,9 +590,9 @@ end subroutine field_manager_init
 !> @brief Routine to read and parse the field table yaml
 subroutine read_field_table_yaml(nfields, table_name)
 integer,                      intent(out), optional :: nfields    !< number of fields
-character(len=FMS_PATH_LEN),  intent(in),  optional :: table_name !< Name of the field table file, default is 'field_table.yaml'
+character(len=*),  intent(in),  optional :: table_name !< Name of the field table file, default is 'field_table.yaml'
 
-character(len=FMS_PATH_LEN)     :: tbl_name !< field_table yaml file
+character(len=FMS_FILE_LEN)     :: tbl_name !< field_table yaml file
 character(len=fm_string_len)    :: method_control !< field_table yaml file
 integer                         :: h, i, j, k, l, m !< dummy integer buffer
 type (fmTable_t)                :: my_table !< the field table

--- a/field_manager/field_manager.F90
+++ b/field_manager/field_manager.F90
@@ -191,7 +191,7 @@ use    fms_mod, only : lowercase,   &
                        write_version_number, &
                        check_nml_error
 use fms2_io_mod, only: file_exists
-use platform_mod, only: r4_kind, r8_kind
+use platform_mod, only: r4_kind, r8_kind, FMS_PATH_LEN
 #ifdef use_yaml
 use fm_yaml_mod
 #endif
@@ -258,8 +258,10 @@ private :: make_list           ! (list_p, name) return field pointer
 
 !> The length of a character string representing the field name.
 integer, parameter, public :: fm_field_name_len = 48
+!! TODO this should be removed in favor of the global FMS_PATH_LEN
+!! when possible, currently used in ocean_BGC and land_lad2
 !> The length of a character string representing the field path.
-integer, parameter, public :: fm_path_name_len  = 512
+integer, parameter, public :: fm_path_name_len  = FMS_PATH_LEN
 !> The length of a character string representing character values for the field.
 integer, parameter, public :: fm_string_len     = 1024
 !> The length of a character string representing the various types that the values of the field can take.
@@ -509,7 +511,7 @@ end type field_def
 
 type(field_mgr_type), dimension(:), allocatable, private :: fields !< fields of field_mgr_type
 
-character(len=fm_path_name_len)  :: loop_list
+character(len=FMS_PATH_LEN)  :: loop_list
 character(len=fm_type_name_len)  :: field_type_name(num_types)
 character(len=fm_field_name_len) :: save_root_name
 ! The string set is the set of characters.
@@ -595,7 +597,7 @@ character(len=fm_string_len)    :: method_control !< field_table yaml file
 integer                         :: h, i, j, k, l, m !< dummy integer buffer
 type (fmTable_t)                :: my_table !< the field table
 integer                         :: model !< model assocaited with the current field
-character(len=fm_path_name_len) :: list_name !< field_manager list name
+character(len=FMS_PATH_LEN) :: list_name !< field_manager list name
 character(len=fm_string_len)    :: subparamvalue !< subparam value to be used when defining new name
 character(len=fm_string_len)    :: fm_yaml_null !< useful hack when OG subparam does not contain an equals sign
 integer                         :: current_field !< field index within loop
@@ -857,7 +859,7 @@ character(len=fm_string_len), intent(in), optional :: table_name !< Name of the 
 
 character(len=1024)              :: record
 character(len=fm_string_len)     :: control_str
-character(len=fm_path_name_len)  :: list_name
+character(len=FMS_PATH_LEN)  :: list_name
 character(len=fm_string_len)     :: method_name
 character(len=fm_string_len)     :: name_str
 character(len=fm_string_len)     :: type_str
@@ -1905,8 +1907,8 @@ character(len=*), intent(in)     :: path !< path to the list of interest
 type (field_def), pointer        :: relative_p !< pointer to the list to which "path" is relative to
 logical,          intent(in)     :: create !< If the list does not exist, it will be created if set to true
 
-character(len=fm_path_name_len)  :: working_path
-character(len=fm_path_name_len)  :: rest
+character(len=FMS_PATH_LEN)  :: working_path
+character(len=FMS_PATH_LEN)  :: rest
 character(len=fm_field_name_len) :: this_list
 integer                          :: i, out_unit
 type (field_def), pointer, save  :: working_path_p
@@ -2172,7 +2174,7 @@ end function  fm_get_index
 !> @returns The path corresponding to the current list
 function  fm_get_current_list()                                        &
           result (path)
-character(len=fm_path_name_len) :: path
+character(len=FMS_PATH_LEN) :: path
 
 type (field_def), pointer, save :: temp_list_p
 !        Initialize the field manager if needed
@@ -2582,7 +2584,7 @@ logical,          intent(in), optional :: keep !< If present and true, make this
 
 logical                          :: create_t
 logical                          :: keep_t
-character(len=fm_path_name_len)  :: path
+character(len=FMS_PATH_LEN)  :: path
 character(len=fm_field_name_len) :: base
 type (field_def), pointer, save  :: temp_list_p
 integer                         :: out_unit
@@ -2652,7 +2654,7 @@ logical                          :: create_t
 integer                          :: i
 integer                          :: index_t
 integer, pointer, dimension(:)   :: temp_i_value
-character(len=fm_path_name_len)  :: path
+character(len=FMS_PATH_LEN)  :: path
 character(len=fm_field_name_len) :: base
 type (field_def), pointer, save  :: temp_list_p
 type (field_def), pointer, save  :: temp_field_p
@@ -2788,7 +2790,7 @@ integer,          intent(in), optional :: index !< The index to an array of valu
 logical,          intent(in), optional :: append !< If present and .true., then append the value to
       !! an array of the present values. If present and .true., then index cannot be greater than 0.
 
-character(len=fm_path_name_len)      :: path
+character(len=FMS_PATH_LEN)      :: path
 character(len=fm_field_name_len)     :: base
 integer                              :: i
 integer                              :: index_t
@@ -2922,7 +2924,7 @@ integer,          intent(in), optional :: index !< The index to an array of valu
 logical,          intent(in), optional :: append !< If present and .true., then append the value to
 
 character(len=fm_string_len), dimension(:), pointer :: temp_s_value
-character(len=fm_path_name_len)                     :: path
+character(len=FMS_PATH_LEN)                     :: path
 character(len=fm_field_name_len)                    :: base
 integer                                             :: i
 integer                                             :: index_t
@@ -3086,7 +3088,7 @@ character(len=*), intent(in)     :: name !< The name of a list that the user wis
 type (field_def), pointer        :: this_list_p !< A pointer to a list that serves as the base point
                                                 !! for searching for name
 
-character(len=fm_path_name_len)  :: path
+character(len=FMS_PATH_LEN)  :: path
 character(len=fm_field_name_len) :: base
 type (field_def), pointer, save  :: temp_p
 
@@ -3122,7 +3124,7 @@ character(len=*), intent(in)     :: oldname !< The name of a field that the user
 character(len=*), intent(in)     :: newname !< The name that the user wishes to change the name of
                                             !! the field to.
 
-character(len=fm_path_name_len)  :: path
+character(len=FMS_PATH_LEN)  :: path
 character(len=fm_field_name_len) :: base
 type (field_def), pointer, save  :: list_p
 type (field_def), pointer, save  :: temp_p
@@ -3263,9 +3265,9 @@ character(len=*), intent(in)  :: name !< name of a list that the user wishes to 
 character(len=*), intent(out) :: method_name !< name of a parameter associated with the named field
 character(len=*), intent(out) :: method_control !< value of parameters associated with the named field
 
-character(len=fm_path_name_len) :: path
-character(len=fm_path_name_len) :: base
-character(len=fm_path_name_len) :: name_loc
+character(len=FMS_PATH_LEN) :: path
+character(len=FMS_PATH_LEN) :: base
+character(len=FMS_PATH_LEN) :: name_loc
 logical                         :: recursive_t
 type (field_def), pointer, save :: temp_list_p
 type (field_def), pointer, save :: temp_value_p
@@ -3571,7 +3573,7 @@ integer,          intent(inout)             :: num_meth !< The number of methods
 character(len=*), intent(out), dimension(:) :: method !< The methods associated with the field pointed to by list_p
 character(len=*), intent(out), dimension(:) :: control !< The control parameters for the methods found
 
-character(len=fm_path_name_len) :: scratch
+character(len=FMS_PATH_LEN) :: scratch
 integer                         :: i
 integer                         :: n
 type (field_def), pointer, save :: this_field_p

--- a/field_manager/fm_util.F90
+++ b/field_manager/fm_util.F90
@@ -28,14 +28,14 @@
 !> @{
 module fm_util_mod  !{
 
-use field_manager_mod, only: fm_string_len, fm_path_name_len, fm_field_name_len, fm_type_name_len
+use field_manager_mod, only: fm_string_len, fm_field_name_len, fm_type_name_len
 use field_manager_mod, only: fm_get_type, fm_get_index, fm_get_length
 use field_manager_mod, only: fm_get_current_list, fm_new_list, fm_change_list, fm_loop_over_list
 use field_manager_mod, only: fm_new_value, fm_get_value
 use field_manager_mod, only: fm_exists, fm_dump_list
 use fms_mod,           only: FATAL, stdout
 use mpp_mod,           only: mpp_error
-use platform_mod,      only: r4_kind, r8_kind
+use platform_mod,      only: r4_kind, r8_kind, FMS_PATH_LEN
 
 implicit none
 
@@ -93,9 +93,9 @@ character(len=128)              :: default_good_name_list = ' '
 character(len=128)              :: save_default_good_name_list = ' '
 logical                         :: default_no_overwrite = .false.
 logical                         :: save_default_no_overwrite = .false.
-character(len=fm_path_name_len) :: save_current_list
-character(len=fm_path_name_len) :: save_path
-character(len=fm_path_name_len) :: save_name
+character(len=FMS_PATH_LEN)     :: save_current_list
+character(len=FMS_PATH_LEN)     :: save_path
+character(len=FMS_PATH_LEN)     :: save_name
 ! Include variable "version" to be written to log file.
 #include<file_version.h>
 
@@ -1602,7 +1602,7 @@ integer, intent(in)                                     :: length
 integer, intent(in)                                     :: ival(length)
 character(len=*), intent(in), optional                  :: caller
 logical, intent(in), optional                           :: no_overwrite
-character(len=fm_path_name_len), intent(in), optional   :: good_name_list
+character(len=FMS_PATH_LEN), intent(in), optional       :: good_name_list
 
 !
 !       Local parameters
@@ -1623,7 +1623,7 @@ integer                         :: field_index
 integer                         :: field_length
 integer                         :: n
 logical                         :: no_overwrite_use
-character(len=fm_path_name_len) :: good_name_list_use
+character(len=FMS_PATH_LEN)     :: good_name_list_use
 logical                         :: add_name
 
 !
@@ -1759,7 +1759,7 @@ integer, intent(in)                                     :: length
 logical, intent(in)                                     :: lval(length)
 character(len=*), intent(in), optional                  :: caller
 logical, intent(in), optional                           :: no_overwrite
-character(len=fm_path_name_len), intent(in), optional   :: good_name_list
+character(len=FMS_PATH_LEN), intent(in), optional       :: good_name_list
 
 !
 !       Local parameters
@@ -1780,7 +1780,7 @@ integer                         :: field_index
 integer                         :: field_length
 integer                         :: n
 logical                         :: no_overwrite_use
-character(len=fm_path_name_len) :: good_name_list_use
+character(len=FMS_PATH_LEN)     :: good_name_list_use
 logical                         :: add_name
 
 !
@@ -1916,7 +1916,7 @@ integer, intent(in)                                     :: length
 character(len=*), intent(in)                            :: sval(length)
 character(len=*), intent(in), optional                  :: caller
 logical, intent(in), optional                           :: no_overwrite
-character(len=fm_path_name_len), intent(in), optional   :: good_name_list
+character(len=FMS_PATH_LEN), intent(in), optional       :: good_name_list
 
 !
 !       Local parameters
@@ -1937,7 +1937,7 @@ integer                         :: field_index
 integer                         :: field_length
 integer                         :: n
 logical                         :: no_overwrite_use
-character(len=fm_path_name_len) :: good_name_list_use
+character(len=FMS_PATH_LEN)     :: good_name_list_use
 logical                         :: add_name
 
 !
@@ -2096,7 +2096,7 @@ character(len=32)               :: str_error
 integer                         :: field_index
 logical                         :: no_overwrite_use
 integer                         :: field_length
-character(len=fm_path_name_len) :: good_name_list_use
+character(len=FMS_PATH_LEN)     :: good_name_list_use
 logical                         :: create
 logical                         :: add_name
 
@@ -2268,7 +2268,7 @@ character(len=32)               :: str_error
 integer                         :: field_index
 logical                         :: no_overwrite_use
 integer                         :: field_length
-character(len=fm_path_name_len) :: good_name_list_use
+character(len=FMS_PATH_LEN)     :: good_name_list_use
 logical                         :: create
 logical                         :: add_name
 
@@ -2439,7 +2439,7 @@ character(len=32)               :: str_error
 integer                         :: field_index
 logical                         :: no_overwrite_use
 integer                         :: field_length
-character(len=fm_path_name_len) :: good_name_list_use
+character(len=FMS_PATH_LEN)     :: good_name_list_use
 logical                         :: create
 logical                         :: add_name
 
@@ -2600,7 +2600,7 @@ character(len=48), parameter  :: sub_name = 'fm_util_start_namelist'
 !
 
 integer                         :: namelist_index
-character(len=fm_path_name_len) :: path_name
+character(len=FMS_PATH_LEN)     :: path_name
 character(len=256)              :: error_header
 character(len=256)              :: warn_header
 character(len=256)              :: note_header
@@ -2764,7 +2764,7 @@ character(len=48), parameter  :: sub_name = 'fm_util_end_namelist'
 !
 
 character(len=fm_string_len), pointer, dimension(:)     :: good_list => NULL()
-character(len=fm_path_name_len)                         :: path_name
+character(len=FMS_PATH_LEN)                             :: path_name
 character(len=256)                                      :: error_header
 character(len=256)                                      :: warn_header
 character(len=256)                                      :: note_header

--- a/field_manager/fm_util.F90
+++ b/field_manager/fm_util.F90
@@ -1602,7 +1602,7 @@ integer, intent(in)                                     :: length
 integer, intent(in)                                     :: ival(length)
 character(len=*), intent(in), optional                  :: caller
 logical, intent(in), optional                           :: no_overwrite
-character(len=FMS_PATH_LEN), intent(in), optional       :: good_name_list
+character(len=*), intent(in), optional                  :: good_name_list
 
 !
 !       Local parameters
@@ -1759,7 +1759,7 @@ integer, intent(in)                                     :: length
 logical, intent(in)                                     :: lval(length)
 character(len=*), intent(in), optional                  :: caller
 logical, intent(in), optional                           :: no_overwrite
-character(len=FMS_PATH_LEN), intent(in), optional       :: good_name_list
+character(len=*), intent(in), optional                  :: good_name_list
 
 !
 !       Local parameters
@@ -1916,7 +1916,7 @@ integer, intent(in)                                     :: length
 character(len=*), intent(in)                            :: sval(length)
 character(len=*), intent(in), optional                  :: caller
 logical, intent(in), optional                           :: no_overwrite
-character(len=FMS_PATH_LEN), intent(in), optional       :: good_name_list
+character(len=*), intent(in), optional       :: good_name_list
 
 !
 !       Local parameters

--- a/field_manager/include/field_manager.inc
+++ b/field_manager/include/field_manager.inc
@@ -117,7 +117,7 @@ logical                          :: create_t
 integer                          :: i
 integer                          :: index_t
 real(r8_kind), allocatable, dimension(:) :: temp_r_value
-character(len=fm_path_name_len)  :: path
+character(len=FMS_PATH_LEN)      :: path
 character(len=fm_field_name_len) :: base
 type (field_def), pointer, save  :: temp_list_p
 type (field_def), pointer, save  :: temp_field_p

--- a/field_manager/include/fm_util.inc
+++ b/field_manager/include/fm_util.inc
@@ -36,7 +36,7 @@ integer, intent(in)                                     :: length
 real(FMS_FM_KIND_), intent(in)                          :: rval(length)
 character(len=*), intent(in), optional                  :: caller
 logical, intent(in), optional                           :: no_overwrite
-character(len=fm_path_name_len), intent(in), optional   :: good_name_list
+character(len=FMS_PATH_LEN), intent(in), optional       :: good_name_list
 
 !
 !       Local parameters
@@ -57,7 +57,7 @@ integer                         :: field_index
 integer                         :: field_length
 integer                         :: n
 logical                         :: no_overwrite_use
-character(len=fm_path_name_len) :: good_name_list_use
+character(len=FMS_PATH_LEN)     :: good_name_list_use
 logical                         :: add_name
 
 integer, parameter :: lkind=FMS_FM_KIND_
@@ -218,7 +218,7 @@ character(len=32)               :: str_error
 integer                         :: field_index
 logical                         :: no_overwrite_use
 integer                         :: field_length
-character(len=fm_path_name_len) :: good_name_list_use
+character(len=FMS_PATH_LEN)     :: good_name_list_use
 logical                         :: create
 logical                         :: add_name
 

--- a/fms2_io/blackboxio.F90
+++ b/fms2_io/blackboxio.F90
@@ -68,7 +68,7 @@ subroutine get_new_filename(path, new_path, directory, timestamp, new_name)
 
   character(len=FMS_PATH_LEN) :: dir
   character(len=FMS_FILE_LEN) :: tstamp
-  character(len=FMS_FILE_LEN) :: nname
+  character(len=FMS_PATH_LEN) :: nname
 
   dir = ""
   if (present(directory)) then

--- a/fms2_io/blackboxio.F90
+++ b/fms2_io/blackboxio.F90
@@ -66,9 +66,9 @@ subroutine get_new_filename(path, new_path, directory, timestamp, new_name)
   character(len=*), intent(in), optional :: timestamp !< Time.
   character(len=*), intent(in), optional :: new_name !< New file basename.
 
-  character(len=256) :: dir
-  character(len=256) :: tstamp
-  character(len=256) :: nname
+  character(len=FMS_PATH_LEN) :: dir
+  character(len=FMS_FILE_LEN) :: tstamp
+  character(len=FMS_FILE_LEN) :: nname
 
   dir = ""
   if (present(directory)) then
@@ -392,7 +392,7 @@ subroutine netcdf_save_restart_wrap2(fileobj, unlim_dim_level, directory, timest
                                                      !! or "netcdf4". Defaults to
                                                      !! "64bit".
 
-  character(len=256) :: new_name
+  character(len=FMS_PATH_LEN) :: new_name
   type(FmsNetcdfFile_t), target :: new_fileobj
   type(FmsNetcdfFile_t), pointer :: p
   logical :: close_new_file
@@ -425,7 +425,7 @@ subroutine netcdf_restore_state_wrap(fileobj, unlim_dim_level, directory, timest
   character(len=*), intent(in), optional :: timestamp !< Model time.
   character(len=*), intent(in), optional :: filename !< New name for the file.
 
-  character(len=256) :: new_name
+  character(len=FMS_PATH_LEN) :: new_name
   type(FmsNetcdfFile_t), target :: new_fileobj
   type(FmsNetcdfFile_t), pointer :: p
   logical :: close_new_file
@@ -534,7 +534,7 @@ subroutine save_domain_restart_wrap(fileobj, unlim_dim_level, directory, timesta
                                                      !! or "netcdf4". Defaults to
                                                      !! "64bit".
 
-  character(len=256) :: new_name
+  character(len=FMS_PATH_LEN) :: new_name
   type(FmsNetcdfDomainFile_t), target :: new_fileobj
   type(FmsNetcdfDomainFile_t), pointer :: p
   logical :: close_new_file
@@ -567,7 +567,7 @@ subroutine restore_domain_state_wrap(fileobj, unlim_dim_level, directory, timest
   character(len=*), intent(in), optional :: filename !< New name for the file.
   logical,          intent(in), optional :: ignore_checksum !< Checksum data integrity flag.
 
-  character(len=256) :: new_name
+  character(len=FMS_PATH_LEN) :: new_name
   type(FmsNetcdfDomainFile_t), target :: new_fileobj
   type(FmsNetcdfDomainFile_t), pointer :: p
   logical :: close_new_file

--- a/fms2_io/fms_io_utils.F90
+++ b/fms2_io/fms_io_utils.F90
@@ -678,7 +678,8 @@ subroutine get_mosaic_tile_file_sg(file_in, file_out, is_no_domain, domain, tile
   type(domain2D),   intent(in), optional, target :: domain !< domain provided
   integer,          intent(in), optional  :: tile_count !< tile count
 
-  character(len=256)                             :: basefile, tilename
+  character(len=FMS_PATH_LEN)                    :: basefile
+  character(len=6)                               :: tilename
   character(len=2)                               :: my_tile_str
   integer                                        :: lens, ntiles, ntileMe, tile, my_tile_id
   integer, dimension(:), allocatable             :: tile_id
@@ -735,7 +736,8 @@ subroutine get_mosaic_tile_file_ug(file_in, file_out, domain)
   character(len=*), intent(out)          :: file_out !< name of tile file
   type(domainUG),   intent(in), optional :: domain !< domain provided
 
-  character(len=256)                     :: basefile, tilename
+  character(len=FMS_PATH_LEN)            :: basefile
+  character(len=6)                       :: tilename
   character(len=2)                       :: my_tile_str
   integer                                :: lens, ntiles, my_tile_id
 

--- a/fms2_io/fms_io_utils.F90
+++ b/fms2_io/fms_io_utils.F90
@@ -678,7 +678,7 @@ subroutine get_mosaic_tile_file_sg(file_in, file_out, is_no_domain, domain, tile
   type(domain2D),   intent(in), optional, target :: domain !< domain provided
   integer,          intent(in), optional  :: tile_count !< tile count
 
-  character(len=FMS_PATH_LEN)                    :: basefile
+  character(len=FMS_FILE_LEN)                    :: basefile
   character(len=6)                               :: tilename
   character(len=2)                               :: my_tile_str
   integer                                        :: lens, ntiles, ntileMe, tile, my_tile_id
@@ -736,7 +736,7 @@ subroutine get_mosaic_tile_file_ug(file_in, file_out, domain)
   character(len=*), intent(out)          :: file_out !< name of tile file
   type(domainUG),   intent(in), optional :: domain !< domain provided
 
-  character(len=FMS_PATH_LEN)            :: basefile
+  character(len=FMS_FILE_LEN)            :: basefile
   character(len=6)                       :: tilename
   character(len=2)                       :: my_tile_str
   integer                                :: lens, ntiles, my_tile_id

--- a/fms2_io/fms_netcdf_domain_io.F90
+++ b/fms2_io/fms_netcdf_domain_io.F90
@@ -65,7 +65,7 @@ type, extends(FmsNetcdfFile_t), public :: FmsNetcdfDomainFile_t
                                                               !! with the "y" axis
                                                               !! of a 2d domain.
   integer :: ny !< Number of "y" dimensions.
-  character(len=256) :: non_mangled_path !< Non-domain-mangled file path.
+  character(len=FMS_PATH_LEN) :: non_mangled_path !< Non-domain-mangled file path.
   logical :: adjust_indices !< Flag telling if indices need to be adjusted
                             !! for domain-decomposed read.
 endtype FmsNetcdfDomainFile_t
@@ -346,9 +346,9 @@ function open_domain_file(fileobj, path, mode, domain, nc_format, is_restart, do
 
   integer, dimension(2) :: io_layout
   integer, dimension(1) :: tile_id
-  character(len=256) :: combined_filepath
+  character(len=FMS_PATH_LEN) :: combined_filepath
   type(domain2d), pointer :: io_domain
-  character(len=256) :: distributed_filepath
+  character(len=FMS_PATH_LEN) :: distributed_filepath
   integer :: pelist_size
   integer, dimension(:), allocatable :: pelist
   logical :: success2

--- a/fms2_io/fms_netcdf_unstructured_domain_io.F90
+++ b/fms2_io/fms_netcdf_unstructured_domain_io.F90
@@ -27,6 +27,7 @@ use netcdf
 use mpp_domains_mod
 use fms_io_utils_mod
 use netcdf_io_mod
+use platform_mod
 implicit none
 private
 
@@ -34,7 +35,7 @@ private
 !> @ingroup fms_netcdf_unstructured_domain_io_mod
 type, public, extends(FmsNetcdfFile_t) :: FmsNetcdfUnstructuredDomainFile_t
   type(domainug) :: domain !< Unstructured domain.
-  character(len=256) :: non_mangled_path !< Non-domain-mangled path.
+  character(len=FMS_PATH_LEN) :: non_mangled_path !< Non-domain-mangled path.
 endtype FmsNetcdfUnstructuredDomainFile_t
 
 !> @addtogroup fms_netcdf_unstructured_domain_io_mod
@@ -94,8 +95,8 @@ function open_unstructured_domain_file(fileobj, path, mode, domain, nc_format, &
   type(domainug), pointer :: io_domain
   integer :: pelist_size
   integer, dimension(:), allocatable :: pelist
-  character(len=256) :: buf
-  character(len=256) :: buf2
+  character(len=FMS_PATH_LEN) :: buf
+  character(len=FMS_PATH_LEN) :: buf2
   integer :: tile_id
 
   !Get the input domain's I/O domain pelist.

--- a/fms2_io/netcdf_io.F90
+++ b/fms2_io/netcdf_io.F90
@@ -126,7 +126,7 @@ endtype dimension_information
 !> @brief Netcdf file type.
 !> @ingroup netcdf_io_mod
 type, public :: FmsNetcdfFile_t
-  character(len=256) :: path !< File path.
+  character(len=FMS_PATH_LEN) :: path !< File path.
   logical :: is_readonly !< Flag telling if the file is readonly.
   integer :: ncid !< Netcdf file id.
   character(len=256) :: nc_format !< Netcdf file format.
@@ -569,8 +569,8 @@ function netcdf_file_open(fileobj, path, mode, nc_format, pelist, is_restart, do
   integer :: err
   integer :: netcdf4 !< Query the file for the _IsNetcdf4 global attribute in the event
                      !! that the open for collective reads fails
-  character(len=256) :: buf !< Filename with .res in the filename if it is a restart
-  character(len=256) :: buf2 !< Filename with the filename appendix if there is one
+  character(len=FMS_PATH_LEN) :: buf !< File path with .res in the filename if it is a restart
+  character(len=FMS_PATH_LEN) :: buf2 !< File path with the filename appendix if there is one
   logical :: is_res
   logical :: dont_add_res !< flag indicated to not add ".res" to the filename
 

--- a/include/fms_platform.h
+++ b/include/fms_platform.h
@@ -88,5 +88,12 @@ use,intrinsic :: iso_c_binding, only: c_double,c_float,c_int64_t, &
 #define QUAD_KIND DOUBLE_KIND
 #endif
 
+!Max string sizes for paths and files
+#ifndef FMS_MAX_PATH_LEN
+#define FMS_MAX_PATH_LEN 1024
+#endif
+#ifndef FMS_MAX_FILE_LEN
+#define FMS_MAX_FILE_LEN 255
+#endif
 
 #endif

--- a/interpolator/include/interpolator.inc
+++ b/interpolator/include/interpolator.inc
@@ -127,7 +127,7 @@ integer         , intent(in), optional  :: vert_interp(:)
 character(len=*), intent(out), optional :: clim_units(:)
 logical,          intent(out), optional :: single_year_file
 
-character(len=128)            :: src_file
+character(len=FMS_FILE_LEN)             :: src_file
 !++lwh
 real(FMS_INTP_KIND_)         :: dlat, dlon
 !--lwh

--- a/interpolator/interpolator.F90
+++ b/interpolator/interpolator.F90
@@ -81,7 +81,7 @@ use time_manager_mod,  only : time_type,   &
                               decrement_time
 use time_interp_mod,   only : time_interp, YEAR
 use constants_mod,     only : grav, PI, SECONDS_PER_DAY
-use platform_mod,      only : r4_kind, r8_kind, r16_kind
+use platform_mod,      only : r4_kind, r8_kind, r16_kind, FMS_PATH_LEN, FMS_FILE_LEN
 
 !--------------------------------------------------------------------
 
@@ -296,7 +296,7 @@ type(interpolate_r8_type) :: r8_type
 type(horiz_interp_type)  :: interph                         !< No description
 type(time_type), allocatable :: time_slice(:) !< An array of the times within the climatology.
 type(FmsNetcdfFile_t)    :: fileobj       ! object that stores opened file information
-character(len=64)        :: file_name     !< Climatology filename
+character(len=FMS_PATH_LEN) :: file_name     !< Climatology filename
 integer                  :: TIME_FLAG     !< Linear or seaonal interpolation?
 integer                  :: level_type    !< Pressure or Sigma level
 integer                  :: is,ie,js,je       !< No description

--- a/mosaic2/grid2.F90
+++ b/mosaic2/grid2.F90
@@ -122,7 +122,6 @@ character(len=*), parameter :: &
 
 integer, parameter :: &
      MAX_NAME = 256,  & !< max length of the variable names
-     MAX_FILE = 1024, & !< max length of the file names
      VERSION_GEOLON_T        = 0,   & !< indicates gelon_t variable is present in grid_file
      VERSION_X_T             = 1,   & !< indicates x_t variable is present in grid_file
      VERSION_OCN_MOSAIC_FILE = 2,   & !< indicates ocn_mosaic_file variable is present in grid_file
@@ -200,7 +199,7 @@ subroutine open_mosaic_file(mymosaicfileobj, component)
   type(FmsNetcdfFile_t), intent(out)  :: mymosaicfileobj !< File object returned
   character(len=3), intent(in)        :: component !< Component (atm, lnd, etc.)
 
-  character(len=MAX_FILE) :: mosaicfilename
+  character(len=FMS_PATH_LEN) :: mosaicfilename
   if (.not. grid_spec_exists) then
     call mpp_error(FATAL, 'grid2_mod(open_mosaic_file): grid_spec does not exist')
   end if
@@ -215,8 +214,8 @@ function read_file_name(thisfileobj, filevar, level)
   character(len=*), intent(in) :: filevar!< Variable containing file names
   integer, intent(in) :: level !< Level of tile file
   integer, dimension(2) :: file_list_size
-  character(len=MAX_FILE) :: read_file_name
-  character(len=MAX_FILE), dimension(:), allocatable :: file_names
+  character(len=FMS_PATH_LEN) :: read_file_name
+  character(len=FMS_PATH_LEN), dimension(:), allocatable :: file_names
 
   call get_variable_size(thisfileobj, filevar, file_list_size)
   allocate(file_names(file_list_size(2)))

--- a/mosaic2/include/grid2.inc
+++ b/mosaic2/include/grid2.inc
@@ -88,7 +88,7 @@ subroutine GET_GRID_COMP_AREA_SG_(component,tile,area,domain)
      xgrid_name, & ! name of the variable holding xgrid names
      tile_name,  & ! name of the tile
      mosaic_name ! name of the mosaic
-  character(len=MAX_FILE) :: &
+  character(len=FMS_PATH_LEN) :: &
      tilefile,   & ! name of current tile file
      xgrid_file  ! name of the current xgrid file
   character(len=4096)     :: attvalue
@@ -301,7 +301,7 @@ subroutine GET_GRID_CELL_VERTICES_1D_(component, tile, glonb, glatb)
   integer                      :: nlon, nlat
   integer                      :: start(4), nread(4)
   real(kind=FMS_MOS_KIND_), allocatable :: tmp(:,:), x_vert_t(:,:,:), y_vert_t(:,:,:)
-  character(len=MAX_FILE)      :: tilefile
+  character(len=FMS_PATH_LEN)      :: tilefile
   type(FmsNetcdfFile_t)  :: tilefileobj
 
   call get_grid_size_for_one_tile(component, tile, nlon, nlat)
@@ -392,7 +392,7 @@ subroutine GET_GRID_CELL_VERTICES_2D_(component, tile, lonb, latb, domain)
   integer :: i0,j0 ! offsets for coordinates
   integer :: isg, jsg
   integer :: start(4), nread(4)
-  character(len=MAX_FILE)      :: tilefile
+  character(len=FMS_PATH_LEN)      :: tilefile
   type(FmsNetcdfFile_t)  :: tilefileobj
 
   call get_grid_size_for_one_tile(component, tile, nlon, nlat)
@@ -581,7 +581,7 @@ subroutine GET_GRID_CELL_CENTERS_1D_(component, tile, glon, glat)
   integer                      :: nlon, nlat
   integer                      :: start(4), nread(4)
   real(kind=FMS_MOS_KIND_), allocatable :: tmp(:,:)
-  character(len=MAX_FILE)      :: tilefile
+  character(len=FMS_PATH_LEN)      :: tilefile
   type(FmsNetcdfFile_t)  :: tilefileobj
 
   call get_grid_size_for_one_tile(component, tile, nlon, nlat)
@@ -657,7 +657,7 @@ subroutine GET_GRID_CELL_CENTERS_2D_(component, tile, lon, lat, domain)
   integer :: i0,j0 ! offsets for coordinates
   integer :: isg, jsg
   integer :: start(4), nread(4)
-  character(len=MAX_FILE)      :: tilefile
+  character(len=FMS_PATH_LEN)      :: tilefile
   type(FmsNetcdfFile_t)  :: tilefileobj
 
   call get_grid_size_for_one_tile(component, tile, nlon, nlat)

--- a/mosaic2/mosaic2.F90
+++ b/mosaic2/mosaic2.F90
@@ -38,7 +38,7 @@ use mpp_domains_mod, only : domain2D, mpp_get_current_ntile, mpp_get_tile_id
 use constants_mod, only : PI, RADIUS
 use fms2_io_mod,   only : FmsNetcdfFile_t, open_file, close_file, get_dimension_size
 use fms2_io_mod,   only : read_data, variable_exists
-use platform_mod,  only : r4_kind, r8_kind
+use platform_mod,  only : r4_kind, r8_kind, FMS_PATH_LEN
 
 implicit none
 private
@@ -48,7 +48,7 @@ character(len=*), parameter :: &
 
 integer, parameter :: &
      MAX_NAME = 256,  & !> max length of the variable names
-     MAX_FILE = 1024, & !> max length of the file names
+     FMS_PATH_LEN = 1024, & !> max length of the file names
      X_REFINE = 2,    & !> supergrid size/model grid size in x-direction
      Y_REFINE = 2       !> supergrid size/model grid size in y-direction
 
@@ -174,7 +174,7 @@ end subroutine mosaic_init
     type(FmsNetcdfFile_t), intent(in)    :: fileobj
     integer, dimension(:), intent(inout) :: nx, ny
 
-    character(len=MAX_FILE) :: gridfile
+    character(len=FMS_PATH_LEN) :: gridfile
     integer                 :: ntiles, n
     type(FmsNetcdfFile_t)   :: gridobj
 

--- a/mosaic2/mosaic2.F90
+++ b/mosaic2/mosaic2.F90
@@ -48,7 +48,6 @@ character(len=*), parameter :: &
 
 integer, parameter :: &
      MAX_NAME = 256,  & !> max length of the variable names
-     FMS_PATH_LEN = 1024, & !> max length of the file names
      X_REFINE = 2,    & !> supergrid size/model grid size in x-direction
      Y_REFINE = 2       !> supergrid size/model grid size in y-direction
 

--- a/mpp/include/mpp_util.inc
+++ b/mpp/include/mpp_util.inc
@@ -1348,7 +1348,8 @@ end function rarray_to_char
     integer, dimension(2) :: get_ascii_file_num_lines_and_length !< number of lines (1) and
                                                                  !! max line length (2)
     integer :: num_lines, max_length
-    character(len=FMS_FILE_LEN) :: str_tmp
+    integer, parameter :: LENGTH=1024
+    character(len=LENGTH) :: str_tmp
     character(len=5) :: text
     integer :: status, f_unit, from_pe
     logical :: file_exist
@@ -1388,10 +1389,10 @@ end function rarray_to_char
                    call mpp_error(FATAL, 'get_ascii_file_num_lines: Error reading line '//trim(text)// &
                         ' in file '//trim(FILENAME)//'.')
                 end if
-                if ( len_trim(str_tmp) == FMS_FILE_LEN ) then
-                   write(UNIT=text, FMT='(I5)') FMS_FILE_LEN
+                if ( len_trim(str_tmp) == LENGTH) then
+                   write(UNIT=text, FMT='(I5)') LENGTH 
                    call mpp_error(FATAL, 'get_ascii_file_num_lines: Length of output string ('//trim(text)//&
-                                       & ' is too small. Increase the FMS_MAX_FILE_LEN cpp value.')
+                                       & ' is too small. Increase the LENGTH value.')
                 end if
                 if (len_trim(str_tmp) > max_length) max_length = len_trim(str_tmp)
                 num_lines = num_lines + 1

--- a/mpp/include/mpp_util.inc
+++ b/mpp/include/mpp_util.inc
@@ -1390,7 +1390,7 @@ end function rarray_to_char
                         ' in file '//trim(FILENAME)//'.')
                 end if
                 if ( len_trim(str_tmp) == LENGTH) then
-                   write(UNIT=text, FMT='(I5)') LENGTH 
+                   write(UNIT=text, FMT='(I5)') LENGTH
                    call mpp_error(FATAL, 'get_ascii_file_num_lines: Length of output string ('//trim(text)//&
                                        & ' is too small. Increase the LENGTH value.')
                 end if

--- a/mpp/include/mpp_util.inc
+++ b/mpp/include/mpp_util.inc
@@ -1348,7 +1348,6 @@ end function rarray_to_char
     integer, dimension(2) :: get_ascii_file_num_lines_and_length !< number of lines (1) and
                                                                  !! max line length (2)
     integer :: num_lines, max_length
-    integer, parameter :: LENGTH=FMS_FILE_LEN
     character(len=FMS_FILE_LEN) :: str_tmp
     character(len=5) :: text
     integer :: status, f_unit, from_pe
@@ -1390,7 +1389,7 @@ end function rarray_to_char
                         ' in file '//trim(FILENAME)//'.')
                 end if
                 if ( len_trim(str_tmp) == FMS_FILE_LEN ) then
-                   write(UNIT=text, FMT='(I5)') length
+                   write(UNIT=text, FMT='(I5)') FMS_FILE_LEN
                    call mpp_error(FATAL, 'get_ascii_file_num_lines: Length of output string ('//trim(text)//&
                                        & ' is too small. Increase the FMS_MAX_FILE_LEN cpp value.')
                 end if

--- a/mpp/include/mpp_util.inc
+++ b/mpp/include/mpp_util.inc
@@ -1228,7 +1228,7 @@ end function rarray_to_char
     integer, dimension(2) :: lines_and_length
     logical :: file_exist
     character(len=len(peset(current_peset_num)%name)) :: pelist_name
-    character(len=128) :: filename
+    character(len=FMS_PATH_LEN) :: filename
 
 ! check the status of input_nml_file
     if ( allocated(input_nml_file) ) then

--- a/mpp/include/mpp_util.inc
+++ b/mpp/include/mpp_util.inc
@@ -870,7 +870,7 @@ end function rarray_to_char
     integer           :: SD_UNIT, total_calls
     integer           :: j,k,ct, msg_cnt
     character(len=2)  :: u
-    character(len=20) :: filename
+    character(len=FMS_FILE_LEN) :: filename
     character(len=20),dimension(MAX_BINS),save :: bin
 
     data bin( 1)  /'  0   -    8    B:  '/
@@ -1348,8 +1348,8 @@ end function rarray_to_char
     integer, dimension(2) :: get_ascii_file_num_lines_and_length !< number of lines (1) and
                                                                  !! max line length (2)
     integer :: num_lines, max_length
-    integer, parameter :: LENGTH=1024
-    character(len=LENGTH) :: str_tmp
+    integer, parameter :: LENGTH=FMS_FILE_LEN
+    character(len=FMS_FILE_LEN) :: str_tmp
     character(len=5) :: text
     integer :: status, f_unit, from_pe
     logical :: file_exist
@@ -1389,10 +1389,10 @@ end function rarray_to_char
                    call mpp_error(FATAL, 'get_ascii_file_num_lines: Error reading line '//trim(text)// &
                         ' in file '//trim(FILENAME)//'.')
                 end if
-                if ( len_trim(str_tmp) == LENGTH ) then
+                if ( len_trim(str_tmp) == FMS_FILE_LEN ) then
                    write(UNIT=text, FMT='(I5)') length
                    call mpp_error(FATAL, 'get_ascii_file_num_lines: Length of output string ('//trim(text)//&
-                                       & ' is too small. Increase the LENGTH value.')
+                                       & ' is too small. Increase the FMS_MAX_FILE_LEN cpp value.')
                 end if
                 if (len_trim(str_tmp) > max_length) max_length = len_trim(str_tmp)
                 num_lines = num_lines + 1

--- a/platform/platform.F90
+++ b/platform/platform.F90
@@ -32,6 +32,8 @@ module platform_mod
                         l8_kind=LONG_KIND, l4_kind=INT_KIND, &
                         i8_kind=LONG_KIND, i4_kind=INT_KIND, i2_kind=SHORT_KIND, &
                         ptr_kind=POINTER_KIND
+  integer, parameter :: FMS_PATH_LEN = FMS_MAX_PATH_LEN
+  integer, parameter :: FMS_FILE_LEN = FMS_MAX_FILE_LEN
 !could additionally define things like OS, compiler...: useful?
 end module platform_mod
 !> @}

--- a/time_interp/include/time_interp_external2.inc
+++ b/time_interp/include/time_interp_external2.inc
@@ -69,7 +69,8 @@
         integer :: nx, ny, nz, interp_method, t1, t2
         integer :: i1, i2, isc, iec, jsc, jec, mod_time
         integer :: yy, mm, dd, hh, min, ss
-        character(len=256) :: err_msg, filename
+        character(len=256) :: err_msg
+        character(len=FMS_PATH_LEN) :: filename
 
         integer :: isw, iew, jsw, jew, nxw, nyw
             ! these are boundaries of the updated portion of the "data" argument
@@ -236,7 +237,8 @@
       integer :: t1, t2
       integer :: i1, i2, mod_time
       integer :: yy, mm, dd, hh, min, ss
-      character(len=256) :: err_msg, filename
+      character(len=256) :: err_msg
+      character(len=FMS_PATH_LEN) :: filename
 
       real(FMS_TI_KIND_) :: w1,w2
       logical :: verb

--- a/time_interp/time_interp_external2.F90
+++ b/time_interp/time_interp_external2.F90
@@ -55,7 +55,7 @@ module time_interp_external2_mod
   use time_interp_mod, only : time_interp, time_interp_init
   use axis_utils2_mod, only : get_axis_cart, get_axis_modulo, get_axis_modulo_times
   use fms_mod, only : lowercase, check_nml_error
-  use platform_mod, only: r8_kind
+  use platform_mod, only: r8_kind, FMS_PATH_LEN
   use horiz_interp_mod, only : horiz_interp, horiz_interp_type
   use fms2_io_mod,      only : Valid_t, FmsNetcdfDomainFile_t, open_file, get_unlimited_dimension_name, &
                                variable_att_exists, FmsNetcdfFile_t, &
@@ -126,7 +126,7 @@ module time_interp_external2_mod
     !> Holds filename and file object
     !> @ingroup time_interp_external2_mod
     type, private :: filetype
-        character(len=128) :: filename = ''
+        character(len=FMS_PATH_LEN) :: filename = ''
         type(FmsNetcdfFile_t), pointer :: fileobj => NULL()
     end type filetype
 

--- a/time_interp/time_interp_external2.F90
+++ b/time_interp/time_interp_external2.F90
@@ -55,7 +55,7 @@ module time_interp_external2_mod
   use time_interp_mod, only : time_interp, time_interp_init
   use axis_utils2_mod, only : get_axis_cart, get_axis_modulo, get_axis_modulo_times
   use fms_mod, only : lowercase, check_nml_error
-  use platform_mod, only: r8_kind, FMS_PATH_LEN
+  use platform_mod, only: r8_kind, FMS_FILE_LEN
   use horiz_interp_mod, only : horiz_interp, horiz_interp_type
   use fms2_io_mod,      only : Valid_t, FmsNetcdfDomainFile_t, open_file, get_unlimited_dimension_name, &
                                variable_att_exists, FmsNetcdfFile_t, &
@@ -126,7 +126,7 @@ module time_interp_external2_mod
     !> Holds filename and file object
     !> @ingroup time_interp_external2_mod
     type, private :: filetype
-        character(len=FMS_PATH_LEN) :: filename = ''
+        character(len=FMS_FILE_LEN) :: filename = ''
         type(FmsNetcdfFile_t), pointer :: fileobj => NULL()
     end type filetype
 

--- a/time_interp/time_interp_external2.F90
+++ b/time_interp/time_interp_external2.F90
@@ -55,7 +55,7 @@ module time_interp_external2_mod
   use time_interp_mod, only : time_interp, time_interp_init
   use axis_utils2_mod, only : get_axis_cart, get_axis_modulo, get_axis_modulo_times
   use fms_mod, only : lowercase, check_nml_error
-  use platform_mod, only: r8_kind, FMS_FILE_LEN
+  use platform_mod, only: r8_kind, FMS_PATH_LEN, FMS_FILE_LEN
   use horiz_interp_mod, only : horiz_interp, horiz_interp_type
   use fms2_io_mod,      only : Valid_t, FmsNetcdfDomainFile_t, open_file, get_unlimited_dimension_name, &
                                variable_att_exists, FmsNetcdfFile_t, &

--- a/topography/topography.F90
+++ b/topography/topography.F90
@@ -51,7 +51,7 @@ use        fms2_io_mod, only: read_data, FmsNetcdfFile_t, file_exists, open_file
 
 use      constants_mod, only: PI
 use            mpp_mod, only: input_nml_file
-use platform_mod,       only: r4_kind, r8_kind
+use platform_mod,       only: r4_kind, r8_kind, FMS_PATH_LEN
 
 implicit none
 private
@@ -217,8 +217,8 @@ end interface determine_ocean_points
 !> @addtogroup topography_mod
 !> @{
 
-character(len=128) :: topog_file = 'DATA/navy_topography.data', &
-                      water_file = 'DATA/navy_pctwater.data'
+character(len=FMS_PATH_LEN) :: topog_file = 'DATA/navy_topography.data', &
+                               water_file = 'DATA/navy_pctwater.data'
 namelist /topography_nml/ topog_file, water_file
 
 integer, parameter    :: TOPOG_INDEX = 1


### PR DESCRIPTION
**Description**
- Adds two parameter values to platform_mod, `FMS_PATH_LEN` and `FMS_FILE_LEN` that are set by the `FMS_MAX_PATH_LEN` and `FMS_MAX_FILE_LEN` cpp macros in the fms_platform.h file and default to 1024 and 255 respectively.
- Replaces/removes any lengths for file/path names with the exception of `fm_path_name_len`. Since it is used externally, I removed internal usage and set the value to FMS_PATH_LEN so we can remove it later along with updating the components, see issue #1564.
- Uses `len=*` instead of a set length for any filename related character arguments

It can be somewhat ambiguous what is intended as a filename vs a full path name, so let me know if you think a length should be one instead of the other or if anything was missed.

Fixes #1518 

**How Has This Been Tested?**
gnu 13 + mpich on the amd box

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

