### PR TITLE
test_diag_integral: Avoid I/O unit 100

### DIFF
--- a/test_fms/diag_integral/test_diag_integral.F90
+++ b/test_fms/diag_integral/test_diag_integral.F90
@@ -175,13 +175,12 @@ contains
   !-------------------------------------
   subroutine read_diag_integral_file
 
-    character(17), parameter :: di_file='diag_integral.out'
-    integer, parameter  :: iunit=100
-
+    character(*), parameter :: di_file='diag_integral.out'
+    integer :: iunit
     character(100) :: cline1, cline2, cline3, cline4, cline5, clin6
 
     !> read in computed values
-    open(unit=iunit,file=trim(di_file))
+    open(newunit=iunit, file=di_file)
     read(iunit,*) cline1, cline2, cline3, cline4, cline5, clin6
     read(iunit,*) itime, field_avg2, field_avg3, field_avgw, field_avgh
     close(iunit)


### PR DESCRIPTION
**Description**
The Cray compiler reserves I/O unit 100 for STDIN, which causes `read_diag_integral_file` to fail. This is fixed by using `newunit` instead of specifying `unit=100`.

**How Has This Been Tested?**
diag_integral test builds, runs, and passes with CCE 18 on C5.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes