### PR TITLE
horiz_interp fixes for r4 tests

### DIFF
--- a/horiz_interp/horiz_interp_bilinear.F90
+++ b/horiz_interp/horiz_interp_bilinear.F90
@@ -71,6 +71,7 @@ module horiz_interp_bilinear_mod
 !> @{
 
   real(r8_kind), parameter :: epsln=1.e-10_r8_kind
+  real(r4_kind), parameter :: epsln_r4=1.e-4_r4_kind
   integer, parameter :: DUMMY = -999
 
 !! Private helper routines, interfaces for mixed real precision support

--- a/horiz_interp/include/horiz_interp_bilinear.inc
+++ b/horiz_interp/include/horiz_interp_bilinear.inc
@@ -399,7 +399,8 @@
                   call mpp_error(FATAL, "horiz_interp_bilinear_mod: weight should be between 0 and 1, x=" &
                      //string(x)//" y="//string(y))
            else
-               if( x>1.0_kindl + epsln2 .or. x<0.0_kindl - epsln2 .or. y>1.0_kindl + epsln2 .or. y < 0.0_kindl - epsln2) &
+               if( x>1.0_kindl + epsln2 .or. x<0.0_kindl - epsln2 .or. &
+                   y>1.0_kindl + epsln2 .or. y < 0.0_kindl - epsln2) &
                   call mpp_error(FATAL, "horiz_interp_bilinear_mod: weight should be between 0 and 1, x=" &
                      //string(x)//" y="//string(y))
            endif

--- a/horiz_interp/include/horiz_interp_bilinear.inc
+++ b/horiz_interp/include/horiz_interp_bilinear.inc
@@ -270,7 +270,11 @@
        epsln2 = real(epsln,FMS_HI_KIND_)* 1.0e5_kindl
        call FIND_NEIGHBOR_NEW_(Interp, lon_in, lat_in, lon_out, lat_out, src_is_modulo, no_crash)
     else
-       epsln2 = real(epsln,FMS_HI_KIND_)
+       if(kindl == r8_kind) then
+          epsln2 = epsln
+       else
+          epsln2 = epsln_r4
+       endif
        call FIND_NEIGHBOR_(Interp, lon_in, lat_in, lon_out, lat_out, src_is_modulo)
     endif
 
@@ -389,8 +393,16 @@
              if (x > 1.0_kindl) x = 1.0_kindl
              if (y > 1.0_kindl) y = 1.0_kindl
            endif
-           if( x>1.0_kindl .or. x<0.0_kindl .or. y>1.0_kindl .or. y < 0.0_kindl) &
-                  call mpp_error(FATAL, "horiz_interp_bilinear_mod: weight should be between 0 and 1")
+           !! if using 4 byte reals, allow a bit more tolerance (1e-4) on weight values
+           if( kindl == r8_kind ) then
+               if( x>1.0_kindl .or. x<0.0_kindl .or. y>1.0_kindl .or. y < 0.0_kindl) &
+                  call mpp_error(FATAL, "horiz_interp_bilinear_mod: weight should be between 0 and 1, x=" &
+                     //string(x)//" y="//string(y))
+           else
+               if( x>1.0_kindl + epsln2 .or. x<0.0_kindl - epsln2 .or. y>1.0_kindl + epsln2 .or. y < 0.0_kindl - epsln2) &
+                  call mpp_error(FATAL, "horiz_interp_bilinear_mod: weight should be between 0 and 1, x=" &
+                     //string(x)//" y="//string(y))
+           endif
            Interp % HI_KIND_TYPE_ % wti(m,n,1)=1.0_kindl-x
            Interp % HI_KIND_TYPE_ % wti(m,n,2)=x
            Interp % HI_KIND_TYPE_ % wtj(m,n,1)=1.0_kindl-y

--- a/horiz_interp/include/horiz_interp_conserve.inc
+++ b/horiz_interp/include/horiz_interp_conserve.inc
@@ -246,16 +246,11 @@ subroutine HORIZ_INTERP_CONSERVE_NEW_1DX1D_ ( Interp, lon_in, lat_in, lon_out, l
 
     integer :: nincrease, ndecrease
     logical :: flip_lat
-    integer :: wordsz
     integer(kind=1) :: one_byte(8)
     integer, parameter :: kindl = FMS_HI_KIND_ !< compiled kind size
 
     if(.not. module_is_initialized) call mpp_error(FATAL, &
          'HORIZ_INTERP_CONSERVE_NEW_1DX2D_: horiz_interp_conserve_init is not called')
-
-    wordsz=size(transfer(lon_in(1), one_byte))
-    if(wordsz .NE. 4 .AND. wordsz .NE. 8) call mpp_error(FATAL, &
-         'HORIZ_INTERP_CONSERVE_NEW_1DX2D_: wordsz should be 4 or 8')
 
     if( (size(lon_out,1) .NE. size(lat_out,1)) .OR. (size(lon_out,2) .NE. size(lat_out,2)) )  &
         call mpp_error(FATAL, 'horiz_interp_conserve_mod: size mismatch between lon_out and lat_out')
@@ -413,16 +408,11 @@ subroutine HORIZ_INTERP_CONSERVE_NEW_1DX1D_ ( Interp, lon_in, lat_in, lon_out, l
     real(r8_kind), allocatable, dimension(:)   :: lon_out_r8, lat_out_r8
     real(r8_kind), allocatable, dimension(:,:) :: lon_in_r8, lat_in_r8
     real(r8_kind), allocatable, dimension(:,:) :: lon_dst, lat_dst
-    integer :: wordsz
     integer(kind=1) :: one_byte(8)
     integer, parameter :: kindl = FMS_HI_KIND_ !< compiled kind size
 
     if(.not. module_is_initialized) call mpp_error(FATAL, &
          'HORIZ_INTERP_CONSERVE_NEW_2DX1D_: horiz_interp_conserve_init is not called')
-
-    wordsz=size(transfer(lon_in(1,1), one_byte))
-    if(wordsz .NE. 8) call mpp_error(FATAL, &
-         'HORIZ_INTERP_CONSERVE_NEW_2DX1D_: currently only support 64-bit real(FMS_HI_KIND_), contact developer')
 
     if( (size(lon_in,1) .NE. size(lat_in,1)) .OR. (size(lon_in,2) .NE. size(lat_in,2)) )  &
         call mpp_error(FATAL, 'horiz_interp_conserve_mod: size mismatch between lon_in and lat_in')
@@ -524,16 +514,11 @@ subroutine HORIZ_INTERP_CONSERVE_NEW_1DX1D_ ( Interp, lon_in, lat_in, lon_out, l
     real(r8_kind), allocatable, dimension(:,:) :: dst_area
     real(r8_kind), allocatable, dimension(:,:) :: lon_in_r8, lat_in_r8
     real(r8_kind), allocatable, dimension(:,:) :: lon_out_r8, lat_out_r8
-    integer :: wordsz
     integer(kind=1) :: one_byte(8)
     integer, parameter :: kindl = FMS_HI_KIND_ !< compiled kind size
 
     if(.not. module_is_initialized) call mpp_error(FATAL, &
          'HORIZ_INTERP_CONSERVE_NEW_2DX2D_: horiz_interp_conserve_init is not called')
-
-    wordsz=size(transfer(lon_in(1,1), one_byte))
-    if(wordsz .NE. 4 .AND. wordsz .NE. 8) call mpp_error(FATAL, &
-         'HORIZ_INTERP_CONSERVE_NEW_2DX2D_: wordsz should be 4 or 8')
 
     if( (size(lon_in,1) .NE. size(lat_in,1)) .OR. (size(lon_in,2) .NE. size(lat_in,2)) )  &
         call mpp_error(FATAL, 'horiz_interp_conserve_mod: size mismatch between lon_in and lat_in')

--- a/test_fms/horiz_interp/Makefile.am
+++ b/test_fms/horiz_interp/Makefile.am
@@ -36,8 +36,8 @@ test_horiz_interp_r4_SOURCES = test_horiz_interp.F90
 test_horiz_interp_r8_SOURCES = test_horiz_interp.F90
 test_create_xgrid_order2_r8_SOURCES = test_create_xgrid_order2.F90
 
-test_horiz_interp_r4_CPPFLAGS=-DHI_TEST_KIND=4 -I$(MODDIR)
-test_horiz_interp_r8_CPPFLAGS=-DHI_TEST_KIND=8 -I$(MODDIR)
+test_horiz_interp_r4_CPPFLAGS=-DHI_TEST_KIND_=4 -I$(MODDIR)
+test_horiz_interp_r8_CPPFLAGS=-DHI_TEST_KIND_=8 -I$(MODDIR)
 test_create_xgrid_order2_r8_CPPFLAGS=-DHI_TEST_KIND_=8 -I$(MODDIR)
 
 TEST_EXTENSIONS = .sh

--- a/test_fms/horiz_interp/test_horiz_interp.F90
+++ b/test_fms/horiz_interp/test_horiz_interp.F90
@@ -650,7 +650,7 @@ implicit none
     if(HI_TEST_KIND_ == r8_kind) then
         small = 1.0e-10_lkind
     else
-        small = 1.0e-1_lkind
+        small = 1.0e-3_lkind
     end if
 
     ! set up longitude and latitude of source/destination grid.
@@ -718,13 +718,13 @@ implicit none
                 if( interp_t%horizInterpReals4_type%is_allocated) then
                     if( interp_t%horizInterpReals4_type%wti(i,j,1) * interp_t%horizInterpReals4_type%wti(i,j,2) &
                         - interp_t%horizInterpReals4_type%wti(i,j,3) .gt. SMALL .or.    &
-                        interp_t%horizInterpReals4_type%wti(i,j,3) - (57.2958_lkind * 57.2958_lkind) .gt. SMALL) then
+                        interp_t%horizInterpReals4_type%wti(i,j,3) - (57.2958_lkind * 57.2958_lkind) .gt. 1.0e-1_lkind) then
                             print *, i, j, interp_t%horizInterpReals4_type%wti(i,j,:)
                             call mpp_error(FATAL, "test_horiz_interp: bicubic test failed 1Dx1D weight calculation")
                     endif
                 else
                     if( interp_t%horizInterpReals8_type%wti(i,j,1) * interp_t%horizInterpReals8_type%wti(i,j,2) &
-                        - interp_t%horizInterpReals8_type%wti(i,j,3) .gt. SMALL .and. &
+                        - interp_t%horizInterpReals8_type%wti(i,j,3) .gt. SMALL .or. &
                         interp_t%horizInterpReals8_type%wti(i,j,3) - (57.2958_lkind * 57.2958_lkind) .gt. SMALL) then
                             print *, i, j, interp_t%horizInterpReals8_type%wti(i,j,:)
                             call mpp_error(FATAL, "test_horiz_interp: bicubic test failed 1Dx1D weight calculation")
@@ -764,7 +764,7 @@ implicit none
                 if( interp_t%horizInterpReals4_type%is_allocated) then
                     if( interp_t%horizInterpReals4_type%wti(i,j,1) * interp_t%horizInterpReals4_type%wti(i,j,2) &
                         - interp_t%horizInterpReals4_type%wti(i,j,3) .gt. SMALL .or.    &
-                        interp_t%horizInterpReals4_type%wti(i,j,3) - (57.2958_lkind * 57.2958_lkind) .gt. SMALL) then
+                        interp_t%horizInterpReals4_type%wti(i,j,3) - (57.2958_lkind * 57.2958_lkind) .gt. 1.0e-1_lkind) then
                             print *, i, j, interp_t%horizInterpReals4_type%wti(i,j,:)
                             call mpp_error(FATAL, "test_horiz_interp: bicubic test failed 1Dx1D weight calculation")
                     endif

--- a/test_fms/horiz_interp/test_horiz_interp.F90
+++ b/test_fms/horiz_interp/test_horiz_interp.F90
@@ -22,11 +22,6 @@
 !! Assignment test checks that the override is copying the data type properly
 !! TODO some larger tests with different data sets
 
-!! defaults to 8 real kind, make check will compile with both 4 and 8
-#ifndef HI_TEST_KIND_
-#define HI_TEST_KIND_ 8
-#endif
-
 program horiz_interp_test
 
 use mpp_mod,          only : mpp_init, mpp_exit, mpp_error, FATAL, stdout, mpp_npes, WARNING
@@ -125,7 +120,7 @@ implicit none
     real(HI_TEST_KIND_) :: lon_dst_beg = -280._lkind, lon_dst_end = 80._lkind
     real(HI_TEST_KIND_) :: lat_dst_beg = -90._lkind,  lat_dst_end = 90._lkind
     real(HI_TEST_KIND_) :: D2R = real(PI,HI_TEST_KIND_)/180._lkind
-    real(HI_TEST_KIND_), parameter :: SMALL = 1.0e-10_lkind
+    real(HI_TEST_KIND_), parameter :: tolerance = 1.0e-5_lkind
 
     ! set up longitude and latitude of source/destination grid.
     dlon_src = (lon_src_end-lon_src_beg)/real(ni_src, HI_TEST_KIND_)
@@ -176,7 +171,7 @@ implicit none
     call mpp_clock_end(id1)
     do i=1, ni_dst-1
         do j=1, nj_dst-1
-            if(data_dst(i,j) - 1.0_lkind .gt. SMALL) then
+            if(data_dst(i,j) - 1.0_lkind .gt. tolerance) then
                 print *, 'data_dst(i=', i, ', j=', j, ')=', data_dst(i,j), ' Expected value: 1.0'
                 call mpp_error(FATAL, "test_horiz_interp_spherical: "// &
                                                                     "invalid output data after interpolation")
@@ -649,7 +644,14 @@ implicit none
     real(HI_TEST_KIND_) :: lon_dst_beg = -280._lkind, lon_dst_end = 80._lkind
     real(HI_TEST_KIND_) :: lat_dst_beg = -90._lkind,  lat_dst_end = 90._lkind
     real(HI_TEST_KIND_) :: D2R = real(PI,HI_TEST_KIND_)/180._lkind
-    real(HI_TEST_KIND_), parameter :: SMALL = 1.0e-10_lkind
+    real(HI_TEST_KIND_) :: SMALL
+
+    ! adjust tolerance used in checks based on kind size
+    if(HI_TEST_KIND_ == r8_kind) then
+        small = 1.0e-10_lkind
+    else
+        small = 1.0e-1_lkind
+    end if
 
     ! set up longitude and latitude of source/destination grid.
     dlon_src = (lon_src_end-lon_src_beg)/real(ni_src, lkind)

--- a/test_fms/horiz_interp/test_horiz_interp.F90
+++ b/test_fms/horiz_interp/test_horiz_interp.F90
@@ -120,7 +120,13 @@ implicit none
     real(HI_TEST_KIND_) :: lon_dst_beg = -280._lkind, lon_dst_end = 80._lkind
     real(HI_TEST_KIND_) :: lat_dst_beg = -90._lkind,  lat_dst_end = 90._lkind
     real(HI_TEST_KIND_) :: D2R = real(PI,HI_TEST_KIND_)/180._lkind
-    real(HI_TEST_KIND_), parameter :: tolerance = 1.0e-5_lkind
+    real(HI_TEST_KIND_) :: tolerance
+
+    if(HI_TEST_KIND_ == r8_kind) then
+      tolerance = 1.0e-10_r8_kind
+    else
+      tolerance = 1.0e-5_r4_kind
+    endif
 
     ! set up longitude and latitude of source/destination grid.
     dlon_src = (lon_src_end-lon_src_beg)/real(ni_src, HI_TEST_KIND_)

--- a/test_fms/horiz_interp/test_horiz_interp.F90
+++ b/test_fms/horiz_interp/test_horiz_interp.F90
@@ -123,9 +123,9 @@ implicit none
     real(HI_TEST_KIND_) :: tolerance
 
     if(HI_TEST_KIND_ == r8_kind) then
-      tolerance = 1.0e-10_r8_kind
+      tolerance = 1.0e-10_lkind
     else
-      tolerance = 1.0e-5_r4_kind
+      tolerance = 1.0e-5_lkind
     endif
 
     ! set up longitude and latitude of source/destination grid.

--- a/test_fms/horiz_interp/test_horiz_interp.F90
+++ b/test_fms/horiz_interp/test_horiz_interp.F90
@@ -724,7 +724,8 @@ implicit none
                 if( interp_t%horizInterpReals4_type%is_allocated) then
                     if( interp_t%horizInterpReals4_type%wti(i,j,1) * interp_t%horizInterpReals4_type%wti(i,j,2) &
                         - interp_t%horizInterpReals4_type%wti(i,j,3) .gt. SMALL .or.    &
-                        interp_t%horizInterpReals4_type%wti(i,j,3) - (57.2958_lkind * 57.2958_lkind) .gt. 1.0e-1_lkind) then
+                        interp_t%horizInterpReals4_type%wti(i,j,3) - (57.2958_lkind * 57.2958_lkind) &
+                        .gt. 1.0e-1_lkind) then
                             print *, i, j, interp_t%horizInterpReals4_type%wti(i,j,:)
                             call mpp_error(FATAL, "test_horiz_interp: bicubic test failed 1Dx1D weight calculation")
                     endif
@@ -770,7 +771,8 @@ implicit none
                 if( interp_t%horizInterpReals4_type%is_allocated) then
                     if( interp_t%horizInterpReals4_type%wti(i,j,1) * interp_t%horizInterpReals4_type%wti(i,j,2) &
                         - interp_t%horizInterpReals4_type%wti(i,j,3) .gt. SMALL .or.    &
-                        interp_t%horizInterpReals4_type%wti(i,j,3) - (57.2958_lkind * 57.2958_lkind) .gt. 1.0e-1_lkind) then
+                        interp_t%horizInterpReals4_type%wti(i,j,3) - (57.2958_lkind * 57.2958_lkind) .gt. 1.0e-1_lkind)&
+                         then
                             print *, i, j, interp_t%horizInterpReals4_type%wti(i,j,:)
                             call mpp_error(FATAL, "test_horiz_interp: bicubic test failed 1Dx1D weight calculation")
                     endif


### PR DESCRIPTION
**Description**
Fixes the r4 tests to build properly (see issue below) and makes some adjustments in the code for when using kind 4 reals. Tolerances needed to be a bit large for the bicubic test in particular, not sure if thats just due to the algorithm.

Fixes #1735

**How Has This Been Tested?**
make distcheck on amd box

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

