### PR TITLE
MODERN DIAG MANAGER: 0 days freq tests

### DIFF
--- a/test_fms/diag_manager/test_output_every_freq.F90
+++ b/test_fms/diag_manager/test_output_every_freq.F90
@@ -27,17 +27,23 @@ program test_output_every_freq
   use time_manager_mod, only: time_type, operator(+), JULIAN, set_time, set_calendar_type, set_date
   use mpp_mod,          only: FATAL, mpp_error
   use fms2_io_mod,      only: FmsNetcdfFile_t, open_file, close_file, read_data, get_dimension_size
+  use block_control_mod,only: define_blocks, block_control_type
 
   implicit none
 
-  integer         :: id_var0, id_var1, id_var2 !< diag field ids
-  integer         :: id_axis1         !< Id for axis
-  logical         :: used             !< for send_data calls
-  integer         :: ntimes = 48      !< Number of time steps
-  real            :: vdata            !< Buffer to store the data
-  type(time_type) :: Time             !< "Model" time
-  type(time_type) :: Time_step        !< Time step for the "simulation"
-  integer         :: i                !< For do loops
+  integer           :: id_var0, id_var01, id_var1, id_var2 !< diag field ids
+  integer           :: id_axis1, id_axis2                  !< Id for axis
+  logical           :: used                                !< for send_data calls
+  integer           :: ntimes = 48                         !< Number of time steps
+  real, allocatable :: vdata(:,:)                          !< Buffer to store the data
+  type(time_type)   :: Time                                !< "Model" time
+  type(time_type)   :: Time_step                           !< Time step for the "simulation"
+  integer           :: i, iblock                           !< For do loops
+  integer           :: npoints = 20                        !< Number of points in the x and y direction
+  real, allocatable :: dummy_axis_data(:)                  !< Variable to store axis "data"
+  integer           :: is, ie, js, je                      !< Starting and ending index of each block
+  logical           :: message                             !< Flag for outputting debug message
+  type(block_control_type) :: my_block                     !< Variable storing the indices of each openmp block
 
   call fms_init
   call set_calendar_type(JULIAN)
@@ -47,18 +53,53 @@ program test_output_every_freq
   Time_step = set_time (3600,0) !< 1 hour
   call diag_manager_set_time_end(set_date(2,1,3,0,0,0))
 
-  id_axis1 = diag_axis_init('dummy_axis', (/real(1.)/), "mullions", "X")
-  id_var0 = register_diag_field  ('ocn_mod', 'var0', Time)
-  id_var1 = register_diag_field  ('ocn_mod', 'var1', Time)
-  id_var2 = register_static_field ('ocn_mod', 'var2', (/id_axis1/))
+  allocate(dummy_axis_data(npoints))
+  do i = 1, npoints
+    dummy_axis_data(i) = i
+  enddo
 
-  used = send_data(id_var2, real(123.456))
+  id_axis1 = diag_axis_init('x_axis', dummy_axis_data, "mullions", "X")
+  id_axis2 = diag_axis_init('y_axis', dummy_axis_data, "mullions", "Y")
+
+  allocate(vdata(npoints, npoints))
+  vdata = -999.99
+
+  ! These are the same variable but one will called from an openmp region and one will not
+  id_var0 = register_diag_field  ('ocn_mod', 'var0', (/id_axis1, id_axis2 /), Time)
+  id_var01 = register_diag_field  ('ocn_mod', 'var0_openmp', (/id_axis1, id_axis2 /), Time)
+
+  id_var1 = register_diag_field  ('ocn_mod', 'var1', (/id_axis1, id_axis2 /), Time)
+  id_var2 = register_static_field ('ocn_mod', 'var2', (/id_axis1, id_axis2/))
+
+  ! The npoints x npoints data are going to divided in blocks
+  call define_blocks ('testing_model', my_block, 1, npoints, 1, npoints, kpts=0, &
+                         nx_block=1, ny_block=4, message=message)
+
+  vdata = real(123.456)
+  used = send_data(id_var2, vdata)
   do i = 1, ntimes
     Time = Time + Time_step
-    vdata = real(i)
 
-    used = send_data(id_var0, vdata, Time) !< Sending data every hour!
-    if (mod(i,2) .eq. 0) used = send_data(id_var1, vdata, Time) !< Sending data every two hours!
+!$OMP parallel do default(shared) private(iblock, is, ie, js, je)
+    do iblock=1, 4
+      ! These are already in 1-based arrays since there is only 1 PE
+      is = my_block%ibs(iblock)
+      ie = my_block%ibe(iblock)
+      js = my_block%jbs(iblock)
+      je = my_block%jbe(iblock)
+
+      vdata(is:ie, js:je) = real(i) + real(iblock)/100.
+
+      used = send_data(id_var01, vdata(is:ie, js:je), Time, is_in=is, js_in=js)
+    enddo
+
+    !< Sending data every hour!
+    used = send_data(id_var0, vdata, Time)
+
+    !< Sending data every two hours!
+    !! Because data is sent at different frequencies var0 and var1 cannot be in the same file,
+    !! if writting at every time step and a failure is expected
+    if (mod(i,2) .eq. 0) used = send_data(id_var1, vdata, Time)
 
     call diag_send_complete(Time_step)
   enddo
@@ -74,8 +115,8 @@ program test_output_every_freq
   subroutine check_output()
     type(FmsNetcdfFile_t) :: fileobj     !< Fms2io fileobj
     integer               :: var_size    !< Size of the variable reading
-    real, allocatable     :: var_data(:) !< Buffer to read variable data to
-    integer               :: j           !< For looping
+    real, allocatable     :: var0_data(:,:,:) !< Buffer to read variable data to
+    real, allocatable     :: var01_data(:,:,:) !< Buffer to read variable data to
 
     if (.not. open_file(fileobj, "test_0days.nc", "read")) &
       call mpp_error(FATAL, "Error opening file:test_0days.nc to read")
@@ -83,14 +124,15 @@ program test_output_every_freq
     call get_dimension_size(fileobj, "time", var_size)
     if (var_size .ne. 48) call mpp_error(FATAL, "The dimension of time in the file:test_0days is not the "//&
                                                  "correct size!")
-    allocate(var_data(var_size))
-    var_data = -999.99
+    allocate(var0_data(npoints, npoints, var_size))
+    var0_data = -999.99
+    allocate(var01_data(npoints, npoints, var_size))
+    var01_data = -999.99
 
-    call read_data(fileobj, "var0", var_data)
-    do j = 1, var_size
-      if (var_data(j) .ne. real(j)) call mpp_error(FATAL, "The variable data for var1 at time level:"//&
-                                                          string(j)//" is not the correct value!")
-    enddo
+    call read_data(fileobj, "var0", var0_data)
+    call read_data(fileobj, "var0_openmp", var01_data)
+
+    if (sum(var01_data) .ne. sum(var0_data)) call mpp_error(FATAL, "Data is not the expected result")
 
     call close_file(fileobj)
   end subroutine check_output

--- a/test_fms/diag_manager/test_output_every_freq.sh
+++ b/test_fms/diag_manager/test_output_every_freq.sh
@@ -45,6 +45,10 @@ diag_files:
     var_name: var2
     reduction: none
     kind: r4
+  - module: ocn_mod
+    var_name: var0_openmp
+    reduction: none
+    kind: r4
 _EOF
 
 my_test_count=1


### PR DESCRIPTION
**Description**
Adds more robust tests for when outputting data at every time step.

The test now ensure that the "0 days" frequency works for when both calling from an openmp region and from a non openmp region. 

Fixes # (issue)

**How Has This Been Tested?**
CI

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

