### PR TITLE
Fix test failures with ifx due to use of host associated arrays

### DIFF
--- a/test_fms/diag_integral/test_diag_integral.F90
+++ b/test_fms/diag_integral/test_diag_integral.F90
@@ -97,7 +97,7 @@ program test_diag_integral
 
 contains
   !-------------------------------------
-  !------------------------------------- 
+  !-------------------------------------
   subroutine initialize_arrays
 
     !> made up numbers

--- a/test_fms/diag_integral/test_diag_integral.F90
+++ b/test_fms/diag_integral/test_diag_integral.F90
@@ -51,14 +51,14 @@ program test_diag_integral
   character(9), parameter :: field_nameh='immadeuph' !> made up field name to test
   character(8), parameter :: std_digits   = 'e23.15e3' !> write out precision for r8_kind data
 
-  real(TEST_DI_KIND_), save :: immadeup2(nxy,nxy)     !> array to test sum_field_2d
-  real(TEST_DI_KIND_), save :: immadeup3(nxy,nxy,nxy) !> array to test sum_field_3d
-  real(TEST_DI_KIND_), save :: immadeupw(nxy,nxy,nxy) !> array to test sum_field_wght_3d
-  real(TEST_DI_KIND_), save :: weight(nxy,nxy,nxy)    !> weights required to test sum_field_wght_3d
-  real(TEST_DI_KIND_), save :: immadeuph(nxy,nxy)     !> array to test sum_field_2d_hemi
+  real(TEST_DI_KIND_) :: immadeup2(nxy,nxy)     !> array to test sum_field_2d
+  real(TEST_DI_KIND_) :: immadeup3(nxy,nxy,nxy) !> array to test sum_field_3d
+  real(TEST_DI_KIND_) :: immadeupw(nxy,nxy,nxy) !> array to test sum_field_wght_3d
+  real(TEST_DI_KIND_) :: weight(nxy,nxy,nxy)    !> weights required to test sum_field_wght_3d
+  real(TEST_DI_KIND_) :: immadeuph(nxy,nxy)     !> array to test sum_field_2d_hemi
 
-  real(r8_kind), save :: lat(nxyp,nxyp), lon(nxyp,nxyp)
-  real(r8_kind), save :: area(nxy,nxy)
+  real(r8_kind)   :: lat(nxyp,nxyp), lon(nxyp,nxyp)
+  real(r8_kind)   :: area(nxy,nxy)
   type(time_type) :: Time_init, Time
 
   !testing and generating answers
@@ -96,6 +96,24 @@ program test_diag_integral
   call test_sum_diag_integral_field !< compare read in values to the expected values.
 
 contains
+  !-------------------------------------
+  !------------------------------------- 
+  subroutine initialize_arrays
+
+    !> made up numbers
+
+    implicit none
+
+    lon=1.0_lkind
+    lat=1.0_lkind
+    area=1.0_lkind
+    immadeup2=1.0_lkind
+    immadeup3=1.0_lkind
+    immadeupw=1.0_lkind
+    immadeuph=1.0_lkind
+    weight=1.0_lkind
+
+  end subroutine initialize_arrays
   !-------------------------------------
   !-------------------------------------
   subroutine test_diag_integral_init
@@ -202,24 +220,6 @@ contains
     end if
 
   end subroutine check_answers
-  !-------------------------------------
-  !-------------------------------------
-  subroutine initialize_arrays
-
-    !> made up numbers
-
-    implicit none
-
-    lon=1.0_lkind
-    lat=1.0_lkind
-    area=1.0_lkind
-    immadeup2=1.0_lkind
-    immadeup3=1.0_lkind
-    immadeupw=1.0_lkind
-    immadeuph=1.0_lkind
-    weight=1.0_lkind
-
-  end subroutine initialize_arrays
   !-------------------------------------
   !-------------------------------------
 end program test_diag_integral

--- a/test_fms/diag_integral/test_diag_integral.F90
+++ b/test_fms/diag_integral/test_diag_integral.F90
@@ -51,14 +51,14 @@ program test_diag_integral
   character(9), parameter :: field_nameh='immadeuph' !> made up field name to test
   character(8), parameter :: std_digits   = 'e23.15e3' !> write out precision for r8_kind data
 
