### PR TITLE
fix: use a bigger real transfering `mask_val`

### DIFF
--- a/mpp/include/mpp_chksum_int.fh
+++ b/mpp/include/mpp_chksum_int.fh
@@ -52,6 +52,7 @@ function MPP_CHKSUM_INT_RMASK_( var, pelist, mask_val )
   MPP_TYPE_, intent(in) :: var MPP_RANK_
   integer, optional :: pelist(:)
   real, intent(in) :: mask_val
+  real(KIND=r8_kind) :: tmp_mask_val
   integer(KIND(var))::imask_val
   integer(KIND=i4_kind)::i4tmp(2)=0
   real(KIND=r4_kind)::r4tmp(2)=0
@@ -74,9 +75,10 @@ function MPP_CHKSUM_INT_RMASK_( var, pelist, mask_val )
 ! Secondary Logic:
 !! We've done something dangerous
   else
-     i8tmp = TRANSFER(mask_val , i8tmp )
-     i4tmp = TRANSFER(mask_val , i4tmp )
-     r4tmp = TRANSFER(mask_val , r4tmp )
+     tmp_mask_val = mask_val
+     i8tmp = TRANSFER(tmp_mask_val , i8tmp )
+     i4tmp = TRANSFER(tmp_mask_val , i4tmp )
+     r4tmp = TRANSFER(tmp_mask_val , r4tmp )
      if ( i8tmp == MPP_FILL_INT ) then
         ! we've packed an MPP_FILL_
         imask_val = MPP_FILL_INT


### PR DESCRIPTION
this change ensures the type of `mask_val` is big enough to satisfy the `transfer`; otherwise, we risk transfering a 4-byte value to 2-element arrays of 4-byte elements (i.e., `i4tmp(2)` and `r4tmp(2)`)

I encountered this issue compiling the project with Flang; see https://godbolt.org/z/91EfY154n

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

