### PR TITLE
Data_override test failures test

### DIFF
--- a/test_fms/data_override/test_data_override2_mono.sh
+++ b/test_fms/data_override/test_data_override2_mono.sh
@@ -27,9 +27,10 @@
 output_dir
 [ ! -d "INPUT" ] && mkdir -p "INPUT"
 
-cat <<_EOF > input.nml
+cat <<_EOF > input_base.nml
 &test_data_override_ongrid_nml
   test_case = 2
+  write_only = .False.
 /
 _EOF
 
@@ -41,6 +42,12 @@ _EOF
 for KIND in r4 r8
 do
   rm -rf INPUT/*
+  sed 's/write_only = .False./write_only = .True./g' input_base.nml > input.nml
+  test_expect_success "Creating input files (${KIND})" '
+      mpirun -n 6 ../test_data_override_ongrid_${KIND}
+      '
+
+  cp input_base.nml input.nml
   test_expect_success "test_data_override with monotonically increasing and decreasing data sets (${KIND})" '
     mpirun -n 6 ../test_data_override_ongrid_${KIND}
     '
@@ -48,9 +55,10 @@ done
 
 rm -rf data_table
 
-cat <<_EOF > input.nml
+cat <<_EOF > input_base.nml
 &test_data_override_ongrid_nml
   test_case = 2
+  write_only = .False.
 /
 &data_override_nml
   use_data_table_yaml = .True.
@@ -80,6 +88,12 @@ if [ -z $parser_skip ]; then
   for KIND in r4 r8
   do
     rm -rf INPUT/*
+    sed 's/write_only = .False./write_only = .True./g' input_base.nml > input.nml
+    test_expect_success "Creating input files (${KIND})" '
+      mpirun -n 6 ../test_data_override_ongrid_${KIND}
+      '
+
+    cp input_base.nml input.nml
     test_expect_success "test_data_override with monotonically increasing and decreasing data sets  -yaml (${KIND})" '
       mpirun -n 6 ../test_data_override_ongrid_${KIND}
       '

--- a/test_fms/data_override/test_data_override2_ongrid.sh
+++ b/test_fms/data_override/test_data_override2_ongrid.sh
@@ -36,6 +36,7 @@ use_data_table_yaml=.False.
 &test_data_override_ongrid_nml
   nhalox=halo_size
   nhaloy=halo_size
+  write_only = .False.
 /
 _EOF
   printf '"OCN", "runoff", "runoff", "./INPUT/runoff.daitren.clim.1440x1080.v20180328.nc", "none" ,  1.0' | cat > data_table
@@ -48,6 +49,7 @@ use_data_table_yaml=.True.
 &test_data_override_ongrid_nml
   nhalox=halo_size
   nhaloy=halo_size
+  write_only = .False.
 /
 _EOF
 cat <<_EOF > data_table.yaml
@@ -65,13 +67,17 @@ fi
 [ ! -d "INPUT" ] && mkdir -p "INPUT"
 for KIND in r4 r8
 do
-rm -rf INPUT/*
+sed -e 's/halo_size/2/g ; s/write_only = .False./write_only = .True./g' input_base.nml > input.nml
+
+test_expect_success "Creating input files (${KIND})" '
+  mpirun -n 6 ../test_data_override_ongrid_${KIND}
+'
+
 sed 's/halo_size/2/g' input_base.nml > input.nml
 test_expect_success "data_override on grid with 2 halos in x and y (${KIND})" '
   mpirun -n 6 ../test_data_override_ongrid_${KIND}
 '
 
-rm -rf INPUT/*
 sed 's/halo_size/0/g' input_base.nml > input.nml
 test_expect_success "data_override on grid with 0 halos in x and y (${KIND})" '
   mpirun -n 6 ../test_data_override_ongrid_${KIND}

--- a/test_fms/data_override/test_data_override2_scalar.sh
+++ b/test_fms/data_override/test_data_override2_scalar.sh
@@ -28,22 +28,24 @@ output_dir
 rm -rf data_table data_table.yaml input.nml input_base.nml
 
 if [ ! -z $parser_skip ]; then
-  cat <<_EOF > input.nml
+  cat <<_EOF > input_base.nml
 &data_override_nml
 use_data_table_yaml=.False.
 /
 &test_data_override_ongrid_nml
   test_case = 3
+  write_only = .False.
 /
 _EOF
   printf '"OCN", "co2", "co2", "./INPUT/scalar.nc", "none" ,  1.0' | cat > data_table
 else
-cat <<_EOF > input.nml
+cat <<_EOF > input_base.nml
 &data_override_nml
 use_data_table_yaml=.True.
 /
 &test_data_override_ongrid_nml
   test_case = 3
+  write_only = .False.
 /
 _EOF
 cat <<_EOF > data_table.yaml
@@ -62,6 +64,12 @@ fi
 for KIND in r4 r8
 do
 rm -rf INPUT/*
+sed 's/write_only = .False./write_only = .True./g' input_base.nml > input.nml
+test_expect_success "Creating input files (${KIND})" '
+  mpirun -n 6 ../test_data_override_ongrid_${KIND}
+'
+
+cp input_base.nml input.nml
 test_expect_success "data_override scalar field (${KIND})" '
   mpirun -n 6 ../test_data_override_ongrid_${KIND}
 '

--- a/test_fms/data_override/test_data_override_ongrid.F90
+++ b/test_fms/data_override/test_data_override_ongrid.F90
@@ -53,8 +53,9 @@ integer, parameter                         :: bilinear = 2
 integer, parameter                         :: scalar = 3
 integer, parameter                         :: weight_file = 4
 integer                                    :: test_case = ongrid
+logical                                    :: write_only=.false. !< True if creating the input files only
 
-namelist / test_data_override_ongrid_nml / nhalox, nhaloy, test_case, nlon, nlat, layout
+namelist / test_data_override_ongrid_nml / nhalox, nhaloy, test_case, nlon, nlat, layout, write_only
 
 call mpp_init
 call fms2_io_init
@@ -75,33 +76,36 @@ call mpp_define_domains( (/1,nlon,1,nlat/), layout, Domain, xhalo=nhalox, yhalo=
 call mpp_define_io_domain(Domain, (/1,1/))
 call mpp_get_data_domain(Domain, is, ie, js, je)
 
-select case (test_case)
-case (ongrid)
-  call generate_ongrid_input_file ()
-case (bilinear)
-  call generate_bilinear_input_file ()
-case (scalar)
-  call generate_scalar_input_file ()
-case (weight_file)
-  call generate_weight_input_file ()
-end select
+if (write_only) then
+  select case (test_case)
+  case (ongrid)
+    call generate_ongrid_input_file ()
+  case (bilinear)
+    call generate_bilinear_input_file ()
+  case (scalar)
+    call generate_scalar_input_file ()
+  case (weight_file)
+    call generate_weight_input_file ()
+  end select
 
-call mpp_sync()
-call mpp_error(NOTE, "Finished creating INPUT Files")
+  call mpp_sync()
+  call mpp_error(NOTE, "Finished creating INPUT Files")
 
-!< Initiliaze data_override
-call data_override_init(Ocean_domain_in=Domain, mode=lkind)
+else
+  !< Initiliaze data_override
+  call data_override_init(Ocean_domain_in=Domain, mode=lkind)
 
-select case (test_case)
-case (ongrid)
-  call ongrid_test()
-case (bilinear)
-  call bilinear_test()
-case (scalar)
-  call scalar_test()
-case (weight_file)
-  call weight_file_test()
-end select
+  select case (test_case)
+  case (ongrid)
+    call ongrid_test()
+  case (bilinear)
+    call bilinear_test()
+  case (scalar)
+    call scalar_test()
+  case (weight_file)
+    call weight_file_test()
+  end select
+endif
 
 call mpp_exit
 

--- a/test_fms/data_override/test_data_override_ongrid.F90
+++ b/test_fms/data_override/test_data_override_ongrid.F90
@@ -33,7 +33,7 @@ use time_manager_mod,  only: set_calendar_type, time_type, set_date, NOLEAP
 use netcdf,            only: nf90_create, nf90_def_dim, nf90_def_var, nf90_enddef, nf90_put_var, &
                              nf90_close, nf90_put_att, nf90_clobber, nf90_64bit_offset, nf90_char, &
                              nf90_double, nf90_unlimited
-use fms_mod, only: string
+use fms_mod, only: string, fms_init, fms_end
 
 implicit none
 
@@ -57,7 +57,7 @@ logical                                    :: write_only=.false. !< True if crea
 
 namelist / test_data_override_ongrid_nml / nhalox, nhaloy, test_case, nlon, nlat, layout, write_only
 
-call mpp_init
+call fms_init
 call fms2_io_init
 
 read (input_nml_file, test_data_override_ongrid_nml, iostat=io_status)
@@ -107,7 +107,7 @@ else
   end select
 endif
 
-call mpp_exit
+call fms_end
 
 contains
 

--- a/test_fms/data_override/test_data_override_weights.sh
+++ b/test_fms/data_override/test_data_override_weights.sh
@@ -48,7 +48,7 @@ data_table:
   factor: 1.0
 _EOF
 
-cat <<_EOF > input.nml
+cat <<_EOF > input_base.nml
 &data_override_nml
   use_data_table_yaml = .True.
 /
@@ -58,6 +58,7 @@ cat <<_EOF > input.nml
   nlon = 5
   nlat = 6
   layout = 1, 2
+  write_only = .False.
 /
 _EOF
 
@@ -66,6 +67,13 @@ if [ -z $parser_skip ]; then
   for KIND in r4 r8
   do
     rm -rf INPUT/.
+
+    sed 's/write_only = .False./write_only = .True./g' input_base.nml > input.nml
+    test_expect_success "Creating input files (${KIND})" '
+      mpirun -n 2 ../test_data_override_ongrid_${KIND}
+    '
+
+    cp input_base.nml input.nml
     test_expect_success "test_data_override with and without weight files  -yaml (${KIND})" '
       mpirun -n 2 ../test_data_override_ongrid_${KIND}
       '


### PR DESCRIPTION
**Description**
This attempts to fix the now consistent crashes with the data_override unit tests
```
FATAL from PE     1: NetCDF: Unknown file format: netcdf_file_open:INPUT/grid_spec.nc
```

The scripts now create the files, and then run the model rather than it all being the same run.

Fixes https://github.com/NOAA-GFDL/FMS/issues/1480

**How Has This Been Tested?**
CI (successfully passed the tests twice)

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

