### PR TITLE
fix r8/r4 configure checks with intel -warn flag

### DIFF
--- a/m4/gx_fortran_options.m4
+++ b/m4/gx_fortran_options.m4
@@ -90,13 +90,12 @@ for ac_flag in none \
                '-qrealsize=8'; do
   test "x$ac_flag" != xnone && FCFLAGS="$gx_fc_default_real_kind8_flag_FCFLAGS_save ${ac_flag}"
   AC_COMPILE_IFELSE([[      program test
-      interface
+      real :: b=1.0
+      call test_sub(b)
+      contains
       subroutine test_sub(a)
       real(kind=selected_real_kind(15,307)) :: a
       end subroutine test_sub
-      end interface
-      real :: b=1.0
-      call test_sub(b)
       end program test]],
      [gx_cv_fc_default_real_kind8_flag=$ac_flag; break])
 done
@@ -148,13 +147,12 @@ for ac_flag in none \
                '-qrealsize=4'; do
   test "x$ac_flag" != xnone && FCFLAGS="$gx_fc_default_real_kind4_flag_FCFLAGS_save ${ac_flag}"
   AC_COMPILE_IFELSE([[      program test
-      interface
+      real :: b=1.0
+      call test_sub(b)
+      contains
       subroutine test_sub(a)
       real(kind=selected_real_kind(6, 37)) :: a
       end subroutine test_sub
-      end interface
-      real :: b=1.0
-      call test_sub(b)
       end program test]],
      [gx_cv_fc_default_real_kind4_flag=$ac_flag; break])
 done


### PR DESCRIPTION
**Description**
When compiling with intel the `-warn` flag breaks the m4 check that looks for real default kind flags. During ./configure when it uses the correct kind default flags with `-warn`, it gets an error stating `There is a conflict between local interface block and external interface block.`.

This modifies the check to remove the interface block and just use a `contains` for the subroutine, this way it won't fail on what seems to be a unrelated error.

**How Has This Been Tested?**
ifort (oneapi 2024.2) with the mkmf debug flags on amd

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

