### PR TITLE
add fms_end call to test_grid2

### DIFF
--- a/test_fms/mosaic2/test_grid2.F90
+++ b/test_fms/mosaic2/test_grid2.F90
@@ -60,6 +60,8 @@ call test_get_grid_comp_area_sg
 if(mpp_pe() .eq. mpp_root_pe()) write(*,*) 'TEST GET_GRID_COMP_AREA_UG'
 call test_get_grid_comp_area_ug
 
+call fms_end()
+
 contains
   !------------------------------------------!
   subroutine test_get_cell_vertices


### PR DESCRIPTION
**Description**
Fixes failures with the grid2 test when using openmpi.

Fixes #1724 

**How Has This Been Tested?**
make check with gcc 14 and openmpi 

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

