### PR TITLE
Update FMSConfig.cmake.in

### DIFF
--- a/cmake/FMSConfig.cmake.in
+++ b/cmake/FMSConfig.cmake.in
@@ -19,7 +19,7 @@ find_dependency(MPI COMPONENTS Fortran)
 
 # ON/OFF implies FMS was compiled with/without OpenMP
 if(@OPENMP@)
-  find_dependency(OpenMP COMPONENTS Fortran)
+  find_dependency(OpenMP COMPONENTS C Fortran)
 endif()
 
 find_dependency(NetCDF COMPONENTS C Fortran)


### PR DESCRIPTION
**Description**
Missing COMPONENT in the cmake.in file when built with OPENMP

Fixes #1662

**How Has This Been Tested?**
Added the missing C component

**Checklist:**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] `make distcheck` passes

I have done an adhoc tests this builds with OPENMP=ON and can now be found through `find_package(fms)` succesfully