### PR TITLE
add deferred-rank-less versions of mpp_pack and mpp_global_field

### DIFF
--- a/diag_manager/diag_data.F90
+++ b/diag_manager/diag_data.F90
@@ -335,9 +335,7 @@ use platform_mod
     class(*), allocatable         :: att_value(:) !< Value of the attribute
     character(len=:), allocatable :: att_name     !< Name of the attribute
     contains
-#ifndef __NVCOMPILER
       procedure :: add => fms_add_attribute
-#endif
       procedure :: write_metadata
   end type fmsDiagAttribute_type
 ! Include variable "version" to be written to log file.
@@ -562,7 +560,6 @@ CONTAINS
     res = base_second
   end function get_base_second
 
-#ifndef __NVCOMPILER
   !> @brief Adds an attribute to the attribute type
   subroutine fms_add_attribute(this, att_name, att_value)
     class(fmsDiagAttribute_type), intent(inout) :: this         !< Diag attribute type
@@ -571,6 +568,7 @@ CONTAINS
 
     integer :: natt !< the size of att_value
 
+#ifndef __NVCOMPILER
     natt = size(att_value)
     this%att_name = att_name
     select type (att_value)
@@ -593,8 +591,8 @@ CONTAINS
           aval = att_value
       end select
     end select
-  end subroutine fms_add_attribute
 #endif
+  end subroutine fms_add_attribute
 
   !> @brief gets the type of a variable
   !> @return the type of the variable (r4,r8,i4,i8,string)

--- a/diag_manager/diag_data.F90
+++ b/diag_manager/diag_data.F90
@@ -335,9 +335,9 @@ use platform_mod
     class(*), allocatable         :: att_value(:) !< Value of the attribute
     character(len=:), allocatable :: att_name     !< Name of the attribute
     contains
-  #ifndef __NVCOMPILER
+#ifndef __NVCOMPILER
       procedure :: add => fms_add_attribute
-  #endif
+#endif
       procedure :: write_metadata
   end type fmsDiagAttribute_type
 ! Include variable "version" to be written to log file.

--- a/diag_manager/diag_data.F90
+++ b/diag_manager/diag_data.F90
@@ -335,7 +335,9 @@ use platform_mod
     class(*), allocatable         :: att_value(:) !< Value of the attribute
     character(len=:), allocatable :: att_name     !< Name of the attribute
     contains
+  #ifndef __NVCOMPILER
       procedure :: add => fms_add_attribute
+  #endif
       procedure :: write_metadata
   end type fmsDiagAttribute_type
 ! Include variable "version" to be written to log file.
@@ -560,6 +562,7 @@ CONTAINS
     res = base_second
   end function get_base_second
 
+#ifndef __NVCOMPILER
   !> @brief Adds an attribute to the attribute type
   subroutine fms_add_attribute(this, att_name, att_value)
     class(fmsDiagAttribute_type), intent(inout) :: this         !< Diag attribute type
@@ -591,6 +594,7 @@ CONTAINS
       end select
     end select
   end subroutine fms_add_attribute
+#endif
 
   !> @brief gets the type of a variable
   !> @return the type of the variable (r4,r8,i4,i8,string)

--- a/diag_manager/fms_diag_axis_object.F90
+++ b/diag_manager/fms_diag_axis_object.F90
@@ -37,7 +37,7 @@ module fms_diag_axis_object_mod
                               DIAG_NULL, index_gridtype, latlon_gridtype, pack_size_str, &
                               get_base_year, get_base_month, get_base_day, get_base_hour, get_base_minute,&
                               get_base_second, is_x_axis, is_y_axis
-  use mpp_mod,         only:  FATAL, mpp_error, uppercase, mpp_pe, mpp_root_pe, stdout
+  use mpp_mod,         only:  FATAL, mpp_error, uppercase, mpp_pe, mpp_root_pe, stdout, NOTE
   use fms2_io_mod,     only:  FmsNetcdfFile_t, FmsNetcdfDomainFile_t, FmsNetcdfUnstructuredDomainFile_t, &
                             & register_axis, register_field, register_variable_attribute, write_data
   use fms_diag_yaml_mod, only: subRegion_type, diag_yaml, MAX_SUBAXES, diagYamlFilesVar_type