-  real(TEST_DI_KIND_) :: immadeup2(nxy,nxy)     !> array to test sum_field_2d
-  real(TEST_DI_KIND_) :: immadeup3(nxy,nxy,nxy) !> array to test sum_field_3d
-  real(TEST_DI_KIND_) :: immadeupw(nxy,nxy,nxy) !> array to test sum_field_wght_3d
-  real(TEST_DI_KIND_) :: weight(nxy,nxy,nxy)    !> weights required to test sum_field_wght_3d
-  real(TEST_DI_KIND_) :: immadeuph(nxy,nxy)     !> array to test sum_field_2d_hemi
+  real(TEST_DI_KIND_), save :: immadeup2(nxy,nxy)     !> array to test sum_field_2d
+  real(TEST_DI_KIND_), save :: immadeup3(nxy,nxy,nxy) !> array to test sum_field_3d
+  real(TEST_DI_KIND_), save :: immadeupw(nxy,nxy,nxy) !> array to test sum_field_wght_3d
+  real(TEST_DI_KIND_), save :: weight(nxy,nxy,nxy)    !> weights required to test sum_field_wght_3d
+  real(TEST_DI_KIND_), save :: immadeuph(nxy,nxy)     !> array to test sum_field_2d_hemi
 
-  real(r8_kind) :: lat(nxyp,nxyp), lon(nxyp,nxyp)
-  real(r8_kind) :: area(nxy,nxy)
+  real(r8_kind), save :: lat(nxyp,nxyp), lon(nxyp,nxyp)
+  real(r8_kind), save :: area(nxy,nxy)
   type(time_type) :: Time_init, Time
 
   !testing and generating answers
@@ -175,12 +175,13 @@ contains
   !-------------------------------------
   subroutine read_diag_integral_file
 
-    character(*), parameter :: di_file='diag_integral.out'
-    integer :: iunit
+    character(17), parameter :: di_file='diag_integral.out'
+    integer, parameter  :: iunit=100
+
     character(100) :: cline1, cline2, cline3, cline4, cline5, clin6
 
     !> read in computed values
-    open(newunit=iunit, file=di_file)
+    open(unit=iunit,file=trim(di_file))
     read(iunit,*) cline1, cline2, cline3, cline4, cline5, clin6
     read(iunit,*) itime, field_avg2, field_avg3, field_avgw, field_avgh
     close(iunit)

--- a/test_fms/diag_integral/test_diag_integral.F90
+++ b/test_fms/diag_integral/test_diag_integral.F90
@@ -194,12 +194,12 @@ contains
   subroutine read_diag_integral_file
 
     character(*), parameter :: di_file='diag_integral.out'
-    integer, parameter  :: iunit=100
+    integer, parameter  :: iunit
 
     character(100) :: cline1, cline2, cline3, cline4, cline5, clin6
 
     !> read in computed values
-    open(newunit=iunit,file=di_file)
+    open(newunit=iunit, file=di_file)
     read(iunit,*) cline1, cline2, cline3, cline4, cline5, clin6
     read(iunit,*) itime, field_avg2, field_avg3, field_avgw, field_avgh
     close(iunit)

--- a/test_fms/diag_integral/test_diag_integral.F90
+++ b/test_fms/diag_integral/test_diag_integral.F90
@@ -194,7 +194,7 @@ contains
   subroutine read_diag_integral_file
 
     character(*), parameter :: di_file='diag_integral.out'
-    integer, parameter  :: iunit
+    integer :: iunit
 
     character(100) :: cline1, cline2, cline3, cline4, cline5, clin6
 

--- a/test_fms/diag_integral/test_diag_integral.F90
+++ b/test_fms/diag_integral/test_diag_integral.F90
@@ -193,13 +193,13 @@ contains
   !-------------------------------------
   subroutine read_diag_integral_file
 
-    character(17), parameter :: di_file='diag_integral.out'
+    character(*), parameter :: di_file='diag_integral.out'
     integer, parameter  :: iunit=100
 
     character(100) :: cline1, cline2, cline3, cline4, cline5, clin6
 
     !> read in computed values
-    open(unit=iunit,file=trim(di_file))
+    open(newunit=iunit,file=di_file)
     read(iunit,*) cline1, cline2, cline3, cline4, cline5, clin6
     read(iunit,*) itime, field_avg2, field_avg3, field_avgw, field_avgh
     close(iunit)

--- a/test_fms/topography/test_topography.F90
+++ b/test_fms/topography/test_topography.F90
@@ -54,8 +54,8 @@ program test_top
   integer, parameter        :: lkind = TEST_TOP_KIND_      ! kind parameter for mixed precision
 
   real(kind=TEST_TOP_KIND_), parameter        :: deg2rad = real(pi, TEST_TOP_KIND_)/180.0_lkind
-  real(kind=TEST_TOP_KIND_), dimension(2,2), save   :: lon2d, lat2d   ! in radians
-  real(kind=TEST_TOP_KIND_), dimension(2), save     :: lon1d, lat1d   ! in radians
+  real(kind=TEST_TOP_KIND_), dimension(2,2)   :: lon2d, lat2d   ! in radians
+  real(kind=TEST_TOP_KIND_), dimension(2)     :: lon1d, lat1d   ! in radians
 
   call fms_init
   call topography_init
