### PR TITLE
replace include fms_platform.h with use platform_mod in mpp unit tests

### DIFF
--- a/test_fms/mpp/test_domains_simple.F90
+++ b/test_fms/mpp/test_domains_simple.F90
@@ -24,11 +24,13 @@
 
 !> @author Ed Hartnett 6/22/20
 program test_domains_simple
+
   use mpp_mod
   use mpp_domains_mod
+  use platform_mod
 
   implicit none
-#include "../../include/fms_platform.h"
+
   integer :: pe, npes     !> This pe and the total number of pes.
   integer :: nx=40, ny=40 !> Size of our 2D domain.
   integer :: layout(2)    !> Layout of our 2D domain.

--- a/test_fms/mpp/test_domains_simple.F90
+++ b/test_fms/mpp/test_domains_simple.F90
@@ -28,7 +28,6 @@ program test_domains_simple
   use mpp_mod
   use mpp_domains_mod
   use platform_mod
-
   implicit none
 
   integer :: pe, npes     !> This pe and the total number of pes.

--- a/test_fms/mpp/test_mpp_mem_dump.F90
+++ b/test_fms/mpp/test_mpp_mem_dump.F90
@@ -30,7 +30,6 @@ program test_mpp_mem_dump
 
   use mpp_memutils_mod, only: mpp_mem_dump
   use platform_mod
-
   implicit none
 
   real :: memuse

--- a/test_fms/mpp/test_mpp_mem_dump.F90
+++ b/test_fms/mpp/test_mpp_mem_dump.F90
@@ -27,8 +27,10 @@
 !! Test that the call to mpp_mem_dump is functional.  On a supported OS, the return value
 !! of mpp_mem_dump should be a positive integer.
 program test_mpp_mem_dump
+
   use mpp_memutils_mod, only: mpp_mem_dump
-#include "../../include/fms_platform.h"
+  use platform_mod
+
   implicit none
 
   real :: memuse

--- a/test_fms/mpp/test_mpp_memutils_begin_2x.F90
+++ b/test_fms/mpp/test_mpp_memutils_begin_2x.F90
@@ -32,7 +32,6 @@ program test_mpp_memutils_init_end
   use mpp_mod, only : mpp_init, mpp_exit
   use mpp_memutils_mod, only: mpp_memuse_begin, mpp_memuse_end
   use platform_mod
-
   implicit none
 
   real, dimension(:), allocatable :: ralloc_mem

--- a/test_fms/mpp/test_mpp_memutils_begin_2x.F90
+++ b/test_fms/mpp/test_mpp_memutils_begin_2x.F90
@@ -28,10 +28,11 @@
 !! code this is an error, which should be caught.  This program should exit
 !! non-zero.
 program test_mpp_memutils_init_end
-#include "../../include/fms_platform.h"
 
   use mpp_mod, only : mpp_init, mpp_exit
   use mpp_memutils_mod, only: mpp_memuse_begin, mpp_memuse_end
+  use platform_mod
+
   implicit none
 
   real, dimension(:), allocatable :: ralloc_mem

--- a/test_fms/mpp/test_mpp_memutils_begin_end.F90
+++ b/test_fms/mpp/test_mpp_memutils_begin_end.F90
@@ -28,10 +28,11 @@
 !! This test will exit with status zero if successful.  The script launching this test
 !! program may, if desired, check if the memory output numbers are sane.
 program test_mpp_memutils_init_end
-#include "../../include/fms_platform.h"
 
   use mpp_mod, only : mpp_init, mpp_exit
   use mpp_memutils_mod, only: mpp_memuse_begin, mpp_memuse_end
+  use platform_mod
+
   implicit none
 
   real, dimension(:), allocatable :: ralloc_mem

--- a/test_fms/mpp/test_mpp_memutils_begin_end.F90
+++ b/test_fms/mpp/test_mpp_memutils_begin_end.F90
@@ -32,7 +32,6 @@ program test_mpp_memutils_init_end
   use mpp_mod, only : mpp_init, mpp_exit
   use mpp_memutils_mod, only: mpp_memuse_begin, mpp_memuse_end
   use platform_mod
-
   implicit none
 
   real, dimension(:), allocatable :: ralloc_mem

