### PR TITLE
Fix time variable in instantaneous outputs from `diag_manager` in both openmp and non-openmp cases

### DIFF
--- a/diag_manager/diag_manager.F90
+++ b/diag_manager/diag_manager.F90
@@ -2072,19 +2072,19 @@ END FUNCTION register_static_field
 
        ! Initialize output time for fields output every time step
        IF ( freq == EVERY_TIME .AND. .NOT.output_fields(out_num)%static ) THEN
-          IF (output_fields(out_num)%next_output == output_fields(out_num)%last_output) THEN
-             IF(PRESENT(time)) THEN
-                output_fields(out_num)%next_output = time
-             ELSE
-                WRITE (error_string,'(a,"/",a)')&
-                     & TRIM(input_fields(diag_field_id)%module_name),&
-                     & TRIM(output_fields(out_num)%output_name)
-                IF ( fms_error_handler('diag_manager_mod::send_data_3d', 'module/output_field '//TRIM(error_string)//&
-                     & ', time must be present when output frequency = EVERY_TIME', err_msg)) THEN
-                   DEALLOCATE(field_out)
-                   DEALLOCATE(oor_mask)
-                   RETURN
-                END IF
+          IF (PRESENT(time)) THEN
+             IF ( time > output_fields(out_num)%last_output ) THEN
+               output_fields(out_num)%next_output = time
+             END IF
+          ELSE IF ( output_fields(out_num)%next_output == output_fields(out_num)%last_output ) THEN
+             WRITE (error_string,'(a,"/",a)')&
+                & TRIM(input_fields(diag_field_id)%module_name),&
+                & TRIM(output_fields(out_num)%output_name)
+             IF ( fms_error_handler('diag_manager_mod::send_data_3d', 'module/output_field '//TRIM(error_string)//&
+                & ', time must be present when output frequency = EVERY_TIME', err_msg)) THEN
+                DEALLOCATE(field_out)
+                DEALLOCATE(oor_mask)
+                RETURN
              END IF
           END IF
        END IF


### PR DESCRIPTION
**Description**
Following pull request #1667, the new commit fixes the issue that instantaneous outputs are missing outside openmp region.

> When writing instantaneous output variables, the input time variable should always be honored and assigned to output_fields%next_output so that it can be written to the output files.

Fixes #1666  (issue)

**How Has This Been Tested?**

- `ncrc5.intel23-classic` with targets `prod-openmp` and `prod` on gaea
- XML at https://gitlab.gfdl.noaa.gov/Chongxing.Fan/am5xml/-/tree/am5f8d5r0-rad-inst-test
    - based on the original am5xml at tag am5f8d5r0
    - Use https://gitlab.gfdl.noaa.gov/Chongxing.Fan/am5_phys/-/tree/am5phys_radiation_diag_time_bug to replace the existing am5_phys component - this is a related bug fix.
- Experiment c96L65_am5f8d5r0_amip_rad_inst_test
    - a new experiment based on c96L65_am5f8d5r0_amip
    - new diag_table entry to test instantaneous output functionality
- Check the time variable in the output file 19790101.rad_inputs.tile1.nc

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [ ] `make distcheck` passes