@@ -144,20 +144,22 @@ program test_top
   end if
   !-------------------------------------------------------------------------------------------------------------!
 
-  call test_topog_mean     ; call test_topog_stdev
-  call test_get_ocean_frac ; call test_get_ocean_mask
-  call test_get_water_frac ; call test_get_water_mask
+  call test_topog_mean(lat2d, lon2d, lat1d, lon1d)     ; call test_topog_stdev(lat2d, lon2d, lat1d, lon1d)
+  call test_get_ocean_frac(lat2d, lon2d, lat1d, lon1d) ; call test_get_ocean_mask(lat2d, lon2d, lat1d, lon1d)
+  call test_get_water_frac(lat2d, lon2d, lat1d, lon1d) ; call test_get_water_mask(lat2d, lon2d, lat1d, lon1d)
 
   call fms_end
 
   contains
 
-  subroutine test_topog_mean()
+  subroutine test_topog_mean(lat2d, lon2d, lat1d, lon1d)
     !! The naming convention of zmean2d/1d in this routine does not relate to their
     !! dimensions but correlates with what dimensions of lat and lon they are being
     !! tested with. In this case, the sizes of both zmean2d and zmean1d are both the
     !! same size but have to be these specific dimensions per the topography_mod code
     implicit none
+    real(kind=TEST_TOP_KIND_), dimension(2,2), intent(in)                 :: lat2d, lon2d
+    real(kind=TEST_TOP_KIND_), dimension(2),   intent(in)                 :: lat1d, lon1d
     real(kind=TEST_TOP_KIND_), dimension(size(lon2d,1)-1,size(lat2d,2)-1) :: zmean2d
     real(kind=TEST_TOP_KIND_), dimension(size(lon1d)-1,size(lat1d)-1)     :: zmean1d
     logical                                                               :: get_mean_answer
@@ -182,13 +184,15 @@ program test_top
 
   end subroutine test_topog_mean
 
-  subroutine test_topog_stdev
+  subroutine test_topog_stdev(lat2d, lon2d, lat1d, lon1d)
 
     !! The naming convention of stdev2d/1d in this routine does not relate to their
     !! dimensions but correlates with what dimensions of lat and lon they are being
     !! tested with. In this case, the sizes of both stdev2d and stdev1d are both the
     !! same size but have to be these specific dimensions per the topography_mod code
     implicit none
+    real(kind=TEST_TOP_KIND_), dimension(2,2), intent(in)                 :: lat2d, lon2d
+    real(kind=TEST_TOP_KIND_), dimension(2),   intent(in)                 :: lat1d, lon1d
     real(kind=TEST_TOP_KIND_), dimension(size(lon2d,1)-1,size(lat2d,2)-1) :: stdev2d
     real(kind=TEST_TOP_KIND_), dimension(size(lon1d)-1,size(lat1d)-1)     :: stdev1d
     logical                                                               :: get_stdev_answer
@@ -213,13 +217,15 @@ program test_top
 
   end subroutine test_topog_stdev
 
-  subroutine test_get_ocean_frac
+  subroutine test_get_ocean_frac(lat2d, lon2d, lat1d, lon1d)
 
     !! The naming convention of ocean_frac2d/1d in this routine does not relate to their
     !! dimensions but correlates with what dimensions of lat and lon they are being
     !! tested with. In this case, the sizes of both ocean_frac2d and ocean_frac1d are both the
     !! same size but have to be these specific dimensions per the topography_mod code
     implicit none
+    real(kind=TEST_TOP_KIND_), dimension(2,2), intent(in)                 :: lat2d, lon2d
+    real(kind=TEST_TOP_KIND_), dimension(2),   intent(in)                 :: lat1d, lon1d
     real(kind=TEST_TOP_KIND_), dimension(size(lon2d,1)-1,size(lat2d,2)-1) :: ocean_frac2d
     real(kind=TEST_TOP_KIND_), dimension(size(lon1d)-1,size(lat1d)-1)     :: ocean_frac1d
     logical                                                               :: get_ocean_frac_answer
@@ -243,16 +249,18 @@ program test_top
     ! with a larger ocean_frac1d array size
   end subroutine test_get_ocean_frac
 
-  subroutine test_get_ocean_mask
+  subroutine test_get_ocean_mask(lat2d, lon2d, lat1d, lon1d)
 
     !! The naming convention of ocean_mask2d/1d in this routine does not relate to their
     !! dimensions but correlates with what dimensions of lat and lon they are being
     !! tested with. In this case, the sizes of both ocean_mask2d and ocean_mask1d are both the
     !! same size but have to be these specific dimensions per the topography_mod code
     implicit none
