### PR TITLE
fix array indices for horiz_interp_type assignment test

### DIFF
--- a/test_fms/horiz_interp/test_horiz_interp.F90
+++ b/test_fms/horiz_interp/test_horiz_interp.F90
@@ -983,6 +983,7 @@ implicit none
         real(HI_TEST_KIND_) :: R2D = 180._lkind/real(PI,HI_TEST_KIND_) !< degrees per radian
         real(HI_TEST_KIND_), allocatable :: lon_src_1d(:), lat_src_1d(:) !< src data used for bicubic test
         real(HI_TEST_KIND_), allocatable :: lon_dst_1d(:), lat_dst_1d(:) !< destination data used for bicubic test
+        integer :: icount !< index for setting the output array when taking midpoints for bilinear
 
 
         ! set up longitude and latitude of source/destination grid.
@@ -1100,21 +1101,25 @@ implicit none
         call horiz_interp_del(Interp_cp)
         ! test deletion after direct calls
         ! this set up is usually done within horiz_interp_new
-        nlon_in  = size(lon_in_1d(:))-1;  nlat_in  = size(lat_in_1d(:))-1
-        nlon_out = size(lon_out_1d(:))-1; nlat_out = size(lat_out_1d(:))-1
+        nlon_in  = size(lon_in_1d(:));  nlat_in  = size(lat_in_1d(:))
+        nlon_out = size(lon_out_1d(:)); nlat_out = size(lat_out_1d(:))
         allocate(lon_src_1d(nlon_in), lat_src_1d(nlat_in))
         allocate(lon_dst_1d(nlon_out), lat_dst_1d(nlat_out))
-        do i = 1, nlon_in
+        do i = 1, nlon_in-1
           lon_src_1d(i) = (lon_in_1d(i) + lon_in_1d(i+1)) * 0.5_lkind
         enddo
-        do j = 1, nlat_in
+        do j = 1, nlat_in-1
           lat_src_1d(j) = (lat_in_1d(j) + lat_in_1d(j+1)) * 0.5_lkind
         enddo
-        do i = 1, nlon_out
-          lon_dst_1d(i) = (lon_out_1d(i) + lon_out_1d(i+1)) * 0.5_lkind
+        icount = 1
+        do i = isc, iec
+          lon_dst_1d(icount) = (lon_out_1d(i) + lon_out_1d(i+1)) * 0.5_lkind
+          icount = icount + 1
         enddo
-        do j = 1, nlat_out
-          lat_dst_1d(j) = (lat_out_1d(j) + lat_out_1d(j+1)) * 0.5_lkind
+        icount = 1
+        do j = jsc, jec
+          lat_dst_1d(icount) = (lat_out_1d(j) + lat_out_1d(j+1)) * 0.5_lkind
+          icount = icount + 1
         enddo
         call horiz_interp_bicubic_new(Interp_new1, lon_src_1d, lat_src_1d, lon_out_2d, lat_out_2d)
         call horiz_interp_del(Interp_new1)

--- a/test_fms/horiz_interp/test_horiz_interp.F90
+++ b/test_fms/horiz_interp/test_horiz_interp.F90
@@ -1101,8 +1101,8 @@ implicit none
         call horiz_interp_del(Interp_cp)
         ! test deletion after direct calls
         ! this set up is usually done within horiz_interp_new
-        nlon_in  = size(lon_in_1d(:));  nlat_in  = size(lat_in_1d(:))
-        nlon_out = size(lon_out_1d(:)); nlat_out = size(lat_out_1d(:))
+        nlon_in  = size(lon_in_1d(:))-1;  nlat_in  = size(lat_in_1d(:))-1
+        nlon_out = size(lon_out_1d(:))-1; nlat_out = size(lat_out_1d(:))-1
         allocate(lon_src_1d(nlon_in), lat_src_1d(nlat_in))
         allocate(lon_dst_1d(nlon_out), lat_dst_1d(nlat_out))
         do i = 1, nlon_in-1


### PR DESCRIPTION
**Description**
Fixes an invalid assignment in the assignment test where it was iterating from 1 to the length of the array when it should have been iterating over the compute domain bounds when taking midpoints. This fixes gcc errors with bounds checking turned on.

**How Has This Been Tested?**
gcc 13 on amd box with `-fcheck=all`

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