--- a/test_fms/mpp/test_mpp_memutils_end_before_begin.F90
+++ b/test_fms/mpp/test_mpp_memutils_end_before_begin.F90
@@ -31,7 +31,6 @@ program test_mpp_memutils_init_end
   use mpp_mod, only : mpp_init, mpp_exit
   use mpp_memutils_mod, only: mpp_memuse_begin, mpp_memuse_end
   use platform_mod
-
   implicit none
 
   real, dimension(:), allocatable :: ralloc_mem

--- a/test_fms/mpp/test_mpp_memutils_end_before_begin.F90
+++ b/test_fms/mpp/test_mpp_memutils_end_before_begin.F90
@@ -27,10 +27,11 @@
 !! Test the error case when mpp_memuse_end() is called before mpp_memuse_begin().
 !! This test program should exit non-zero if successful.
 program test_mpp_memutils_init_end
-#include "../../include/fms_platform.h"
 
   use mpp_mod, only : mpp_init, mpp_exit
   use mpp_memutils_mod, only: mpp_memuse_begin, mpp_memuse_end
+  use platform_mod
+
   implicit none
 
   real, dimension(:), allocatable :: ralloc_mem

--- a/test_fms/mpp/test_mpp_print_memuse_stats_file.F90
+++ b/test_fms/mpp/test_mpp_print_memuse_stats_file.F90
@@ -37,7 +37,6 @@ program test_mpp_mem_print_stats_file
   use mpp_memutils_mod, only: mpp_memuse_begin, mpp_memuse_end
   use mpp_memutils_mod, only: mpp_print_memuse_stats
   use platform_mod
-
   implicit none
 
   real, dimension(:), allocatable :: ralloc_mem1, ralloc_mem2

--- a/test_fms/mpp/test_mpp_print_memuse_stats_file.F90
+++ b/test_fms/mpp/test_mpp_print_memuse_stats_file.F90
@@ -32,11 +32,12 @@
 !! successful.  The script calling the program can check if the numbers are sane, if
 !! desired.
 program test_mpp_mem_print_stats_file
-#include "../../include/fms_platform.h"
 
   use mpp_mod, only : mpp_init, mpp_exit, stdout
   use mpp_memutils_mod, only: mpp_memuse_begin, mpp_memuse_end
   use mpp_memutils_mod, only: mpp_print_memuse_stats
+  use platform_mod
+
   implicit none
 
   real, dimension(:), allocatable :: ralloc_mem1, ralloc_mem2

--- a/test_fms/mpp/test_mpp_print_memuse_stats_stderr.F90
+++ b/test_fms/mpp/test_mpp_print_memuse_stats_stderr.F90
@@ -35,7 +35,6 @@ program test_mpp_mem_print_stats_stderr
   use mpp_memutils_mod, only: mpp_memuse_begin, mpp_memuse_end
   use mpp_memutils_mod, only: mpp_print_memuse_stats
   use platform_mod
-
   implicit none
 
   real, dimension(:), allocatable :: ralloc_mem1, ralloc_mem2

--- a/test_fms/mpp/test_mpp_print_memuse_stats_stderr.F90
+++ b/test_fms/mpp/test_mpp_print_memuse_stats_stderr.F90
@@ -30,11 +30,12 @@
 !! successful.  The script calling the program can check if the numbers are sane, if
 !! desired.
 program test_mpp_mem_print_stats_stderr
-#include "../../include/fms_platform.h"
 
   use mpp_mod, only : mpp_init, mpp_exit
   use mpp_memutils_mod, only: mpp_memuse_begin, mpp_memuse_end
   use mpp_memutils_mod, only: mpp_print_memuse_stats
+  use platform_mod
+
   implicit none
 
   real, dimension(:), allocatable :: ralloc_mem1, ralloc_mem2


### PR DESCRIPTION
**Description**
In this PR, `#include fms_platform.h` has been replaced with `use platform_mod` in several mpp unit tests.  This is to avoid compilations when FMS is compiled with `--enable-portable-kinds`.  See issue below for more details.

Fixes #1615 

**How Has This Been Tested?**
Unit tests in test_fms/mpp pass with GCC 14 on the amdbox.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

