### PR TITLE
update yaml parser to read in arrays and output them

### DIFF
--- a/diag_manager/diag_yaml_format.md
+++ b/diag_manager/diag_yaml_format.md
@@ -43,14 +43,14 @@ diag_files:
 ### 2.1 Global Section
 The diag_yaml requires “title” and the “baseDate”.
 - The **title** is a string that labels the diag yaml.  The equivalent in the legacy diag_table would be the experiment.  It is recommended that each diag_yaml have a separate title label that is descriptive of the experiment that is using it.
-- The **basedate** is an array of 6 integers indicating the base_date in the format [year month day hour minute second].
+- The **basedate** is an array of 6 integers indicating the base_date in the format [year, month, day, hour, minute, second].
 
 **Example:**
 
 In the YAML format:
 ```yaml
 title: ESM4_piControl
-base_date: 2022 5 26 12 3 1
+base_date: [2022, 5, 26, 12, 3, 1]
 ```
 
 In the legacy ascii format:
@@ -281,7 +281,7 @@ The sub region can be listed under the sub_region section as a dashed array. The
 Bellow is a complete example of diag_table.yaml:
 ```yaml
 title: test_diag_manager
-base_date: 2 1 1 0 0 0
+base_date: [2, 1, 1, 0, 0, 0]
 diag_files:
 - file_name: wild_card_name%4yr%2mo%2dy%2hr
   freq: 6 hours

--- a/diag_manager/diag_yaml_format.md
+++ b/diag_manager/diag_yaml_format.md
@@ -43,7 +43,7 @@ diag_files:
 ### 2.1 Global Section
 The diag_yaml requires “title” and the “baseDate”.
 - The **title** is a string that labels the diag yaml.  The equivalent in the legacy diag_table would be the experiment.  It is recommended that each diag_yaml have a separate title label that is descriptive of the experiment that is using it.
-- The **basedate** is an array of 6 integers indicating the base_date in the format [year, month, day, hour, minute, second].
+- The **base_date** is a comma-separated array of 6 integers indicating the base_date in the format [year, month, day, hour, minute, second]. Spacing is not significant.
 
 **Example:**
 

--- a/diag_manager/fms_diag_yaml.F90
+++ b/diag_manager/fms_diag_yaml.F90
@@ -1667,13 +1667,14 @@ subroutine fms_diag_yaml_out()
   call fms_f2c_string( keys(1)%key2, 'base_date')
   basedate_loc = diag_yaml%get_basedate()
   tmpstr1 = ''; tmpstr2 = ''
-  tmpstr1 = string(basedate_loc(1))
+  tmpstr1 = '[ '//string(basedate_loc(1))
   tmpstr2 = trim(tmpstr1)
   do i=2, basedate_size
     tmpstr1 = string(basedate_loc(i))
-    tmpstr2 = trim(tmpstr2) // ' ' // trim(tmpstr1)
+    tmpstr2 = trim(tmpstr2) // ', ' // trim(tmpstr1)
   enddo
-  call fms_f2c_string(vals(1)%val2, trim(tmpstr2))
+  tmpstr1 = trim(tmpstr2) // ']'
+  call fms_f2c_string(vals(1)%val2, trim(tmpstr1))
   call yaml_out_add_level2key('diag_files', keys(1))
   key3_i = 0
   !! tier 2 - diag files

--- a/parser/yaml_output_functions.c
+++ b/parser/yaml_output_functions.c
@@ -91,7 +91,7 @@ void keyerror(yaml_event_t * event, yaml_emitter_t * emitter){
 }
 /* \brief Writes the key/value pairs of the fmsyamloutkeys and fmsyamloutvalues structs
  * \note If any values start with '[' it will be assumed the value is a yaml array
- * There may be slight differences in spacing for array outputs 
+ * There may be slight differences in spacing for array outputs
  * \param emitter The libyaml emitter for this file
  * \param event The libyaml eent pointer
  * \param aindex The index of keys and vals that are being written currently

--- a/parser/yaml_output_functions.c
+++ b/parser/yaml_output_functions.c
@@ -90,8 +90,8 @@ void keyerror(yaml_event_t * event, yaml_emitter_t * emitter){
   fprintf(stdout, "WARNING: YAML_OUTPUT: Failed to emit event %d: %s\n", event->type, emitter->problem);
 }
 /* \brief Writes the key/value pairs of the fmsyamloutkeys and fmsyamloutvalues structs
- * \note If any values start with '[' it will be assumed the value is a yaml array
- * There may be slight differences in spacing for array outputs
+ * \note If second value (val2) in struct starts with '[' it will be assumed the value is a yaml array
+ * There may be slight differences in spacing for array outputs vs what is read in.
  * \param emitter The libyaml emitter for this file
  * \param event The libyaml eent pointer
  * \param aindex The index of keys and vals that are being written currently

--- a/parser/yaml_parser.F90
+++ b/parser/yaml_parser.F90
@@ -70,6 +70,8 @@ integer, parameter :: SUCCESSFUL = 1          !< "Error" code if the parsing was
 interface
 
 !> @brief Private c function that opens and parses a yaml file (see yaml_parser_binding.c)
+!! Any arrays (formatted as [a, b, c] or a multiline '-' tabbed list) will be
+!! read in as a space-separated list of characters
 !! @return Flag indicating if the read was successful
 function open_and_parse_file_wrap(filename, file_id) bind(c) &
    result(error_code)

--- a/test_fms/diag_manager/test_cell_measures.sh
+++ b/test_fms/diag_manager/test_cell_measures.sh
@@ -28,7 +28,7 @@ output_dir
 
 cat <<_EOF > diag_table.yaml
 title: test_diag_manager
-base_date: 2 1 1 0 0 0
+base_date: [2, 1, 1, 0, 0, 0]
 
 diag_files:
 - file_name: static_file

--- a/test_fms/diag_manager/test_diag_manager2.sh
+++ b/test_fms/diag_manager/test_diag_manager2.sh
@@ -514,7 +514,7 @@ if [ -z "${skipflag}" ]; then
 
   cat <<_EOF > diag_table.yaml
 title: test_diag_manager
-base_date: 2 1 1 0 0 0
+base_date: [ 2, 1, 1, 0, 0, 0 ]
 diag_files:
 - file_name: wild_card_name%4yr%2mo%2dy%2hr
   filename_time: end
@@ -592,7 +592,7 @@ my_test_count=`expr $my_test_count + 1`
 
   cat <<_EOF > diag_table.yaml
 title: test_diag_manager
-base_date: 2 1 1 0 0 0
+base_date: [2, 1, 1, 0, 0, 0 ]
 diag_files:
 - file_name: wild_card_name%4yr%2mo%2dy%2hr
   filename_time: end
@@ -673,7 +673,7 @@ _EOF
   printf "&diag_manager_nml \n use_modern_diag = .true. \n/" | cat > input.nml
   cat <<_EOF > diag_table.yaml
 title: test_diag_manager
-base_date: 2 1 1 0 0 0
+base_date: [2, 1, 1, 0, 0, 0 ]
 diag_files:
 - file_name: file1
   freq: 6 hours
@@ -722,7 +722,7 @@ _EOF
   printf "&diag_manager_nml \n use_modern_diag = .true. \n do_diag_field_log = .true. \n/" | cat > input.nml
   cat <<_EOF > diag_table.yaml
 title: test_diag_manager
-base_date: 2 1 1 0 0 0
+base_date: [2, 1, 1, 0, 0, 0 ]
 
 diag_files:
 - file_name: static_file
@@ -886,7 +886,7 @@ _EOF
   cat <<_EOF > diag_out_ref.yaml
 ---
 title: test_diag_manager
-base_date: 2 1 1 0 0 0
+base_date: [2, 1, 1, 0, 0, 0]
 diag_files:
 - file_name: static_file
   freq: -1
@@ -1296,7 +1296,7 @@ test_expect_success "check modern diag manager yaml output (test $my_test_count)
 printf "&diag_manager_nml \n use_modern_diag = .true. \n use_clock_average = .true. \n /" | cat > input.nml
 cat <<_EOF > diag_table.yaml
 title: test_diag_manager
-base_date: 2 1 1 0 0 0
+base_date: [2, 1, 1, 0, 0, 0 ]
 
 diag_files:
 - file_name: file1_clock
@@ -1318,7 +1318,7 @@ my_test_count=`expr $my_test_count + 1`
 printf "&diag_manager_nml \n use_modern_diag = .true. \n use_clock_average = .false. \n /" | cat > input.nml
 cat <<_EOF > diag_table.yaml
 title: test_diag_manager
-base_date: 2 1 1 0 0 0
+base_date: [2, 1, 1, 0, 0, 0 ]
 
 diag_files:
 - file_name: file1_forecast

--- a/test_fms/diag_manager/test_dm_weights.sh
+++ b/test_fms/diag_manager/test_dm_weights.sh
@@ -28,7 +28,7 @@ output_dir
 
 cat <<_EOF > diag_table.yaml
 title: test_weights
-base_date: 2 1 1 0 0 0
+base_date: [2, 1, 1, 0, 0, 0]
 diag_files:
 - file_name: test_weights
   time_units: hours

--- a/test_fms/diag_manager/test_flush_nc_file.sh
+++ b/test_fms/diag_manager/test_flush_nc_file.sh
@@ -28,7 +28,7 @@ output_dir
 
 cat <<_EOF > diag_table.yaml
 title: test_nc_flush
-base_date: 2 1 1 0 0 0
+base_date: [2, 1, 1, 0, 0, 0]
 diag_files:
 - file_name: test_flush
   time_units: hours

--- a/test_fms/diag_manager/test_multiple_send_data.sh
+++ b/test_fms/diag_manager/test_multiple_send_data.sh
@@ -28,7 +28,7 @@ output_dir
 
 cat <<_EOF > diag_table.yaml
 title: test_multiple_sends
-base_date: 2 1 1 0 0 0
+base_date: [2, 1, 1, 0, 0, 0]
 diag_files:
 - file_name: test_multiple_sends
   time_units: hours

--- a/test_fms/diag_manager/test_output_every_freq.sh
+++ b/test_fms/diag_manager/test_output_every_freq.sh
@@ -30,7 +30,7 @@ output_dir
 
 cat <<_EOF > diag_table.yaml
 title: test_diag_manager_01
-base_date: 2 1 1 0 0 0
+base_date: [2, 1, 1, 0, 0, 0]
 diag_files:
 - file_name: test_0days
   time_units: days

--- a/test_fms/diag_manager/test_prepend_date.sh
+++ b/test_fms/diag_manager/test_prepend_date.sh
@@ -28,7 +28,7 @@ output_dir
 
 cat <<_EOF > diag_table.yaml
 title: test_prepend_date
-base_date: 1 1 1 0 0 0
+base_date: [1, 1, 1, 0, 0, 0]
 diag_files:
 - file_name: test_non_static
   time_units: hours

--- a/test_fms/diag_manager/test_subregional.sh
+++ b/test_fms/diag_manager/test_subregional.sh
@@ -28,7 +28,7 @@ output_dir
 
 cat <<_EOF > diag_table.yaml
 title: test_subregional
-base_date: 2 1 1 0 0 0
+base_date: [2, 1, 1, 0, 0, 0]
 
 diag_files:
 # This is to test a file with multiple z axis

--- a/test_fms/diag_manager/test_time_avg.sh
+++ b/test_fms/diag_manager/test_time_avg.sh
@@ -28,7 +28,7 @@ output_dir
 
 cat <<_EOF > diag_table.yaml
 title: test_avg
-base_date: 2 1 1 0 0 0
+base_date: [2, 1, 1, 0, 0, 0]
 diag_files:
 - file_name: test_avg
   time_units: hours

--- a/test_fms/diag_manager/test_time_diurnal.sh
+++ b/test_fms/diag_manager/test_time_diurnal.sh
@@ -28,7 +28,7 @@ output_dir
 
 cat <<_EOF > diag_table.yaml
 title: test_diurnal
-base_date: 2 1 1 0 0 0
+base_date: [2, 1, 1, 0, 0, 0]
 diag_files:
 - file_name: test_diurnal
   time_units: hours

--- a/test_fms/diag_manager/test_time_max.sh
+++ b/test_fms/diag_manager/test_time_max.sh
@@ -31,7 +31,7 @@ output_dir
 #TODO replace with yaml diag_table and set diag_manager_nml::use_modern_diag=.true.
 cat <<_EOF > diag_table.yaml
 title: test_max
-base_date: 2 1 1 0 0 0
+base_date: [2, 1, 1, 0, 0, 0]
 diag_files:
 - file_name: test_max
   time_units: hours

--- a/test_fms/diag_manager/test_time_min.sh
+++ b/test_fms/diag_manager/test_time_min.sh
@@ -31,7 +31,7 @@ output_dir
 #TODO replace with yaml diag_table and set diag_manager_nml::use_modern_diag=.true.
 cat <<_EOF > diag_table.yaml
 title: test_min
-base_date: 2 1 1 0 0 0
+base_date: [2, 1, 1, 0, 0, 0]
 diag_files:
 - file_name: test_min
   time_units: hours

--- a/test_fms/diag_manager/test_time_none.sh
+++ b/test_fms/diag_manager/test_time_none.sh
@@ -30,7 +30,7 @@ output_dir
 
 cat <<_EOF > diag_table.yaml
 title: test_none
-base_date: 2 1 1 0 0 0
+base_date: [2, 1, 1, 0, 0, 0]
 diag_files:
 - file_name: test_none
   freq: 6 hours

--- a/test_fms/diag_manager/test_time_pow.sh
+++ b/test_fms/diag_manager/test_time_pow.sh
@@ -28,7 +28,7 @@ output_dir
 
 cat <<_EOF > diag_table.yaml
 title: test_pow
-base_date: 2 1 1 0 0 0
+base_date: [2, 1, 1, 0, 0, 0]
 diag_files:
 - file_name: test_pow
   time_units: hours

--- a/test_fms/diag_manager/test_time_rms.sh
+++ b/test_fms/diag_manager/test_time_rms.sh
@@ -28,7 +28,7 @@ output_dir
 
 cat <<_EOF > diag_table.yaml
 title: test_rms
-base_date: 2 1 1 0 0 0
+base_date: [2, 1, 1, 0, 0, 0]
 diag_files:
 - file_name: test_rms
   time_units: hours

--- a/test_fms/diag_manager/test_time_sum.sh
+++ b/test_fms/diag_manager/test_time_sum.sh
@@ -28,7 +28,7 @@ output_dir
 
 cat <<_EOF > diag_table.yaml
 title: test_sum
-base_date: 2 1 1 0 0 0
+base_date: [2, 1, 1, 0, 0, 0]
 diag_files:
 - file_name: test_sum
   time_units: hours

--- a/test_fms/diag_manager/test_var_masks.sh
+++ b/test_fms/diag_manager/test_var_masks.sh
@@ -28,7 +28,7 @@ output_dir
 
 cat <<_EOF > diag_table.yaml
 title: test_var_masks
-base_date: 2 1 1 0 0 0
+base_date: [2, 1, 1, 0, 0, 0]
 diag_files:
 - file_name: test_var_masks
   freq: 1 days


### PR DESCRIPTION
**Description**
Updates the yaml parser to be able to read in arrays as the base date for the new diag yaml format. It just converts any yaml format arrays to a space-separated string at the read in time, so the old format will still work as well.

Also makes updates to be able to output them when writing the output yaml file. Right now it only checks if the second value in a yaml block is an array (since thats where the base date will be) but if preferable I can add the check for every value written.

**How Has This Been Tested?**
gcc and oneapi on the amd box

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

