### PR TITLE
Remove sst_anom and sst_ncep from the amip_interp code.  

### DIFF
--- a/amip_interp/amip_interp.F90
+++ b/amip_interp/amip_interp.F90
@@ -156,9 +156,8 @@ integer :: i_sst = 1200
 integer :: j_sst = 600
 real(r8_kind), parameter:: big_number = 1.E30_r8_kind
 logical :: forecast_mode = .false.
-real(r8_kind), allocatable, dimension(:,:) ::  sst_ncep, sst_anom
 
-public i_sst, j_sst, sst_ncep, sst_anom, forecast_mode, use_ncep_sst
+public i_sst, j_sst, forecast_mode, use_ncep_sst
 
 !-----------------------------------------------------------------------
 !--------------------- private below here ------------------------------
@@ -460,14 +459,6 @@ contains
 !--- Added by SJL ----------------------------------------------
         if ( use_ncep_sst ) then
              mobs = i_sst;  nobs = j_sst
-            if (.not. allocated (sst_ncep)) then
-                allocate (sst_ncep(i_sst,j_sst))
-                sst_ncep(:,:) = big_number
-            endif
-            if (.not. allocated (sst_anom)) then
-                allocate (sst_anom(i_sst,j_sst))
-                sst_anom(:,:) = big_number
-            endif
         else
              mobs = 360;    nobs = 180
         endif

--- a/amip_interp/include/amip_interp.inc
+++ b/amip_interp/include/amip_interp.inc
@@ -114,9 +114,6 @@ if ( .not.use_daily ) then
               temp1(:,:) = temp2(:,:)   ! SJL BUG fix: June 24, 2011
           else
               call READ_RECORD_ ('sst', Date1, Udate1, temp1)
-              if ( use_ncep_sst .and. (.not. no_anom_sst) ) then
-                   temp1 = temp1 + SST_ANOM_
-              endif
               call horiz_interp ( Interp%Hintrp, temp1, Interp%DATA1_)
               call CLIP_DATA_ ('sst', Interp%DATA1_)
              Interp%Date1 = Date1
@@ -127,9 +124,6 @@ if ( .not.use_daily ) then
 
       if (Date2 /= Interp%Date2) then
           call READ_RECORD_ ('sst', Date2, Udate2, temp2)
-          if ( use_ncep_sst .and. (.not. no_anom_sst) ) then
-               temp2 = temp2 + SST_ANOM_
-          endif
           call horiz_interp ( Interp%Hintrp, temp2, Interp%DATA2_)
           call CLIP_DATA_ ('sst', Interp%DATA2_)
           Interp%Date2 = Date2
@@ -145,11 +139,6 @@ if ( .not.use_daily ) then
 !      Nudging runs: (Note: NCEP SST updated only every 6-hr)
 !      Compute SST anomaly from global SST datasets for subsequent forecast runs
 !-------------------------------------------------------------------------------
-    if ( use_ncep_sst .and. no_anom_sst ) then
-         sst_anom = SST_NCEP_ - (temp1 + fmonth*(temp2 - temp1))
-         call horiz_interp (Interp%Hintrp, SST_NCEP_, sst)
-         call CLIP_DATA_ ('sst', sst)
-    endif
 
 !! DEBUG CODE
     if (DEBUG) then
@@ -380,15 +369,7 @@ else
 !-- SJL -------------------------------------------------------------
 ! Can NOT use ncep_sst to determine sea_ice For seasonal forecast
 ! Use climo sea ice for seasonal runs
-            if ( use_ncep_sst .and. use_ncep_ice ) then
-               where ( SST_NCEP_ <= (real(TFREEZE, FMS_AMIP_INTERP_KIND_)+real(tice_crit, FMS_AMIP_INTERP_KIND_)) )
-                   sice = 1._lkind
-               elsewhere
-                   sice = 0._lkind
-               endwhere
-            else
-               call READ_RECORD_ ('ice', Date1, Udate1, sice)
-            endif
+            call READ_RECORD_ ('ice', Date1, Udate1, sice)
 !--------------------------------------------------------------------
             call horiz_interp ( Interp%Hintrp, sice, Interp%DATA1_)
             call CLIP_DATA_ ('ice', Interp%DATA1_)
