### PR TITLE
test_horiz_interp: Don't over-allocate arrays

### DIFF
--- a/test_fms/horiz_interp/test_horiz_interp.F90
+++ b/test_fms/horiz_interp/test_horiz_interp.F90
@@ -1131,7 +1131,7 @@ implicit none
         ! this set up is usually done within horiz_interp_new
         nlon_in  = size(lon_in_1d(:))-1;  nlat_in  = size(lat_in_1d(:))-1
         nlon_out = size(lon_out_1d(:))-1; nlat_out = size(lat_out_1d(:))-1
-        allocate(lon_src_1d(nlon_in), lat_src_1d(nlat_in))
+        allocate(lon_src_1d(nlon_in-1), lat_src_1d(nlat_in-1))
         allocate(lon_dst_1d(nlon_out), lat_dst_1d(nlat_out))
         do i = 1, nlon_in-1
           lon_src_1d(i) = (lon_in_1d(i) + lon_in_1d(i+1)) * 0.5_lkind
@@ -1213,7 +1213,7 @@ implicit none
         call horiz_interp_del(Interp_cp)
         ! 2dx1d
         deallocate(lon_out_1D, lat_out_1D)
-        allocate(lon_out_1D(ni_dst+1), lat_out_1D(nj_dst+1))
+        allocate(lon_out_1D(ni_dst), lat_out_1D(nj_dst))
         do i=1, ni_dst
             lon_out_1d(i) = real(i-1, HI_TEST_KIND_) * dlon_dst + lon_dst_beg
         enddo


### PR DESCRIPTION
**Description**
In the horiz_interp_type assignment 1x2d bicubic test, there are four allocatable arrays for which the number of elements allocated exceeds the number that get initialized:
* `lon_src_1d`
* `lat_src_1d`
* `lon_out_1d`
* `lat_out_1d`

This PR shortens the sizes of the arrays to match the number of elements that get initialized.

Fixes horiz_interp tests 23-24 with ifort using strict debug flags. It also fixes the tests with the Cray compiler. I'm requesting a careful review from @rem1776, because while this change does make the tests pass, I'm not sure whether or not the over-allocation may be a deliberate part of the test.

**How Has This Been Tested?**
horiz_interp tests build, run, and pass with CCE 18 on C5 and with ifort using the following debug flags:
```
-check all -fpe0 -fp-stack-check -fstack-security-check -ftrapuv -init=arrays,minus_huge,snan
```

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes