### PR TITLE
Fix `mosaic2` tests with strict debug flags

### DIFF
--- a/mosaic2/include/mosaic2.inc
+++ b/mosaic2/include/mosaic2.inc
@@ -86,14 +86,12 @@
   !> <br>Example usage:
   !!            call calc_mosaic_grid_area(lon, lat, area)
   subroutine CALC_MOSAIC_GRID_AREA_(lon, lat, area)
-     real(kind=FMS_MOS_KIND_), dimension(:,:), intent(in)    :: lon
-     real(kind=FMS_MOS_KIND_), dimension(:,:), intent(in)    :: lat
-     real(kind=FMS_MOS_KIND_), dimension(:,:), intent(inout) :: area
+     real(kind=FMS_MOS_KIND_), dimension(:,:), intent(in)  :: lon
+     real(kind=FMS_MOS_KIND_), dimension(:,:), intent(in)  :: lat
+     real(kind=FMS_MOS_KIND_), dimension(:,:), intent(out) :: area
      integer :: nlon, nlat
 
      real(r8_kind) :: area_r8(size(area,1),size(area,2))
-
-     area_r8=real(area,r8_kind)
 
      nlon = size(area,1)
      nlat = size(area,2)

--- a/test_fms/mosaic2/test_mosaic2.F90
+++ b/test_fms/mosaic2/test_mosaic2.F90
@@ -254,7 +254,7 @@ subroutine test_is_inside_polygon
   z2(1)=2.0_lkind ; z2(2)=4.0_lkind ; z2(3)=4.0_lkind ; z2(4)=2.0_lkind ; z2(5)=2.0_lkind
   do i=1, n
      r = sqrt( x2(i)**2 + y2(i)**2 + z2(i)**2 )
-     lon2(i)=atan(y2(i)/x2(i))
+     lon2(i)=atan2(y2(i), x2(i))
      lat2(i)=asin(z2(i)/r)
   end do
 
@@ -263,7 +263,7 @@ subroutine test_is_inside_polygon
   y1=5.0_lkind
   z1=4.2_lkind
   r = sqrt(x1**2+y1**2+z1**2)
-  lon1=atan(y1/x1)
+  lon1=atan2(y1, x1)
   lat1=asin(z1/r)
 
   answer=.false.
@@ -275,7 +275,7 @@ subroutine test_is_inside_polygon
   y1=3.0_lkind
   z1=2.5_lkind
   r = sqrt(x1**2+y1**2+z1**2)
-  lon1=atan(y1/x1)
+  lon1=atan2(y1, x1)
   lat1=asin(z1/r)
 
   answer=.true.


### PR DESCRIPTION
**Description**
This fixes two issues that occur in the `mosaic2` tests when FMS is built using strict debug flags:

1) The `area` argument of `calc_mosaic_grid_area` has been changed from `intent(inout)` to `intent(out)`, to avoid an uninitialized value error.

2) `atan` has been changed to `atan2` in the unit tests, to avoid divide-by-zero errors.

**How Has This Been Tested?**
Fixes the `mosaic2` unit tests when FMS is built with ifort 2021.13.0 on the AMD box with the following debug flags:
`-check all -fpe0 -fp-stack-check -fstack-security-check -ftrapuv -init=arrays,minus_huge,snan`

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes