### PR TITLE
add allocation check to astronomy_end

### DIFF
--- a/astronomy/astronomy.F90
+++ b/astronomy/astronomy.F90
@@ -768,7 +768,7 @@ subroutine astronomy_end
     !----------------------------------------------------------------------
     !>    deallocate module variables.
     !----------------------------------------------------------------------
-    deallocate (orb_angle)
+    if (allocated(orb_angle)) deallocate (orb_angle)
     if (allocated(cosz_ann) ) then
         deallocate (cosz_ann)
         deallocate (fracday_ann)


### PR DESCRIPTION
**Description**
In astronomy_end, there was no check for if orb_angle was allocated before deallocating.  This fixes that.

Fixes #1368 

**How Has This Been Tested?**
Tested on AMD dev box with intel compiler

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

