### PR TITLE
Set `fms_diag_accept_data`

### DIFF
--- a/diag_manager/diag_manager.F90
+++ b/diag_manager/diag_manager.F90
@@ -1789,7 +1789,7 @@ END FUNCTION register_static_field
       allocate(mask_remap(1:size(mask,1), 1:size(mask,2), 1:size(mask,3), 1))
       mask_remap(:,:,:,1) = mask
     endif
-    diag_send_data = fms_diag_object%fms_diag_accept_data(diag_field_id, field_remap, mask_remap, rmask_remap, &
+    call fms_diag_object%fms_diag_accept_data(diag_field_id, field_remap, mask_remap, rmask_remap, &
                                                           time, is_in, js_in, ks_in, ie_in, je_in, ke_in, weight, &
                                                           err_msg)
     deallocate (field_remap)
@@ -3518,7 +3518,7 @@ END FUNCTION register_static_field
     if (present(mask)) mask_local = mask
     if (present(rmask)) rmask_local = rmask
 
-    send_data_4d = fms_diag_object%fms_diag_accept_data(diag_field_id, field, mask_local, rmask_local, &
+    call fms_diag_object%fms_diag_accept_data(diag_field_id, field, mask_local, rmask_local, &
                                                           time, is_in, js_in, ks_in, ie_in, je_in, ke_in, weight, &
                                                           err_msg)
 

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -537,7 +537,7 @@ end function fms_diag_axis_init
 !! multithreaded case.
 !! \note If some of the diag manager is offloaded in the future, then it should be treated similarly
 !! to the multi-threaded option for processing later
-logical function fms_diag_accept_data (this, diag_field_id, field_data, mask, rmask, &
+subroutine fms_diag_accept_data (this, diag_field_id, field_data, mask, rmask, &
                                        time, is_in, js_in, ks_in, &
                                        ie_in, je_in, ke_in, weight, err_msg)
   class(fmsDiagObject_type),TARGET,      INTENT(inout)          :: this          !< Diaj_obj to fill
@@ -710,9 +710,8 @@ CALL MPP_ERROR(FATAL,"You can not use the modern diag manager without compiling 
     call this%FMS_diag_fields(diag_field_id)%set_mask(oor_mask, field_info)
   end if main_if
   !> Return false if nothing is done
-  fms_diag_accept_data = .TRUE.
 #endif
-end function fms_diag_accept_data
+end subroutine fms_diag_accept_data
 
 !< @brief Do the math for all the buffers
 subroutine do_buffer_math(this)

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -680,8 +680,6 @@ CALL MPP_ERROR(FATAL,"You can not use the modern diag manager without compiling 
 !$omp end critical
     call this%FMS_diag_fields(diag_field_id)%set_data_buffer(field_data, oor_mask, field_weight, &
                                                              is, js, ks, ie, je, ke)
-    fms_diag_accept_data = .TRUE.
-    return
   else
 
     !< At this point if we are no longer in an openmp region or running with 1 thread
@@ -709,11 +707,9 @@ CALL MPP_ERROR(FATAL,"You can not use the modern diag manager without compiling 
     if(.not. this%FMS_diag_fields(diag_field_id)%has_mask_allocated()) &
       call this%FMS_diag_fields(diag_field_id)%allocate_mask(oor_mask)
     call this%FMS_diag_fields(diag_field_id)%set_mask(oor_mask, field_info)
-    return
   end if main_if
   !> Return false if nothing is done
-  fms_diag_accept_data = .FALSE.
-  return
+  fms_diag_accept_data = .TRUE.
 #endif
 end function fms_diag_accept_data
 

--- a/test_fms/diag_manager/test_diag_manager2.sh
+++ b/test_fms/diag_manager/test_diag_manager2.sh
@@ -786,7 +786,7 @@ diag_files:
     kind: r4
   - module: atm_mod
     var_name: var7
-    reduction: average
+    reduction: none
     kind: r4
 - file_name: file4
   freq: 6 hours
@@ -1050,7 +1050,7 @@ diag_files:
     dimensions: time grid_index
   - module: atm_mod
     var_name: var7
-    reduction: average
+    reduction: none
     kind: r4
     output_name:
     long_name:

--- a/test_fms/diag_manager/test_modern_diag.F90
+++ b/test_fms/diag_manager/test_modern_diag.F90
@@ -199,6 +199,7 @@ call diag_manager_set_time_end(set_date(2,1,2,0,0,0))
 
 call allocate_dummy_data(var_data, domain, Domain_cube_sph, land_domain, nz)
 Time_step = set_time (3600,0) !< 1 hour
+call set_dummy_data(var_data, 666)
 used = send_data(id_var8, var_data%var6, Time)
 do i=1,23
   Time = Time + Time_step

--- a/test_fms/diag_manager/test_modern_diag.F90
+++ b/test_fms/diag_manager/test_modern_diag.F90
@@ -199,6 +199,7 @@ call diag_manager_set_time_end(set_date(2,1,2,0,0,0))
 
 call allocate_dummy_data(var_data, domain, Domain_cube_sph, land_domain, nz)
 Time_step = set_time (3600,0) !< 1 hour
+used = send_data(id_var8, var_data%var6, Time)
 do i=1,23
   Time = Time + Time_step
   call set_dummy_data(var_data, i)
@@ -209,9 +210,6 @@ do i=1,23
   used = send_data(id_var5, var_data%var5, Time)
   used = send_data(id_var6, var_data%var6, Time)
   used = send_data(id_var7, var_data%var6, Time)
-
-  !TODO I don't know about this (scalar field) or how this is suppose to work #WUT
-  used = send_data(id_var8, var_data%var6, Time)
 
   call diag_send_complete(Time_step)
 enddo


### PR DESCRIPTION
**Description**
1. Ensure that `fms_diag_accept_data` is always set by removing return statements and setting it in the end. This is to prevent errors in debug mode in cases where `fms_diag_accept_data` is not set.  `fms_diag_accept_data` is always set to .true., if there any errors in the subroutine it will crash with a FATAL.
2. Fixes the calls to send_data for a static variable in the unit tests. 

Fixes #1591 

**How Has This Been Tested?**
CI

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

