### PR TITLE
Fix type mismatch error in coupler test

### DIFF
--- a/test_fms/coupler/test_atmos_ocean_fluxes.F90
+++ b/test_fms/coupler/test_atmos_ocean_fluxes.F90
@@ -106,7 +106,8 @@ contains
 
     character(100) :: cresults, thelist
     real(FMS_CP_TEST_KIND_) :: rresults, rresults2(num_bcs)
-    integer :: i, success, n
+    integer :: i, n
+    logical :: success
 
     write(*,*) "*** TEST_AOF_SET_COUPLER_FLUX ***"
 


### PR DESCRIPTION
**Description**
Fixes a type mismatch error in the coupler test, which causes a build error when the test is built with the Cray compiler.

**How Has This Been Tested?**
coupler tests build and pass with Cray compiler version 18 on C5.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes