### PR TITLE
diag_manifest patch

### DIFF
--- a/diag_manager/fms_diag_field_object.F90
+++ b/diag_manager/fms_diag_field_object.F90
@@ -344,6 +344,12 @@ subroutine fms_register_diag_field_obj &
 !> get the optional arguments if included and the diagnostic is in the diag table
   if (present(longname))      this%longname      = trim(longname)
   if (present(standname))     this%standname     = trim(standname)
+  do i=1, SIZE(diag_field_indices)
+    yaml_var_ptr => diag_yaml%get_diag_field_from_id(diag_field_indices(i))
+
+    !! Add standard name to the diag_yaml object, so that it can be used when writing the diag_manifest
+    call yaml_var_ptr%add_standname(standname)
+  enddo
 
   !> Ignore the units if they are set to "none". This is to reproduce previous diag_manager behavior
   if (present(units)) then

--- a/test_fms/diag_manager/check_subregional.F90
+++ b/test_fms/diag_manager/check_subregional.F90
@@ -23,6 +23,7 @@ program check_subregional
   use fms2_io_mod,       only: FmsNetcdfFile_t, read_data, close_file, open_file, get_dimension_size, file_exists
   use mpp_mod,           only: mpp_npes, mpp_error, FATAL, mpp_pe
   use platform_mod,      only: r4_kind, r8_kind
+  use yaml_parser_mod,   only: open_and_parse_file, get_num_blocks, get_block_ids, get_value_from_key
 
   implicit none
 
@@ -33,6 +34,7 @@ program check_subregional
   call check_subregional_file("test_subregional.nc")
   call check_subregional_file("test_subregional2.nc")
   call check_corner_files()
+  call check_manifest()
 
   call fms_end()
 
@@ -203,4 +205,29 @@ program check_subregional
 
   end subroutine check_corner_files
 
+  !> @brief Check that the number of time levels was written correctly in the diag manifest yaml
+  subroutine check_manifest()
+    integer              :: diag_yaml_id !< Id for the diag manifest yaml
+    integer              :: nfiles       !< Number of diag files in the yaml
+    integer, allocatable :: file_ids(:)  !< Ids for all the diag files in the yaml
+    integer              :: i            !< For do loops
+    integer              :: ntime_levels !< Number of time levels are read from the yaml
+
+    if ( .not. file_exists("diag_manifest.yaml.0")) &
+      call mpp_error(FATAL, "diag manifest file does not exist!")
+
+    diag_yaml_id = open_and_parse_file("diag_manifest.yaml.0")
+
+    nfiles = get_num_blocks(diag_yaml_id, "diag_files")
+    allocate(file_ids(nfiles))
+    call get_block_ids(diag_yaml_id, "diag_files", file_ids)
+
+    do i = 1, nfiles
+      ntime_levels = -999
+      call get_value_from_key(diag_yaml_id, file_ids(i), "number_of_timelevels", ntime_levels)
+
+      if (ntime_levels .ne. 8) call mpp_error(FATAL, "The number of time levels is not correct:: "//string(ntime_levels))
+    enddo
+
+  end subroutine check_manifest
 end program

--- a/test_fms/diag_manager/check_subregional.F90
+++ b/test_fms/diag_manager/check_subregional.F90
@@ -227,7 +227,8 @@ program check_subregional
       ntime_levels = -999
       call get_value_from_key(diag_yaml_id, file_ids(i), "number_of_timelevels", ntime_levels)
 
-      if (ntime_levels .ne. 8) call mpp_error(FATAL, "The number of time levels is not correct:: "//string(ntime_levels))
+      if (ntime_levels .ne. 8)&
+        call mpp_error(FATAL, "The number of time levels is not correct:: "//string(ntime_levels))
     enddo
 
   end subroutine check_manifest

--- a/test_fms/diag_manager/check_subregional.F90
+++ b/test_fms/diag_manager/check_subregional.F90
@@ -19,6 +19,7 @@
 
 !> @brief Checks the output file after running test_subregional
 program check_subregional
+#ifdef use_yaml
   use fms_mod,           only: fms_init, fms_end, string
   use fms2_io_mod,       only: FmsNetcdfFile_t, read_data, close_file, open_file, get_dimension_size, file_exists
   use mpp_mod,           only: mpp_npes, mpp_error, FATAL, mpp_pe
@@ -230,4 +231,5 @@ program check_subregional
     enddo
 
   end subroutine check_manifest
+#endif
 end program

--- a/test_fms/diag_manager/test_diag_manager2.sh
+++ b/test_fms/diag_manager/test_diag_manager2.sh
@@ -913,6 +913,7 @@ diag_files:
     n_diurnal:
     pow_value:
     dimensions: z
+    standard_name:
   sub_region:
   - grid_type:
     tile:
@@ -948,6 +949,7 @@ diag_files:
     n_diurnal:
     pow_value:
     dimensions: time y x
+    standard_name:
   - module: ocn_mod
     var_name: var2
     reduction: average
@@ -959,6 +961,7 @@ diag_files:
     n_diurnal:
     pow_value:
     dimensions: time x y
+    standard_name:
   sub_region:
   - grid_type:
     tile:
@@ -993,6 +996,7 @@ diag_files:
     n_diurnal:
     pow_value:
     dimensions: time y3 x3
+    standard_name:
   - module: atm_mod
     var_name: var4
     reduction: average
@@ -1004,6 +1008,7 @@ diag_files:
     n_diurnal:
     pow_value:
     dimensions: time z y3 x3
+    standard_name:
   - module: atm_mod
     var_name: var6
     reduction: average
@@ -1015,6 +1020,7 @@ diag_files:
     n_diurnal:
     pow_value:
     dimensions: time z
+    standard_name: I hope this is the MDTF tables
   - module: atm_mod
     var_name: var4
     reduction: average
@@ -1026,6 +1032,7 @@ diag_files:
     n_diurnal:
     pow_value:
     dimensions: time z_sub01 y3 x3
+    standard_name:
   sub_region:
   - grid_type:
     tile:
@@ -1060,6 +1067,7 @@ diag_files:
     n_diurnal:
     pow_value:
     dimensions: time grid_index
+    standard_name:
   - module: atm_mod
     var_name: var7
     reduction: none
@@ -1071,6 +1079,7 @@ diag_files:
     n_diurnal:
     pow_value:
     dimensions: z
+    standard_name:
   sub_region:
   - grid_type:
     tile:
@@ -1105,6 +1114,7 @@ diag_files:
     n_diurnal:
     pow_value:
     dimensions: time
+    standard_name: Land is important!
   sub_region:
   - grid_type:
     tile:
@@ -1139,6 +1149,7 @@ diag_files:
     n_diurnal:
     pow_value:
     dimensions: time z y3_sub01 x3_sub01
+    standard_name:
   sub_region:
   - grid_type: index
     tile: 1
@@ -1173,6 +1184,7 @@ diag_files:
     n_diurnal:
     pow_value:
     dimensions: time y x
+    standard_name:
   sub_region:
   - grid_type:
     tile:
@@ -1207,6 +1219,7 @@ diag_files:
     n_diurnal:
     pow_value:
     dimensions: time y x
+    standard_name:
   sub_region:
   - grid_type:
     tile:
@@ -1241,6 +1254,7 @@ diag_files:
     n_diurnal:
     pow_value:
     dimensions: time y x
+    standard_name:
   sub_region:
   - grid_type:
     tile:
@@ -1275,6 +1289,7 @@ diag_files:
     n_diurnal:
     pow_value:
     dimensions: time y x
+    standard_name:
   sub_region:
   - grid_type:
     tile:
@@ -1309,6 +1324,7 @@ diag_files:
     n_diurnal: 12
     pow_value:
     dimensions: time time_of_day_12 y x
+    standard_name:
   sub_region:
   - grid_type:
     tile:

--- a/test_fms/diag_manager/test_modern_diag.F90
+++ b/test_fms/diag_manager/test_modern_diag.F90
@@ -161,11 +161,13 @@ id_var3 = register_diag_field  ('atm_mod', 'var3', (/id_x3, id_y3/), Time, 'Var 
 id_var4 = register_diag_field  ('atm_mod', 'var4', (/id_x3, id_y3, id_z/), Time, &
                                 '3D var in a cube sphere domain', 'mullions')
 id_var5 = register_diag_field  ('lnd_mod', 'var5', (/id_ug/), Time, 'Var in a UG domain', 'mullions')
-id_var6 = register_diag_field  ('atm_mod', 'var6', (/id_z/), Time, 'Var not domain decomposed', 'mullions')
+id_var6 = register_diag_field  ('atm_mod', 'var6', (/id_z/), Time, 'Var not domain decomposed', 'mullions', &
+                                standard_name="I hope this is the MDTF tables")
 
 !< This has the same name as var1, but it should have a different id because the module is different
 !! so it should have its own diag_obj
-id_var7 = register_diag_field  ('lnd_mod', 'var1', Time, 'Some scalar var', 'mullions')
+id_var7 = register_diag_field  ('lnd_mod', 'var1', Time, 'Some scalar var', 'mullions', &
+                                 standard_name="Land is important!")
 id_var8 = register_static_field ('atm_mod', 'var7', (/id_z/), "Be static!", "none")
 
 if (.not. debug) then


### PR DESCRIPTION
**Description**
Fix so that the standard name is written out to the diag manifest file
Fix so that the number of time levels is written out correctly for subregional files

Fixes # (issue)

**How Has This Been Tested?**
CI

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

