### PR TITLE
CMake: install FindNetCDF.cmake when exporting configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -446,7 +446,7 @@ export(EXPORT FMSExports
 configure_package_config_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/cmake/FMSConfig.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/fms-config.cmake
   INSTALL_DESTINATION ${CONFIG_INSTALL_DESTINATION})
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/fms-config.cmake
+install(FILES ${CMAKE_SOURCE_DIR}/cmake/FindNetCDF.cmake ${CMAKE_CURRENT_BINARY_DIR}/fms-config.cmake
   DESTINATION ${CONFIG_INSTALL_DESTINATION})
 
 write_basic_package_version_file(

--- a/cmake/FMSConfig.cmake.in
+++ b/cmake/FMSConfig.cmake.in
@@ -22,7 +22,10 @@ if(@OPENMP@)
   find_dependency(OpenMP COMPONENTS C Fortran)
 endif()
 
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
 find_dependency(NetCDF COMPONENTS C Fortran)
+list(REMOVE_ITEM CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
+
 
 set(FMSVersion "${PACKAGE_VERSION}")
 set_and_check(FMS_INSTALL_PREFIX "${PACKAGE_PREFIX_DIR}")


### PR DESCRIPTION
**Description**

Currently there is a call to  `find_dependency(NetCDF COMPONENTS C Fortran)` in [FMSConfig.cmake.in](https://github.com/NOAA-GFDL/FMS/blob/e8b8c19c5d67b35440acc10b3180f535e3c6e7d6/cmake/FMSConfig.cmake.in#L24C1-L25C45) to ensure that the NetCDF libraries needed by FMS are correctly found. Unfortunately the corresponding  `FindNetCDF.cmake` file is not installed alongside the exported configuration. This means that calling `find_package(FMS ...)`  from a package that does not depend itself directly on NetCDF will fail with an error similar to this one:

> CMake Error at /opt/release/linux-rocky8-x86_64/intel-2021.10.0/cmake-3.24.4-l4wz2zzrh6mqroxffa25vifqmpzxainq/share/cmake-3.24/Modules/CMakeFindDependencyMacro.cmake:47 (find_package):
>   By not providing "FindNetCDF.cmake" in CMAKE_MODULE_PATH this project has
>   asked CMake to find a package configuration file provided by "NetCDF", but
>   CMake did not find one.
> 
>   Could not find a package configuration file provided by "NetCDF" with any
>   of the following names:
> 
>     NetCDFConfig.cmake
>     netcdf-config.cmake
> 
>   Add the installation prefix of "NetCDF" to CMAKE_PREFIX_PATH or set
>   "NetCDF_DIR" to a directory containing one of the above files.  If "NetCDF"
>   provides a separate development package or SDK, be sure it has been
>   installed.

This PR changes the build system to install the `FindNetCDF.cmake` and make sure it's used when other packages try to find FMS.

**How Has This Been Tested?**
I've tested this locally by installing FMS and then calling `find_package(FMS ...)` form another package that has FMS as a dependency.

**Checklist:**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] `make distcheck` passes

