### PR TITLE
diag yaml manifest fix for subregional diag files

### DIFF
--- a/test_fms/diag_manager/check_subregional.F90
+++ b/test_fms/diag_manager/check_subregional.F90
@@ -23,6 +23,7 @@ program check_subregional
   use fms2_io_mod,       only: FmsNetcdfFile_t, read_data, close_file, open_file, get_dimension_size, file_exists
   use mpp_mod,           only: mpp_npes, mpp_error, FATAL, mpp_pe
   use platform_mod,      only: r4_kind, r8_kind
+  use yaml_parser_mod,   only: open_and_parse_file, get_num_blocks, get_block_ids, get_value_from_key
 
   implicit none
 
@@ -33,6 +34,7 @@ program check_subregional
   call check_subregional_file("test_subregional.nc")
   call check_subregional_file("test_subregional2.nc")
   call check_corner_files()
+  call check_manifest()
 
   call fms_end()
 
@@ -203,4 +205,29 @@ program check_subregional
 
   end subroutine check_corner_files
 
+  !> @brief Check that the number of time levels was written correctly in the diag manifest yaml
+  subroutine check_manifest()
+    integer              :: diag_yaml_id !< Id for the diag manifest yaml
+    integer              :: nfiles       !< Number of diag files in the yaml
+    integer, allocatable :: file_ids(:)  !< Ids for all the diag files in the yaml
+    integer              :: i            !< For do loops
+    integer              :: ntime_levels !< Number of time levels are read from the yaml
+
+    if ( .not. file_exists("diag_manifest.yaml.0")) &
+      call mpp_error(FATAL, "diag manifest file does not exist!")
+
+    diag_yaml_id = open_and_parse_file("diag_manifest.yaml.0")
+
+    nfiles = get_num_blocks(diag_yaml_id, "diag_files")
+    allocate(file_ids(nfiles))
+    call get_block_ids(diag_yaml_id, "diag_files", file_ids)
+
+    do i = 1, nfiles
+      ntime_levels = -999
+      call get_value_from_key(diag_yaml_id, file_ids(i), "number_of_timelevels", ntime_levels)
+
+      if (ntime_levels .ne. 8) call mpp_error(FATAL, "The number of time levels is not correct:: "//string(ntime_levels))
+    enddo
+
+  end subroutine check_manifest
 end program

--- a/test_fms/diag_manager/check_subregional.F90
+++ b/test_fms/diag_manager/check_subregional.F90
@@ -227,7 +227,8 @@ program check_subregional
       ntime_levels = -999
       call get_value_from_key(diag_yaml_id, file_ids(i), "number_of_timelevels", ntime_levels)
 
-      if (ntime_levels .ne. 8) call mpp_error(FATAL, "The number of time levels is not correct:: "//string(ntime_levels))
+      if (ntime_levels .ne. 8)&
+        call mpp_error(FATAL, "The number of time levels is not correct:: "//string(ntime_levels))
     enddo
 
   end subroutine check_manifest

--- a/test_fms/diag_manager/check_subregional.F90
+++ b/test_fms/diag_manager/check_subregional.F90
@@ -19,6 +19,7 @@
 
 !> @brief Checks the output file after running test_subregional
 program check_subregional
+#ifdef use_yaml
   use fms_mod,           only: fms_init, fms_end, string
   use fms2_io_mod,       only: FmsNetcdfFile_t, read_data, close_file, open_file, get_dimension_size, file_exists
   use mpp_mod,           only: mpp_npes, mpp_error, FATAL, mpp_pe
@@ -230,4 +231,5 @@ program check_subregional
     enddo
 
   end subroutine check_manifest
+#endif
 end program


### PR DESCRIPTION
**Description**
Fix so the number of time levels is written correctly in the diag yaml manifest for subregional files

Fixes #1697 
**How Has This Been Tested?**
CI

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

