### PR TITLE
add f2c_string in libFMS.F90

### DIFF
--- a/libFMS.F90
+++ b/libFMS.F90
@@ -742,6 +742,7 @@ module fms
                                   fms_string_utils_sort_this => fms_sort_this, &
                                   fms_string_utils_find_my_string => fms_find_my_string, &
                                   fms_string_utils_find_unique => fms_find_unique, &
+                                  fms_string_utils_f2c_string => fms_f2c_string, &
                                   fms_string_utils_c2f_string => fms_c2f_string, &
                                   fms_string_utils_cstring2cpointer => fms_cstring2cpointer, &
                                   fms_string_utils_copy => string_copy


### PR DESCRIPTION
**Description**
This PR adds `fms_string_utils_f2c_string` that  is made available  via `use libFMS`

Fixes #1600 

**How Has This Been Tested?**
`fms_string_utils_f2c_string` can be called in an external module with `use libFMS`

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

