### PR TITLE
fix for mosaic2 test

### DIFF
--- a/test_fms/mosaic2/test_mosaic2.F90
+++ b/test_fms/mosaic2/test_mosaic2.F90
@@ -96,6 +96,7 @@ subroutine test_get_mosaic_grid_sizes
 
   allocate( nx_out(c1_ntiles), ny_out(c1_ntiles) )
   call get_mosaic_grid_sizes(fileobj, nx_out, ny_out)
+  ntiles = get_mosaic_ntiles(fileobj)
   do n=1, ntiles
      call check_answer(c1_nx/2, nx_out(n), 'atm TEST_GET_MOSAIC_GRID_SIZES')
      call check_answer(c1_nx/2, ny_out(n), 'atm TEST_GET_MOSAIC_GRID_SIZES')


### PR DESCRIPTION
**Description**
Adds a line that fixes a failure i saw with intel 2024.2 + debug flags, just assigns a previously undeclared variable.

**How Has This Been Tested?**
amd box with oneapi 2024.2

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

