### PR TITLE
Add --enable-portable-kinds option to configure 

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -112,6 +112,13 @@ AS_IF([test ${enable_r8_default:-yes} = yes],
   [enable_r8_default=yes],
   [enable_r8_default=no])
 
+AC_ARG_ENABLE([portable-kinds],
+  [AS_HELP_STRING([--enable-portable-kinds],
+    [Enables compilation with -DPORTABLE_KINDS with iso_c_binding KIND type parameters])])
+AS_IF([test ${enable_portable_kinds:-no} = yes],
+  [enable_portable_kinds=yes],
+  [enable_portable_kinds=no])
+
 # user enabled testing with input files
 AC_MSG_CHECKING([whether to enable tests with input files])
 AC_ARG_ENABLE([test-input],
@@ -340,6 +347,11 @@ if test $enable_setting_flags = yes; then
   fi
   if test $enable_8byte_int = yes; then
     AC_DEFINE([no_8byte_integers], [1], [Set to disable 8 byte integer Fortran routines])
+  fi
+
+  # Builds with C data types
+  if test $enable_portable_kinds = yes; then
+    AC_DEFINE([PORTABLE_KINDS], [1], [Set to define KIND parameters to iso_c_binding KIND parameters])
   fi
 
   # Add Cray Pointer support flag


### PR DESCRIPTION
**Description**
In this PR,

`configure.ac` file has been modified to accept `--enable-portable-kinds` argument during configuration.
This option will define `-DPORTABLE_KINDS=1` for compilation and FMS variables will be compiled with `iso_c_binding` kind parameters.

Fixes #1571 

**How Has This Been Tested?**
FMS compiles with -DPORTABLE_KINDS=1 when `./configure --enable-portable-kinds` with gcc on the amdbox.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

