### PR TITLE
Fix GNU compiler warnings 

### DIFF
--- a/diag_manager/diag_data.F90
+++ b/diag_manager/diag_data.F90
@@ -206,7 +206,7 @@ use platform_mod
      INTEGER :: num_attributes !< Number of defined attibutes
 !----------
 !ug support
-     logical(I4_KIND) :: use_domainUG = .false.
+     logical(L4_KIND) :: use_domainUG = .false.
      logical(I4_KIND) :: use_domain2D = .false.
 !----------
 !Check if time axis was already registered

--- a/diag_manager/fms_diag_field_object.F90
+++ b/diag_manager/fms_diag_field_object.F90
@@ -393,7 +393,7 @@ subroutine fms_register_diag_field_obj &
              allocate(integer(kind=i8_kind) :: this%data_RANGE(2))
              this%data_RANGE = varRANGE
      type is (real(kind=r4_kind))
-             allocate(integer(kind=r4_kind) :: this%data_RANGE(2))
+             allocate(integer(kind=i4_kind) :: this%data_RANGE(2))
              this%data_RANGE = varRANGE
      type is (real(kind=r8_kind))
              allocate(integer(kind=r8_kind) :: this%data_RANGE(2))

--- a/mosaic2/Makefile.am
+++ b/mosaic2/Makefile.am
@@ -23,7 +23,7 @@
 # Ed Hartnett 2/22/19
 
 # Include .h and .mod files.
-AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/mosaic -I$(top_srcdir)/mosaic2/include
+AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/mosaic2/include
 AM_FCFLAGS = $(FC_MODINC). $(FC_MODOUT)$(MODDIR)
 
 # Build these uninstalled convenience libraries.


### PR DESCRIPTION
**Description**
Update type and kind declarations to fix GNU warnings with -DPORTABLE_KINDS

Fixes #1792 

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes. Please also note
any relevant details for your test configuration (e.g. compiler, OS).  Include
enough information so someone can reproduce your tests.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

