### PR TITLE
Fix type mismatch error in tracer_manager test

### DIFF
--- a/test_fms/tracer_manager/test_tracer_manager.F90
+++ b/test_fms/tracer_manager/test_tracer_manager.F90
@@ -45,7 +45,8 @@ contains
   integer, parameter :: numlevels=10
   integer, parameter :: npoints=5
 
-  integer :: tracer_index, success, i, j, k
+  integer :: tracer_index, i, j, k
+  logical :: success
   real(TEST_TM_KIND_) :: top_value, bottom_value, surf_value, multiplier
   real(TEST_TM_KIND_) :: tracer_out1(1,1,1), tracer_out2(npoints,npoints,numlevels)
   real(TEST_TM_KIND_) :: answer1(1,1,1), answer2(npoints,npoints,numlevels)


### PR DESCRIPTION
**Description**
Fixes a type mismatch error in the tracer_manager test, which causes the test's build to fail with the Cray compiler.

Analogous to PR #1599.

**How Has This Been Tested?**
tracer_manager test builds and passes with Cray compiler version 18 on C5.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes