### PR TITLE
update actions versions

### DIFF
--- a/.github/workflows/github_autotools_gnu.yml
+++ b/.github/workflows/github_autotools_gnu.yml
@@ -28,7 +28,7 @@ jobs:
         DEBUG_FLAGS: "-O0 -g -fbounds-check -ffpe-trap=invalid,zero,overflow" # debug compiler flags taken from the mkmf template
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4.2.2
     - name: Prepare GNU autoconf for build
       run: autoreconf -if
     - name: Configure the build

--- a/.github/workflows/github_autotools_intel.yml
+++ b/.github/workflows/github_autotools_intel.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
     - name: Cache dependencies
       id: cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4.2.0
       with:
         path: /libs
         key: ${{ runner.os }}-intel-libs
@@ -53,7 +53,7 @@ jobs:
         ./configure --prefix=/libs
         make -j install && cd
     - name: checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4.2.2
     - name: Configure
       run: |
         autoreconf -if ./configure.ac

--- a/.github/workflows/github_cmake_gnu.yml
+++ b/.github/workflows/github_cmake_gnu.yml
@@ -22,7 +22,7 @@ jobs:
         CMAKE_FLAGS: "${{ matrix.build-type }} ${{ matrix.omp-flags }} ${{ matrix.io-flag  }} ${{ matrix.libyaml-flag }} -D64BIT=on"
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4.2.2
     - name: Generate makefiles with CMake
       run: cmake $CMAKE_FLAGS -DNetCDF_ROOT=/opt/view -DLIBYAML_ROOT=/opt/view
     - name: Build the library

--- a/.github/workflows/github_coupler_gnu.yml
+++ b/.github/workflows/github_coupler_gnu.yml
@@ -22,11 +22,11 @@ jobs:
         LDFLAGS: '-L/opt/view/lib'
     steps:
     - name: Checkout FMS
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4.2.2
       with:
         path: FMS
     - name: Checkout FMScoupler
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4.2.2
       with:
         repository: 'NOAA-GFDL/FMScoupler'
         path: FMScoupler

--- a/.github/workflows/github_doc_site.yml
+++ b/.github/workflows/github_doc_site.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
       - name: Setup repo
         run: | # do autotool's job for substitutes since we don't need a full build environement
           mkdir gen_docs
@@ -24,7 +24,7 @@ jobs:
           sudo apt -y install doxygen graphviz
           doxygen gen_docs/Doxyfile
       - name: Upload Pages Artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3.0.1
         with:
           path: 'gen_docs/html'
   deploy:
@@ -45,4 +45,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4.0.5

--- a/.github/workflows/github_linter.yml
+++ b/.github/workflows/github_linter.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
       - name: Run Lint
         uses: NOAA-GFDL/simple_lint@f5aa1fe976bd4c231db0536ba00cbfdc26708253
         with:

--- a/.github/workflows/github_mom_gnu.yml
+++ b/.github/workflows/github_mom_gnu.yml
@@ -18,12 +18,12 @@ jobs:
         password: ${{ secrets.github_token }}
     steps:
     - name: Checkout MOM6 repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4.2.2
       with:
         repository: 'NOAA-GFDL/MOM6'
         submodules: recursive
     - name: Checkout FMS into MOM build
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4.2.2
       with:
         path: .testing/deps/fms/src
     - name: Build FMS and MOM test suite

--- a/.github/workflows/pw_am5_intel.yaml
+++ b/.github/workflows/pw_am5_intel.yaml
@@ -36,7 +36,7 @@ jobs:
         ln -s /contrib/am5/ci/latest/src/rte-rrtmgp am5_src/rte-rrtmgp
         ln -s /contrib/am5/ci/latest/src/coupler am5_src/coupler
     - name: Checkout FMS
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4.2.2
       with:
         path: ${{github.sha}}/am5_src/FMS
     - name: Build AM5 in Intel container

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -7,11 +7,11 @@ jobs:
   add-dev-to-version:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v4.2.2
     - name: Append version with dev
       run: sed -i '/20[0-9][0-9]\.[0-9][0-9]/ s/]/-dev]/' configure.ac
     - name: Create pull request
-      uses: peter-evans/create-pull-request@v4
+      uses: peter-evans/create-pull-request@v7.0.6
       with:
         base: main                   # creates a new branch off of main
         branch: add-dev-post-release # name of the created branch


### PR DESCRIPTION
**Description**
some annual version updates for any external github action steps. They unfortunately get deprecated pretty quick and stop working, this fixes an error from the doc site action and updates anything used to the latest available.

**How Has This Been Tested?**
CI

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

