### PR TITLE
fix temporary array warning in mpp_init

### DIFF
--- a/mpp/include/mpp_util_mpi.inc
+++ b/mpp/include/mpp_util_mpi.inc
@@ -101,6 +101,7 @@ function get_peset(pelist)
   integer, intent(in), optional :: pelist(:)
   integer                       :: errunit
   integer                       :: i, n
+  integer, allocatable          :: pelist_tmp(:)
 
   if( .NOT.PRESENT(pelist) )then !set it to current_peset_num
      get_peset = current_peset_num; return
@@ -134,11 +135,13 @@ function get_peset(pelist)
   peset(i)%list(:) = pelist(:)
   peset(i)%count = size(pelist(:))
 
-  call MPI_GROUP_INCL( peset(current_peset_num)%group, size(pelist(:)), pelist-mpp_root_pe(), peset(i)%group, error )
+  allocate(pelist_tmp(size(pelist(:))))
+  pelist_tmp = pelist - mpp_root_pe()
+  call MPI_GROUP_INCL( peset(current_peset_num)%group, size(pelist(:)), pelist_tmp, peset(i)%group, error )
   call MPI_COMM_CREATE_GROUP(peset(current_peset_num)%id, peset(i)%group, &
                              DEFAULT_TAG, peset(i)%id, error )
   get_peset = i
-
+  deallocate(pelist_tmp)
   return
 
 end function get_peset


### PR DESCRIPTION
**Description**
This just fixes "array temporary created" runtime warnings during `mpp_init` when compiled with intel and the `-check` flag.

**How Has This Been Tested?**
make check

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

