### PR TITLE
add unit testing information for cmake

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -76,7 +76,7 @@ To rerun failed tests with debug output from a previous failed ctest command:
 ```
 ctest --rerun-failed --verbose
 ```
-All tests are labeled with the subdirectory they are in in the `test_fms` directory. 
+All tests are labeled with the subdirectory they are in in the `test_fms` directory.
 To run tests for a specific area of the code, such as the mpp modules:
 ```
 ctest -L mpp

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,18 +1,24 @@
 # Unit Testing
 
-FMS includes a suite of MPI unit tests using the testing infrastructure included in the GNU autotools build system
-in order to check the functionality of the library's modules.
+FMS includes a suite of MPI unit tests for most subdirectories and modules that make up the library.
 
 It consists of programs in the test_fms/ directory, with shell scripts to handle directory set up and input files.
 test_lib.sh.in and tap-driver.sh provide additional helper functions used in the scripts and manage output.
 
+The unit tests can be run either through the autotools build system, or through cmake via ctest.
+The different build systems will run the exact same scripts and executables, but there are some differences in the commands used to start the testing.
+
+## Autotools Unit Testing
+
 ### Running the Tests
 
-1. Configure with autotools
+1. Configure and build the code with autotools
 ```
 mkdir build # create a build directory in FMS
+cd build
 autoreconf -if ../configure.ac
 ../configure <configure options>
+make
 ```
 
 2. Build and run suite
@@ -21,7 +27,7 @@ make check
 ```
 This will compile any code not already compiled and then proceed to run the test scripts.
 
-### Debugging Output and Test Options
+### Debugging Output and Test Options for Autotools
 
 Setting the environment variable TEST_VERBOSE will direct output to stdout as the test runs, while setting VERBOSE will only output on failure.
 Logs are created for each test as well, with the name \<test script name\>.log in its corresponding test_fms/ directory.
@@ -44,3 +50,36 @@ for the build system:
 -    `--enable-test-input=/path/to/input` turns on test scripts that require input netcdf files (interpolator, xgrid, data_override).
      This option is mainly used internally and in automated testing since we do not host the input data publicly.
 -    `--with-yaml` compile with yaml input and enable its associated tests
+
+## CMake Unit Testing
+
+### Running the tests
+
+1. Configure and build the code and tests with cmake
+```
+mkdir build
+cd build
+cmake <Any cmake options such as -DWITH_YAML=on> ..
+make
+```
+2. Run the tests with ctest
+```
+ctest
+```
+Alternatively, the generated makefile can be used as well:
+```
+make test
+```
+### Debugging and Test Options for CMake
+
+All tests are labeled with the subdirectory they are in in the `test_fms` directory. 
+To run tests for a specific area of the code, such as the mpp modules:
+```
+ctest -L mpp
+```
+To rerun failed tests with debug output from a previous failed ctest command:
+```
+ctest --rerun-failed --verbose
+```
+
+For more testing options with ctest, you can look to the [ctest documentation]().

--- a/TESTING.md
+++ b/TESTING.md
@@ -72,14 +72,18 @@ make test
 ```
 ### Debugging and Test Options for CMake
 
+To rerun failed tests with debug output from a previous failed ctest command:
+```
+ctest --rerun-failed --verbose
+```
 All tests are labeled with the subdirectory they are in in the `test_fms` directory. 
 To run tests for a specific area of the code, such as the mpp modules:
 ```
 ctest -L mpp
 ```
-To rerun failed tests with debug output from a previous failed ctest command:
+To run specific tests matching the given regex:
 ```
-ctest --rerun-failed --verbose
+ctest -R <regex>
 ```
 
-For more testing options with ctest, you can look to the [ctest documentation]().
+For more testing options with ctest, you can look to the [ctest documentation](https://cmake.org/cmake/help/latest/manual/ctest.1.html).


### PR DESCRIPTION
**Description**
Adds some information on using ctest to the unit testing markdown page.

**How Has This Been Tested?**
just a documentation update

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

