### PR TITLE
1594: Fix for new_file_freq, start_time, and file_duration keys in diag manager

### DIFF
--- a/diag_manager/Makefile.am
+++ b/diag_manager/Makefile.am
@@ -69,7 +69,7 @@ diag_util_mod.$(FC_MODEXT): diag_data_mod.$(FC_MODEXT) diag_axis_mod.$(FC_MODEXT
                             diag_grid_mod.$(FC_MODEXT) fms_diag_time_utils_mod.$(FC_MODEXT) fms_diag_bbox_mod.$(FC_MODEXT)
 fms_diag_time_utils_mod.$(FC_MODEXT): diag_data_mod.$(FC_MODEXT)
 diag_table_mod.$(FC_MODEXT): diag_data_mod.$(FC_MODEXT) diag_util_mod.$(FC_MODEXT)
-fms_diag_yaml_mod.$(FC_MODEXT): diag_data_mod.$(FC_MODEXT)
+fms_diag_yaml_mod.$(FC_MODEXT): diag_data_mod.$(FC_MODEXT)  fms_diag_time_utils_mod.$(FC_MODEXT)
 fms_diag_object_mod.$(FC_MODEXT): diag_data_mod.$(FC_MODEXT) fms_diag_file_object_mod.$(FC_MODEXT) fms_diag_field_object_mod.$(FC_MODEXT) fms_diag_yaml_mod.$(FC_MODEXT) \
                                   fms_diag_time_utils_mod.$(FC_MODEXT) \
                                   fms_diag_output_buffer_mod.$(FC_MODEXT) \

--- a/diag_manager/diag_manager.F90
+++ b/diag_manager/diag_manager.F90
@@ -3859,6 +3859,9 @@ END FUNCTION register_static_field
     TYPE (time_type), INTENT(in) :: Time_end_in
 
     Time_end = Time_end_in
+    if (use_modern_diag) then
+      call fms_diag_object%set_time_end(time_end_in)
+    endif
 
   END SUBROUTINE diag_manager_set_time_end
 

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -70,6 +70,8 @@ private
   logical, private :: fields_initialized=.false. !< True if the fmsDiagObject is initialized
   logical, private :: buffers_initialized=.false. !< True if the fmsDiagObject is initialized
   logical, private :: axes_initialized=.false. !< True if the fmsDiagObject is initialized
+  type(time_type) :: model_end_time !< The time that the simulation is going to end
+                                    !! (set by calling diag_manager_set_time_end)
 #endif
   contains
     procedure :: init => fms_diag_object_init
@@ -94,6 +96,7 @@ private
     procedure :: fms_diag_field_add_cell_measures
     procedure :: allocate_diag_field_output_buffers
     procedure :: fms_diag_compare_window
+    procedure :: set_time_end
 #ifdef use_yaml
     procedure :: get_diag_buffer
 #endif
@@ -821,7 +824,6 @@ subroutine fms_diag_do_io(this, end_time)
 
     !< Go away if the file is a subregional file and the current PE does not have any data for it
     if (.not. diag_file%writing_on_this_pe()) cycle
-    if (diag_file%FMS_diag_file%is_done_writing_data()) cycle
 
     if (present (end_time)) then
       force_write = .true.
@@ -829,6 +831,7 @@ subroutine fms_diag_do_io(this, end_time)
     else
       model_time => diag_file%get_model_time()
     endif
+    if (diag_file%FMS_diag_file%is_done_writing_data()) cycle
 
     call diag_file%open_diag_file(model_time, file_is_opened_this_time_step)
     if (file_is_opened_this_time_step) then
@@ -842,7 +845,7 @@ subroutine fms_diag_do_io(this, end_time)
       call diag_file%write_axis_data(this%diag_axis)
     endif
 
-    finish_writing = diag_file%is_time_to_write(model_time, this%FMS_diag_output_buffers, &
+    call diag_file%check_file_times(model_time, this%FMS_diag_output_buffers, &
       this%FMS_diag_fields, do_not_write)
     unlim_dim_was_increased = .false.
 
@@ -881,16 +884,14 @@ subroutine fms_diag_do_io(this, end_time)
       call diag_file%write_time_data()
       call diag_file%flush_diag_file()
       call diag_file%update_next_write(model_time)
-    endif
-
-    if (finish_writing) then
       call diag_file%update_current_new_file_freq_index(model_time)
-      if (diag_file%is_time_to_close_file(model_time)) call diag_file%close_diag_file(this%FMS_diag_output_buffers, &
-        diag_fields = this%FMS_diag_fields)
+      if (diag_file%is_time_to_close_file(model_time, force_write)) call diag_file%close_diag_file(this%FMS_diag_output_buffers, &
+        this%model_end_time, diag_fields = this%FMS_diag_fields)
     else if (force_write) then
       call diag_file%prepare_for_force_write()
       call diag_file%write_time_data()
-      call diag_file%close_diag_file(this%FMS_diag_output_buffers, diag_fields = this%FMS_diag_fields)
+      call diag_file%close_diag_file(this%FMS_diag_output_buffers, &
+        this%model_end_time, diag_fields = this%FMS_diag_fields)
     endif
   enddo
 #endif
@@ -979,6 +980,7 @@ function fms_diag_do_reduction(this, field_data, diag_field_id, oor_mask, weight
     if (buffer_ptr%is_done_with_math()) cycle
 
     if (present(time)) call file_ptr%set_model_time(time)
+    if (.not. file_ptr%time_to_start_doing_math()) cycle
 
     bounds_out = bounds
     if (.not. using_blocking) then
@@ -1502,5 +1504,14 @@ function fms_diag_compare_window(this, field, field_id, &
     "you can not use the modern diag manager without compiling with -Duse_yaml")
 #endif
 end function fms_diag_compare_window
+
+!> @brief Set the model_end_time in a diag object
+subroutine set_time_end(this, time_end_in)
+  class(fmsDiagObject_type), intent(inout) :: this        !< Diag Object
+  type(time_type),           intent(in)    :: time_end_in !< Time at the end of the simulation
+#ifdef use_yaml
+  this%model_end_time = time_end_in
+#endif
+end subroutine
 
 end module fms_diag_object_mod

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -885,8 +885,9 @@ subroutine fms_diag_do_io(this, end_time)
       call diag_file%flush_diag_file()
       call diag_file%update_next_write(model_time)
       call diag_file%update_current_new_file_freq_index(model_time)
-      if (diag_file%is_time_to_close_file(model_time, force_write)) call diag_file%close_diag_file(this%FMS_diag_output_buffers, &
-        this%model_end_time, diag_fields = this%FMS_diag_fields)
+      if (diag_file%is_time_to_close_file(model_time, force_write)) &
+        call diag_file%close_diag_file(this%FMS_diag_output_buffers, &
+          this%model_end_time, diag_fields = this%FMS_diag_fields)
     else if (force_write) then
       call diag_file%prepare_for_force_write()
       call diag_file%write_time_data()

--- a/test_fms/diag_manager/Makefile.am
+++ b/test_fms/diag_manager/Makefile.am
@@ -34,7 +34,7 @@ check_PROGRAMS = test_diag_manager test_diag_manager_time \
  check_time_min check_time_max check_time_sum check_time_avg test_diag_diurnal check_time_diurnal \
  check_time_pow check_time_rms check_subregional test_cell_measures test_var_masks \
  check_var_masks test_multiple_send_data test_diag_out_yaml test_output_every_freq \
- test_dm_weights test_prepend_date test_ens_runs test_diag_attribute_add
+ test_dm_weights test_prepend_date test_ens_runs test_multi_file test_diag_attribute_add
 
 # This is the source code for the test.
 test_output_every_freq_SOURCES = test_output_every_freq.F90
@@ -65,6 +65,7 @@ test_var_masks_SOURCES = test_var_masks.F90
 check_var_masks_SOURCES = check_var_masks.F90
 test_multiple_send_data_SOURCES = test_multiple_send_data.F90
 test_prepend_date_SOURCES = test_prepend_date.F90
+test_multi_file_SOURCES = test_multi_file.F90
 test_ens_runs_SOURCES = test_ens_runs.F90
 test_diag_attribute_add_SOURCES = test_diag_attribute_add.F90
 
@@ -76,7 +77,8 @@ SH_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
 TESTS = test_diag_manager2.sh test_time_none.sh test_time_min.sh test_time_max.sh test_time_sum.sh \
         test_time_avg.sh test_time_pow.sh test_time_rms.sh test_time_diurnal.sh test_cell_measures.sh \
         test_subregional.sh test_var_masks.sh test_multiple_send_data.sh test_output_every_freq.sh \
-        test_dm_weights.sh test_flush_nc_file.sh test_prepend_date.sh test_ens_runs.sh test_diag_attribute_add.sh
+        test_dm_weights.sh test_flush_nc_file.sh test_prepend_date.sh test_ens_runs.sh test_multi_file.sh \
+        test_diag_attribute_add.sh
 
 testing_utils.mod: testing_utils.$(OBJEXT)
 
@@ -85,7 +87,7 @@ EXTRA_DIST = test_diag_manager2.sh check_crashes.sh test_time_none.sh test_time_
              test_time_sum.sh test_time_avg.sh test_time_pow.sh test_time_rms.sh test_time_diurnal.sh \
              test_cell_measures.sh test_subregional.sh test_var_masks.sh test_multiple_send_data.sh \
              test_flush_nc_file.sh test_dm_weights.sh test_output_every_freq.sh test_prepend_date.sh \
-             test_ens_runs.sh test_diag_attribute_add.sh
+             test_ens_runs.sh test_multi_file.sh test_diag_attribute_add.sh
 
 if USING_YAML
 skipflag=""

--- a/test_fms/diag_manager/test_diag_manager2.sh
+++ b/test_fms/diag_manager/test_diag_manager2.sh
@@ -1137,7 +1137,7 @@ diag_files:
   unlimdim: time
   new_file_freq: 6
   new_file_freq_units: hours
-  start_time: 2 1 1 0 0 0
+  start_time: 00020101.000000
   file_duration: 12
   file_duration_units: hours
   varlist:
@@ -1199,7 +1199,7 @@ diag_files:
   unlimdim: time
   new_file_freq: 6 3 1
   new_file_freq_units: hours hours hours
-  start_time: 2 1 1 0 0 0
+  start_time: 00020101.000000
   file_duration: 12 3 9
   file_duration_units: hours hours hours
   varlist:
@@ -1230,7 +1230,7 @@ diag_files:
   unlimdim: time
   new_file_freq: 6 3 1
   new_file_freq_units: hours hours hours
-  start_time: 2 1 1 0 0 0
+  start_time: 00020101.000000
   file_duration: 12 3 9
   file_duration_units: hours hours hours
   varlist:

--- a/test_fms/diag_manager/test_diag_yaml.F90
+++ b/test_fms/diag_manager/test_diag_yaml.F90
@@ -26,7 +26,7 @@ use fms_diag_yaml_mod
 use diag_data_mod, only: DIAG_NULL, DIAG_ALL, get_base_year, get_base_month, get_base_day, get_base_hour, &
                        & get_base_minute, get_base_second, diag_data_init, DIAG_HOURS, DIAG_NULL, DIAG_DAYS, &
                        & time_average, r4, middle_time, end_time, time_none
-use  time_manager_mod, only: set_calendar_type, JULIAN
+use  time_manager_mod, only: set_calendar_type, JULIAN, date_to_string
 use mpp_mod
 use platform_mod
 
@@ -243,9 +243,9 @@ subroutine compare_diag_files(res)
   call compare_result("file_duration_units 2", res(2)%get_file_duration_units(), DIAG_NULL)
   call compare_result("file_duration_units 3", res(3)%get_file_duration_units(), DIAG_NULL)
 
-  call compare_result("file_start_time 1", res(1)%get_file_start_time(), "2 1 1 0 0 0")
-  call compare_result("file_start_time 2", res(2)%get_file_start_time(), "")
-  call compare_result("file_start_time 3", res(3)%get_file_start_time(), "")
+  call compare_result("file_start_time 1", date_to_string(res(1)%get_file_start_time()), "00020101.000000")
+  if (res(2)%has_file_start_time()) call mpp_error(FATAL, "The second file should not have a start time")
+  if (res(3)%has_file_start_time()) call mpp_error(FATAL, "The third file should not have a start time")
 
   varlist = res(1)%get_file_varlist()
   if (.not. allocated(varlist)) call mpp_error(FATAL, "The varlist for the first file was not set")

--- a/test_fms/diag_manager/test_multi_file.F90
+++ b/test_fms/diag_manager/test_multi_file.F90
@@ -1,0 +1,211 @@
+!***********************************************************************
+!*                   GNU Lesser General Public License
+!*
+!* This file is part of the GFDL Flexible Modeling System (FMS).
+!*
+!* FMS is free software: you can redistribute it and/or modify it under
+!* the terms of the GNU Lesser General Public License as published by
+!* the Free Software Foundation, either version 3 of the License, or (at
+!* your option) any later version.
+!*
+!* FMS is distributed in the hope that it will be useful, but WITHOUT
+!* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+!* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+!* for more details.
+!*
+!* You should have received a copy of the GNU Lesser General Public
+!* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
+!***********************************************************************
+program test_multi_file
+  use fms_mod, only: fms_init, fms_end
+  use diag_manager_mod, only: diag_manager_init, diag_axis_init, register_diag_field, send_data, &
+                              diag_send_complete, diag_manager_set_time_end, diag_manager_end
+  use mpp_mod, only: mpp_error, mpp_pe, mpp_root_pe, FATAL, input_nml_file
+  use time_manager_mod, only: time_type, set_calendar_type, JULIAN, set_time, set_date, operator(+)
+  use fms2_io_mod
+
+  implicit none
+
+  type(time_type)                    :: Time             !< Time of the simulation
+  type(time_type)                    :: Time_step        !< Time_step of the simulation
+  integer                            :: nx               !< Number of x points
+  integer                            :: ny               !< Number of y points
+  integer                            :: id_x             !< Axis id for the x dimension
+  integer                            :: id_y             !< Axis id for the y dimension
+  integer                            :: id_var1          !< Field id for 1st variable
+  integer                            :: id_var2          !< Field id for 2nd variable
+  logical                            :: used             !< Dummy argument to send_data
+  real,                  allocatable :: x(:)             !< X axis data
+  real,                  allocatable :: y(:)             !< Y axis_data
+  real,                  allocatable :: var1_data(:,:)   !< Data for variable 1
+  integer                            :: i                !< For do loops
+  integer                            :: ntimes           !< Number of times to run the simulation for
+  integer                            :: io_status        !< Status after reading the namelist
+
+  integer :: test_case = 1 !< Test case to do:
+                           !! 1 Test new_file_freq
+                           !! 2 Test file start_time and file_duration with new_file_freq
+                           !! 3 Test file start_time and file_duration without new_file_freq
+                           !! 4 Flexible output timings
+  namelist / test_multi_file_nml / test_case
+
+  call fms_init()
+  call set_calendar_type(JULIAN)
+  call diag_manager_init()
+
+  read (input_nml_file, test_multi_file_nml, iostat=io_status)
+  if (io_status > 0) call mpp_error(FATAL,'=>test_multi_file: Error reading input.nml')
+
+  nx = 10
+  ny = 15
+
+  ntimes = 24
+
+  allocate(x(nx), y(ny))
+  allocate(var1_data(nx,ny))
+  do i=1,nx
+    x(i) = i
+  enddo
+  do i=1,ny
+    y(i) = -91 + i
+  enddo
+
+  Time = set_date(2,1,1,0,0,0)
+  Time_step = set_time (3600,0) !< 1 hour
+
+  id_x  = diag_axis_init('x',  x,  'point_E', 'x', long_name='point_E')
+  id_y  = diag_axis_init('y',  y,  'point_N', 'y', long_name='point_N')
+
+  id_var1 = register_diag_field  ('atmos', 'ua', (/id_x, id_y/), Time)
+
+  call diag_manager_set_time_end(set_date(2,1,2,0,0,0))
+  do i = 1, ntimes
+    Time = Time + Time_step
+    var1_data = real(i)
+    used = send_data(id_var1, var1_data, Time)
+    call diag_send_complete(Time_step)
+  enddo
+
+  call diag_manager_end(Time)
+
+  call check_answers()
+  call fms_end()
+
+  contains
+
+  subroutine check_file(fileobj, expected_ntimes, start, filename, expected_ans)
+    type(FmsNetcdfFile_t), intent(in) :: fileobj
+    integer,               intent(in) :: start
+    integer,               intent(in) :: expected_ntimes
+    character(len=*),      intent(in) :: filename
+    real, optional,     intent(in) :: expected_ans
+
+    integer :: j
+    real :: ans_var
+    real :: vardata_out(nx, ny)
+    integer :: ntimes
+
+    call get_dimension_size(fileobj, "time", ntimes)
+    if (ntimes .ne. expected_ntimes) call mpp_error(FATAL, "The time dimension for "//trim(filename)//&
+      " is not the correct size!")
+    do j = 1, ntimes
+      ans_var = real((start + 2*(j-1) + 1) + (start + 2*(j-1) + 2) ) / real(2.)
+      if (present(expected_ans) .and. j .eq. 1) ans_var = expected_ans
+      call read_data(fileobj, "ua", vardata_out, unlim_dim_level = j)
+      if (any(vardata_out .ne. ans_var)) &
+        call mpp_error(FATAL, "The data in "//trim(filename)//" is not the expected result!")
+    enddo
+  end subroutine
+
+  subroutine check_answers_case_1()
+    type(FmsNetcdfFile_t) :: fileobj
+
+    if (.not. open_file(fileobj, "test_multi_file_0002_01_01_12.nc", "read")) &
+      call mpp_error(FATAL, "Unable to open the file: test_multi_file_0002_01_01_12.nc")
+    call check_file(fileobj, 6, 0, "test_multi_file_0002_01_01_12.nc")
+    call close_file(fileobj)
+
+    if (.not. open_file(fileobj, "test_multi_file_0002_01_02_00.nc", "read")) &
+      call mpp_error(FATAL, "Unable to open the file: test_multi_file_0002_01_02_00.nc")
+    call check_file(fileobj, 6, 12, "test_multi_file_0002_01_02_00.nc")
+
+    if (file_exists("test_multi_file_0002_01_02_12.nc")) &
+      call mpp_error(FATAL, "The file test_multi_file_0002_01_02_12.nc should not exist!")
+
+    call close_file(fileobj)
+  end subroutine check_answers_case_1
+
+  subroutine check_answers_case_2()
+    type(FmsNetcdfFile_t) :: fileobj
+
+    if (file_exists("test_multi_file_0002_01_01_04.nc")) &
+      call mpp_error(FATAL, "The file test_multi_file_0002_01_01_04 should not exist!")
+
+    if (file_exists("test_multi_file_0002_01_01_08.nc")) &
+      call mpp_error(FATAL, "The file test_multi_file_0002_01_01_08 should not exist!")
+
+    if (file_exists("test_multi_file_0002_01_01_12.nc")) &
+      call mpp_error(FATAL, "The file test_multi_file_0002_01_01_12 should not exist!")
+
+    if (file_exists("test_multi_file_0002_01_02_00.nc")) &
+      call mpp_error(FATAL, "The file test_multi_file_0002_01_02_00 should not exist!")
+
+    if (.not. open_file(fileobj, "test_multi_file_0002_01_01_16.nc", "read")) &
+      call mpp_error(FATAL, "Unable to open the file: test_multi_file_0002_01_01_16.nc")
+    call check_file(fileobj, 2, 12, "test_multi_file_0002_01_01_16.nc", expected_ans = real(13))
+    call close_file(fileobj)
+
+    if (.not. open_file(fileobj, "test_multi_file_0002_01_01_20.nc", "read")) &
+      call mpp_error(FATAL, "Unable to open the file: test_multi_file_0002_01_01_20.nc")
+    call check_file(fileobj, 2, 16, "test_multi_file_0002_01_01_20.nc")
+    call close_file(fileobj)
+
+  end subroutine check_answers_case_2
+
+  subroutine check_answers_case_3()
+    type(FmsNetcdfFile_t) :: fileobj
+
+    if (.not. open_file(fileobj, "test_multi_file.nc", "read")) &
+      call mpp_error(FATAL, "Unable to open the file: test_multi_file.nc")
+    call check_file(fileobj, 4, 12, "test_multi_file.nc", expected_ans = real(13))
+    call close_file(fileobj)
+  end subroutine check_answers_case_3
+
+  subroutine check_answers_case_4()
+    type(FmsNetcdfFile_t) :: fileobj
+
+    if (.not. open_file(fileobj, "test_multi_file_0002_01_01_04.nc", "read")) &
+      call mpp_error(FATAL, "Unable to open the file: test_multi_file_0002_01_01_04.nc")
+    call check_file(fileobj, 2, 0, "test_multi_file_0002_01_01_04.nc")
+    call close_file(fileobj)
+
+    if (.not. open_file(fileobj, "test_multi_file_0002_01_01_08.nc", "read")) &
+      call mpp_error(FATAL, "Unable to open the file: test_multi_file_0002_01_01_08.nc")
+    call check_file(fileobj, 2, 4, "test_multi_file_0002_01_01_08.nc")
+    call close_file(fileobj)
+
+    if (.not. open_file(fileobj, "test_multi_file_0002_01_01_10.nc", "read")) &
+      call mpp_error(FATAL, "Unable to open the file: test_multi_file_0002_01_01_10.nc")
+    call check_file(fileobj, 1, 8, "test_multi_file_0002_01_01_10.nc")
+    call close_file(fileobj)
+
+    if (.not. open_file(fileobj, "test_multi_file_0002_01_01_22.nc", "read")) &
+      call mpp_error(FATAL, "Unable to open the file: test_multi_file_0002_01_01_22.nc")
+    call check_file(fileobj, 6, 10, "test_multi_file_0002_01_01_22.nc")
+    call close_file(fileobj)
+
+  end subroutine check_answers_case_4
+
+  subroutine check_answers()
+    select case (test_case)
+    case (1)
+      call check_answers_case_1()
+    case (2)
+      call check_answers_case_2()
+    case (3)
+      call check_answers_case_3()
+    case (4)
+      call check_answers_case_4()
+    end select
+  end subroutine check_answers
+end program test_multi_file

--- a/test_fms/diag_manager/test_multi_file.sh
+++ b/test_fms/diag_manager/test_multi_file.sh
@@ -1,0 +1,160 @@
+#!/bin/sh
+
+#***********************************************************************
+#*                   GNU Lesser General Public License
+#*
+#* This file is part of the GFDL Flexible Modeling System (FMS).
+#*
+#* FMS is free software: you can redistribute it and/or modify it under
+#* the terms of the GNU Lesser General Public License as published by
+#* the Free Software Foundation, either version 3 of the License, or (at
+#* your option) any later version.
+#*
+#* FMS is distributed in the hope that it will be useful, but WITHOUT
+#* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+#* for more details.
+#*
+#* You should have received a copy of the GNU Lesser General Public
+#* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
+#***********************************************************************
+
+# Set common test settings.
+. ../test-lib.sh
+
+if [ -z "${skipflag}" ]; then
+# create and enter directory for in/output files
+output_dir
+
+###########################################################################
+# CASE 1: In this example, a file is going to be created every 12 hours, it is going to use the
+# end of the time_bounds (i.e 2 1 1 0 12 0 and 2 1 1 1 0 0) for the filename
+cat <<_EOF > diag_table.yaml
+title: test_diag_manager_01
+base_date: 2 1 1 0 0 0
+diag_files:
+- file_name: test_multi_file%4yr%2mo%2dy%2hr
+  time_units: days
+  unlimdim: time
+  freq: 2 hours
+  new_file_freq: 12 hours
+  module: atmos
+  reduction: average
+  kind: r4
+  filename_time: end
+  varlist:
+  - var_name: ua
+_EOF
+
+# remove any existing files that would result in false passes during checks
+rm -f *.nc
+my_test_count=1
+printf "&diag_manager_nml \n use_modern_diag=.true. \n/" | cat > input.nml
+test_expect_success "Running diag_manager (test $my_test_count)" '
+  mpirun -n 1 ../test_multi_file
+'
+
+###########################################################################
+# CASE 2: In this example, a file is going to be created starting from [2 1 1 12 0 0],
+# every 4 hours, for 8 hours (so 2 files!)
+rm -f *.nc
+cat <<_EOF > diag_table.yaml
+title: test_diag_manager_01
+base_date: 2 1 1 0 0 0
+diag_files:
+- file_name: test_multi_file%4yr%2mo%2dy%2hr
+  time_units: days
+  unlimdim: time
+  freq: 2 hours
+  start_time: 2 1 1 12 0 0
+  new_file_freq: 4 hours
+  file_duration: 8 hours
+  module: atmos
+  reduction: average
+  kind: r4
+  filename_time: end
+  varlist:
+  - var_name: ua
+_EOF
+
+cat <<_EOF > input.nml
+&diag_manager_nml
+ use_modern_diag=.true.
+/
+&test_multi_file_nml
+ test_case = 2
+/
+_EOF
+test_expect_success "Running diag_manager (test $my_test_count)" '
+  mpirun -n 1 ../test_multi_file
+'
+
+###########################################################################
+# CASE 3: In this example, a file is going to be created using data from [2 1 12 0 0]
+# to [2 1 1 20 0 0] (8 hours!)
+rm -f *.nc
+cat <<_EOF > diag_table.yaml
+title: test_diag_manager_01
+base_date: 2 1 1 0 0 0
+diag_files:
+- file_name: test_multi_file
+  time_units: days
+  unlimdim: time
+  freq: 2 hours
+  start_time: 2 1 1 12 0 0
+  file_duration: 8 hours
+  module: atmos
+  reduction: average
+  kind: r4
+  varlist:
+  - var_name: ua
+_EOF
+
+cat <<_EOF > input.nml
+&diag_manager_nml
+ use_modern_diag=.true.
+/
+&test_multi_file_nml
+ test_case = 3
+/
+_EOF
+test_expect_success "Running diag_manager (test $my_test_count)" '
+  mpirun -n 1 ../test_multi_file
+'
+
+###########################################################################
+# CASE 4: In this example, a file is going to be created every 4 hours for 8 hours
+# (so 2 files), then every 2 hours for 2 hours (so 1 file), then every 12 hours for 12 hours
+# (so 1 file)
+rm -f *.nc
+cat <<_EOF > diag_table.yaml
+title: test_diag_manager_01
+base_date: 2 1 1 0 0 0
+diag_files:
+- file_name: test_multi_file%4yr%2mo%2dy%2hr
+  time_units: days
+  unlimdim: time
+  freq: 2 hours, 2 hours, 2 hours
+  new_file_freq: 4 hours, 2 hours, 12 hours
+  file_duration: 8 hours, 2 hours, 12 hours
+  filename_time: end
+  module: atmos
+  reduction: average
+  kind: r4
+  varlist:
+  - var_name: ua
+_EOF
+
+cat <<_EOF > input.nml
+&diag_manager_nml
+ use_modern_diag=.true.
+/
+&test_multi_file_nml
+ test_case = 4
+/
+_EOF
+test_expect_success "Running diag_manager (test $my_test_count)" '
+  mpirun -n 1 ../test_multi_file
+'
+fi
+test_done


### PR DESCRIPTION
**Description**
Fix for new_file_freq, start_time, and file_duration keys in diag manager
Adds tests to confirm the fix worked

Fixes #1594 

**How Has This Been Tested?**
CI, including new tests

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

