### PR TITLE
Fix warnings raising with GCC 15

### DIFF
--- a/include/fms_platform.h
+++ b/include/fms_platform.h
@@ -80,11 +80,13 @@ use,intrinsic :: iso_c_binding, only: c_double,c_float,c_int64_t, &
 
  !If you do not want to use 64-bit integers.
 #ifdef no_8byte_integers
+#undef  LONG_KIND
 #define LONG_KIND INT_KIND
 #endif
 
 !If you want to use quad-precision.
 #ifndef ENABLE_QUAD_PRECISION
+#undef  QUAD_KIND
 #define QUAD_KIND DOUBLE_KIND
 #endif
 

--- a/test_fms/fms2_io/test_fms2_io.F90
+++ b/test_fms/fms2_io/test_fms2_io.F90
@@ -17,7 +17,7 @@
 !***********************************************************************
 
 program main
-use, intrinsic :: iso_fortran_env
+use, intrinsic :: iso_fortran_env, only: output_unit, error_unit
 use argparse
 use mpi
 use mpp_mod

--- a/test_fms/fms2_io/test_get_is_valid.F90
+++ b/test_fms/fms2_io/test_get_is_valid.F90
@@ -27,7 +27,6 @@ use   mpp_mod    , only: mpp_init, mpp_exit, mpp_npes, mpp_get_current_pelist, &
 use   netcdf     , only: nf90_create, nf90_def_var, nf90_put_att, nf90_enddef, &
                          nf90_close, nf90_clobber, nf90_64bit_offset, nf90_double
 
-use, intrinsic :: iso_fortran_env
 use platform_mod
 
 implicit none

--- a/test_fms/mosaic2/write_files.F90
+++ b/test_fms/mosaic2/write_files.F90
@@ -2,6 +2,7 @@ module write_files_r4
 
 #define TEST_FMS_KIND_ r4_kind
 #include "write_files.inc"
+#undef TEST_FMS_KIND_
 
 end module
 
@@ -10,5 +11,6 @@ module write_files_r8
 
 #define TEST_FMS_KIND_ r8_kind
 #include "write_files.inc"
+#undef TEST_FMS_KIND_
 
 end module

--- a/test_fms/sat_vapor_pres/test_sat_vapor_pres.F90
+++ b/test_fms/sat_vapor_pres/test_sat_vapor_pres.F90
@@ -958,8 +958,8 @@ contains
 !!  see smithsonian meteorological tables page 350.
       x = -7.90298_r8_kind*(TBASW/tem(i)-one) &
            +5.02808_r8_kind*log10(TBASW/tem(i)) &
-           -1.3816e-07_r8_kind*(ten**((one-tem(i)/TBASW)*11.344_r8_kind)-one)    &
-           +8.1328e-03_r8_kind*(ten**((TBASW/tem(i)-one)*-3.49149_r8_kind)-one)&
+           -1.3816e-07_r8_kind*(ten**(11.344_r8_kind  *(one-tem(i)/TBASW))-one) &
+           +8.1328e-03_r8_kind*(ten**(-3.49149_r8_kind*(TBASW/tem(i)-one))-one) &
            +log10(ESBASW)
       esh2o = ten**(x)
       es(i) = esh2o

--- a/test_fms/tridiagonal/test_tridiagonal.F90
+++ b/test_fms/tridiagonal/test_tridiagonal.F90
@@ -98,7 +98,7 @@ program test_tridiagonal
     enddo
     !! check with stored data arrays
     d = -1.0_kindl
-    ref_array = ref_array * -1.0_kindl
+    ref_array = -1.0_kindl * ref_array
     call tri_invert(x, d)
     do i=1, IN_LEN
       if(ABS(x(1,1,i) - ref_array(1,1,i)) .gt. 1.0e-6_kindl) then


### PR DESCRIPTION
**Description**

This PR fixes warnings which I observed during FMS compilation with GCC 15 on MacOS using CMake build system.
All detected warnings were fixed.

**How Has This Been Tested?**
Tested using compilation with GCC 15.1 (gcc + gfortran), MacOS 22.6.0, CMake 4.0.2. OpenMPI 5.0.5 & NetCDF 4.9.3 were found. Release build was used.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [ ] `make distcheck` passes

