### PR TITLE
Fms io deprecation warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -257,8 +257,8 @@ if(WITH_YAML)
 endif()
 
 if(USE_DEPRECATED_IO)
-  message( WARNING "FMS_io will be deprecated in a future release. Please update to use fms2_io and remove "
-                   "-DUSE_DEPRECATED_IO=on from your options")
+  message( WARNING "fms_io WILL BE DEPRECATED IN A FUTURE RELEASE. PLEASE UPDATE TO USE FMS2_IO AND REMOVE "
+                   "-DUSE_DEPRECATED_IO=on FROM YOUR OPTIONS")
   list(APPEND fms_defs use_deprecated_io)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -257,6 +257,8 @@ if(WITH_YAML)
 endif()
 
 if(USE_DEPRECATED_IO)
+  message( WARNING "FMS_io will be deprecated in a future release. Please update to use fms2_io and remove "
+                   "-DUSE_DEPRECATED_IO=on from your options")
   list(APPEND fms_defs use_deprecated_io)
 endif()
 

--- a/configure.ac
+++ b/configure.ac
@@ -317,7 +317,6 @@ if test $enable_deprecated_io = yes; then
   # this macro was only removed from non-deprecated code so still needs to be set
   AC_DEFINE([use_netCDF], [1], [This has been removed elsewhere but is still required to build with deprecated io])
   AM_CONDITIONAL([SKIP_DEPRECATED_IO_TESTS], true)
-  AC_MSG_WARN(FMS_io will be deprecated in a future release. Please update to use fms2_io and remove --enable-deprecated-io from your configure options)
 else
   AM_CONDITIONAL([SKIP_DEPRECATED_IO_TESTS], false)
 fi
@@ -538,3 +537,7 @@ AC_CONFIG_FILES([
   ])
 
 AC_OUTPUT()
+
+if test $enable_deprecated_io = yes; then
+  AC_MSG_WARN(FMS_IO WILL BE DEPRECATED IN A FUTURE RLEASE. PLEASE UPDATE TO USE FMS2_IO AND REMOVE --enable-deprecated-io FROM YOUR CONFIGURE OPTIONS)
+fi

--- a/configure.ac
+++ b/configure.ac
@@ -317,6 +317,7 @@ if test $enable_deprecated_io = yes; then
   # this macro was only removed from non-deprecated code so still needs to be set
   AC_DEFINE([use_netCDF], [1], [This has been removed elsewhere but is still required to build with deprecated io])
   AM_CONDITIONAL([SKIP_DEPRECATED_IO_TESTS], true)
+  AC_MSG_WARN(FMS_io will be deprecated in a future release. Please update to use fms2_io and remove --enable-deprecated-io from your configure options)
 else
   AM_CONDITIONAL([SKIP_DEPRECATED_IO_TESTS], false)
 fi

--- a/fms/fms_io.F90
+++ b/fms/fms_io.F90
@@ -693,10 +693,10 @@ subroutine fms_io_init()
      call mpp_error(FATAL,'=>fms_io_init: Error reading input nml file')
   endif
 
-  call mpp_error(NOTE, "fms_io_init: fms_io will be deprecated in a future release. "// &
-                       "Please remove -Duse_deprecated_io from your compile flags "// &
-                       "and move to fms2_io. Contact your model liaison if you need "// &
-                       "assistance")
+  call mpp_error(NOTE, "fms_io_init: fms_io WILL BE DEPRECATED IN A FUTURE RELEASE! "//&
+                       "PLEASE REMOVE -Duse_deprecated_io FROM YOUR COMPILE FLAGS "// &
+                       "AND MOVE TO FMS2_IO. CONTACT YOUR MODEL LIASISON IF YOU NEED "// &
+                       "ASSISTANCE")
 
 ! take namelist options if present
 ! read_data_bug is no longer supported.
@@ -807,10 +807,10 @@ subroutine fms_io_exit()
 
     if( .NOT.module_is_initialized )return !make sure it's only called once per PE
 
-    call mpp_error(NOTE, "fms_io_exit: fms_io will be deprecated in a future release. "// &
-                         "Please remove -Duse_deprecated_io from your compile flags "// &
-                         "and move to fms2_io. Contact your model liaison if you need "// &
-                         "assistance.")
+    call mpp_error(NOTE, "fms_io_exit: fms_io WILL BE DEPRECATED IN A FUTURE RELEASE! "//&
+                         "PLEASE REMOVE -Duse_deprecated_io FROM YOUR COMPILE FLAGS "// &
+                         "AND MOVE TO FMS2_IO. CONTACT YOUR MODEL LIASISON IF YOU NEED "// &
+                         "ASSISTANCE")
 
     do i=1,max_axis_size
        axisdata(i) = i

--- a/fms/fms_io.F90
+++ b/fms/fms_io.F90
@@ -693,6 +693,11 @@ subroutine fms_io_init()
      call mpp_error(FATAL,'=>fms_io_init: Error reading input nml file')
   endif
 
+  call mpp_error(NOTE, "fms_io_init: fms_io will be deprecated in a future release. "// &
+                       "Please remove -Duse_deprecated_io from your compile flags "// &
+                       "and move to fms2_io. Contact your model liaison if you need "// &
+                       "assistance")
+
 ! take namelist options if present
 ! read_data_bug is no longer supported.
   if (read_data_bug) then
@@ -801,6 +806,11 @@ subroutine fms_io_exit()
     type(domain2d), pointer :: io_domain =>NULL()
 
     if( .NOT.module_is_initialized )return !make sure it's only called once per PE
+
+    call mpp_error(NOTE, "fms_io_exit: fms_io will be deprecated in a future release. "// &
+                         "Please remove -Duse_deprecated_io from your compile flags "// &
+                         "and move to fms2_io. Contact your model liaison if you need "// &
+                         "assistance.")
 
     do i=1,max_axis_size
        axisdata(i) = i

--- a/test_fms/mpp/test_stdlog.F90
+++ b/test_fms/mpp/test_stdlog.F90
@@ -85,7 +85,7 @@ program test_stdlog
       if (trim(line) == '') cycle
       !! if we're testing with the old io enabled, we'll have some additional output we can skip
       if (trim(line) == 'NOTE from PE     0: MPP_IO_SET_STACK_SIZE: stack size set to     131072.') cycle
-      if (index(trim(line), "fms_io") .ne. 0) cycle 
+      if (index(trim(line), "fms_io") .ne. 0) cycle
       if(trim(line) .ne. trim(ref_line(ref_num))) call mpp_error(FATAL, "warnfile output does not match reference data"&
                                                                 //"reference line:"//ref_line(ref_num) &
                                                                 //"output line:"//line)

--- a/test_fms/mpp/test_stdlog.F90
+++ b/test_fms/mpp/test_stdlog.F90
@@ -85,6 +85,7 @@ program test_stdlog
       if (trim(line) == '') cycle
       !! if we're testing with the old io enabled, we'll have some additional output we can skip
       if (trim(line) == 'NOTE from PE     0: MPP_IO_SET_STACK_SIZE: stack size set to     131072.') cycle
+      if (index(trim(line), "fms_io") .ne. 0) cycle 
       if(trim(line) .ne. trim(ref_line(ref_num))) call mpp_error(FATAL, "warnfile output does not match reference data"&
                                                                 //"reference line:"//ref_line(ref_num) &
                                                                 //"output line:"//line)


### PR DESCRIPTION
**Description**
Adds a warning to warn users that fms_io/mpp_io will be removed soon.

Fixes #1608 

**How Has This Been Tested?**
CI

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

