### PR TITLE
1630: Fix for when each ensemble is using the same diag/field/data yaml

### DIFF
--- a/data_override/include/data_override.inc
+++ b/data_override/include/data_override.inc
@@ -599,6 +599,10 @@ subroutine read_table_yaml(data_table)
     if (index(trim(filename), "ens_") .ne. 0) then
       if (file_exists(filename) .and. file_exists("data_table.yaml")) &
         call mpp_error(FATAL, "Both data_table.yaml and "//trim(filename)//" exists, pick one!")
+
+      !< If the end_* file does not exist, revert back to "data_table.yaml"
+      !! where every ensemble is using the same yaml
+      if (.not. file_exists(filename)) filename = "data_table.yaml"
     endif
 
     file_id = open_and_parse_file(trim(filename))

--- a/diag_manager/fms_diag_yaml.F90
+++ b/diag_manager/fms_diag_yaml.F90
@@ -36,7 +36,7 @@ use diag_data_mod,   only: DIAG_NULL, DIAG_OCEAN, DIAG_ALL, DIAG_OTHER, set_base
                            time_diurnal, time_power, time_none, r8, i8, r4, i4, DIAG_NOT_REGISTERED, &
                            middle_time, begin_time, end_time, MAX_STR_LEN
 use yaml_parser_mod, only: open_and_parse_file, get_value_from_key, get_num_blocks, get_nkeys, &
-                           get_block_ids, get_key_value, get_key_ids, get_key_name
+                           get_block_ids, get_key_value, get_key_ids, get_key_name, missing_file_error_code
 use fms_yaml_output_mod, only: fmsYamlOutKeys_type, fmsYamlOutValues_type, write_yaml_from_struct_3, &
                                yaml_out_add_level2key, initialize_key_struct, initialize_val_struct
 use mpp_mod,         only: mpp_error, FATAL, NOTE, mpp_pe, mpp_root_pe, stdout
@@ -391,8 +391,12 @@ subroutine diag_yaml_object_init(diag_subset_output)
   if (index(trim(yamlfilename), "ens_") .ne. 0) then
     if (file_exists(yamlfilename) .and. file_exists("diag_table.yaml")) &
       call mpp_error(FATAL, "Both diag_table.yaml and "//trim(yamlfilename)//" exists, pick one!")
+    !< If the end_* file does not exist, revert back to "diag_table.yaml"
+    !! where every ensemble is using the same yaml
+    if (.not. file_exists(yamlfilename)) yamlfilename = "diag_table.yaml"
   endif
   diag_yaml_id = open_and_parse_file(trim(yamlfilename))
+  if (diag_yaml_id .eq. missing_file_error_code) call mpp_error(FATAL, "The "//trim(yamlfilename)//" is not present and it is required!")
 
   call diag_get_value_from_key(diag_yaml_id, 0, "title", diag_yaml%diag_title)
   call get_value_from_key(diag_yaml_id, 0, "base_date", diag_yaml%diag_basedate)

--- a/diag_manager/fms_diag_yaml.F90
+++ b/diag_manager/fms_diag_yaml.F90
@@ -396,7 +396,8 @@ subroutine diag_yaml_object_init(diag_subset_output)
     if (.not. file_exists(yamlfilename)) yamlfilename = "diag_table.yaml"
   endif
   diag_yaml_id = open_and_parse_file(trim(yamlfilename))
-  if (diag_yaml_id .eq. missing_file_error_code) call mpp_error(FATAL, "The "//trim(yamlfilename)//" is not present and it is required!")
+  if (diag_yaml_id .eq. missing_file_error_code) &
+    call mpp_error(FATAL, "The "//trim(yamlfilename)//" is not present and it is required!")
 
   call diag_get_value_from_key(diag_yaml_id, 0, "title", diag_yaml%diag_title)
   call get_value_from_key(diag_yaml_id, 0, "base_date", diag_yaml%diag_basedate)

--- a/field_manager/field_manager.F90
+++ b/field_manager/field_manager.F90
@@ -618,6 +618,10 @@ call get_instance_filename(tbl_name, filename)
 if (index(trim(filename), "ens_") .ne. 0) then
   if (file_exists(filename) .and. file_exists(tbl_name)) &
     call mpp_error(FATAL, "Both "//trim(tbl_name)//" and "//trim(filename)//" exists, pick one!")
+
+  !< If the end_* file does not exist, revert back to tbl_name
+  !! where every ensemble is using the same yaml
+  if (.not. file_exists(filename)) filename = tbl_name
 endif
 
 if (.not. file_exists(trim(filename))) then

--- a/parser/yaml_parser.F90
+++ b/parser/yaml_parser.F90
@@ -39,6 +39,7 @@ implicit none
 private
 
 public :: open_and_parse_file
+public :: missing_file_error_code
 public :: get_num_unique_blocks
 public :: get_unique_block_ids
 public :: get_block_name
@@ -51,6 +52,8 @@ public :: get_key_name
 public :: get_key_value
 !public :: clean_up
 !> @}
+
+integer, parameter :: missing_file_error_code = 999
 
 !> @brief Dermine the value of a key from a keyname
 !> @ingroup yaml_parser_mod
@@ -253,7 +256,7 @@ function open_and_parse_file(filename) &
 
    inquire(file=trim(filename), EXIST=yaml_exists)
    if (.not. yaml_exists) then
-      file_id = 999
+      file_id = missing_file_error_code
       call mpp_error(NOTE, "The yaml file:"//trim(filename)//" does not exist, hopefully this is your intent!")
       return
    end if

--- a/test_fms/data_override/test_data_override_ensembles.sh
+++ b/test_fms/data_override/test_data_override_ensembles.sh
@@ -86,7 +86,7 @@ data_table:
    fieldname_in_model: runoff
    override_file:
    - fieldname_in_file: runoff
-     file_name: INPUT/runoff.daitren.clim.1440x1080.v20180328_ens_02.nc
+     file_name: INPUT/runoff.daitren.clim.1440x1080.v20180328_ens_01.nc
      interp_method: none
    factor: 1.0
 _EOF
@@ -94,6 +94,28 @@ _EOF
     test_expect_failure "test_data_override with both data_table.yaml and data_table.ens_xx.yaml files" '
       mpirun -n 12 ../test_data_override_ongrid_${KIND}
       '
+
+cat <<_EOF > input.nml
+&data_override_nml
+  use_data_table_yaml = .True.
+/
+
+&test_data_override_ongrid_nml
+  test_case = 6
+  write_only = .False.
+/
+
+&ensemble_nml
+   ensemble_size = 2
+/
+_EOF
+
+rm -rf INPUT/.
+rm -rf data_table.ens_01.yaml data_table.ens_02.yaml
+test_expect_success "test_data_override with two ensembles, same yaml file (${KIND})" '
+      mpirun -n 12 ../test_data_override_ongrid_${KIND}
+      '
+
 rm -rf INPUT
 fi
 test_done

--- a/test_fms/diag_manager/test_ens_runs.sh
+++ b/test_fms/diag_manager/test_ens_runs.sh
@@ -77,10 +77,10 @@ cat <<_EOF > diag_table.yaml
 title: test_diag_manager_01
 base_date: 2 1 1 0 0 0
 diag_files:
-- file_name: test_0days
+- file_name: test_ens
   time_units: days
   unlimdim: time
-  freq: 0 days
+  freq: 1 hours
   varlist:
   - module: ocn_mod
     var_name: var0
@@ -90,6 +90,25 @@ _EOF
 
 my_test_count=`expr $my_test_count + 1`
 test_expect_failure "Running diag_manager with both diag_table.yaml and diag_table.ens_xx.yaml files present (test $my_test_count)" '
+  mpirun -n 2 ../test_ens_runs
+'
+
+# Both ensembles have the same diag table yaml
+cat <<_EOF > input.nml
+&diag_manager_nml
+  use_modern_diag = .True.
+/
+
+&ensemble_nml
+   ensemble_size = 2
+/
+&test_ens_runs_nml
+  using_ens_yaml = .false.
+/
+_EOF
+rm -rf diag_table.ens_01.yaml diag_table.ens_02.yaml
+my_test_count=`expr $my_test_count + 1`
+test_expect_success "Running diag_manager with 2 ensembles, both ensembles have the same yaml (test $my_test_count)" '
   mpirun -n 2 ../test_ens_runs
 '
 

--- a/test_fms/field_manager/test_field_manager2.sh
+++ b/test_fms/field_manager/test_field_manager2.sh
@@ -148,6 +148,33 @@ _EOF
   rm -rf field_table.yaml
 
   test_expect_success "field manager test with 2 ensembles" 'mpirun -n 2 ./test_field_table_read'
+
+cat <<_EOF > input.nml
+&field_manager_nml
+  use_field_table_yaml = .true.
+/
+&test_field_table_read_nml
+  test_case = 2
+/
+&ensemble_nml
+   ensemble_size = 2
+/
+_EOF
+
+  cat <<_EOF > field_table.yaml
+field_table:
+- field_type: tracer
+  modlist:
+  - model_type: atmos_mod
+    varlist:
+    - variable: radon
+    - variable: radon2
+    - variable: radon3
+      longname: bad radon!
+_EOF
+
+rm -rf field_table.ens_01.yaml field_table.ens_02.yaml
+test_expect_success "field manager test with 2 ensembles same yaml" 'mpirun -n 2 ./test_field_table_read'
 fi
 
 test_done

--- a/test_fms/field_manager/test_field_table_read.F90
+++ b/test_fms/field_manager/test_field_table_read.F90
@@ -53,6 +53,7 @@ integer :: ensemble_id
 character(len=10) :: text
 integer, parameter :: default_test = 0
 integer, parameter :: ensemble_test = 1
+integer, parameter :: ensemble_same_yaml_test = 2
 
 ! namelist parameters
 integer :: test_case = default_test
@@ -69,7 +70,7 @@ call mpp_get_current_pelist(pelist)
 
 nfields_expected = 4
 select case (test_case)
-case (ensemble_test)
+case (ensemble_test, ensemble_same_yaml_test)
   if (npes .ne. 2) &
     call mpp_error(FATAL, "test_field_table_read:: this test requires 2 PEs!")
 
@@ -78,16 +79,16 @@ case (ensemble_test)
   if (ens_siz(1) .ne. 2) &
     call mpp_error(FATAL, "This test requires 2 ensembles")
 
+  nfields_expected = 3
   if (mpp_pe() .eq. 0) then
     !PEs 0 is the first ensemble
     ensemble_id = 1
     call mpp_set_current_pelist((/0/))
-    nfields_expected = 3
   else
     !PEs 1 is the second ensemble
     ensemble_id = 2
     call mpp_set_current_pelist((/1/))
-    nfields_expected = 4
+    if (test_case .eq. ensemble_test) nfields_expected = 4
   endif
 
   write( text,'(a,i2.2)' ) 'ens_', ensemble_id


### PR DESCRIPTION
**Description**
Fixes issue when running with multiple ensembles and each ensemble is using the same diag/field/data yaml file
Fixes #1630 

**How Has This Been Tested?**
CI
SPEAR with 3 ensembles

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

