### PR TITLE
Remove strange `wordlen` variable in `mpp_do_redistribute.fh`

### DIFF
--- a/mpp/include/mpp_do_redistribute.fh
+++ b/mpp/include/mpp_do_redistribute.fh
@@ -35,7 +35,7 @@
       integer :: to_pe, from_pe
       MPP_TYPE_ :: buffer(size(mpp_domains_stack(:)))
       pointer( ptr, buffer )
-      integer :: buffer_pos, wordlen, errunit
+      integer :: buffer_pos, errunit
 
 !fix ke
       errunit = stderr()
@@ -45,7 +45,6 @@
 
       buffer_pos = 0
       ptr = LOC(mpp_domains_stack)
-      wordlen = size(TRANSFER(buffer(1),mpp_domains_stack))
 
 !pre-post recv
       n = d_comm%Rlist_size


### PR DESCRIPTION
**Description**
During rewriting cray pointers in `mpp/`, I've noticed strange variable `wordlen` which is not used. So, here I've deleted it.

**How Has This Been Tested?**
Compilation with GCC 15.2, CMake 4.1.1, NetCDF 4.9.3.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

