### PR TITLE
add root pe to diag_manifest.yaml file name

### DIFF
--- a/diag_manager/fms_diag_yaml.F90
+++ b/diag_manager/fms_diag_yaml.F90
@@ -1979,7 +1979,7 @@ subroutine fms_diag_yaml_out(ntimes)
   enddo
   tier2size = i
 
-  call write_yaml_from_struct_3( 'diag_manifest.yaml'//c_null_char,  1, keys, vals,          &
+  call write_yaml_from_struct_3( 'diag_manifest.yaml.'//string(mpp_pe())//c_null_char,  1, keys, vals, &
                                  SIZE(diag_yaml%diag_files), keys2, vals2, &
                                  tier3size, tier3each, keys3, vals3,       &
                                  (/size(diag_yaml%diag_files), 0, 0, 0, 0, 0, 0, 0/))

--- a/test_fms/diag_manager/test_diag_out_yaml.F90
+++ b/test_fms/diag_manager/test_diag_out_yaml.F90
@@ -41,7 +41,7 @@ subroutine check_output_yaml
   integer, parameter :: yaml_len = 402
   character(len=128) :: out_yaml_line, ref_yaml_line
   character(len=17), parameter :: ref_fname = 'diag_out_ref.yaml'
-  character(len=18), parameter :: out_fname = 'diag_manifest.yaml'
+  character(len=20), parameter :: out_fname = 'diag_manifest.yaml.0'
   if( mpp_root_pe() .ne. mpp_pe()) return
   open(newunit=un_out, file=out_fname, status="old", action="read")
   open(newunit=un_ref, file=ref_fname, status="old", action="read")


### PR DESCRIPTION
**Description**
Adds the pe number to the output yaml so the atmos and ocean root pe's dont end up overwriting the file.

**How Has This Been Tested?**
the output yaml unit test on the amd box.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

