### PR TITLE
`yaml_parser_mod`: Use integral error code

### DIFF
--- a/parser/yaml_parser.F90
+++ b/parser/yaml_parser.F90
@@ -76,7 +76,7 @@ function open_and_parse_file_wrap(filename, file_id) bind(c) &
    use iso_c_binding, only: c_char, c_int, c_bool
    character(kind=c_char), intent(in) :: filename(*) !< Filename of the yaml file
    integer(kind=c_int), intent(out) :: file_id !< File id corresponding to the yaml file that was opened
-   logical(kind=c_int) :: error_code !< Flag indicating the error message (1 if sucessful)
+   integer(kind=c_int) :: error_code !< Flag indicating the error message (1 if sucessful)
 end function open_and_parse_file_wrap
 
 !> @brief Private c function that checks if a file_id is valid (see yaml_parser_binding.c)


### PR DESCRIPTION
**Description**
PR #1563 introduced an error code which is returned by `open_and_parse_file_wrap` in `yaml_parser_mod`. This PR corrects the error code's type, which fixes a type mismatch error which occurs when building with the Cray compiler.

**How Has This Been Tested?**
Fixes the type mismatch error when building `yaml_parser_mod` with the Cray compiler.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes