### PR TITLE
Fix `output_yaml` tests

### DIFF
--- a/test_fms/parser/test_output_yaml.F90
+++ b/test_fms/parser/test_output_yaml.F90
@@ -203,11 +203,12 @@ if(test_lvl2keys) then
   call yaml_out_add_level2key( "order 4",k1(1))
   call yaml_out_add_level2key( "sides", k2(1))
   call yaml_out_add_level2key( "specials",  k2(2))
-  call write_yaml_from_struct_3 (trim(filename), 1, k1, v1, a2, k2, v2, a3, (/1, 1, 1, 1, 2, 1/), k3, v3, &
-                               & (/ 1, 1, 1 , 1, 0 ,0 ,0 ,0/))
+  call write_yaml_from_struct_3 (trim(filename) // c_null_char, 1, k1, v1, a2, k2, v2, a3, &
+                               & (/1, 1, 1, 1, 2, 1/), k3, v3, (/ 1, 1, 1 , 1, 0 ,0 ,0 ,0/))
 else
   !> Write the yaml
-  call write_yaml_from_struct_3 (trim(filename), 1, k1, v1, a2, k2, v2, a3, a3each, k3, v3,(/3, 0, 0, 0, 0, 0, 0, 0/))
+  call write_yaml_from_struct_3 (trim(filename) // c_null_char, 1, k1, v1, a2, k2, v2, a3, &
+                               & a3each, k3, v3, (/3, 0, 0, 0, 0, 0, 0, 0/))
 endif
 
 !> Check yaml output against reference


### PR DESCRIPTION
**Description**
This fixes an issue where the filename argument of `write_yaml_from_struct_3` is passed as a Fortran-style string, when a null-terminated string is expected. When the test is built with the Cray compiler, this issue causes `test.yaml` to be created with junk characters at the end of the filename, which causes a "file not found" error when the test subsequently attempts to read the file.

**How Has This Been Tested?**
output_yaml test builds, runs, and passes with CCE 18 on C5.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes