### PR TITLE
fix format string overflow in diag_integral test

### DIFF
--- a/diag_integral/diag_integral.F90
+++ b/diag_integral/diag_integral.F90
@@ -40,7 +40,7 @@ use fms_mod,          only:  error_mesg, &
                              fms_init, &
                              mpp_pe, mpp_root_pe,&
                              FATAL, write_version_number, &
-                             stdlog
+                             stdlog, string
 use fms2_io_mod,      only:  file_exists
 use constants_mod,    only:  radius, constants_init
 use mpp_mod,          only:  mpp_sum, mpp_init
@@ -195,7 +195,6 @@ integer                     :: field_count  (max_num_field) !< number of values 
 !-------------------------------------------------------------------------------
 character(len=160) :: format_text !< format statement for header
 character(len=160) :: format_data !< format statement for data output
-logical            :: do_format_data = .true. !< a data format needs to be generated ?
 integer            :: nd !< number of characters in data format statement
 integer            :: nt !< number of characters in text format statement
 
@@ -711,6 +710,8 @@ type (time_type), intent(in) :: Time !< integral time stamp at the current time
       integer :: nn, ninc, nst, nend, fields_to_print
       integer :: i, kount
       integer(i8_kind) :: icount
+      character(len=128) :: xtime_str
+      logical :: use_exp_format
 
 !-------------------------------------------------------------------------------
 !    each header and data format may be different and must be generated
@@ -765,6 +766,12 @@ type (time_type), intent(in) :: Time !< integral time stamp at the current time
       xtime = get_axis_time (Time-Time_init_save, time_units)
 
 !-------------------------------------------------------------------------------
+!    check if the time value is too long for decimal output
+!-------------------------------------------------------------------------------
+      xtime_str = trim(string(xtime))
+      use_exp_format = len_trim(xtime_str(1:INDEX(xtime_str, "."))) .ge. 9
+
+!-------------------------------------------------------------------------------
 !    generate the new header and data formats.
 !-------------------------------------------------------------------------------
       nst = 1
@@ -774,7 +781,7 @@ type (time_type), intent(in) :: Time !< integral time stamp at the current time
         nst = 1 + (nn-1)*fields_per_print_line
         nend = MIN (nn*fields_per_print_line, num_field)
         if (print_header)  call format_text_init (nst, nend)
-        call format_data_init (nst, nend)
+        call format_data_init (nst, nend, use_exp_format)
         if (diag_unit /= 0) then
           write (diag_unit,format_data(1:nd)) &
                  xtime, (field_avg(i),i=nst,nend)
@@ -890,18 +897,22 @@ end subroutine format_text_init
 !! <b> Parameters: </b>
 !!
 !! @code{.f90}
-!! integer, intent(in), optional :: nst_in, nend_in
+!! integer, intent(in) :: nst_in, nend_in
 !! @endcode
 !!
 !! @param [in] <nst_in, nend_in> starting/ending integral index which will be
 !!        included in this format statement
+!! @param [in] <nst_in, nend_in> starting/ending integral index which will be
+!!        included in this format statement
 !!
-subroutine format_data_init (nst_in, nend_in)
+subroutine format_data_init (nst_in, nend_in, use_exp_format)
 
-integer, intent(in), optional :: nst_in !< starting/ending integral index which will be
+integer, intent(in) :: nst_in !< starting/ending integral index which will be
                                                  !! included in this format statement
-integer, intent(in), optional :: nend_in !< starting/ending integral index which will be
+integer, intent(in) :: nend_in !< starting/ending integral index which will be
                                                  !! included in this format statement
+logical, intent(in) :: use_exp_format !< if true, uses exponent notation for the first format code
+                                      !! to avoid overflow with larger time values
 
 !-------------------------------------------------------------------------------
 ! local variables:
@@ -917,19 +928,18 @@ integer, intent(in), optional :: nend_in !< starting/ending integral index which
 !    integrals. this section is 9 characters long.
 !-------------------------------------------------------------------------------
       nd = 9
-      format_data(1:nd) = '(1x,e10.2'
+      if( use_exp_format ) then
+        format_data(1:nd) = '(1x,e10.2'
+      else
+        format_data(1:nd) = '(1x,f10.2'
+      endif
 
 !-------------------------------------------------------------------------------
 !    define the indices of the integrals that are to be written by this
 !    format statement.
 !-------------------------------------------------------------------------------
-      if ( present (nst_in) ) then
-        nst = nst_in
-        nend = nend_in
-      else
-        nst = 1
-        nend = num_field
-      endif
+      nst = nst_in
+      nend = nend_in
 
 !-------------------------------------------------------------------------------
 !    complete the data format. use the format defined for the

--- a/diag_integral/diag_integral.F90
+++ b/diag_integral/diag_integral.F90
@@ -902,8 +902,8 @@ end subroutine format_text_init
 !!
 !! @param [in] <nst_in, nend_in> starting/ending integral index which will be
 !!        included in this format statement
-!! @param [in] <nst_in, nend_in> starting/ending integral index which will be
-!!        included in this format statement
+!! @param [in] <use_exp_format>  if true, uses exponent notation for the first format code
+!!        to avoid overflow with larger time values
 !!
 subroutine format_data_init (nst_in, nend_in, use_exp_format)
 

--- a/diag_integral/diag_integral.F90
+++ b/diag_integral/diag_integral.F90
@@ -917,7 +917,7 @@ integer, intent(in), optional :: nend_in !< starting/ending integral index which
 !    integrals. this section is 9 characters long.
 !-------------------------------------------------------------------------------
       nd = 9
-      format_data(1:nd) = '(1x,f10.2'
+      format_data(1:nd) = '(1x,e10.2'
 
 !-------------------------------------------------------------------------------
 !    define the indices of the integrals that are to be written by this
@@ -937,8 +937,8 @@ integer, intent(in), optional :: nend_in !< starting/ending integral index which
 !-------------------------------------------------------------------------------
       do i=nst,nend
          nc = len_trim(field_format(i))
-         format_data(nd+1:nd+nc+5) =  ',1x,' // field_format(i)(1:nc)
-         nd = nd+nc+5
+         format_data(nd+1:nd+nc+4) =  ',1x,' // field_format(i)(1:nc)
+         nd = nd+nc+4
       end do
 
 !-------------------------------------------------------------------------------

--- a/test_fms/diag_integral/test_diag_integral.F90
+++ b/test_fms/diag_integral/test_diag_integral.F90
@@ -62,7 +62,6 @@ program test_diag_integral
   type(time_type) :: Time_init, Time
 
   !testing and generating answers
-  integer :: i, j, k !> counters for do loop
   real(r8_kind) :: area_sum !> global area.  sum of the grid cell areas.
   real(r8_kind) :: itime    !> made up time
   !> The field_avg* values are only declared as r8_kind because they correspond to the values

--- a/test_fms/diag_integral/test_diag_integral2.sh
+++ b/test_fms/diag_integral/test_diag_integral2.sh
@@ -32,4 +32,6 @@ mkdir -p INPUT
 test_expect_success "test_diag_integral r4" 'mpirun -n 1 ./test_diag_integral_r4'
 test_expect_success "test_diag_integral r8" 'mpirun -n 1 ./test_diag_integral_r8'
 
+rm -rf INPUT
+
 test_done

--- a/test_fms/diag_integral/test_diag_integral2.sh
+++ b/test_fms/diag_integral/test_diag_integral2.sh
@@ -30,11 +30,6 @@ EOF
 mkdir -p INPUT
 
 test_expect_success "test_diag_integral r4" 'mpirun -n 1 ./test_diag_integral_r4'
-rm diag_integral.out
 test_expect_success "test_diag_integral r8" 'mpirun -n 1 ./test_diag_integral_r8'
-rm diag_integral.out
-
-rm input.nml
-rm -rf INPUT
 
 test_done


### PR DESCRIPTION
**Description**
The diag_integral test failing from the issue below ended up being from overflow due to the `xtime` variable's value having more digits before the decimal than the given width of 10 will allow. With this PR it'll check the count of digits before the decimal, and if its greater than ten it'll just output using the exponent notation instead.

I cleaned up the `format_data_init` routine a bit by adjusting the indices used when it sets the data format string so it won't have additional spaces throughout. Also changed it's arguments to required (its private and only called with args) and removed some unused variables.

Fixes #1623 

**How Has This Been Tested?**
oneapi 2024.2 on the amd box.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

