### PR TITLE
change diag output yaml name

### DIFF
--- a/diag_manager/diag_manager.F90
+++ b/diag_manager/diag_manager.F90
@@ -3518,6 +3518,7 @@ END FUNCTION register_static_field
     call fms_diag_object%fms_diag_accept_data(diag_field_id, field, mask_local, rmask_local, &
                                                           time, is_in, js_in, ks_in, ie_in, je_in, ke_in, weight, &
                                                           err_msg)
+    send_data_4d = .true.
 
     if (present(err_msg)) then
       if (err_msg .ne. "") then

--- a/diag_manager/fms_diag_yaml.F90
+++ b/diag_manager/fms_diag_yaml.F90
@@ -1976,7 +1976,7 @@ subroutine fms_diag_yaml_out()
   enddo
   tier2size = i
 
-  call write_yaml_from_struct_3( 'diag_out.yaml'//c_null_char,  1, keys, vals,          &
+  call write_yaml_from_struct_3( 'diag_yaml.out'//c_null_char,  1, keys, vals,          &
                                  SIZE(diag_yaml%diag_files), keys2, vals2, &
                                  tier3size, tier3each, keys3, vals3,       &
                                  (/size(diag_yaml%diag_files), 0, 0, 0, 0, 0, 0, 0/))

--- a/diag_manager/fms_diag_yaml.F90
+++ b/diag_manager/fms_diag_yaml.F90
@@ -1976,7 +1976,7 @@ subroutine fms_diag_yaml_out()
   enddo
   tier2size = i
 
-  call write_yaml_from_struct_3( 'diag_yaml.out'//c_null_char,  1, keys, vals,          &
+  call write_yaml_from_struct_3( 'diag_manifest.yaml'//c_null_char,  1, keys, vals,          &
                                  SIZE(diag_yaml%diag_files), keys2, vals2, &
                                  tier3size, tier3each, keys3, vals3,       &
                                  (/size(diag_yaml%diag_files), 0, 0, 0, 0, 0, 0, 0/))

--- a/test_fms/diag_manager/test_diag_out_yaml.F90
+++ b/test_fms/diag_manager/test_diag_out_yaml.F90
@@ -41,7 +41,7 @@ subroutine check_output_yaml
   integer, parameter :: yaml_len = 402
   character(len=128) :: out_yaml_line, ref_yaml_line
   character(len=17), parameter :: ref_fname = 'diag_out_ref.yaml'
-  character(len=13), parameter :: out_fname = 'diag_out.yaml'
+  character(len=13), parameter :: out_fname = 'diag_yaml.out'
   if( mpp_root_pe() .ne. mpp_pe()) return
   open(newunit=un_out, file=out_fname, status="old", action="read")
   open(newunit=un_ref, file=ref_fname, status="old", action="read")

--- a/test_fms/diag_manager/test_diag_out_yaml.F90
+++ b/test_fms/diag_manager/test_diag_out_yaml.F90
@@ -41,7 +41,7 @@ subroutine check_output_yaml
   integer, parameter :: yaml_len = 402
   character(len=128) :: out_yaml_line, ref_yaml_line
   character(len=17), parameter :: ref_fname = 'diag_out_ref.yaml'
-  character(len=13), parameter :: out_fname = 'diag_manifest.yaml'
+  character(len=18), parameter :: out_fname = 'diag_manifest.yaml'
   if( mpp_root_pe() .ne. mpp_pe()) return
   open(newunit=un_out, file=out_fname, status="old", action="read")
   open(newunit=un_ref, file=ref_fname, status="old", action="read")

--- a/test_fms/diag_manager/test_diag_out_yaml.F90
+++ b/test_fms/diag_manager/test_diag_out_yaml.F90
@@ -41,7 +41,7 @@ subroutine check_output_yaml
   integer, parameter :: yaml_len = 402
   character(len=128) :: out_yaml_line, ref_yaml_line
   character(len=17), parameter :: ref_fname = 'diag_out_ref.yaml'
-  character(len=13), parameter :: out_fname = 'diag_yaml.out'
+  character(len=13), parameter :: out_fname = 'diag_manifest.yaml'
   if( mpp_root_pe() .ne. mpp_pe()) return
   open(newunit=un_out, file=out_fname, status="old", action="read")
   open(newunit=un_ref, file=ref_fname, status="old", action="read")


### PR DESCRIPTION
**Description**
Changes the name of the output yaml table from `diag_out.yaml` to `diag_manifest.yaml`.

The change in `diag_manager.F90` is just fixing a uninitialized return value that was setting off a runtime check.

**How Has This Been Tested?**
make check on the amd box

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

