### PR TITLE
column_diagnostics test: Fix syntax error in `Makefile.am`

### DIFF
--- a/test_fms/column_diagnostics/Makefile.am
+++ b/test_fms/column_diagnostics/Makefile.am
@@ -34,8 +34,8 @@ check_PROGRAMS = test_column_diagnostics_r4 test_column_diagnostics_r8
 test_column_diagnostics_r4_SOURCES = test_column_diagnostics.F90
 test_column_diagnostics_r8_SOURCES = test_column_diagnostics.F90
 
-test_column_diagnostics_r4_CPPFLAGS=-DTEST_CD_KIND_=4 -I$(AM_CPPFLAGS)
-test_column_diagnostics_r8_CPPFLAGS=-DTEST_CD_KIND_=8 -I$(AM_CPPFLAGS)
+test_column_diagnostics_r4_CPPFLAGS=$(AM_CPPFLAGS) -DTEST_CD_KIND_=4
+test_column_diagnostics_r8_CPPFLAGS=$(AM_CPPFLAGS) -DTEST_CD_KIND_=8
 
 TEST_EXTENSIONS = .sh
 SH_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) $(abs_top_srcdir)/test_fms/tap-driver.sh


### PR DESCRIPTION
**Description**
Remove a duplicate `-I` in the column_diagnostics test's `Makefile.am` file, which causes the `ftn` command to fail when the test is built with the Cray compiler.

**How Has This Been Tested?**
column_diagnostics test builds and passes with Cray compiler version 18 on C5.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes