### PR TITLE
remove unused variables in time_interp

### DIFF
--- a/time_interp/include/time_interp_external2.inc
+++ b/time_interp/include/time_interp_external2.inc
@@ -21,13 +21,12 @@
 !> @{
 
     !> @brief 2D interpolation for @ref time_interp_external
-    subroutine TIME_INTERP_EXTERNAL_2D_(index, time, data_in, interp, verbose,horz_interp, mask_out, &
+    subroutine TIME_INTERP_EXTERNAL_2D_(index, time, data_in, verbose,horz_interp, mask_out, &
                is_in, ie_in, js_in, je_in, window_id)
 
       integer, intent(in) :: index
       type(time_type), intent(in) :: time
       real(FMS_TI_KIND_), dimension(:,:), intent(inout) :: data_in
-      integer, intent(in), optional :: interp
       logical, intent(in), optional :: verbose
       type(horiz_interp_type),intent(in), optional :: horz_interp
       logical, dimension(:,:), intent(out), optional :: mask_out !< set to true where output data is valid
@@ -38,7 +37,7 @@
       logical, dimension(size(data_in,1), size(data_in,2), 1) :: mask3d
 
       data_out(:,:,1) = data_in(:,:) ! fill initial values for the portions of array that are not touched by 3d routine
-      call time_interp_external(index, time, data_out, interp, verbose, horz_interp, mask3d, &
+      call time_interp_external(index, time, data_out, verbose, horz_interp, mask3d, &
                                    is_in=is_in,ie_in=ie_in,js_in=js_in,je_in=je_in,window_id=window_id)
       data_in(:,:) = data_out(:,:,1)
       if (PRESENT(mask_out)) mask_out(:,:) = mask3d(:,:,1)
@@ -52,21 +51,20 @@
     !! Provide data from external file interpolated to current model time.
     !! Data may be local to current processor or global, depending on
     !! "init_external_field" flags.
-    subroutine TIME_INTERP_EXTERNAL_3D_(index, time, time_data, interp,verbose,horz_interp, mask_out, is_in, ie_in, &
+    subroutine TIME_INTERP_EXTERNAL_3D_(index, time, time_data, verbose,horz_interp, mask_out, is_in, ie_in, &
                                       &  js_in, je_in, window_id)
 
         integer,                    intent(in)           :: index !< index of external field from previous call
                                                                   !! to init_external_field
         type(time_type),            intent(in)           :: time !< target time for data
         real(FMS_TI_KIND_), dimension(:,:,:),  intent(inout)           :: time_data !< global or local data array
-        integer,                    intent(in), optional :: interp
         logical,                    intent(in), optional :: verbose !< flag for debugging
         type(horiz_interp_type),    intent(in), optional :: horz_interp
         logical, dimension(:,:,:), intent(out), optional :: mask_out !< set to true where output data is valid
         integer,                    intent(in), optional :: is_in, ie_in, js_in, je_in
         integer,                    intent(in), optional :: window_id
 
-        integer :: nx, ny, nz, interp_method, t1, t2
+        integer :: nx, ny, nz, t1, t2
         integer :: i1, i2, isc, iec, jsc, jec, mod_time
         integer :: yy, mm, dd, hh, min, ss
         character(len=256) :: err_msg
@@ -87,8 +85,6 @@
         ny = size(time_data,2)
         nz = size(time_data,3)
 
-        interp_method = LINEAR_TIME_INTERP
-        if (PRESENT(interp)) interp_method = interp
         verb=.false.
         if (PRESENT(verbose)) verb=verbose
         if (debug_this_module) verb = .true.

--- a/time_interp/include/time_interp_external2_bridge.inc
+++ b/time_interp/include/time_interp_external2_bridge.inc
@@ -21,14 +21,13 @@
 !> @{
 
     !> @brief 2D interpolation for @ref time_interp_external_bridge
-    subroutine TIME_INTERP_EXTERNAL_BRIDGE_2D_(index1, index2, time, data_in, interp, verbose,horz_interp, mask_out, &
+    subroutine TIME_INTERP_EXTERNAL_BRIDGE_2D_(index1, index2, time, data_in, verbose,horz_interp, mask_out, &
                is_in, ie_in, js_in, je_in, window_id)
 
       integer, intent(in) :: index1 !< index of first external field
       integer, intent(in) :: index2 !< index of second external field
       type(time_type), intent(in) :: time !< target time for data
       real(FMS_TI_KIND_), dimension(:,:), intent(inout) :: data_in !< global or local data array
-      integer, intent(in), optional :: interp !< hardcoded to linear
       logical, intent(in), optional :: verbose !< flag for debugging
       type(horiz_interp_type),intent(in), optional :: horz_interp !< horizontal interpolation type
       logical, dimension(:,:), intent(out), optional :: mask_out !< set to true where output data is valid
@@ -39,7 +38,7 @@
       logical, dimension(size(data_in,1), size(data_in,2), 1) :: mask3d !< 3d version of mask_out
 
       data_out(:,:,1) = data_in(:,:) ! fill initial values for the portions of array that are not touched by 3d routine
-      call time_interp_external_bridge(index1, index2, time, data_out, interp, verbose, horz_interp, mask3d, &
+      call time_interp_external_bridge(index1, index2, time, data_out, verbose, horz_interp, mask3d, &
                                    is_in=is_in,ie_in=ie_in,js_in=js_in,je_in=je_in,window_id=window_id)
       data_in(:,:) = data_out(:,:,1)
       if (PRESENT(mask_out)) mask_out(:,:) = mask3d(:,:,1)
@@ -51,14 +50,13 @@
     !! Provide data from external file interpolated to current model time.
     !! Data may be local to current processor or global, depending on
     !! "init_external_field" flags.
-    subroutine TIME_INTERP_EXTERNAL_BRIDGE_3D_(index1, index2, time, time_data, interp,verbose,horz_interp, mask_out, &
+    subroutine TIME_INTERP_EXTERNAL_BRIDGE_3D_(index1, index2, time, time_data, verbose,horz_interp, mask_out, &
                                              &  is_in, ie_in, js_in, je_in, window_id)
 
       integer,                    intent(in) :: index1 !< index of first external field
       integer,                    intent(in) :: index2 !< index of second external field
       type(time_type),            intent(in) :: time   !< target time for data
       real(FMS_TI_KIND_), dimension(:,:,:),  intent(inout) :: time_data !< global or local data array
-      integer,                    intent(in), optional :: interp !< hardcoded to linear
       logical,                    intent(in), optional :: verbose !< flag for debugging
       type(horiz_interp_type),    intent(in), optional :: horz_interp !< horizontal interpolation type
       logical, dimension(:,:,:), intent(out), optional :: mask_out !< set to true where output data is valid
@@ -71,7 +69,6 @@
       integer :: dims1(4) !< dimensions XYZT of index1
       integer :: dims2(4) !< dimensions XYZT of index2
       integer :: nx, ny, nz !< size in X,Y,Z of array
-      integer :: interp_method !< hardcoded to linear in time
       integer :: t1, t2 !< temporary to store time index
       integer :: i1, i2 !< temporary to store time index
       integer :: isc, iec, jsc, jec !< start/end arrays in X,Y
@@ -95,8 +92,6 @@
       ny = size(time_data,2)
       nz = size(time_data,3)
 
-      interp_method = LINEAR_TIME_INTERP
-      if (PRESENT(interp)) interp_method = interp
       verb=.false.
       if (PRESENT(verbose)) verb=verbose
       if (debug_this_module) verb = .true.


### PR DESCRIPTION
**Description**
In this PR,

unused variables for `time_interp_mod` have been removed and are the following:
1. `LINEAR_TIME_INTERP`  is a module parameter that is not used since no other time interpolation schemes are supported.
2. `interp` is an optional subroutine argument to set the time interpolation scheme.  This variable is not used since only linear interpolation is supported.
3. 'DEFAULT_MISSING_VALUE'  is not used after its declaration
4. `desired_units` and `units`, as the mpp_error message indicates, have been "temporarily deprecated" and are not used.

In addition,
1.  a call to `mpp_get_compute_domain` has been changed to also retrieve the size of the domain.  This replaces the following line where the size is computed from the indices.
2.  The number `4320` used to compute seconds has been changed to `int(SECONDS_PER_DAY)/2` where `SECONDS_PER_DAY` is taken from `constants_mod`

Fixes #1757 

**How Has This Been Tested?**
Make check passes for time_interp unit tests 

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

