### PR TITLE
Bugfix: mpp_scatter/gather allocates

### DIFF
--- a/fms2_io/include/compressed_write.inc
+++ b/fms2_io/include/compressed_write.inc
@@ -137,6 +137,19 @@ subroutine compressed_write_1d(fileobj, variable_name, cdata, unlim_dim_level, &
       class default
         call error("unsupported variable type: "//trim(append_error_msg))
      end select
+  else
+     select type(cdata)
+      type is (integer(kind=i4_kind))
+        allocate(buf_i4_kind(1))
+      type is (integer(kind=i8_kind))
+        allocate(buf_i8_kind(1))
+      type is (real(kind=r4_kind))
+        allocate(buf_r4_kind(1))
+      type is (real(kind=r8_kind))
+        allocate(buf_r8_kind(1))
+      class default
+        call error("unsupported variable type: "//trim(append_error_msg))
+     end select
   endif
 
   !Gather the data onto the I/O root and write it out.
@@ -164,12 +177,10 @@ subroutine compressed_write_1d(fileobj, variable_name, cdata, unlim_dim_level, &
     class default
       call error("unsupported variable type: "//trim(append_error_msg))
   end select
-  if (fileobj%is_root) then
-    if (allocated(buf_i4_kind)) deallocate(buf_i4_kind)
-    if (allocated(buf_i8_kind)) deallocate(buf_i8_kind)
-    if (allocated(buf_r4_kind)) deallocate(buf_r4_kind)
-    if (allocated(buf_r8_kind)) deallocate(buf_r8_kind)
-  endif
+  if (allocated(buf_i4_kind)) deallocate(buf_i4_kind)
+  if (allocated(buf_i8_kind)) deallocate(buf_i8_kind)
+  if (allocated(buf_r4_kind)) deallocate(buf_r4_kind)
+  if (allocated(buf_r8_kind)) deallocate(buf_r8_kind)
 end subroutine compressed_write_1d
 
 

--- a/mpp/include/mpp_gather.fh
+++ b/mpp/include/mpp_gather.fh
@@ -86,13 +86,15 @@ subroutine MPP_GATHER_1DV_(sbuf, ssize, rbuf, rsize, pelist)
       do l = 2, nproc
          displs(l) = displs(l-1) + rsize(l-1)
       enddo
+   else
+      allocate(displs(1))
    endif
 
    call mpp_gather( sbuf, ssize, rbuf, rsize, displs, op_root, pelist2, ierr )
 
    call mpp_sync_self()
    deallocate(pelist2)
-   if(pe .eq. op_root) deallocate(displs)
+   deallocate(displs)
 end subroutine MPP_GATHER_1DV_
 
 

--- a/mpp/include/mpp_scatter.fh
+++ b/mpp/include/mpp_scatter.fh
@@ -114,7 +114,8 @@ subroutine MPP_SCATTER_PELIST_3D_(is, ie, js, je, nk, pelist, array_seg, input_d
             enddo
          enddo
        enddo
-
+   else
+      allocate(temp(1))
    endif
 
    ! Compute recv_count on each rank
@@ -124,7 +125,7 @@ subroutine MPP_SCATTER_PELIST_3D_(is, ie, js, je, nk, pelist, array_seg, input_d
 
    call mpp_sync_self()
 
-   if (is_root_pe) deallocate(temp)
+   deallocate(temp)
 
    return
 


### PR DESCRIPTION
**Description**
To get around the issue with intel -check all flags, I am allocating `temp` for mpp_scatter and `displs` for mpp_gather for all pes.
The fms2io tests that crashed were due to the `recv_data` argument to `MPI_SCATTERV` being unallocated. I traced this back to compressed_writes.inc and now allocate the receive buffer for all pes.

Fixes #1671 

**How Has This Been Tested?**
Tested by reproduce steps from the issue.  Tests pass.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

