### PR TITLE
Yaml deprecation warnings

### DIFF
--- a/data_override/include/data_override.inc
+++ b/data_override/include/data_override.inc
@@ -240,6 +240,10 @@ end if
     else
        if (file_exists("data_table.yaml"))&
          call mpp_error(FATAL, "You cannot have the yaml data_table if use_data_table_yaml=.false.")
+         call mpp_error(NOTE, &
+       &"data_override_init:: You are using the yaml version of the data_table. &
+The legacy data_table format will be deprecated in a future release, &
+please switch to the yaml format.")
        allocate(data_table(max_table))
        do i = 1, max_table
           data_table(i) = default_table
@@ -252,6 +256,10 @@ end if
 
     if (use_data_table_yaml) then
        call mpp_error(FATAL, "You cannot have use_data_table_yaml=.true. without compiling with -Duse_yaml")
+       call mpp_error(NOTE, &
+       &"data_override_init:: You are using the yaml version of the data_table. &
+The legacy data_table format will be deprecated in a future release, &
+please switch to the yaml format.")
     else
 
        allocate(data_table(max_table))

--- a/field_manager/field_manager.F90
+++ b/field_manager/field_manager.F90
@@ -557,12 +557,20 @@ if (use_field_table_yaml) then
     call mpp_error(FATAL, "You cannot have the legacy field_table if use_field_table_yaml=.true.")
 
   call mpp_error(NOTE, "field_manager_init:: You are using the yaml version of the field_table")
+  call mpp_error(NOTE, &
+       &"field_manager_init:: You are using the yaml version of the field_table. &
+The legacy field_table format will be deprecated in a future release, &
+please switch to the yaml format.")
   call read_field_table_yaml(nfields, table_name)
 #endif
 else
   if (file_exists("field_table.yaml")) &
     call mpp_error(FATAL, "You cannot have the yaml field_table if use_field_table_yaml=.false.")
   call mpp_error(NOTE, "field_manager_init:: You are using the legacy version of the field_table")
+  call mpp_error(NOTE, &
+       &"field_manager_init:: You are using the yaml version of the field_table. &
+The legacy field_table format will be deprecated in a future release, &
+please switch to the yaml format.")
   call read_field_table_legacy(nfields, table_name)
 endif
 


### PR DESCRIPTION
**Description**
adds a deprecation warning to users of legacy field_table and data_table which has been updated to a yaml format

Fixes #1768 

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes. Please also note
any relevant details for your test configuration (e.g. compiler, OS).  Include
enough information so someone can reproduce your tests.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

