### PR TITLE
fix for doxygen site differences

### DIFF
--- a/.github/workflows/github_doc_site.yml
+++ b/.github/workflows/github_doc_site.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.2.2


### PR DESCRIPTION
**Description**
Updates the action to specify the older ubuntu image to get the site back to how it was (see #1664 for more details). This is more of a short term fix while I work on updating it to build correctly with the the latest doxygen versions.

**How Has This Been Tested?**
my copy:
https://rem1776.github.io/FMS/index.html

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