--- a/diag_manager/fms_diag_object.F90
+++ b/diag_manager/fms_diag_object.F90
@@ -1183,8 +1183,12 @@ CALL MPP_ERROR(FATAL,"You can not use the modern diag manager without compiling 
   if ( diag_field_id .LE. 0 ) THEN
     RETURN
   else
-    if (this%FMS_diag_fields(diag_field_id)%is_registered() ) &
+    if (this%FMS_diag_fields(diag_field_id)%is_registered() ) then
+#ifdef __NVCOMPILER
+      call mpp_error(NOTE, "use_modern_diag:: metadata output is currently unsupported for NVHPC compilers")
+#endif
       call this%FMS_diag_fields(diag_field_id)%add_attribute(att_name, att_value)
+    endif
   endif
 #endif
 end subroutine fms_diag_field_add_attribute
@@ -1230,6 +1234,9 @@ CALL MPP_ERROR(FATAL,"You can not use the modern diag manager without compiling 
       enddo
       call axis%add_structured_axis_ids(uncmx_ids)
     endif
+#ifdef __NVCOMPILER
+    call mpp_error(NOTE, "use_modern_diag:: metadata output is currently unsupported for NVHPC compilers")
+#endif
   end select
 #endif
 end subroutine fms_diag_axis_add_attribute

--- a/mpp/include/mpp_domains_reduce.inc
+++ b/mpp/include/mpp_domains_reduce.inc
@@ -976,7 +976,7 @@
 #include <mpp_global_field.fh>
 
 
-!! if __NVCOMPILER is defined, use compatibility version 
+!! if __NVCOMPILER is defined, use compatibility version
 #else
 
 #undef MPP_TYPE_

--- a/mpp/include/mpp_domains_reduce.inc
+++ b/mpp/include/mpp_domains_reduce.inc
@@ -905,6 +905,8 @@
 #undef MPP_TYPE_INIT_VALUE
 
 !****************************************************
+#ifndef __NVCOMPILER
+
 #undef MPP_GLOBAL_FIELD_
 #define MPP_GLOBAL_FIELD_ mpp_global_field_r8
 #undef MPP_TYPE_
@@ -972,6 +974,127 @@
 #undef DEFAULT_VALUE_
 #define DEFAULT_VALUE_ .false._l4_kind
 #include <mpp_global_field.fh>
+
+
+!! if __NVCOMPILER is defined, use compatibility version 
+#else
+
+#undef MPP_TYPE_
+#define MPP_TYPE_ real(r8_kind)
+#undef DEFAULT_VALUE_
+#define DEFAULT_VALUE_ 0._r8_kind
+#undef MPP_GLOBAL_FIELD_2D_
+#define MPP_GLOBAL_FIELD_2D_ mpp_global_field_r8_2d
+#undef MPP_GLOBAL_FIELD_3D_
+#define MPP_GLOBAL_FIELD_3D_ mpp_global_field_r8_3d
+#undef MPP_GLOBAL_FIELD_4D_
+#define MPP_GLOBAL_FIELD_4D_ mpp_global_field_r8_4d
+#undef MPP_GLOBAL_FIELD_5D_
+#define MPP_GLOBAL_FIELD_5D_ mpp_global_field_r8_5d
+#include <mpp_global_field_compat.fh>
+
+#undef MPP_TYPE_
+#define MPP_TYPE_ integer(i8_kind)
+#undef DEFAULT_VALUE_
+#define DEFAULT_VALUE_ 0_i8_kind
+#undef MPP_GLOBAL_FIELD_2D_
+#define MPP_GLOBAL_FIELD_2D_ mpp_global_field_i8_2d
+#undef MPP_GLOBAL_FIELD_3D_
+#define MPP_GLOBAL_FIELD_3D_ mpp_global_field_i8_3d
+#undef MPP_GLOBAL_FIELD_4D_
+#define MPP_GLOBAL_FIELD_4D_ mpp_global_field_i8_4d
+#undef MPP_GLOBAL_FIELD_5D_
+#define MPP_GLOBAL_FIELD_5D_ mpp_global_field_i8_5d
+#include <mpp_global_field_compat.fh>
+
+#ifdef OVERLOAD_C8
+#undef MPP_TYPE_
+#define MPP_TYPE_ complex(c8_kind)
+#undef DEFAULT_VALUE_
+#define DEFAULT_VALUE_ (0._r8_kind,0._r8_kind)
+#undef MPP_GLOBAL_FIELD_2D_
+#define MPP_GLOBAL_FIELD_2D_ mpp_global_field_c8_2d
+#undef MPP_GLOBAL_FIELD_3D_
+#define MPP_GLOBAL_FIELD_3D_ mpp_global_field_c8_3d
+#undef MPP_GLOBAL_FIELD_4D_
+#define MPP_GLOBAL_FIELD_4D_ mpp_global_field_c8_4d
+#undef MPP_GLOBAL_FIELD_5D_
+#define MPP_GLOBAL_FIELD_5D_ mpp_global_field_c8_5d
+#include <mpp_global_field_compat.fh>
+#endif
+
+#ifdef OVERLOAD_C4
+#undef MPP_TYPE_
+#define MPP_TYPE_ complex(c4_kind)
+#undef DEFAULT_VALUE_
+#define DEFAULT_VALUE_ (0._r4_kind,0._r4_kind)
+#undef MPP_GLOBAL_FIELD_2D_
+#define MPP_GLOBAL_FIELD_2D_ mpp_global_field_c4_2d
+#undef MPP_GLOBAL_FIELD_3D_
+#define MPP_GLOBAL_FIELD_3D_ mpp_global_field_c4_3d
+#undef MPP_GLOBAL_FIELD_4D_
+#define MPP_GLOBAL_FIELD_4D_ mpp_global_field_c4_4d
+#undef MPP_GLOBAL_FIELD_5D_
+#define MPP_GLOBAL_FIELD_5D_ mpp_global_field_c4_5d
+#include <mpp_global_field_compat.fh>
+#endif
+
+#undef MPP_TYPE_
+#define MPP_TYPE_ logical(l8_kind)
+#undef DEFAULT_VALUE_
+#define DEFAULT_VALUE_ .false._l8_kind
+#undef MPP_GLOBAL_FIELD_2D_
+#define MPP_GLOBAL_FIELD_2D_ mpp_global_field_l8_2d
+#undef MPP_GLOBAL_FIELD_3D_
+#define MPP_GLOBAL_FIELD_3D_ mpp_global_field_l8_3d
+#undef MPP_GLOBAL_FIELD_4D_
+#define MPP_GLOBAL_FIELD_4D_ mpp_global_field_l8_4d
+#undef MPP_GLOBAL_FIELD_5D_
+#define MPP_GLOBAL_FIELD_5D_ mpp_global_field_l8_5d
+#include <mpp_global_field_compat.fh>
+
+#undef MPP_TYPE_
+#define MPP_TYPE_ real(r4_kind)
+#undef DEFAULT_VALUE_
+#define DEFAULT_VALUE_ 0._r4_kind
+#undef MPP_GLOBAL_FIELD_2D_
+#define MPP_GLOBAL_FIELD_2D_ mpp_global_field_r4_2d
+#undef MPP_GLOBAL_FIELD_3D_
+#define MPP_GLOBAL_FIELD_3D_ mpp_global_field_r4_3d
+#undef MPP_GLOBAL_FIELD_4D_
+#define MPP_GLOBAL_FIELD_4D_ mpp_global_field_r4_4d
+#undef MPP_GLOBAL_FIELD_5D_
+#define MPP_GLOBAL_FIELD_5D_ mpp_global_field_r4_5d
+#include <mpp_global_field_compat.fh>
+
+#undef MPP_TYPE_
+#define MPP_TYPE_ integer(i4_kind)
+#undef DEFAULT_VALUE_
+#define DEFAULT_VALUE_ 0_i4_kind
+#undef MPP_GLOBAL_FIELD_2D_
+#define MPP_GLOBAL_FIELD_2D_ mpp_global_field_i4_2d
+#undef MPP_GLOBAL_FIELD_3D_
+#define MPP_GLOBAL_FIELD_3D_ mpp_global_field_i4_3d
+#undef MPP_GLOBAL_FIELD_4D_
+#define MPP_GLOBAL_FIELD_4D_ mpp_global_field_i4_4d
+#undef MPP_GLOBAL_FIELD_5D_
+#define MPP_GLOBAL_FIELD_5D_ mpp_global_field_i4_5d
+#include <mpp_global_field_compat.fh>
+
+#undef MPP_TYPE_
+#define MPP_TYPE_ logical(l4_kind)
+#undef DEFAULT_VALUE_
+#define DEFAULT_VALUE_ .false._l4_kind
+#undef MPP_GLOBAL_FIELD_2D_
+#define MPP_GLOBAL_FIELD_2D_ mpp_global_field_l4_2d
+#undef MPP_GLOBAL_FIELD_3D_
+#define MPP_GLOBAL_FIELD_3D_ mpp_global_field_l4_3d
+#undef MPP_GLOBAL_FIELD_4D_
+#define MPP_GLOBAL_FIELD_4D_ mpp_global_field_l4_4d
+#undef MPP_GLOBAL_FIELD_5D_
+#define MPP_GLOBAL_FIELD_5D_ mpp_global_field_l4_5d
+#include <mpp_global_field_compat.fh>
+#endif
 !****************************************************
 #undef MPP_DO_GLOBAL_FIELD_3D_AD_
 #define MPP_DO_GLOBAL_FIELD_3D_AD_ mpp_do_global_field2D_r8_3d_ad

--- a/mpp/include/mpp_global_field_compat.fh
+++ b/mpp/include/mpp_global_field_compat.fh
@@ -1,0 +1,1038 @@
+!***********************************************************************
+!*                             Apache License 2.0
+!*
+!* This file is part of the GFDL Flexible Modeling System (FMS).
+!*
+!* Licensed under the Apache License, Version 2.0 (the "License");
+!* you may not use this file except in compliance with the License.
+!* You may obtain a copy of the License at
+!*
+!*     http://www.apache.org/licenses/LICENSE-2.0
+!*
+!* FMS is distributed in the hope that it will be useful, but WITHOUT
+!* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied;
+!* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+!* PARTICULAR PURPOSE. See the License for the specific language
+!* governing permissions and limitations under the License.
+!***********************************************************************
+!> @addtogroup mpp_domains_mod
+!> {@
+    !> get a global field from a local field
+    !! local field may be on compute OR data domain
+
+      !> Gets a global field from a local field
+      !! local field may be on compute OR data domain
+    subroutine MPP_GLOBAL_FIELD_2D_( domain, local, global, flags, position, tile_count, default_data, xdim, ydim)
+      type(domain2D), intent(in)    :: domain
+      MPP_TYPE_, intent(in)         ::  local(:,:)
+      MPP_TYPE_, intent(out)        :: global(:,:)
+      integer, intent(in), optional :: flags
+      integer, intent(in), optional :: position
+      integer, intent(in), optional :: tile_count
+      MPP_TYPE_, intent(in), optional :: default_data
+      integer, intent(in), optional :: xdim, ydim !< Indices of the domain-decomposed dimensions. In typical
+                                                  !! Fortran-based code, xdim=1 and ydim=2.
+
+      integer :: i, j, k, m, n, nd, num_words, lpos, rpos, ioff, joff, from_pe, root_pe, tile_id
+      integer :: ke, isc, iec, jsc, jec, is, ie, js, je, num_word_me
+      integer :: ipos, jpos, n_per_gridpoint_local, n_per_gridpoint_global
+      logical :: xonly, yonly, root_only, global_on_this_pe
+      integer :: ix, iy
+      MPP_TYPE_, pointer, dimension(:) :: clocal, cremote
+      integer :: stackuse
+      character(len=8) :: text
+      type(c_ptr) :: stack_cptr !< Workaround for GFortran bug
+
+      integer :: tile, ishift, jshift, ipos0, jpos0
+      integer :: size_clocal, size_cremote
+
+      tile = 1
+      if(present(tile_count)) tile = tile_count
+
+      call mpp_get_domain_shift(domain, ishift, jshift, position)
+
+      ipos0 = -domain%x(tile)%global%begin + 1
+      jpos0 = -domain%y(tile)%global%begin + 1
+
+      if (present(xdim)) then
+        ix = xdim
+      else
+        ix = 1
+      endif
+
+      if (present(ydim)) then
+        iy = ydim
+      else
+        iy = 2
+      endif
+
+      n_per_gridpoint_local = size(local) / (size(local,ix) * size(local,iy))
+      n_per_gridpoint_global = size(global) / (size(global,ix) * size(global,iy))
+      size_clocal = (domain%x(1)%compute%size+ishift) * (domain%y(1)%compute%size+jshift) * n_per_gridpoint_local
+      size_cremote = (domain%x(1)%compute%max_size+ishift) * (domain%y(1)%compute%max_size+jshift) * &
+                     n_per_gridpoint_local
+
+      stackuse = size_clocal + size_cremote
+      if( stackuse.GT.mpp_domains_stack_size )then
+          write( text, '(i8)' )stackuse
+          call mpp_error( FATAL, &
+               'MPP_DO_GLOBAL_FIELD user stack overflow: call mpp_domains_set_stack_size('//trim(text)// &
+               & ') from all PEs.' )
+      end if
+      mpp_domains_stack_hwm = max( mpp_domains_stack_hwm, stackuse )
+
+      stack_cptr = c_loc(mpp_domains_stack(1))
+      call c_f_pointer(stack_cptr, clocal, [size_clocal])
+
+      stack_cptr = c_loc(mpp_domains_stack(1+size_clocal))
+      call c_f_pointer(stack_cptr, cremote, [size_cremote])
+
+      if( .NOT.module_is_initialized )call mpp_error( FATAL, 'MPP_GLOBAL_FIELD: must first call mpp_domains_init.' )
+
+      xonly = .FALSE.
+      yonly = .FALSE.
+      root_only = .FALSE.
+      if( PRESENT(flags) ) then
+         xonly = BTEST(flags,EAST)
+         yonly = BTEST(flags,SOUTH)
+         if( .NOT.xonly .AND. .NOT.yonly )call mpp_error( WARNING,  &
+                   'MPP_GLOBAL_FIELD: you must have flags=XUPDATE, YUPDATE or XUPDATE+YUPDATE' )
+         if(xonly .AND. yonly) then
+            xonly = .false.; yonly = .false.
+         endif
+         root_only = BTEST(flags, ROOT_GLOBAL)
+         if( (xonly .or. yonly) .AND. root_only ) then
+            call mpp_error( WARNING, 'MPP_GLOBAL_FIELD: flags = XUPDATE+GLOBAL_ROOT_ONLY or ' // &
+                 'flags = YUPDATE+GLOBAL_ROOT_ONLY is not supported, will ignore GLOBAL_ROOT_ONLY' )
+            root_only = .FALSE.
+         endif
+      endif
+
+      global_on_this_pe =  .NOT. root_only .OR. domain%pe == domain%tile_root_pe
+      ipos = 0; jpos = 0
+      if(global_on_this_pe ) then
+         if(n_per_gridpoint_local.ne.n_per_gridpoint_global) then
+           call mpp_error(FATAL, 'MPP_GLOBAL_FIELD: mismatch of global and local dimension sizes')
+         endif
+         if( size(global,ix).NE.(domain%x(tile)%global%size+ishift) .OR. &
+             size(global,iy).NE.(domain%y(tile)%global%size+jshift))then
+            if(xonly) then
+               if(size(global,ix).NE.(domain%x(tile)%global%size+ishift) .OR. &
+                   size(global,iy).NE.(domain%y(tile)%compute%size+jshift)) &
+                  call mpp_error( FATAL, &
+                                 &  'MPP_GLOBAL_FIELD: incoming arrays do not match domain for xonly global field.' )
+               jpos = -domain%y(tile)%compute%begin + 1
+            else if(yonly) then
+               if(size(global,ix).NE.(domain%x(tile)%compute%size+ishift) .OR. &
+                   size(global,iy).NE.(domain%y(tile)%global%size+jshift)) &
+                  call mpp_error( FATAL, &
+                                 &  'MPP_GLOBAL_FIELD: incoming arrays do not match domain for yonly global field.' )
+               ipos = -domain%x(tile)%compute%begin + 1
+            else
+               call mpp_error( FATAL, 'MPP_GLOBAL_FIELD: incoming arrays do not match domain.' )
+            endif
+         endif
+      endif
+
+      if( size(local,ix).EQ.(domain%x(tile)%compute%size+ishift) .AND. &
+          size(local,iy).EQ.(domain%y(tile)%compute%size+jshift) )then
+         !local is on compute domain
+         ioff = -domain%x(tile)%compute%begin + 1
+         joff = -domain%y(tile)%compute%begin + 1
+      else if( size(local,ix).EQ.(domain%x(tile)%memory%size+ishift) .AND. &
+               size(local,iy).EQ.(domain%y(tile)%memory%size+jshift) )then
+         !local is on data domain
+         ioff = -domain%x(tile)%domain_data%begin + 1
+         joff = -domain%y(tile)%domain_data%begin + 1
+      else
+         call mpp_error( FATAL, &
+                       & 'MPP_GLOBAL_FIELD_: incoming field array must match either compute domain or memory domain.')
+      end if
+
+      !ke  = size(local,3)
+      ke  = n_per_gridpoint_local
+      isc = domain%x(tile)%compute%begin; iec = domain%x(tile)%compute%end+ishift
+      jsc = domain%y(tile)%compute%begin; jec = domain%y(tile)%compute%end+jshift
+
+      num_word_me = (iec-isc+1)*(jec-jsc+1)*n_per_gridpoint_local
+
+! make contiguous array from compute domain
+      m = 0
+      if(global_on_this_pe) then
+         !z1l: initialize global = 0 to support mask domain
+         if(present(default_data)) then
+           call arr_init(global, default_data)
+         else
+           call arr_init(global, DEFAULT_VALUE_)
+         endif
+
+        call arr2vec(local, clocal, ix, iy, ioff+isc, ioff+iec, joff+jsc, joff+jec)
+
+        ! Fill local domain directly
+        call vec2arr(clocal, global, ix, iy, ipos0+ipos+isc, ipos0+ipos+iec, jpos0+jpos+jsc, jpos0+jpos+jec)
+      else
+        call arr2vec(local, clocal, ix, iy, ioff+isc, ioff+iec, joff+jsc, joff+jec)
+      endif
+
+! if there is more than one tile on this pe, then no decomposition for all tiles on this pe, so we can just return
+      if(size(domain%x(:))>1) then
+         !--- the following is needed to avoid deadlock.
+         if( tile == size(domain%x(:)) ) call mpp_sync_self( )
+         return
+      end if
+
+      root_pe = mpp_root_pe()
+
+!fill off-domains (note loops begin at an offset of 1)
+      if( xonly )then
+          nd = size(domain%x(1)%list(:))
+          do n = 1,nd-1
+             lpos = mod(domain%x(1)%pos+nd-n,nd)
+             rpos = mod(domain%x(1)%pos   +n,nd)
+             from_pe = domain%x(1)%list(rpos)%pe
+             rpos = from_pe - root_pe ! for concurrent run, root_pe may not be 0.
+             if (from_pe == NULL_PE) then
+                num_words = 0
+             else
+                num_words = (domain%list(rpos)%x(1)%compute%size+ishift) &
+                       * (domain%list(rpos)%y(1)%compute%size+jshift) * ke
+             endif
+           ! Force use of scalar, integer ptr interface
+             call mpp_transmit( put_data=clocal(1), plen=num_word_me, to_pe=domain%x(1)%list(lpos)%pe, &
+                                get_data=cremote(1), glen=num_words, from_pe=from_pe )
+             m = 0
+             if (from_pe /= NULL_PE) then
+                is = domain%list(rpos)%x(1)%compute%begin; ie = domain%list(rpos)%x(1)%compute%end+ishift
+                call vec2arr(cremote, global, ix, iy, ipos0+is, ipos0+ie, jpos0+jpos+jsc, jpos0+jpos+jec)
+             endif
+             call mpp_sync_self()  !-ensure MPI_ISEND is done.
+          end do
+      else if( yonly )then
+          nd = size(domain%y(1)%list(:))
+          do n = 1,nd-1
+             lpos = mod(domain%y(1)%pos+nd-n,nd)
+             rpos = mod(domain%y(1)%pos   +n,nd)
+             from_pe = domain%y(1)%list(rpos)%pe
+             rpos = from_pe - root_pe
+             if (from_pe == NULL_PE) then
+                num_words = 0
+             else
+                num_words = (domain%list(rpos)%x(1)%compute%size+ishift) &
+                       * (domain%list(rpos)%y(1)%compute%size+jshift) * ke
+             endif
+           ! Force use of scalar, integer pointer interface
+             call mpp_transmit( put_data=clocal(1), plen=num_word_me, to_pe=domain%y(1)%list(lpos)%pe, &
+                                get_data=cremote(1), glen=num_words, from_pe=from_pe )
+             m = 0
+             if (from_pe /= NULL_PE) then
+               js = domain%list(rpos)%y(1)%compute%begin; je = domain%list(rpos)%y(1)%compute%end+jshift
+               call vec2arr(cremote, global, ix, iy, ipos0+ipos+isc, ipos0+ipos+iec, jpos0+js, jpos0+je)
+             endif
+             call mpp_sync_self()  !-ensure MPI_ISEND is done.
+          end do
+      else
+         tile_id = domain%tile_id(1)
+         nd = size(domain%list(:))
+         if(root_only) then
+            if(domain%pe .NE. domain%tile_root_pe) then
+               call mpp_send( clocal(1), plen=num_word_me, to_pe=domain%tile_root_pe, tag=COMM_TAG_1 )
+            else
+               do n = 1,nd-1
+                  rpos = mod(domain%pos+n,nd)
+                  if( domain%list(rpos)%tile_id(1) .NE. tile_id ) cycle
+                  num_words = (domain%list(rpos)%x(1)%compute%size+ishift) * &
+                            & (domain%list(rpos)%y(1)%compute%size+jshift) * ke
+                  call mpp_recv(cremote(1), glen=num_words, from_pe=domain%list(rpos)%pe, tag=COMM_TAG_1 )
+                  m = 0
+                  is = domain%list(rpos)%x(1)%compute%begin; ie = domain%list(rpos)%x(1)%compute%end+ishift
+                  js = domain%list(rpos)%y(1)%compute%begin; je = domain%list(rpos)%y(1)%compute%end+jshift
+
+                  call vec2arr(cremote, global, ix, iy, ipos0+is, ipos0+ie, jpos0+js, jpos0+je)
+               end do
+            endif
+         else
+            do n = 1,nd-1
+               lpos = mod(domain%pos+nd-n,nd)
+               if( domain%list(lpos)%tile_id(1).NE. tile_id ) cycle ! global field only within tile
+               call mpp_send( clocal(1), plen=num_word_me, to_pe=domain%list(lpos)%pe, tag=COMM_TAG_2 )
+            end do
+            do n = 1,nd-1
+               rpos = mod(domain%pos+n,nd)
+               if( domain%list(rpos)%tile_id(1) .NE. tile_id ) cycle ! global field only within tile
+               num_words = (domain%list(rpos)%x(1)%compute%size+ishift) * &
+                         & (domain%list(rpos)%y(1)%compute%size+jshift) * ke
+               call mpp_recv( cremote(1), glen=num_words, from_pe=domain%list(rpos)%pe, tag=COMM_TAG_2 )
+               m = 0
+               is = domain%list(rpos)%x(1)%compute%begin; ie = domain%list(rpos)%x(1)%compute%end+ishift
+               js = domain%list(rpos)%y(1)%compute%begin; je = domain%list(rpos)%y(1)%compute%end+jshift
+
+               call vec2arr(cremote, global, ix, iy, ipos0+is, ipos0+ie, jpos0+js, jpos0+je)
+            end do
+         endif
+      end if
+
+      call mpp_sync_self
+    end subroutine MPP_GLOBAL_FIELD_2D_
+
+      !> Gets a global field from a local field
+      !! local field may be on compute OR data domain
+    subroutine MPP_GLOBAL_FIELD_3D_( domain, local, global, flags, position, tile_count, default_data, xdim, ydim)
+      type(domain2D), intent(in)    :: domain
+      MPP_TYPE_, intent(in)         ::  local(:,:,:)
+      MPP_TYPE_, intent(out)        :: global(:,:,:)
+      integer, intent(in), optional :: flags
+      integer, intent(in), optional :: position
+      integer, intent(in), optional :: tile_count
+      MPP_TYPE_, intent(in), optional :: default_data
+      integer, intent(in), optional :: xdim, ydim !< Indices of the domain-decomposed dimensions. In typical
+                                                  !! Fortran-based code, xdim=1 and ydim=2.
+
+      integer :: i, j, k, m, n, nd, num_words, lpos, rpos, ioff, joff, from_pe, root_pe, tile_id
+      integer :: ke, isc, iec, jsc, jec, is, ie, js, je, num_word_me
+      integer :: ipos, jpos, n_per_gridpoint_local, n_per_gridpoint_global
+      logical :: xonly, yonly, root_only, global_on_this_pe
+      integer :: ix, iy
+      MPP_TYPE_, pointer, dimension(:) :: clocal, cremote
+      integer :: stackuse
+      character(len=8) :: text
+      type(c_ptr) :: stack_cptr !< Workaround for GFortran bug
+
+      integer :: tile, ishift, jshift, ipos0, jpos0
+      integer :: size_clocal, size_cremote
+
+      tile = 1
+      if(present(tile_count)) tile = tile_count
+
+      call mpp_get_domain_shift(domain, ishift, jshift, position)
+
+      ipos0 = -domain%x(tile)%global%begin + 1
+      jpos0 = -domain%y(tile)%global%begin + 1
+
+      if (present(xdim)) then
+        ix = xdim
+      else
+        ix = 1
+      endif
+
+      if (present(ydim)) then
+        iy = ydim
+      else
+        iy = 2
+      endif
+
+      n_per_gridpoint_local = size(local) / (size(local,ix) * size(local,iy))
+      n_per_gridpoint_global = size(global) / (size(global,ix) * size(global,iy))
+      size_clocal = (domain%x(1)%compute%size+ishift) * (domain%y(1)%compute%size+jshift) * n_per_gridpoint_local
+      size_cremote = (domain%x(1)%compute%max_size+ishift) * (domain%y(1)%compute%max_size+jshift) * &
+                     n_per_gridpoint_local
+
+      stackuse = size_clocal + size_cremote
+      if( stackuse.GT.mpp_domains_stack_size )then
+          write( text, '(i8)' )stackuse
+          call mpp_error( FATAL, &
+               'MPP_DO_GLOBAL_FIELD user stack overflow: call mpp_domains_set_stack_size('//trim(text)// &
+               & ') from all PEs.' )
+      end if
+      mpp_domains_stack_hwm = max( mpp_domains_stack_hwm, stackuse )
+
+      stack_cptr = c_loc(mpp_domains_stack(1))
+      call c_f_pointer(stack_cptr, clocal, [size_clocal])
+
+      stack_cptr = c_loc(mpp_domains_stack(1+size_clocal))
+      call c_f_pointer(stack_cptr, cremote, [size_cremote])
+
+      if( .NOT.module_is_initialized )call mpp_error( FATAL, 'MPP_GLOBAL_FIELD: must first call mpp_domains_init.' )
+
+      xonly = .FALSE.
+      yonly = .FALSE.
+      root_only = .FALSE.
+      if( PRESENT(flags) ) then
+         xonly = BTEST(flags,EAST)
+         yonly = BTEST(flags,SOUTH)
+         if( .NOT.xonly .AND. .NOT.yonly )call mpp_error( WARNING,  &
+                   'MPP_GLOBAL_FIELD: you must have flags=XUPDATE, YUPDATE or XUPDATE+YUPDATE' )
+         if(xonly .AND. yonly) then
+            xonly = .false.; yonly = .false.
+         endif
+         root_only = BTEST(flags, ROOT_GLOBAL)
+         if( (xonly .or. yonly) .AND. root_only ) then
+            call mpp_error( WARNING, 'MPP_GLOBAL_FIELD: flags = XUPDATE+GLOBAL_ROOT_ONLY or ' // &
+                 'flags = YUPDATE+GLOBAL_ROOT_ONLY is not supported, will ignore GLOBAL_ROOT_ONLY' )
+            root_only = .FALSE.
+         endif
+      endif
+
+      global_on_this_pe =  .NOT. root_only .OR. domain%pe == domain%tile_root_pe
+      ipos = 0; jpos = 0
+      if(global_on_this_pe ) then
+         if(n_per_gridpoint_local.ne.n_per_gridpoint_global) then
+           call mpp_error(FATAL, 'MPP_GLOBAL_FIELD: mismatch of global and local dimension sizes')
+         endif
+         if( size(global,ix).NE.(domain%x(tile)%global%size+ishift) .OR. &
+             size(global,iy).NE.(domain%y(tile)%global%size+jshift))then
+            if(xonly) then
+               if(size(global,ix).NE.(domain%x(tile)%global%size+ishift) .OR. &
+                   size(global,iy).NE.(domain%y(tile)%compute%size+jshift)) &
+                  call mpp_error( FATAL, &
+                                 &  'MPP_GLOBAL_FIELD: incoming arrays do not match domain for xonly global field.' )
+               jpos = -domain%y(tile)%compute%begin + 1
+            else if(yonly) then
+               if(size(global,ix).NE.(domain%x(tile)%compute%size+ishift) .OR. &
+                   size(global,iy).NE.(domain%y(tile)%global%size+jshift)) &
+                  call mpp_error( FATAL, &
+                                 &  'MPP_GLOBAL_FIELD: incoming arrays do not match domain for yonly global field.' )
+               ipos = -domain%x(tile)%compute%begin + 1
+            else
+               call mpp_error( FATAL, 'MPP_GLOBAL_FIELD: incoming arrays do not match domain.' )
+            endif
+         endif
+      endif
+
+      if( size(local,ix).EQ.(domain%x(tile)%compute%size+ishift) .AND. &
+          size(local,iy).EQ.(domain%y(tile)%compute%size+jshift) )then
+         !local is on compute domain
+         ioff = -domain%x(tile)%compute%begin + 1
+         joff = -domain%y(tile)%compute%begin + 1
+      else if( size(local,ix).EQ.(domain%x(tile)%memory%size+ishift) .AND. &
+               size(local,iy).EQ.(domain%y(tile)%memory%size+jshift) )then
+         !local is on data domain
+         ioff = -domain%x(tile)%domain_data%begin + 1
+         joff = -domain%y(tile)%domain_data%begin + 1
+      else
+         call mpp_error( FATAL, &
+                       & 'MPP_GLOBAL_FIELD_: incoming field array must match either compute domain or memory domain.')
+      end if
+
+      !ke  = size(local,3)
+      ke  = n_per_gridpoint_local
+      isc = domain%x(tile)%compute%begin; iec = domain%x(tile)%compute%end+ishift
+      jsc = domain%y(tile)%compute%begin; jec = domain%y(tile)%compute%end+jshift
+
+      num_word_me = (iec-isc+1)*(jec-jsc+1)*n_per_gridpoint_local
+
+! make contiguous array from compute domain
+      m = 0
+      if(global_on_this_pe) then
+         !z1l: initialize global = 0 to support mask domain
+         if(present(default_data)) then
+           call arr_init(global, default_data)
+         else
+           call arr_init(global, DEFAULT_VALUE_)
+         endif
+
+        call arr2vec(local, clocal, ix, iy, ioff+isc, ioff+iec, joff+jsc, joff+jec)
+
+        ! Fill local domain directly
+        call vec2arr(clocal, global, ix, iy, ipos0+ipos+isc, ipos0+ipos+iec, jpos0+jpos+jsc, jpos0+jpos+jec)
+      else
+        call arr2vec(local, clocal, ix, iy, ioff+isc, ioff+iec, joff+jsc, joff+jec)
+      endif
+
+! if there is more than one tile on this pe, then no decomposition for all tiles on this pe, so we can just return
+      if(size(domain%x(:))>1) then
+         !--- the following is needed to avoid deadlock.
+         if( tile == size(domain%x(:)) ) call mpp_sync_self( )
+         return
+      end if
+
+      root_pe = mpp_root_pe()
+
+!fill off-domains (note loops begin at an offset of 1)
+      if( xonly )then
+          nd = size(domain%x(1)%list(:))
+          do n = 1,nd-1
+             lpos = mod(domain%x(1)%pos+nd-n,nd)
+             rpos = mod(domain%x(1)%pos   +n,nd)
+             from_pe = domain%x(1)%list(rpos)%pe
+             rpos = from_pe - root_pe ! for concurrent run, root_pe may not be 0.
+             if (from_pe == NULL_PE) then
+                num_words = 0
+             else
+                num_words = (domain%list(rpos)%x(1)%compute%size+ishift) &
+                       * (domain%list(rpos)%y(1)%compute%size+jshift) * ke
+             endif
+           ! Force use of scalar, integer ptr interface
+             call mpp_transmit( put_data=clocal(1), plen=num_word_me, to_pe=domain%x(1)%list(lpos)%pe, &
+                                get_data=cremote(1), glen=num_words, from_pe=from_pe )
+             m = 0
+             if (from_pe /= NULL_PE) then
+                is = domain%list(rpos)%x(1)%compute%begin; ie = domain%list(rpos)%x(1)%compute%end+ishift
+                call vec2arr(cremote, global, ix, iy, ipos0+is, ipos0+ie, jpos0+jpos+jsc, jpos0+jpos+jec)
+             endif
+             call mpp_sync_self()  !-ensure MPI_ISEND is done.
+          end do
+      else if( yonly )then
+          nd = size(domain%y(1)%list(:))
+          do n = 1,nd-1
+             lpos = mod(domain%y(1)%pos+nd-n,nd)
+             rpos = mod(domain%y(1)%pos   +n,nd)
+             from_pe = domain%y(1)%list(rpos)%pe
+             rpos = from_pe - root_pe
+             if (from_pe == NULL_PE) then
+                num_words = 0
+             else
+                num_words = (domain%list(rpos)%x(1)%compute%size+ishift) &
+                       * (domain%list(rpos)%y(1)%compute%size+jshift) * ke
+             endif
+           ! Force use of scalar, integer pointer interface
+             call mpp_transmit( put_data=clocal(1), plen=num_word_me, to_pe=domain%y(1)%list(lpos)%pe, &
+                                get_data=cremote(1), glen=num_words, from_pe=from_pe )
+             m = 0
+             if (from_pe /= NULL_PE) then
+               js = domain%list(rpos)%y(1)%compute%begin; je = domain%list(rpos)%y(1)%compute%end+jshift
+               call vec2arr(cremote, global, ix, iy, ipos0+ipos+isc, ipos0+ipos+iec, jpos0+js, jpos0+je)
+             endif
+             call mpp_sync_self()  !-ensure MPI_ISEND is done.
+          end do
+      else
+         tile_id = domain%tile_id(1)
+         nd = size(domain%list(:))
+         if(root_only) then
+            if(domain%pe .NE. domain%tile_root_pe) then
+               call mpp_send( clocal(1), plen=num_word_me, to_pe=domain%tile_root_pe, tag=COMM_TAG_1 )
+            else
+               do n = 1,nd-1
+                  rpos = mod(domain%pos+n,nd)
+                  if( domain%list(rpos)%tile_id(1) .NE. tile_id ) cycle
+                  num_words = (domain%list(rpos)%x(1)%compute%size+ishift) * &
+                            & (domain%list(rpos)%y(1)%compute%size+jshift) * ke
+                  call mpp_recv(cremote(1), glen=num_words, from_pe=domain%list(rpos)%pe, tag=COMM_TAG_1 )
+                  m = 0
+                  is = domain%list(rpos)%x(1)%compute%begin; ie = domain%list(rpos)%x(1)%compute%end+ishift
+                  js = domain%list(rpos)%y(1)%compute%begin; je = domain%list(rpos)%y(1)%compute%end+jshift
+
+                  call vec2arr(cremote, global, ix, iy, ipos0+is, ipos0+ie, jpos0+js, jpos0+je)
+               end do
+            endif
+         else
+            do n = 1,nd-1
+               lpos = mod(domain%pos+nd-n,nd)
+               if( domain%list(lpos)%tile_id(1).NE. tile_id ) cycle ! global field only within tile
+               call mpp_send( clocal(1), plen=num_word_me, to_pe=domain%list(lpos)%pe, tag=COMM_TAG_2 )
+            end do
+            do n = 1,nd-1
+               rpos = mod(domain%pos+n,nd)
+               if( domain%list(rpos)%tile_id(1) .NE. tile_id ) cycle ! global field only within tile
+               num_words = (domain%list(rpos)%x(1)%compute%size+ishift) * &
+                         & (domain%list(rpos)%y(1)%compute%size+jshift) * ke
+               call mpp_recv( cremote(1), glen=num_words, from_pe=domain%list(rpos)%pe, tag=COMM_TAG_2 )
+               m = 0
+               is = domain%list(rpos)%x(1)%compute%begin; ie = domain%list(rpos)%x(1)%compute%end+ishift
+               js = domain%list(rpos)%y(1)%compute%begin; je = domain%list(rpos)%y(1)%compute%end+jshift
+
+               call vec2arr(cremote, global, ix, iy, ipos0+is, ipos0+ie, jpos0+js, jpos0+je)
+            end do
+         endif
+      end if
+
+      call mpp_sync_self
+    end subroutine MPP_GLOBAL_FIELD_3D_
+
+      !> Gets a global field from a local field
+      !! local field may be on compute OR data domain
+    subroutine MPP_GLOBAL_FIELD_4D_( domain, local, global, flags, position, tile_count, default_data, xdim, ydim)
+      type(domain2D), intent(in)    :: domain
+      MPP_TYPE_, intent(in)         ::  local(:,:,:,:)
+      MPP_TYPE_, intent(out)        :: global(:,:,:,:)
+      integer, intent(in), optional :: flags
+      integer, intent(in), optional :: position
+      integer, intent(in), optional :: tile_count
+      MPP_TYPE_, intent(in), optional :: default_data
+      integer, intent(in), optional :: xdim, ydim !< Indices of the domain-decomposed dimensions. In typical
+                                                  !! Fortran-based code, xdim=1 and ydim=2.
+
+      integer :: i, j, k, m, n, nd, num_words, lpos, rpos, ioff, joff, from_pe, root_pe, tile_id
+      integer :: ke, isc, iec, jsc, jec, is, ie, js, je, num_word_me
+      integer :: ipos, jpos, n_per_gridpoint_local, n_per_gridpoint_global
+      logical :: xonly, yonly, root_only, global_on_this_pe
+      integer :: ix, iy
+      MPP_TYPE_, pointer, dimension(:) :: clocal, cremote
+      integer :: stackuse
+      character(len=8) :: text
+      type(c_ptr) :: stack_cptr !< Workaround for GFortran bug
+
+      integer :: tile, ishift, jshift, ipos0, jpos0
+      integer :: size_clocal, size_cremote
+
+      tile = 1
+      if(present(tile_count)) tile = tile_count
+
+      call mpp_get_domain_shift(domain, ishift, jshift, position)
+
+      ipos0 = -domain%x(tile)%global%begin + 1
+      jpos0 = -domain%y(tile)%global%begin + 1
+
+      if (present(xdim)) then
+        ix = xdim
+      else
+        ix = 1
+      endif
+
+      if (present(ydim)) then
+        iy = ydim
+      else
+        iy = 2
+      endif
+
+      n_per_gridpoint_local = size(local) / (size(local,ix) * size(local,iy))
+      n_per_gridpoint_global = size(global) / (size(global,ix) * size(global,iy))
+      size_clocal = (domain%x(1)%compute%size+ishift) * (domain%y(1)%compute%size+jshift) * n_per_gridpoint_local
+      size_cremote = (domain%x(1)%compute%max_size+ishift) * (domain%y(1)%compute%max_size+jshift) * &
+                     n_per_gridpoint_local
+
+      stackuse = size_clocal + size_cremote
+      if( stackuse.GT.mpp_domains_stack_size )then
+          write( text, '(i8)' )stackuse
+          call mpp_error( FATAL, &
+               'MPP_DO_GLOBAL_FIELD user stack overflow: call mpp_domains_set_stack_size('//trim(text)// &
+               & ') from all PEs.' )
+      end if
+      mpp_domains_stack_hwm = max( mpp_domains_stack_hwm, stackuse )
+
+      stack_cptr = c_loc(mpp_domains_stack(1))
+      call c_f_pointer(stack_cptr, clocal, [size_clocal])
+
+      stack_cptr = c_loc(mpp_domains_stack(1+size_clocal))
+      call c_f_pointer(stack_cptr, cremote, [size_cremote])
+
+      if( .NOT.module_is_initialized )call mpp_error( FATAL, 'MPP_GLOBAL_FIELD: must first call mpp_domains_init.' )
+
+      xonly = .FALSE.
+      yonly = .FALSE.
+      root_only = .FALSE.
+      if( PRESENT(flags) ) then
+         xonly = BTEST(flags,EAST)
+         yonly = BTEST(flags,SOUTH)
+         if( .NOT.xonly .AND. .NOT.yonly )call mpp_error( WARNING,  &
+                   'MPP_GLOBAL_FIELD: you must have flags=XUPDATE, YUPDATE or XUPDATE+YUPDATE' )
+         if(xonly .AND. yonly) then
+            xonly = .false.; yonly = .false.
+         endif
+         root_only = BTEST(flags, ROOT_GLOBAL)
+         if( (xonly .or. yonly) .AND. root_only ) then
+            call mpp_error( WARNING, 'MPP_GLOBAL_FIELD: flags = XUPDATE+GLOBAL_ROOT_ONLY or ' // &
+                 'flags = YUPDATE+GLOBAL_ROOT_ONLY is not supported, will ignore GLOBAL_ROOT_ONLY' )
+            root_only = .FALSE.
+         endif
+      endif
+
+      global_on_this_pe =  .NOT. root_only .OR. domain%pe == domain%tile_root_pe
+      ipos = 0; jpos = 0
+      if(global_on_this_pe ) then
+         if(n_per_gridpoint_local.ne.n_per_gridpoint_global) then
+           call mpp_error(FATAL, 'MPP_GLOBAL_FIELD: mismatch of global and local dimension sizes')
+         endif
+         if( size(global,ix).NE.(domain%x(tile)%global%size+ishift) .OR. &
+             size(global,iy).NE.(domain%y(tile)%global%size+jshift))then
+            if(xonly) then
+               if(size(global,ix).NE.(domain%x(tile)%global%size+ishift) .OR. &
+                   size(global,iy).NE.(domain%y(tile)%compute%size+jshift)) &
+                  call mpp_error( FATAL, &
+                                 &  'MPP_GLOBAL_FIELD: incoming arrays do not match domain for xonly global field.' )
+               jpos = -domain%y(tile)%compute%begin + 1
+            else if(yonly) then
+               if(size(global,ix).NE.(domain%x(tile)%compute%size+ishift) .OR. &
+                   size(global,iy).NE.(domain%y(tile)%global%size+jshift)) &
+                  call mpp_error( FATAL, &
+                                 &  'MPP_GLOBAL_FIELD: incoming arrays do not match domain for yonly global field.' )
+               ipos = -domain%x(tile)%compute%begin + 1
+            else
+               call mpp_error( FATAL, 'MPP_GLOBAL_FIELD: incoming arrays do not match domain.' )
+            endif
+         endif
+      endif
+
+      if( size(local,ix).EQ.(domain%x(tile)%compute%size+ishift) .AND. &
+          size(local,iy).EQ.(domain%y(tile)%compute%size+jshift) )then
+         !local is on compute domain
+         ioff = -domain%x(tile)%compute%begin + 1
+         joff = -domain%y(tile)%compute%begin + 1
+      else if( size(local,ix).EQ.(domain%x(tile)%memory%size+ishift) .AND. &
+               size(local,iy).EQ.(domain%y(tile)%memory%size+jshift) )then
+         !local is on data domain
+         ioff = -domain%x(tile)%domain_data%begin + 1
+         joff = -domain%y(tile)%domain_data%begin + 1
+      else
+         call mpp_error( FATAL, &
+                       & 'MPP_GLOBAL_FIELD_: incoming field array must match either compute domain or memory domain.')
+      end if
+
+      !ke  = size(local,3)
+      ke  = n_per_gridpoint_local
+      isc = domain%x(tile)%compute%begin; iec = domain%x(tile)%compute%end+ishift
+      jsc = domain%y(tile)%compute%begin; jec = domain%y(tile)%compute%end+jshift
+
+      num_word_me = (iec-isc+1)*(jec-jsc+1)*n_per_gridpoint_local
+
+! make contiguous array from compute domain
+      m = 0
+      if(global_on_this_pe) then
+         !z1l: initialize global = 0 to support mask domain
+         if(present(default_data)) then
+           call arr_init(global, default_data)
+         else
+           call arr_init(global, DEFAULT_VALUE_)
+         endif
+
+        call arr2vec(local, clocal, ix, iy, ioff+isc, ioff+iec, joff+jsc, joff+jec)
+
+        ! Fill local domain directly
+        call vec2arr(clocal, global, ix, iy, ipos0+ipos+isc, ipos0+ipos+iec, jpos0+jpos+jsc, jpos0+jpos+jec)
+      else
+        call arr2vec(local, clocal, ix, iy, ioff+isc, ioff+iec, joff+jsc, joff+jec)
+      endif
+
+! if there is more than one tile on this pe, then no decomposition for all tiles on this pe, so we can just return
+      if(size(domain%x(:))>1) then
+         !--- the following is needed to avoid deadlock.
+         if( tile == size(domain%x(:)) ) call mpp_sync_self( )
+         return
+      end if
+
+      root_pe = mpp_root_pe()
+
+!fill off-domains (note loops begin at an offset of 1)
+      if( xonly )then
+          nd = size(domain%x(1)%list(:))
+          do n = 1,nd-1
+             lpos = mod(domain%x(1)%pos+nd-n,nd)
+             rpos = mod(domain%x(1)%pos   +n,nd)
+             from_pe = domain%x(1)%list(rpos)%pe
+             rpos = from_pe - root_pe ! for concurrent run, root_pe may not be 0.
+             if (from_pe == NULL_PE) then
+                num_words = 0
+             else
+                num_words = (domain%list(rpos)%x(1)%compute%size+ishift) &
+                       * (domain%list(rpos)%y(1)%compute%size+jshift) * ke
+             endif
+           ! Force use of scalar, integer ptr interface
+             call mpp_transmit( put_data=clocal(1), plen=num_word_me, to_pe=domain%x(1)%list(lpos)%pe, &
+                                get_data=cremote(1), glen=num_words, from_pe=from_pe )
+             m = 0
+             if (from_pe /= NULL_PE) then
+                is = domain%list(rpos)%x(1)%compute%begin; ie = domain%list(rpos)%x(1)%compute%end+ishift
+                call vec2arr(cremote, global, ix, iy, ipos0+is, ipos0+ie, jpos0+jpos+jsc, jpos0+jpos+jec)
+             endif
+             call mpp_sync_self()  !-ensure MPI_ISEND is done.
+          end do
+      else if( yonly )then
+          nd = size(domain%y(1)%list(:))
+          do n = 1,nd-1
+             lpos = mod(domain%y(1)%pos+nd-n,nd)
+             rpos = mod(domain%y(1)%pos   +n,nd)
+             from_pe = domain%y(1)%list(rpos)%pe
+             rpos = from_pe - root_pe
+             if (from_pe == NULL_PE) then
+                num_words = 0
+             else
+                num_words = (domain%list(rpos)%x(1)%compute%size+ishift) &
+                       * (domain%list(rpos)%y(1)%compute%size+jshift) * ke
+             endif
+           ! Force use of scalar, integer pointer interface
+             call mpp_transmit( put_data=clocal(1), plen=num_word_me, to_pe=domain%y(1)%list(lpos)%pe, &
+                                get_data=cremote(1), glen=num_words, from_pe=from_pe )
+             m = 0
+             if (from_pe /= NULL_PE) then
+               js = domain%list(rpos)%y(1)%compute%begin; je = domain%list(rpos)%y(1)%compute%end+jshift
+               call vec2arr(cremote, global, ix, iy, ipos0+ipos+isc, ipos0+ipos+iec, jpos0+js, jpos0+je)
+             endif
+             call mpp_sync_self()  !-ensure MPI_ISEND is done.
+          end do
+      else
+         tile_id = domain%tile_id(1)
+         nd = size(domain%list(:))
+         if(root_only) then
+            if(domain%pe .NE. domain%tile_root_pe) then
+               call mpp_send( clocal(1), plen=num_word_me, to_pe=domain%tile_root_pe, tag=COMM_TAG_1 )
+            else
+               do n = 1,nd-1
+                  rpos = mod(domain%pos+n,nd)
+                  if( domain%list(rpos)%tile_id(1) .NE. tile_id ) cycle
+                  num_words = (domain%list(rpos)%x(1)%compute%size+ishift) * &
+                            & (domain%list(rpos)%y(1)%compute%size+jshift) * ke
+                  call mpp_recv(cremote(1), glen=num_words, from_pe=domain%list(rpos)%pe, tag=COMM_TAG_1 )
+                  m = 0
+                  is = domain%list(rpos)%x(1)%compute%begin; ie = domain%list(rpos)%x(1)%compute%end+ishift
+                  js = domain%list(rpos)%y(1)%compute%begin; je = domain%list(rpos)%y(1)%compute%end+jshift
+
+                  call vec2arr(cremote, global, ix, iy, ipos0+is, ipos0+ie, jpos0+js, jpos0+je)
+               end do
+            endif
+         else
+            do n = 1,nd-1
+               lpos = mod(domain%pos+nd-n,nd)
+               if( domain%list(lpos)%tile_id(1).NE. tile_id ) cycle ! global field only within tile
+               call mpp_send( clocal(1), plen=num_word_me, to_pe=domain%list(lpos)%pe, tag=COMM_TAG_2 )
+            end do
+            do n = 1,nd-1
+               rpos = mod(domain%pos+n,nd)
+               if( domain%list(rpos)%tile_id(1) .NE. tile_id ) cycle ! global field only within tile
+               num_words = (domain%list(rpos)%x(1)%compute%size+ishift) * &
+                         & (domain%list(rpos)%y(1)%compute%size+jshift) * ke
+               call mpp_recv( cremote(1), glen=num_words, from_pe=domain%list(rpos)%pe, tag=COMM_TAG_2 )
+               m = 0
+               is = domain%list(rpos)%x(1)%compute%begin; ie = domain%list(rpos)%x(1)%compute%end+ishift
+               js = domain%list(rpos)%y(1)%compute%begin; je = domain%list(rpos)%y(1)%compute%end+jshift
+
+               call vec2arr(cremote, global, ix, iy, ipos0+is, ipos0+ie, jpos0+js, jpos0+je)
+            end do
+         endif
+      end if
+
+      call mpp_sync_self
+    end subroutine MPP_GLOBAL_FIELD_4D_
+
+      !> Gets a global field from a local field
+      !! local field may be on compute OR data domain
+    subroutine MPP_GLOBAL_FIELD_5D_( domain, local, global, flags, position, tile_count, default_data, xdim, ydim)
+      type(domain2D), intent(in)    :: domain
+      MPP_TYPE_, intent(in)         ::  local(:,:,:,:,:)
+      MPP_TYPE_, intent(out)        :: global(:,:,:,:,:)
+      integer, intent(in), optional :: flags
+      integer, intent(in), optional :: position
+      integer, intent(in), optional :: tile_count
+      MPP_TYPE_, intent(in), optional :: default_data
+      integer, intent(in), optional :: xdim, ydim !< Indices of the domain-decomposed dimensions. In typical
+                                                  !! Fortran-based code, xdim=1 and ydim=2.
+
+      integer :: i, j, k, m, n, nd, num_words, lpos, rpos, ioff, joff, from_pe, root_pe, tile_id
+      integer :: ke, isc, iec, jsc, jec, is, ie, js, je, num_word_me
+      integer :: ipos, jpos, n_per_gridpoint_local, n_per_gridpoint_global
+      logical :: xonly, yonly, root_only, global_on_this_pe
+      integer :: ix, iy
+      MPP_TYPE_, pointer, dimension(:) :: clocal, cremote
+      integer :: stackuse
+      character(len=8) :: text
+      type(c_ptr) :: stack_cptr !< Workaround for GFortran bug
+
+      integer :: tile, ishift, jshift, ipos0, jpos0
+      integer :: size_clocal, size_cremote
+
+      tile = 1
+      if(present(tile_count)) tile = tile_count
+
+      call mpp_get_domain_shift(domain, ishift, jshift, position)
+
+      ipos0 = -domain%x(tile)%global%begin + 1
+      jpos0 = -domain%y(tile)%global%begin + 1
+
+      if (present(xdim)) then
+        ix = xdim
+      else
+        ix = 1
+      endif
+
+      if (present(ydim)) then
+        iy = ydim
+      else
+        iy = 2
+      endif
+
+      n_per_gridpoint_local = size(local) / (size(local,ix) * size(local,iy))
+      n_per_gridpoint_global = size(global) / (size(global,ix) * size(global,iy))
+      size_clocal = (domain%x(1)%compute%size+ishift) * (domain%y(1)%compute%size+jshift) * n_per_gridpoint_local
+      size_cremote = (domain%x(1)%compute%max_size+ishift) * (domain%y(1)%compute%max_size+jshift) * &
+                     n_per_gridpoint_local
+
+      stackuse = size_clocal + size_cremote
+      if( stackuse.GT.mpp_domains_stack_size )then
+          write( text, '(i8)' )stackuse
+          call mpp_error( FATAL, &
+               'MPP_DO_GLOBAL_FIELD user stack overflow: call mpp_domains_set_stack_size('//trim(text)// &
+               & ') from all PEs.' )
+      end if
+      mpp_domains_stack_hwm = max( mpp_domains_stack_hwm, stackuse )
+
+      stack_cptr = c_loc(mpp_domains_stack(1))
+      call c_f_pointer(stack_cptr, clocal, [size_clocal])
+
+      stack_cptr = c_loc(mpp_domains_stack(1+size_clocal))
+      call c_f_pointer(stack_cptr, cremote, [size_cremote])
+
+      if( .NOT.module_is_initialized )call mpp_error( FATAL, 'MPP_GLOBAL_FIELD: must first call mpp_domains_init.' )
+
+      xonly = .FALSE.
+      yonly = .FALSE.
+      root_only = .FALSE.
+      if( PRESENT(flags) ) then
+         xonly = BTEST(flags,EAST)
+         yonly = BTEST(flags,SOUTH)
+         if( .NOT.xonly .AND. .NOT.yonly )call mpp_error( WARNING,  &
+                   'MPP_GLOBAL_FIELD: you must have flags=XUPDATE, YUPDATE or XUPDATE+YUPDATE' )
+         if(xonly .AND. yonly) then
+            xonly = .false.; yonly = .false.
+         endif
+         root_only = BTEST(flags, ROOT_GLOBAL)
+         if( (xonly .or. yonly) .AND. root_only ) then
+            call mpp_error( WARNING, 'MPP_GLOBAL_FIELD: flags = XUPDATE+GLOBAL_ROOT_ONLY or ' // &
+                 'flags = YUPDATE+GLOBAL_ROOT_ONLY is not supported, will ignore GLOBAL_ROOT_ONLY' )
+            root_only = .FALSE.
+         endif
+      endif
+
+      global_on_this_pe =  .NOT. root_only .OR. domain%pe == domain%tile_root_pe
+      ipos = 0; jpos = 0
+      if(global_on_this_pe ) then
+         if(n_per_gridpoint_local.ne.n_per_gridpoint_global) then
+           call mpp_error(FATAL, 'MPP_GLOBAL_FIELD: mismatch of global and local dimension sizes')
+         endif
+         if( size(global,ix).NE.(domain%x(tile)%global%size+ishift) .OR. &
+             size(global,iy).NE.(domain%y(tile)%global%size+jshift))then
+            if(xonly) then
+               if(size(global,ix).NE.(domain%x(tile)%global%size+ishift) .OR. &
+                   size(global,iy).NE.(domain%y(tile)%compute%size+jshift)) &
+                  call mpp_error( FATAL, &
+                                 &  'MPP_GLOBAL_FIELD: incoming arrays do not match domain for xonly global field.' )
+               jpos = -domain%y(tile)%compute%begin + 1
+            else if(yonly) then
+               if(size(global,ix).NE.(domain%x(tile)%compute%size+ishift) .OR. &
+                   size(global,iy).NE.(domain%y(tile)%global%size+jshift)) &
+                  call mpp_error( FATAL, &
+                                 &  'MPP_GLOBAL_FIELD: incoming arrays do not match domain for yonly global field.' )
+               ipos = -domain%x(tile)%compute%begin + 1
+            else
+               call mpp_error( FATAL, 'MPP_GLOBAL_FIELD: incoming arrays do not match domain.' )
+            endif
+         endif
+      endif
+
+      if( size(local,ix).EQ.(domain%x(tile)%compute%size+ishift) .AND. &
+          size(local,iy).EQ.(domain%y(tile)%compute%size+jshift) )then
+         !local is on compute domain
+         ioff = -domain%x(tile)%compute%begin + 1
+         joff = -domain%y(tile)%compute%begin + 1
+      else if( size(local,ix).EQ.(domain%x(tile)%memory%size+ishift) .AND. &
+               size(local,iy).EQ.(domain%y(tile)%memory%size+jshift) )then
+         !local is on data domain
+         ioff = -domain%x(tile)%domain_data%begin + 1
+         joff = -domain%y(tile)%domain_data%begin + 1
+      else
+         call mpp_error( FATAL, &
+                       & 'MPP_GLOBAL_FIELD_: incoming field array must match either compute domain or memory domain.')
+      end if
+
+      !ke  = size(local,3)
+      ke  = n_per_gridpoint_local
+      isc = domain%x(tile)%compute%begin; iec = domain%x(tile)%compute%end+ishift
+      jsc = domain%y(tile)%compute%begin; jec = domain%y(tile)%compute%end+jshift
+
+      num_word_me = (iec-isc+1)*(jec-jsc+1)*n_per_gridpoint_local
+
+! make contiguous array from compute domain
+      m = 0
+      if(global_on_this_pe) then
+         !z1l: initialize global = 0 to support mask domain
+         if(present(default_data)) then
+           call arr_init(global, default_data)
+         else
+           call arr_init(global, DEFAULT_VALUE_)
+         endif
+
+        call arr2vec(local, clocal, ix, iy, ioff+isc, ioff+iec, joff+jsc, joff+jec)
+
+        ! Fill local domain directly
+        call vec2arr(clocal, global, ix, iy, ipos0+ipos+isc, ipos0+ipos+iec, jpos0+jpos+jsc, jpos0+jpos+jec)
+      else
+        call arr2vec(local, clocal, ix, iy, ioff+isc, ioff+iec, joff+jsc, joff+jec)
+      endif
+
+! if there is more than one tile on this pe, then no decomposition for all tiles on this pe, so we can just return
+      if(size(domain%x(:))>1) then
+         !--- the following is needed to avoid deadlock.
+         if( tile == size(domain%x(:)) ) call mpp_sync_self( )
+         return
+      end if
+
+      root_pe = mpp_root_pe()
+
+!fill off-domains (note loops begin at an offset of 1)
+      if( xonly )then
+          nd = size(domain%x(1)%list(:))
+          do n = 1,nd-1
+             lpos = mod(domain%x(1)%pos+nd-n,nd)
+             rpos = mod(domain%x(1)%pos   +n,nd)
+             from_pe = domain%x(1)%list(rpos)%pe
+             rpos = from_pe - root_pe ! for concurrent run, root_pe may not be 0.
+             if (from_pe == NULL_PE) then
+                num_words = 0
+             else
+                num_words = (domain%list(rpos)%x(1)%compute%size+ishift) &
+                       * (domain%list(rpos)%y(1)%compute%size+jshift) * ke
+             endif
+           ! Force use of scalar, integer ptr interface
+             call mpp_transmit( put_data=clocal(1), plen=num_word_me, to_pe=domain%x(1)%list(lpos)%pe, &
+                                get_data=cremote(1), glen=num_words, from_pe=from_pe )
+             m = 0
+             if (from_pe /= NULL_PE) then
+                is = domain%list(rpos)%x(1)%compute%begin; ie = domain%list(rpos)%x(1)%compute%end+ishift
+                call vec2arr(cremote, global, ix, iy, ipos0+is, ipos0+ie, jpos0+jpos+jsc, jpos0+jpos+jec)
+             endif
+             call mpp_sync_self()  !-ensure MPI_ISEND is done.
+          end do
+      else if( yonly )then
+          nd = size(domain%y(1)%list(:))
+          do n = 1,nd-1
+             lpos = mod(domain%y(1)%pos+nd-n,nd)
+             rpos = mod(domain%y(1)%pos   +n,nd)
+             from_pe = domain%y(1)%list(rpos)%pe
+             rpos = from_pe - root_pe
+             if (from_pe == NULL_PE) then
+                num_words = 0
+             else
+                num_words = (domain%list(rpos)%x(1)%compute%size+ishift) &
+                       * (domain%list(rpos)%y(1)%compute%size+jshift) * ke
+             endif
+           ! Force use of scalar, integer pointer interface
+             call mpp_transmit( put_data=clocal(1), plen=num_word_me, to_pe=domain%y(1)%list(lpos)%pe, &
+                                get_data=cremote(1), glen=num_words, from_pe=from_pe )
+             m = 0
+             if (from_pe /= NULL_PE) then
+               js = domain%list(rpos)%y(1)%compute%begin; je = domain%list(rpos)%y(1)%compute%end+jshift
+               call vec2arr(cremote, global, ix, iy, ipos0+ipos+isc, ipos0+ipos+iec, jpos0+js, jpos0+je)
+             endif
+             call mpp_sync_self()  !-ensure MPI_ISEND is done.
+          end do
+      else
+         tile_id = domain%tile_id(1)
+         nd = size(domain%list(:))
+         if(root_only) then
+            if(domain%pe .NE. domain%tile_root_pe) then
+               call mpp_send( clocal(1), plen=num_word_me, to_pe=domain%tile_root_pe, tag=COMM_TAG_1 )
+            else
+               do n = 1,nd-1
+                  rpos = mod(domain%pos+n,nd)
+                  if( domain%list(rpos)%tile_id(1) .NE. tile_id ) cycle
+                  num_words = (domain%list(rpos)%x(1)%compute%size+ishift) * &
+                            & (domain%list(rpos)%y(1)%compute%size+jshift) * ke
+                  call mpp_recv(cremote(1), glen=num_words, from_pe=domain%list(rpos)%pe, tag=COMM_TAG_1 )
+                  m = 0
+                  is = domain%list(rpos)%x(1)%compute%begin; ie = domain%list(rpos)%x(1)%compute%end+ishift
+                  js = domain%list(rpos)%y(1)%compute%begin; je = domain%list(rpos)%y(1)%compute%end+jshift
+
+                  call vec2arr(cremote, global, ix, iy, ipos0+is, ipos0+ie, jpos0+js, jpos0+je)
+               end do
+            endif
+         else
+            do n = 1,nd-1
+               lpos = mod(domain%pos+nd-n,nd)
+               if( domain%list(lpos)%tile_id(1).NE. tile_id ) cycle ! global field only within tile
+               call mpp_send( clocal(1), plen=num_word_me, to_pe=domain%list(lpos)%pe, tag=COMM_TAG_2 )
+            end do
+            do n = 1,nd-1
+               rpos = mod(domain%pos+n,nd)
+               if( domain%list(rpos)%tile_id(1) .NE. tile_id ) cycle ! global field only within tile
+               num_words = (domain%list(rpos)%x(1)%compute%size+ishift) * &
+                         & (domain%list(rpos)%y(1)%compute%size+jshift) * ke
+               call mpp_recv( cremote(1), glen=num_words, from_pe=domain%list(rpos)%pe, tag=COMM_TAG_2 )
+               m = 0
+               is = domain%list(rpos)%x(1)%compute%begin; ie = domain%list(rpos)%x(1)%compute%end+ishift
+               js = domain%list(rpos)%y(1)%compute%begin; je = domain%list(rpos)%y(1)%compute%end+jshift
+
+               call vec2arr(cremote, global, ix, iy, ipos0+is, ipos0+ie, jpos0+js, jpos0+je)
+            end do
+         endif
+      end if
+
+      call mpp_sync_self
+    end subroutine MPP_GLOBAL_FIELD_5D_
+!> @}

--- a/mpp/include/mpp_pack.inc
+++ b/mpp/include/mpp_pack.inc
@@ -1,3 +1,5 @@
+#ifndef __NVCOMPILER
+
 #undef MPP_TYPE_
 #define MPP_TYPE_ real(r8_kind)
 #undef ARR2VEC_
@@ -81,3 +83,251 @@
 #undef ARR_INIT_
 #define ARR_INIT_ arr_init_l4
 #include <mpp_pack.fh>
+
+#else
+
+#undef MPP_TYPE_
+#define MPP_TYPE_ real(r8_kind)
+#undef ARR2VEC_2D
+#define ARR2VEC_2D arr2vec_r8_2d
+#undef ARR2VEC_3D
+#define ARR2VEC_3D arr2vec_r8_3d
+#undef ARR2VEC_4D
+#define ARR2VEC_4D arr2vec_r8_4d
+#undef ARR2VEC_5D
+#define ARR2VEC_5D arr2vec_r8_5d
+#undef VEC2ARR_2D
+#define VEC2ARR_2D vec2arr_r8_2d
+#undef VEC2ARR_3D
+#define VEC2ARR_3D vec2arr_r8_3d
+#undef VEC2ARR_4D
+#define VEC2ARR_4D vec2arr_r8_4d
+#undef VEC2ARR_5D
+#define VEC2ARR_5D vec2arr_r8_5d
+#undef ARR_INIT_1D
+#define ARR_INIT_1D arr_init_r8_1d
+#undef ARR_INIT_2D
+#define ARR_INIT_2D arr_init_r8_2d
+#undef ARR_INIT_3D
+#define ARR_INIT_3D arr_init_r8_3d
+#undef ARR_INIT_4D
+#define ARR_INIT_4D arr_init_r8_4d
+#undef ARR_INIT_5D
+#define ARR_INIT_5D arr_init_r8_5d
+#include <mpp_pack_compat.fh>
+
+#ifdef OVERLOAD_C8
+#undef MPP_TYPE_
+#define MPP_TYPE_ complex(c8_kind)
+#undef ARR2VEC_2D
+#define ARR2VEC_2D arr2vec_c8_2d
+#undef ARR2VEC_3D
+#define ARR2VEC_3D arr2vec_c8_3d
+#undef ARR2VEC_4D
+#define ARR2VEC_4D arr2vec_c8_4d
+#undef ARR2VEC_5D
+#define ARR2VEC_5D arr2vec_c8_5d
+#undef VEC2ARR_2D
+#define VEC2ARR_2D vec2arr_c8_2d
+#undef VEC2ARR_3D
+#define VEC2ARR_3D vec2arr_c8_3d
+#undef VEC2ARR_4D
+#define VEC2ARR_4D vec2arr_c8_4d
+#undef VEC2ARR_5D
+#define VEC2ARR_5D vec2arr_c8_5d
+#undef ARR_INIT_1D
+#define ARR_INIT_1D arr_init_c8_1d
+#undef ARR_INIT_2D
+#define ARR_INIT_2D arr_init_c8_2d
+#undef ARR_INIT_3D
+#define ARR_INIT_3D arr_init_c8_3d
+#undef ARR_INIT_4D
+#define ARR_INIT_4D arr_init_c8_4d
+#undef ARR_INIT_5D
+#define ARR_INIT_5D arr_init_c8_5d
+#include <mpp_pack_compat.fh>
+#endif
+
+#undef MPP_TYPE_
+#define MPP_TYPE_ integer(i8_kind)
+#undef ARR2VEC_2D
+#define ARR2VEC_2D arr2vec_i8_2d
+#undef ARR2VEC_3D
+#define ARR2VEC_3D arr2vec_i8_3d
+#undef ARR2VEC_4D
+#define ARR2VEC_4D arr2vec_i8_4d
+#undef ARR2VEC_5D
+#define ARR2VEC_5D arr2vec_i8_5d
+#undef VEC2ARR_2D
+#define VEC2ARR_2D vec2arr_i8_2d
+#undef VEC2ARR_3D
+#define VEC2ARR_3D vec2arr_i8_3d
+#undef VEC2ARR_4D
+#define VEC2ARR_4D vec2arr_i8_4d
+#undef VEC2ARR_5D
+#define VEC2ARR_5D vec2arr_i8_5d
+#undef ARR_INIT_1D
+#define ARR_INIT_1D arr_init_i8_1d
+#undef ARR_INIT_2D
+#define ARR_INIT_2D arr_init_i8_2d
+#undef ARR_INIT_3D
+#define ARR_INIT_3D arr_init_i8_3d
+#undef ARR_INIT_4D
+#define ARR_INIT_4D arr_init_i8_4d
+#undef ARR_INIT_5D
+#define ARR_INIT_5D arr_init_i8_5d
+#include <mpp_pack_compat.fh>
+
+#undef MPP_TYPE_
+#define MPP_TYPE_ logical(l8_kind)
+#undef ARR2VEC_2D
+#define ARR2VEC_2D arr2vec_l8_2d
+#undef ARR2VEC_3D
+#define ARR2VEC_3D arr2vec_l8_3d
+#undef ARR2VEC_4D
+#define ARR2VEC_4D arr2vec_l8_4d
+#undef ARR2VEC_5D
+#define ARR2VEC_5D arr2vec_l8_5d
+#undef VEC2ARR_2D
+#define VEC2ARR_2D vec2arr_l8_2d
+#undef VEC2ARR_3D
+#define VEC2ARR_3D vec2arr_l8_3d
+#undef VEC2ARR_4D
+#define VEC2ARR_4D vec2arr_l8_4d
+#undef VEC2ARR_5D
+#define VEC2ARR_5D vec2arr_l8_5d
+#undef ARR_INIT_1D
+#define ARR_INIT_1D arr_init_l8_1d
+#undef ARR_INIT_2D
+#define ARR_INIT_2D arr_init_l8_2d
+#undef ARR_INIT_3D
+#define ARR_INIT_3D arr_init_l8_3d
+#undef ARR_INIT_4D
+#define ARR_INIT_4D arr_init_l8_4d
+#undef ARR_INIT_5D
+#define ARR_INIT_5D arr_init_l8_5d
+#include <mpp_pack_compat.fh>
+
+#undef MPP_TYPE_
+#define MPP_TYPE_ real(r4_kind)
+#undef ARR2VEC_2D
+#define ARR2VEC_2D arr2vec_r4_2d
+#undef ARR2VEC_3D
+#define ARR2VEC_3D arr2vec_r4_3d
+#undef ARR2VEC_4D
+#define ARR2VEC_4D arr2vec_r4_4d
+#undef ARR2VEC_5D
+#define ARR2VEC_5D arr2vec_r4_5d
+#undef VEC2ARR_2D
+#define VEC2ARR_2D vec2arr_r4_2d
+#undef VEC2ARR_3D
+#define VEC2ARR_3D vec2arr_r4_3d
+#undef VEC2ARR_4D
+#define VEC2ARR_4D vec2arr_r4_4d
+#undef VEC2ARR_5D
+#define VEC2ARR_5D vec2arr_r4_5d
+#undef ARR_INIT_1D
+#define ARR_INIT_1D arr_init_r4_1d
+#undef ARR_INIT_2D
+#define ARR_INIT_2D arr_init_r4_2d
+#undef ARR_INIT_3D
+#define ARR_INIT_3D arr_init_r4_3d
+#undef ARR_INIT_4D
+#define ARR_INIT_4D arr_init_r4_4d
+#undef ARR_INIT_5D
+#define ARR_INIT_5D arr_init_r4_5d
+#include <mpp_pack_compat.fh>
+
+#ifdef OVERLOAD_C4
+#undef MPP_TYPE_
+#define MPP_TYPE_ complex(c4_kind)
+#undef ARR2VEC_2D
+#define ARR2VEC_2D arr2vec_c4_2d
+#undef ARR2VEC_3D
+#define ARR2VEC_3D arr2vec_c4_3d
+#undef ARR2VEC_4D
+#define ARR2VEC_4D arr2vec_c4_4d
+#undef ARR2VEC_5D
+#define ARR2VEC_5D arr2vec_c4_5d
+#undef VEC2ARR_2D
+#define VEC2ARR_2D vec2arr_c4_2d
+#undef VEC2ARR_3D
+#define VEC2ARR_3D vec2arr_c4_3d
+#undef VEC2ARR_4D
+#define VEC2ARR_4D vec2arr_c4_4d
+#undef VEC2ARR_5D
+#define VEC2ARR_5D vec2arr_c4_5d
+#undef ARR_INIT_1D
+#define ARR_INIT_1D arr_init_c4_1d
+#undef ARR_INIT_2D
+#define ARR_INIT_2D arr_init_c4_2d
+#undef ARR_INIT_3D
+#define ARR_INIT_3D arr_init_c4_3d
+#undef ARR_INIT_4D
+#define ARR_INIT_4D arr_init_c4_4d
+#undef ARR_INIT_5D
+#define ARR_INIT_5D arr_init_c4_5d
+#include <mpp_pack_compat.fh>
+#endif
+
+#undef MPP_TYPE_
+#define MPP_TYPE_ integer(i4_kind)
+#undef ARR2VEC_2D
+#define ARR2VEC_2D arr2vec_i4_2d
+#undef ARR2VEC_3D
+#define ARR2VEC_3D arr2vec_i4_3d
+#undef ARR2VEC_4D
+#define ARR2VEC_4D arr2vec_i4_4d
+#undef ARR2VEC_5D
+#define ARR2VEC_5D arr2vec_i4_5d
+#undef VEC2ARR_2D
+#define VEC2ARR_2D vec2arr_i4_2d
+#undef VEC2ARR_3D
+#define VEC2ARR_3D vec2arr_i4_3d
+#undef VEC2ARR_4D
+#define VEC2ARR_4D vec2arr_i4_4d
+#undef VEC2ARR_5D
+#define VEC2ARR_5D vec2arr_i4_5d
+#undef ARR_INIT_1D
+#define ARR_INIT_1D arr_init_i4_1d
+#undef ARR_INIT_2D
+#define ARR_INIT_2D arr_init_i4_2d
+#undef ARR_INIT_3D
+#define ARR_INIT_3D arr_init_i4_3d
+#undef ARR_INIT_4D
+#define ARR_INIT_4D arr_init_i4_4d
+#undef ARR_INIT_5D
+#define ARR_INIT_5D arr_init_i4_5d
+#include <mpp_pack_compat.fh>
+
+#undef MPP_TYPE_
+#define MPP_TYPE_ logical(l4_kind)
+#undef ARR2VEC_2D
+#define ARR2VEC_2D arr2vec_l4_2d
+#undef ARR2VEC_3D
+#define ARR2VEC_3D arr2vec_l4_3d
+#undef ARR2VEC_4D
+#define ARR2VEC_4D arr2vec_l4_4d
+#undef ARR2VEC_5D
+#define ARR2VEC_5D arr2vec_l4_5d
+#undef VEC2ARR_2D
+#define VEC2ARR_2D vec2arr_l4_2d
+#undef VEC2ARR_3D
+#define VEC2ARR_3D vec2arr_l4_3d
+#undef VEC2ARR_4D
+#define VEC2ARR_4D vec2arr_l4_4d
+#undef VEC2ARR_5D
+#define VEC2ARR_5D vec2arr_l4_5d
+#undef ARR_INIT_1D
+#define ARR_INIT_1D arr_init_l4_1d
+#undef ARR_INIT_2D
+#define ARR_INIT_2D arr_init_l4_2d
+#undef ARR_INIT_3D
+#define ARR_INIT_3D arr_init_l4_3d
+#undef ARR_INIT_4D
+#define ARR_INIT_4D arr_init_l4_4d
+#undef ARR_INIT_5D
+#define ARR_INIT_5D arr_init_l4_5d
+#include <mpp_pack_compat.fh>
+
+#endif

--- a/mpp/include/mpp_pack_compat.fh
+++ b/mpp/include/mpp_pack_compat.fh
@@ -1,0 +1,385 @@
+!***********************************************************************
+!*                             Apache License 2.0
+!*
+!* This file is part of the GFDL Flexible Modeling System (FMS).
+!*
+!* Licensed under the Apache License, Version 2.0 (the "License");
+!* you may not use this file except in compliance with the License.
+!* You may obtain a copy of the License at
+!*
+!*     http://www.apache.org/licenses/LICENSE-2.0
+!*
+!* FMS is distributed in the hope that it will be useful, but WITHOUT
+!* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied;
+!* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+!* PARTICULAR PURPOSE. See the License for the specific language
+!* governing permissions and limitations under the License.
+!***********************************************************************
+
+      !> @brief This file provides duplicate subroutines for the mpp_pack.fh, specifically for compatibility with
+      !! Fortran compilers that do not support the 2018 standard, specfically deferred rank arrays and select rank
+      !! constructs.
+
+      !> @brief Pack a 2D domain-decomposed array into a contiguous 1D array. This is
+      !!        typically used to prepare a contiguous array which will be transmitted via MPI.
+      subroutine ARR2VEC_2D (arr, vec, xdim, ydim, is, ie, js, je)
+        MPP_TYPE_, intent(in) :: arr(:,:) !< The array to be packed
+        MPP_TYPE_, intent(out) :: vec(:) !< The vector to copy the data into
+        integer, intent(in) :: xdim, ydim !< Indices of the domain-decomposed dimensions. In typical Fortran-based
+                                          !! code, xdim=1 and ydim=2.
+        integer, intent(in) :: is, ie, js, je !< Starting and ending indices of the x and y dimensions, expressed
+                                              !! in terms of the 1-based indices seen within ARR2VEC_2D. These indices
+                                              !! may be different from the indices used in the calling code! If `arr`
+                                              !! is defined over the data domain, e.g. dimension(isd:ied,jsd:jed),
+                                              !! and you wish to pack only the compute domain, the following values
+                                              !! should be passed:
+                                              !! is = isc - isd + 1
+                                              !! ie = iec - isd + 1
+                                              !! js = jsc - jsd + 1
+                                              !! je = jec - jsd + 1
+        integer, allocatable, dimension(:) :: lb, ub !< These are 1 and shape(arr) respectively for all dimensions
+                                                     !! except the domain-decomposed dimensions, for which they are
+                                                     !! set according to the is,ie,js,je options.
+        integer :: ndims, n
+        integer :: i1, i2, i3, i4, i5
+
+        ndims = 2
+        allocate (lb(ndims), ub(ndims))
+
+        lb = 1
+        ub = shape(arr)
+
+        lb(xdim) = is
+        lb(ydim) = js
+
+        ub(xdim) = ie
+        ub(ydim) = je
+
+        n = product(ub - lb + 1)
+
+        vec(1:n) = reshape(arr(lb(1):ub(1), lb(2):ub(2)), [n])
+      end subroutine ARR2VEC_2D
+
+      !> @brief Pack a 3D domain-decomposed array into a contiguous 1D array. This is
+      !!        typically used to prepare a contiguous array which will be transmitted via MPI.
+      subroutine ARR2VEC_3D (arr, vec, xdim, ydim, is, ie, js, je)
+        MPP_TYPE_, intent(in) :: arr(:,:,:) !< The array to be packed
+        MPP_TYPE_, intent(out) :: vec(:) !< The vector to copy the data into
+        integer, intent(in) :: xdim, ydim !< Indices of the domain-decomposed dimensions. In typical Fortran-based
+                                          !! code, xdim=1 and ydim=2.
+        integer, intent(in) :: is, ie, js, je !< Starting and ending indices of the x and y dimensions, expressed
+                                              !! in terms of the 1-based indices seen within ARR2VEC_3D. These indices
+                                              !! may be different from the indices used in the calling code! If `arr`
+                                              !! is defined over the data domain, e.g. dimension(isd:ied,jsd:jed,...),
+                                              !! and you wish to pack only the compute domain, the following values
+                                              !! should be passed:
+                                              !! is = isc - isd + 1
+                                              !! ie = iec - isd + 1
+                                              !! js = jsc - jsd + 1
+                                              !! je = jec - jsd + 1
+        integer, allocatable, dimension(:) :: lb, ub !< These are 1 and shape(arr) respectively for all dimensions
+                                                     !! except the domain-decomposed dimensions, for which they are
+                                                     !! set according to the is,ie,js,je options.
+        integer :: ndims, n
+        integer :: i1, i2, i3, i4, i5
+
+        ndims = 3
+        allocate (lb(ndims), ub(ndims))
+
+        lb = 1
+        ub = shape(arr)
+
+        lb(xdim) = is
+        lb(ydim) = js
+
+        ub(xdim) = ie
+        ub(ydim) = je
+
+        n = product(ub - lb + 1)
+
+        vec(1:n) = reshape(arr(lb(1):ub(1), lb(2):ub(2), lb(3):ub(3)), [n])
+      end subroutine ARR2VEC_3D
+
+      !> @brief Pack a 4D domain-decomposed array into a contiguous 1D array. This is
+      !!        typically used to prepare a contiguous array which will be transmitted via MPI.
+      subroutine ARR2VEC_4D (arr, vec, xdim, ydim, is, ie, js, je)
+        MPP_TYPE_, intent(in) :: arr(:,:,:,:) !< The array to be packed
+        MPP_TYPE_, intent(out) :: vec(:) !< The vector to copy the data into
+        integer, intent(in) :: xdim, ydim !< Indices of the domain-decomposed dimensions. In typical Fortran-based
+                                          !! code, xdim=1 and ydim=2.
+        integer, intent(in) :: is, ie, js, je !< Starting and ending indices of the x and y dimensions, expressed
+                                              !! in terms of the 1-based indices seen within ARR2VEC_4D. These indices
+                                              !! may be different from the indices used in the calling code! If `arr`
+                                              !! is defined over the data domain, e.g. dimension(isd:ied,jsd:jed,...),
+                                              !! and you wish to pack only the compute domain, the following values
+                                              !! should be passed:
+                                              !! is = isc - isd + 1
+                                              !! ie = iec - isd + 1
+                                              !! js = jsc - jsd + 1
+                                              !! je = jec - jsd + 1
+        integer, allocatable, dimension(:) :: lb, ub !< These are 1 and shape(arr) respectively for all dimensions
+                                                     !! except the domain-decomposed dimensions, for which they are
+                                                     !! set according to the is,ie,js,je options.
+        integer :: ndims, n
+        integer :: i1, i2, i3, i4, i5
+
+        ndims = 4
+        allocate (lb(ndims), ub(ndims))
+
+        lb = 1
+        ub = shape(arr)
+
+        lb(xdim) = is
+        lb(ydim) = js
+
+        ub(xdim) = ie
+        ub(ydim) = je
+
+        n = product(ub - lb + 1)
+
+        vec(1:n) = reshape(arr(lb(1):ub(1), lb(2):ub(2), lb(3):ub(3), lb(4):ub(4)), [n])
+      end subroutine ARR2VEC_4D
+
+      !> @brief Pack a 5D domain-decomposed array into a contiguous 1D array. This is
+      !!        typically used to prepare a contiguous array which will be transmitted via MPI.
+      subroutine ARR2VEC_5D (arr, vec, xdim, ydim, is, ie, js, je)
+        MPP_TYPE_, intent(in) :: arr(:,:,:,:,:) !< The array to be packed
+        MPP_TYPE_, intent(out) :: vec(:) !< The vector to copy the data into
+        integer, intent(in) :: xdim, ydim !< Indices of the domain-decomposed dimensions. In typical Fortran-based
+                                          !! code, xdim=1 and ydim=2.
+        integer, intent(in) :: is, ie, js, je !< Starting and ending indices of the x and y dimensions, expressed
+                                              !! in terms of the 1-based indices seen within ARR2VEC_5D. These indices
+                                              !! may be different from the indices used in the calling code! If `arr`
+                                              !! is defined over the data domain, e.g. dimension(isd:ied,jsd:jed,...),
+                                              !! and you wish to pack only the compute domain, the following values
+                                              !! should be passed:
+                                              !! is = isc - isd + 1
+                                              !! ie = iec - isd + 1
+                                              !! js = jsc - jsd + 1
+                                              !! je = jec - jsd + 1
+        integer, allocatable, dimension(:) :: lb, ub !< These are 1 and shape(arr) respectively for all dimensions
+                                                     !! except the domain-decomposed dimensions, for which they are
+                                                     !! set according to the is,ie,js,je options.
+        integer :: ndims, n
+        integer :: i1, i2, i3, i4, i5
+
+        ndims = 5
+        allocate (lb(ndims), ub(ndims))
+
+        lb = 1
+        ub = shape(arr)
+
+        lb(xdim) = is
+        lb(ydim) = js
+
+        ub(xdim) = ie
+        ub(ydim) = je
+
+        n = product(ub - lb + 1)
+
+        vec(1:n) = reshape(arr(lb(1):ub(1), lb(2):ub(2), lb(3):ub(3), lb(4):ub(4), lb(5):ub(5)), [n])
+      end subroutine ARR2VEC_5D
+
+      !> @brief Unpack a contiguous 1D array into a 2D array. This is typically used to transform
+      !!        data obtained from an MPI call into the format that is expected by the calling code.
+      subroutine VEC2ARR_2D (vec, arr, xdim, ydim, is, ie, js, je)
+        MPP_TYPE_, intent(in) :: vec(:) !< The 1D array to be unpacked
+        MPP_TYPE_, intent(out) :: arr(:,:) !< The multi-dimensional array to copy the data into
+        integer, intent(in) :: xdim, ydim !< Indices of the domain-decomposed dimensions. In typical Fortran-based
+                                          !! code, xdim=1 and ydim=2.
+        integer, intent(in) :: is, ie, js, je !< Starting and ending indices of the x and y dimensions, expressed
+                                              !! in terms of the 1-based indices seen within VEC2ARR_2D. These indices
+                                              !! may be different from the indices used in the calling code! If `arr`
+                                              !! is defined over the data domain, e.g. dimension(isd:ied,jsd:jed),
+                                              !! and you wish to unpack only the compute domain, the following values
+                                              !! should be passed:
+                                              !! is = isc - isd + 1
+                                              !! ie = iec - isd + 1
+                                              !! js = jsc - jsd + 1
+                                              !! je = jec - jsd + 1
+        integer, allocatable, dimension(:) :: lb, ub !< These are 1 and shape(arr) respectively for all dimensions
+                                                     !! except the domain-decomposed dimensions, for which they are
+                                                     !! set according to the is,ie,js,je options.
+        integer :: ndims, n
+        integer :: i1, i2, i3, i4, i5
+
+        ndims = 2
+        allocate (lb(ndims), ub(ndims))
+
+        lb = 1
+        ub = shape(arr)
+
+        lb(xdim) = is
+        lb(ydim) = js
+
+        ub(xdim) = ie
+        ub(ydim) = je
+
+        associate (s => ub - lb + 1)
+          n = product(s)
+          arr(lb(1):ub(1), lb(2):ub(2)) = reshape(vec(1:n), s(1:2))
+        end associate
+      end subroutine VEC2ARR_2D
+
+      !> @brief Unpack a contiguous 1D array into a 3D array. This is typically used to transform
+      !!        data obtained from an MPI call into the format that is expected by the calling code.
+      subroutine VEC2ARR_3D (vec, arr, xdim, ydim, is, ie, js, je)
+        MPP_TYPE_, intent(in) :: vec(:) !< The 1D array to be unpacked
+        MPP_TYPE_, intent(out) :: arr(:,:,:) !< The multi-dimensional array to copy the data into
+        integer, intent(in) :: xdim, ydim !< Indices of the domain-decomposed dimensions. In typical Fortran-based
+                                          !! code, xdim=1 and ydim=2.
+        integer, intent(in) :: is, ie, js, je !< Starting and ending indices of the x and y dimensions, expressed
+                                              !! in terms of the 1-based indices seen within VEC2ARR_3D. These indices
+                                              !! may be different from the indices used in the calling code! If `arr`
+                                              !! is defined over the data domain, e.g. dimension(isd:ied,jsd:jed,...),
+                                              !! and you wish to unpack only the compute domain, the following values
+                                              !! should be passed:
+                                              !! is = isc - isd + 1
+                                              !! ie = iec - isd + 1
+                                              !! js = jsc - jsd + 1
+                                              !! je = jec - jsd + 1
+        integer, allocatable, dimension(:) :: lb, ub !< These are 1 and shape(arr) respectively for all dimensions
+                                                     !! except the domain-decomposed dimensions, for which they are
+                                                     !! set according to the is,ie,js,je options.
+        integer :: ndims, n
+        integer :: i1, i2, i3, i4, i5
+
+        ndims = 3
+        allocate (lb(ndims), ub(ndims))
+
+        lb = 1
+        ub = shape(arr)
+
+        lb(xdim) = is
+        lb(ydim) = js
+
+        ub(xdim) = ie
+        ub(ydim) = je
+
+        associate (s => ub - lb + 1)
+          n = product(s)
+          arr(lb(1):ub(1), lb(2):ub(2), lb(3):ub(3)) = reshape(vec(1:n), s(1:3))
+        end associate
+      end subroutine VEC2ARR_3D
+
+      !> @brief Unpack a contiguous 1D array into a 4D array. This is typically used to transform
+      !!        data obtained from an MPI call into the format that is expected by the calling code.
+      subroutine VEC2ARR_4D (vec, arr, xdim, ydim, is, ie, js, je)
+        MPP_TYPE_, intent(in) :: vec(:) !< The 1D array to be unpacked
+        MPP_TYPE_, intent(out) :: arr(:,:,:,:) !< The multi-dimensional array to copy the data into
+        integer, intent(in) :: xdim, ydim !< Indices of the domain-decomposed dimensions. In typical Fortran-based
+                                          !! code, xdim=1 and ydim=2.
+        integer, intent(in) :: is, ie, js, je !< Starting and ending indices of the x and y dimensions, expressed
+                                              !! in terms of the 1-based indices seen within VEC2ARR_4D. These indices
+                                              !! may be different from the indices used in the calling code! If `arr`
+                                              !! is defined over the data domain, e.g. dimension(isd:ied,jsd:jed,...),
+                                              !! and you wish to unpack only the compute domain, the following values
+                                              !! should be passed:
+                                              !! is = isc - isd + 1
+                                              !! ie = iec - isd + 1
+                                              !! js = jsc - jsd + 1
+                                              !! je = jec - jsd + 1
+        integer, allocatable, dimension(:) :: lb, ub !< These are 1 and shape(arr) respectively for all dimensions
+                                                     !! except the domain-decomposed dimensions, for which they are
+                                                     !! set according to the is,ie,js,je options.
+        integer :: ndims, n
+        integer :: i1, i2, i3, i4, i5
+
+        ndims = 4
+        allocate (lb(ndims), ub(ndims))
+
+        lb = 1
+        ub = shape(arr)
+
+        lb(xdim) = is
+        lb(ydim) = js
+
+        ub(xdim) = ie
+        ub(ydim) = je
+
+        associate (s => ub - lb + 1)
+          n = product(s)
+          arr(lb(1):ub(1), lb(2):ub(2), lb(3):ub(3), lb(4):ub(4)) = reshape(vec(1:n), s(1:4))
+        end associate
+      end subroutine VEC2ARR_4D
+
+      !> @brief Unpack a contiguous 1D array into a 5D array. This is typically used to transform
+      !!        data obtained from an MPI call into the format that is expected by the calling code.
+      subroutine VEC2ARR_5D (vec, arr, xdim, ydim, is, ie, js, je)
+        MPP_TYPE_, intent(in) :: vec(:) !< The 1D array to be unpacked
+        MPP_TYPE_, intent(out) :: arr(:,:,:,:,:) !< The multi-dimensional array to copy the data into
+        integer, intent(in) :: xdim, ydim !< Indices of the domain-decomposed dimensions. In typical Fortran-based
+                                          !! code, xdim=1 and ydim=2.
+        integer, intent(in) :: is, ie, js, je !< Starting and ending indices of the x and y dimensions, expressed
+                                              !! in terms of the 1-based indices seen within VEC2ARR_5D. These indices
+                                              !! may be different from the indices used in the calling code! If `arr`
+                                              !! is defined over the data domain, e.g. dimension(isd:ied,jsd:jed,...),
+                                              !! and you wish to unpack only the compute domain, the following values
+                                              !! should be passed:
+                                              !! is = isc - isd + 1
+                                              !! ie = iec - isd + 1
+                                              !! js = jsc - jsd + 1
+                                              !! je = jec - jsd + 1
+        integer, allocatable, dimension(:) :: lb, ub !< These are 1 and shape(arr) respectively for all dimensions
+                                                     !! except the domain-decomposed dimensions, for which they are
+                                                     !! set according to the is,ie,js,je options.
+        integer :: ndims, n
+        integer :: i1, i2, i3, i4, i5
+
+        ndims = 5
+        allocate (lb(ndims), ub(ndims))
+
+        lb = 1
+        ub = shape(arr)
+
+        lb(xdim) = is
+        lb(ydim) = js
+
+        ub(xdim) = ie
+        ub(ydim) = je
+
+        associate (s => ub - lb + 1)
+          n = product(s)
+          arr(lb(1):ub(1), lb(2):ub(2), lb(3):ub(3), lb(4):ub(4), lb(5):ub(5)) = reshape(vec(1:n), s(1:5))
+        end associate
+      end subroutine VEC2ARR_5D
+
+      !> @brief Initialize a 1D array to `val`.
+      subroutine ARR_INIT_1D (arr, val)
+        MPP_TYPE_, dimension(:), intent(out) :: arr !< The array to be initialized
+        MPP_TYPE_, intent(in) :: val !< The value to initialize to
+
+        arr = val
+      end subroutine ARR_INIT_1D
+
+      !> @brief Initialize a 2D array to `val`.
+      subroutine ARR_INIT_2D (arr, val)
+        MPP_TYPE_, dimension(:,:), intent(out) :: arr !< The array to be initialized
+        MPP_TYPE_, intent(in) :: val !< The value to initialize to
+
+        arr = val
+      end subroutine ARR_INIT_2D
+
+      !> @brief Initialize a 3D array to `val`.
+      subroutine ARR_INIT_3D (arr, val)
+        MPP_TYPE_, dimension(:,:,:), intent(out) :: arr !< The array to be initialized
+        MPP_TYPE_, intent(in) :: val !< The value to initialize to
+
+        arr = val
+      end subroutine ARR_INIT_3D
+
+      !> @brief Initialize a 4D array to `val`.
+      subroutine ARR_INIT_4D (arr, val)
+        MPP_TYPE_, dimension(:,:,:,:), intent(out) :: arr !< The array to be initialized
+        MPP_TYPE_, intent(in) :: val !< The value to initialize to
+
+        arr = val
+      end subroutine ARR_INIT_4D
+
+      !> @brief Initialize a 5D array to `val`.
+      subroutine ARR_INIT_5D (arr, val)
+        MPP_TYPE_, dimension(:,:,:,:,:), intent(out) :: arr !< The array to be initialized
+        MPP_TYPE_, intent(in) :: val !< The value to initialize to
+
+        arr = val
+      end subroutine ARR_INIT_5D

--- a/mpp/mpp_domains.F90
+++ b/mpp/mpp_domains.F90
@@ -1774,6 +1774,8 @@ module mpp_domains_mod
 !! @endcode
 !> @ingroup mpp_domains_mod
   interface mpp_global_field
+
+#ifndef __NVCOMPILER
      module procedure mpp_global_field_r8
 #ifdef OVERLOAD_C8
      module procedure mpp_global_field_c8
@@ -1786,6 +1788,45 @@ module mpp_domains_mod
 #endif
      module procedure mpp_global_field_i4
      module procedure mpp_global_field_l4
+!! rank specific interfaces are needed for NVHPC because it does not support deferred-rank arrays
+#else
+     module procedure mpp_global_field_r8_2d
+     module procedure mpp_global_field_r8_3d
+     module procedure mpp_global_field_r8_4d
+     module procedure mpp_global_field_r8_5d
+#ifdef OVERLOAD_C8
+     module procedure mpp_global_field_c8_2d
+     module procedure mpp_global_field_c8_3d
+     module procedure mpp_global_field_c8_4d
+     module procedure mpp_global_field_c8_5d
+#endif
+     module procedure mpp_global_field_i8_2d
+     module procedure mpp_global_field_i8_3d
+     module procedure mpp_global_field_i8_4d
+     module procedure mpp_global_field_i8_5d
+     module procedure mpp_global_field_l8_2d
+     module procedure mpp_global_field_l8_3d
+     module procedure mpp_global_field_l8_4d
+     module procedure mpp_global_field_l8_5d
+     module procedure mpp_global_field_r4_2d
+     module procedure mpp_global_field_r4_3d
+     module procedure mpp_global_field_r4_4d
+     module procedure mpp_global_field_r4_5d
+#ifdef OVERLOAD_C4
+     module procedure mpp_global_field_c4_2d
+     module procedure mpp_global_field_c4_3d
+     module procedure mpp_global_field_c4_4d
+     module procedure mpp_global_field_c4_5d
+#endif
+     module procedure mpp_global_field_i4_2d
+     module procedure mpp_global_field_i4_3d
+     module procedure mpp_global_field_i4_4d
+     module procedure mpp_global_field_i4_5d
+     module procedure mpp_global_field_l4_2d
+     module procedure mpp_global_field_l4_3d
+     module procedure mpp_global_field_l4_4d
+     module procedure mpp_global_field_l4_5d
+#endif
   end interface
 
 !> @ingroup mpp_domains_mod
@@ -2286,6 +2327,7 @@ module mpp_domains_mod
   !> Private interface to pack an array into a vector
   !> @ingroup mpp_domains_mod
   interface arr2vec
+#ifndef __NVCOMPILER
      module procedure arr2vec_r8
 #ifdef OVERLOAD_C8
      module procedure arr2vec_c8
@@ -2298,11 +2340,38 @@ module mpp_domains_mod
 #endif
      module procedure arr2vec_i4
      module procedure arr2vec_l4
+#else
+     module procedure arr2vec_r8_2d
+     module procedure arr2vec_r8_3d
+     module procedure arr2vec_r8_4d
+     module procedure arr2vec_r8_5d
+     module procedure arr2vec_i8_2d
+     module procedure arr2vec_i8_3d
+     module procedure arr2vec_i8_4d
+     module procedure arr2vec_i8_5d
+     module procedure arr2vec_l8_2d
+     module procedure arr2vec_l8_3d
+     module procedure arr2vec_l8_4d
+     module procedure arr2vec_l8_5d
+     module procedure arr2vec_r4_2d
+     module procedure arr2vec_r4_3d
+     module procedure arr2vec_r4_4d
+     module procedure arr2vec_r4_5d
+     module procedure arr2vec_i4_2d
+     module procedure arr2vec_i4_3d
+     module procedure arr2vec_i4_4d
+     module procedure arr2vec_i4_5d
+     module procedure arr2vec_l4_2d
+     module procedure arr2vec_l4_3d
+     module procedure arr2vec_l4_4d
+     module procedure arr2vec_l4_5d
+#endif
   end interface
 
   !> Private interface to unpack a vector into an array
   !> @ingroup mpp_domains_mod
   interface vec2arr
+#ifndef __NVCOMPILER
      module procedure vec2arr_r8
 #ifdef OVERLOAD_C8
      module procedure vec2arr_c8
@@ -2315,11 +2384,38 @@ module mpp_domains_mod
 #endif
      module procedure vec2arr_i4
      module procedure vec2arr_l4
+#else
+     module procedure vec2arr_r8_2d
+     module procedure vec2arr_r8_3d
+     module procedure vec2arr_r8_4d
+     module procedure vec2arr_r8_5d
+     module procedure vec2arr_i8_2d
+     module procedure vec2arr_i8_3d
+     module procedure vec2arr_i8_4d
+     module procedure vec2arr_i8_5d
+     module procedure vec2arr_l8_2d
+     module procedure vec2arr_l8_3d
+     module procedure vec2arr_l8_4d
+     module procedure vec2arr_l8_5d
+     module procedure vec2arr_r4_2d
+     module procedure vec2arr_r4_3d
+     module procedure vec2arr_r4_4d
+     module procedure vec2arr_r4_5d
+     module procedure vec2arr_i4_2d
+     module procedure vec2arr_i4_3d
+     module procedure vec2arr_i4_4d
+     module procedure vec2arr_i4_5d
+     module procedure vec2arr_l4_2d
+     module procedure vec2arr_l4_3d
+     module procedure vec2arr_l4_4d
+     module procedure vec2arr_l4_5d
+#endif
   end interface
 
   !> Private interface to initialize an assumed-rank array
   !> @ingroup mpp_domains_mod
   interface arr_init
+#ifndef __NVCOMPILER
      module procedure arr_init_r8
 #ifdef OVERLOAD_C8
      module procedure arr_init_c8
@@ -2332,6 +2428,32 @@ module mpp_domains_mod
 #endif
      module procedure arr_init_i4
      module procedure arr_init_l4
+#else
+     module procedure arr_init_r8_2d
+     module procedure arr_init_r8_3d
+     module procedure arr_init_r8_4d
+     module procedure arr_init_r8_5d
+     module procedure arr_init_i8_2d
+     module procedure arr_init_i8_3d
+     module procedure arr_init_i8_4d
+     module procedure arr_init_i8_5d
+     module procedure arr_init_l8_2d
+     module procedure arr_init_l8_3d
+     module procedure arr_init_l8_4d
+     module procedure arr_init_l8_5d
+     module procedure arr_init_r4_2d
+     module procedure arr_init_r4_3d
+     module procedure arr_init_r4_4d
+     module procedure arr_init_r4_5d
+     module procedure arr_init_i4_2d
+     module procedure arr_init_i4_3d
+     module procedure arr_init_i4_4d
+     module procedure arr_init_i4_5d
+     module procedure arr_init_l4_2d
+     module procedure arr_init_l4_3d
+     module procedure arr_init_l4_4d
+     module procedure arr_init_l4_5d
+#endif
   end interface
 
   ! Include variable "version" to be written to log file.
@@ -2346,8 +2468,8 @@ contains
 #include <mpp_domains_comm.inc>
 #include <mpp_domains_define.inc>
 #include <mpp_domains_misc.inc>
+#include <mpp_pack.inc>
 #include <mpp_domains_reduce.inc>
 #include <mpp_unstruct_domain.inc>
-#include <mpp_pack.inc>
 
 end module mpp_domains_mod


### PR DESCRIPTION
**Description**
adds a workaround for nvhpc's lack of support for deferred-rank arrays. Copies over the nice new routines that use deferred ranks and makes them worse by using explicit rank sizes, then adds them to the corresponding interfaces to support all required dimensions the classic fortran way.

Open to any advice for how to name/manage the macro. not sure if i should just leave it as __NVCOMPILER, but it would be more convenient.

Fixes #1864

**How Has This Been Tested?**
nvhpc 26.1ng (beta release) + mpich was able to compile and pass most of the mpp tests. I got 3 failures, but I think they are all unrelated to these updates.

25.1 was able to compile too, but many of the mpp tests fail.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

