### PR TITLE
add checks for oneapi 2025.1 bug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -361,6 +361,10 @@ foreach(kind ${kinds})
     endif()
   endif()
 
+  if ( CMAKE_Fortran_COMPILER_VERSION MATCHES "2025\.1\..*" AND CMAKE_Fortran_COMPILER_ID MATCHES "IntelLLVM")
+    message(FATAL_ERROR "Intel LLVM Fortran compiler version 2025.1 is not supported due to internal compiler error")
+  endif()
+
   # FMS (C + Fortran)
   if (SHARED_LIBS)
       message(STATUS "Shared library target: ${libTgt}")

--- a/configure.ac
+++ b/configure.ac
@@ -437,6 +437,16 @@ else
   AC_MSG_RESULT([no])
 fi
 
+# Check if intel is 2025.1 for ICE
+AC_MSG_CHECKING([if using Intel 2025.1])
+if [ test -n "`$FC --version | grep ifx | grep 2025\.1\..*`" ]; then
+  AC_MSG_RESULT([yes])
+  AC_MSG_ERROR([Compilation with Oneapi 2025.1 is unsupported \
+by this version of FMS due to a bug in the compiler. Please use a different version of oneapi.])
+else
+  AC_MSG_RESULT([no])
+fi
+
 #####
 # Create output variables from various
 # shell variables, for use in generating


### PR DESCRIPTION
**Description**
Adds compiler version checks to error out if using the onapi version that causes an ICE

**How Has This Been Tested?**
tested on the amd box

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

