### PR TITLE
set the init time in diag_integral test

### DIFF
--- a/test_fms/diag_integral/test_diag_integral.F90
+++ b/test_fms/diag_integral/test_diag_integral.F90
@@ -80,6 +80,7 @@ program test_diag_integral
 
   !> Made up time.  Set the initial time.
   Time=set_time(0,1,0)
+  Time_init = set_time(0,0,0)
 
   call test_diag_integral_init       !< Test that diag_integral_init call works
   call test_diag_integral_field_init !< Register the fields


### PR DESCRIPTION
**Description**
fixes a failing unit test for diag_integral. had a uninitialized init_time value at the beginning which causes errors when writing output.

Fixes #1729 

**How Has This Been Tested?**
amd box with gcc + openmpi

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

