### PR TITLE
`axis_utils`: Fix `get_axis_cart` test with Cray compiler

### DIFF
--- a/test_fms/axis_utils/test_axis_utils.F90
+++ b/test_fms/axis_utils/test_axis_utils.F90
@@ -143,13 +143,23 @@ subroutine test_get_axis_cart
   character(:), allocatable :: var_name, attr_name, attr_value
   integer :: i, j
 
-  character(*), parameter, dimension(*) :: &
-    & special_axis_names_x = [character(12) :: "lon", "x", "degrees_e", "degrees_east", "degreese"], &
-    & special_axis_names_y = [character(13) :: "lat", "y", "degrees_n", "degrees_north", "degreesn"], &
-    & special_axis_names_z = [character(6) :: "depth", "height", "z", "cm", "m", "pa", "hpa"], &
-    & special_axis_names_t = [character(4) :: "time", "t", "sec", "min", "hou", "day", "mon", "yea"], &
-    & attr_names           = [character(14) :: "cartesian_axis", "axis"], &
-    & xyzt_uc              = ["X", "Y", "Z", "T"]
+  character(12), dimension(*), parameter :: special_axis_names_x = &
+  & [character(12) :: "lon", "x", "degrees_e", "degrees_east", "degreese"]
+
+  character(13), dimension(*), parameter :: special_axis_names_y = &
+  & [character(13) :: "lat", "y", "degrees_n", "degrees_north", "degreesn"]
+
+  character( 6), dimension(*), parameter :: special_axis_names_z = &
+  & [character(6) :: "depth", "height", "z", "cm", "m", "pa", "hpa"]
+
+  character( 4), dimension(*), parameter :: special_axis_names_t = &
+  & [character(4) :: "time", "t", "sec", "min", "hou", "day", "mon", "yea"]
+
+  character(14), dimension(*), parameter :: attr_names           = &
+  & [character(14) :: "cartesian_axis", "axis"]
+
+  character( 1), dimension(*), parameter :: xyzt_uc              = &
+  & ["X", "Y", "Z", "T"]
 
   call open_netcdf_w(test%fileobj)
   call register_axis(test%fileobj, "dim1", 1)


### PR DESCRIPTION
**Description**
This modification to the `get_axis_cart` test is a workaround for the Cray compiler's erroneous handling of assumed-length string parameter arrays.

Fixes `get_axis_cart` unit test failure when built with the Cray compiler.

**How Has This Been Tested?**
Builds with Cray and the test passes

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes