### PR TITLE
monin_obukhov tests: Avoid continuation lines containing only a comment

### DIFF
--- a/test_fms/monin_obukhov/test_monin_obukhov.F90
+++ b/test_fms/monin_obukhov/test_monin_obukhov.F90
@@ -125,17 +125,10 @@ program test_monin_obukhov
     integer(ki), dimension(n_1d) :: del_m, del_t, del_q
   end type
 
-  type(drag_input_t), parameter :: drag_input = drag_input_t() &
-  & !< Input arguments for mo_drag
-
-  type(stable_mix_input_t), parameter :: stable_mix_input = stable_mix_input_t() &
-  & !< Input arguments for stable_mix
-
-  type(diff_input_t), parameter :: diff_input = diff_input_t() &
-  & !< Input arguments for mo_diff
-
-  type(profile_input_t), parameter :: profile_input = profile_input_t() &
-  & !< Input arguments for mo_profile
+  type(drag_input_t), parameter :: drag_input = drag_input_t() !< Input arguments for mo_drag
+  type(stable_mix_input_t), parameter :: stable_mix_input = stable_mix_input_t() !< Input arguments for stable_mix
+  type(diff_input_t), parameter :: diff_input = diff_input_t() !< Input arguments for mo_diff
+  type(profile_input_t), parameter :: profile_input = profile_input_t() !< Input arguments for mo_profile
 
   ! Entries 1:n of the arrays below contain known answer keys. Entry n+1 contains
   ! the answers that we calculate. Represent answer data using integral arrays,


### PR DESCRIPTION
**Description**
The Cray compiler does not like continuation lines which contain only a comment. For example, the following will result in a syntax error:

```
real, parameter :: g = 9.81 &
& !< Acceleration due to gravity (m / s^2)
```

The workaround is to move the comment onto the same line as the variable declaration.

**How Has This Been Tested?**
monin_obukhov tests build with CCE 18 on C5.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes