### PR TITLE
Fix Typos in Comments for Domain Overlapping and Simulation

### DIFF
--- a/mpp/include/mpp_domains_define.inc
+++ b/mpp/include/mpp_domains_define.inc
@@ -3550,7 +3550,7 @@ end subroutine check_message_size
             !fold is within domain
              if( domain%y(tMe)%domain_data%begin .LE. jsg .AND. jsg .LE. domain%y(tMe)%domain_data%end+jshift )then
                 dir = 3
-                !--- calculating overlapping for receving on north
+                !--- calculating overlapping for receiving on north
                 if( domain%x(tMe)%pos .GE. size(domain%x(tMe)%list(:))/2 )then
                    jsd = domain%y(tMe)%compute%begin;   jed = jsd
                    if( jsd == jsg )then   ! fold is within domain.

--- a/test_fms/drifters/test_drifters.F90
+++ b/test_fms/drifters/test_drifters.F90
@@ -129,7 +129,7 @@ program test_drifters
   call mpp_declare_pelist( (/ (i, i=pe_beg, pe_end) /), '_drifters')
 !#endif
 
-  ! this sumulates a run on a subset of PEs
+  ! this simulates a run on a subset of PEs
   if(pe >= pe_beg .and. pe <= pe_end) then
 
 !#ifndef _SERIAL


### PR DESCRIPTION


Description:  
This pull request corrects minor typographical errors in comments within the codebase. Specifically, it updates the spelling of "receiving" and "simulates" in the following files:
- `mpp/include/mpp_domains_define.inc`: Fixes the comment regarding overlapping for receiving on the north.
- `test_fms/drifters/test_drifters.F90`: Corrects the comment describing the simulation of a run on a subset of PEs.

These changes improve code readability and maintain consistency in documentation. No functional code has been altered.