-    logical, dimension(size(lon2d,1)-1,size(lat2d,2)-1) :: ocean_mask2d
-    logical, dimension(size(lon1d)-1,size(lat1d)-1)     :: ocean_mask1d
-    logical                                             :: get_ocean_mask_answer
+    real(kind=TEST_TOP_KIND_), dimension(2,2), intent(in)                 :: lat2d, lon2d
+    real(kind=TEST_TOP_KIND_), dimension(2),   intent(in)                 :: lat1d, lon1d
+    logical, dimension(size(lon2d,1)-1,size(lat2d,2)-1)                   :: ocean_mask2d
+    logical, dimension(size(lon1d)-1,size(lat1d)-1)                       :: ocean_mask1d
+    logical                                                               :: get_ocean_mask_answer
 
     !---------------------------------------- test get_ocean_mask 2d ---------------------------------------------!
 
@@ -275,12 +283,14 @@ program test_top
 
   end subroutine test_get_ocean_mask
 
-  subroutine test_get_water_frac
+  subroutine test_get_water_frac(lat2d, lon2d, lat1d, lon1d)
     !! The naming convention of water_frac2d/1d in this routine does not relate to their
     !! dimensions but correlates with what dimensions of lat and lon they are being
     !! tested with. In this case, the sizes of both water_frac2d and water_frac1d are both the
     !! same size but have to be these specific dimensions per the topography_mod code
     implicit none
+    real(kind=TEST_TOP_KIND_), dimension(2,2), intent(in)                 :: lat2d, lon2d
+    real(kind=TEST_TOP_KIND_), dimension(2),   intent(in)                 :: lat1d, lon1d
     real(kind=TEST_TOP_KIND_), dimension(size(lon2d,1)-1,size(lat2d,2)-1) :: water_frac2d
     real(kind=TEST_TOP_KIND_), dimension(size(lon1d)-1,size(lat1d)-1)     :: water_frac1d
     logical                                                               :: get_water_frac_answer
@@ -305,16 +315,18 @@ program test_top
 
   end subroutine test_get_water_frac
 
-  subroutine test_get_water_mask
+  subroutine test_get_water_mask(lat2d, lon2d, lat1d, lon1d)
 
     !! The naming convention of water_mask2d/1d in this routine does not relate to their
     !! dimensions but correlates with what dimensions of lat and lon they are being
     !! tested with. In this case, the sizes of both water_mask2d and water_mask1d are both the
     !! same size but have to be these specific dimensions per the topography_mod code
     implicit none
-    logical, dimension(size(lon2d,1)-1,size(lat2d,2)-1) :: water_mask2d
-    logical, dimension(size(lon1d)-1,size(lat1d)-1)     :: water_mask1d
-    logical                                             :: get_water_mask_answer
+    real(kind=TEST_TOP_KIND_), dimension(2,2), intent(in)                 :: lat2d, lon2d
+    real(kind=TEST_TOP_KIND_), dimension(2),   intent(in)                 :: lat1d, lon1d
+    logical, dimension(size(lon2d,1)-1,size(lat2d,2)-1)                   :: water_mask2d
+    logical, dimension(size(lon1d)-1,size(lat1d)-1)                       :: water_mask1d
+    logical                                                               :: get_water_mask_answer
 
     !---------------------------------------- test get_water_mask 2d ---------------------------------------------!
 

--- a/test_fms/topography/test_topography.F90
+++ b/test_fms/topography/test_topography.F90
@@ -54,8 +54,8 @@ program test_top
   integer, parameter        :: lkind = TEST_TOP_KIND_      ! kind parameter for mixed precision
 
   real(kind=TEST_TOP_KIND_), parameter        :: deg2rad = real(pi, TEST_TOP_KIND_)/180.0_lkind
-  real(kind=TEST_TOP_KIND_), dimension(2,2)   :: lon2d, lat2d   ! in radians
-  real(kind=TEST_TOP_KIND_), dimension(2)     :: lon1d, lat1d   ! in radians
+  real(kind=TEST_TOP_KIND_), dimension(2,2), save   :: lon2d, lat2d   ! in radians
+  real(kind=TEST_TOP_KIND_), dimension(2), save     :: lon1d, lat1d   ! in radians
 
   call fms_init
   call topography_init


### PR DESCRIPTION
**Description**
Adds save attribute to host associated arrays in test_topography and test_diag_integral so that these tests now pass with the ifx compiler.

**How Has This Been Tested?**
The Topography and Diag_integral unit tests successfully build and pass using the Intel oneAPI 2024.2 IFX compiler on an AMD box.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