@@ -401,15 +382,7 @@ else
     if (Date2 /= Interp%Date2) then
 
 !-- SJL -------------------------------------------------------------
-            if ( use_ncep_sst .and. use_ncep_ice ) then
-               where ( SST_NCEP_ <= (real(TFREEZE, FMS_AMIP_INTERP_KIND_)+real(tice_crit, FMS_AMIP_INTERP_KIND_)) )
-                   sice = 1._lkind
-               elsewhere
-                   sice = 0._lkind
-               endwhere
-            else
-               call READ_RECORD_ ('ice', Date2, Udate2, sice)
-            endif
+            call READ_RECORD_ ('ice', Date2, Udate2, sice)
 !--------------------------------------------------------------------
         call horiz_interp ( Interp%Hintrp, sice, Interp%DATA2_)
         call CLIP_DATA_ ('ice', Interp%DATA2_)

--- a/amip_interp/include/amip_interp_r4.fh
+++ b/amip_interp/include/amip_interp_r4.fh
@@ -1,6 +1,4 @@
 #undef FMS_AMIP_INTERP_KIND_
-#undef SST_NCEP_
-#undef SST_ANOM_
 #undef LON_BND_
 #undef LAT_BND_
 #undef TEMPAMIP_
@@ -18,8 +16,6 @@
 #undef ZONAL_SST_
 
 #define FMS_AMIP_INTERP_KIND_ r4_kind
-#define SST_NCEP_ real(sst_ncep, r4_kind)
-#define SST_ANOM_ real(sst_anom, r4_kind)
 #define LON_BND_ real(lon_bnd, r4_kind)
 #define LAT_BND_ real(lat_bnd, r4_kind)
 #define TEMPAMIP_ real(tempamip, r4_kind)
@@ -39,8 +35,6 @@
 #include "amip_interp.inc"
 
 #undef FMS_AMIP_INTERP_KIND_
-#undef SST_NCEP_
-#undef SST_ANOM_
 #undef LON_BND_
 #undef LAT_BND_
 #undef TEMPAMIP_

--- a/amip_interp/include/amip_interp_r8.fh
+++ b/amip_interp/include/amip_interp_r8.fh
@@ -1,6 +1,4 @@
 #undef FMS_AMIP_INTERP_KIND_
-#undef SST_NCEP_
-#undef SST_ANOM_
 #undef LON_BND_
 #undef LAT_BND_
 #undef TEMPAMIP_
@@ -18,8 +16,6 @@
 #undef ZONAL_SST_
 
 #define FMS_AMIP_INTERP_KIND_ r8_kind
-#define SST_NCEP_ sst_ncep
-#define SST_ANOM_ sst_anom
 #define LON_BND_ lon_bnd
 #define LAT_BND_ lat_bnd
 #define TEMPAMIP_ tempamip
@@ -39,8 +35,6 @@
 #include "amip_interp.inc"
 
 #undef FMS_AMIP_INTERP_KIND_
-#undef SST_NCEP_
-#undef SST_ANOM_
 #undef LON_BND_
 #undef LAT_BND_
 #undef TEMPAMIP_

--- a/libFMS.F90
+++ b/libFMS.F90
@@ -81,8 +81,6 @@ module fms
                              assignment(=), &
                              fms_amip_interp_i_sst        => i_sst, &
                              fms_amip_interp_j_sst        => j_sst, &
-                             fms_amip_interp_sst_ncep     => sst_ncep, &
-                             fms_amip_interp_sst_anom     => sst_anom, &
                              fms_amip_interp_forecast_mode=> forecast_mode, &
                              fms_amip_interp_use_ncep_sst => use_ncep_sst
   !> astronomy


### PR DESCRIPTION
**Description**
sst_ncep and sst_anom should not be in amip_interp_mod and should be defined by the model components. Right now the dycore and the ice model seem to be the only components using these variables and they are defined in their respective components. This PR removes the two from amip_interp

Fixes #1393 

**How Has This Been Tested?**
Tested via compiling and running SHiELD.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

