### PR TITLE
DIAG MANAGER: Fixes to zbounds

### DIFF
--- a/diag_manager/fms_diag_axis_object.F90
+++ b/diag_manager/fms_diag_axis_object.F90
@@ -458,7 +458,13 @@ module fms_diag_axis_object_mod
       if (present(parent_axis)) then
         select type(parent_axis)
         type is (fmsDiagFullAxis_type)
-          call write_data(fms2io_fileobj, this%subaxis_name, parent_axis%axis_data(i:j))
+          ! Added this select type so the the data is indexed correctly
+          select type (vardata => parent_axis%axis_data)
+          type is (real(kind=r8_kind))
+              call write_data(fms2io_fileobj, this%subaxis_name, vardata(i:j))
+          type is (real(kind=r4_kind))
+              call write_data(fms2io_fileobj, this%subaxis_name, vardata(i:j))
+          end select
         end select
       endif
     type is (fmsDiagDiurnalAxis_type)
@@ -881,8 +887,10 @@ module fms_diag_axis_object_mod
     if (present(nz_subaxis)) nsubaxis = nz_subaxis
 
     this%axis_id = axis_id
-    this%starting_index = starting_index
-    this%ending_index = ending_index
+
+    ! The min and max were added here to support axis that are both increasing and decreasing
+    this%starting_index = min(starting_index, ending_index)
+    this%ending_index = max(starting_index, ending_index)
     this%parent_axis_id = parent_id
     write(nsubaxis_char, '(i2.2)')  nsubaxis
     this%subaxis_name = trim(parent_axis_name)//"_sub"//nsubaxis_char

--- a/test_fms/diag_manager/test_multiple_zbounds.F90
+++ b/test_fms/diag_manager/test_multiple_zbounds.F90
@@ -29,9 +29,12 @@ program test_multiple_zbounds
     type(time_type)                    :: Time_step        !< Time_step of the simulation
     integer                            :: id_z1            !< Axis id for the z dimension
     integer                            :: id_z2            !< Axis id for the z dimension
+    integer                            :: id_z_reverse     !< Axis id for the z dimension (decreasing)
     integer                            :: id_var1          !< var id for the first variable
     integer                            :: id_var2          !< var_id for the second variable
+    integer                            :: id_var3          !< var_id for the third variable
     real,                  allocatable :: z(:)             !< z axis data
+    real,                  allocatable :: z_reverse(:)     !< z axis data (decreasing)
     integer                            :: nz               !< Size of the z dimension
     integer                            :: i
     logical                            :: used             !< Dummy argument to send_data
@@ -42,8 +45,10 @@ program test_multiple_zbounds
 
     nz = 10
     allocate(z(nz))
+    allocate(z_reverse(nz))
     do i=1, nz
         z(i) = i
+        z(i) = nz - i + 1
     enddo
 
     Time = set_date(2,1,1,0,0,0)
@@ -51,8 +56,10 @@ program test_multiple_zbounds
 
     id_z1 =  diag_axis_init('zaxis1',  z,  'z', 'z', long_name='Z1')
     id_z2 =  diag_axis_init('zaxis2',  z,  'z', 'z', long_name='Z2')
+    id_z_reverse =  diag_axis_init('zaxis3',  z,  'z_reverse', 'z', long_name='Z3')
     id_var1 = register_diag_field  ('atmos', 'ua_1', (/id_z1/), Time)
     id_var2 = register_diag_field  ('atmos', 'ua_2', (/id_z2/), Time)
+    id_var3 = register_diag_field  ('atmos', 'ua_3', (/id_z_reverse/), Time)
 
     call diag_manager_set_time_end(set_date(2,1,2,0,0,0))
     do i = 1, 24
@@ -60,7 +67,7 @@ program test_multiple_zbounds
         z = real(i)
         used = send_data(id_var1, z, Time)
         used = send_data(id_var2, z, Time)
-
+        used = send_data(id_var3, z, Time)
         call diag_send_complete(Time_step)
     end do
 

--- a/test_fms/diag_manager/test_multiple_zbounds.F90
+++ b/test_fms/diag_manager/test_multiple_zbounds.F90
@@ -48,7 +48,7 @@ program test_multiple_zbounds
     allocate(z_reverse(nz))
     do i=1, nz
         z(i) = i
-        z(i) = nz - i + 1
+        z_reverse(i) = nz - i + 1
     enddo
 
     Time = set_date(2,1,1,0,0,0)
@@ -56,7 +56,7 @@ program test_multiple_zbounds
 
     id_z1 =  diag_axis_init('zaxis1',  z,  'z', 'z', long_name='Z1')
     id_z2 =  diag_axis_init('zaxis2',  z,  'z', 'z', long_name='Z2')
-    id_z_reverse =  diag_axis_init('zaxis3',  z,  'z_reverse', 'z', long_name='Z3')
+    id_z_reverse =  diag_axis_init('zaxis3',  z_reverse,  'z_reverse', 'z', long_name='Z3')
     id_var1 = register_diag_field  ('atmos', 'ua_1', (/id_z1/), Time)
     id_var2 = register_diag_field  ('atmos', 'ua_2', (/id_z2/), Time)
     id_var3 = register_diag_field  ('atmos', 'ua_3', (/id_z_reverse/), Time)
@@ -64,7 +64,6 @@ program test_multiple_zbounds
     call diag_manager_set_time_end(set_date(2,1,2,0,0,0))
     do i = 1, 24
         Time = Time + Time_step
-        z = real(i)
         used = send_data(id_var1, z, Time)
         used = send_data(id_var2, z, Time)
         used = send_data(id_var3, z, Time)
@@ -84,6 +83,9 @@ program test_multiple_zbounds
         integer :: SUB1_SIZE = 3
         integer :: SUB2_SIZE = 1
         character(len=20) :: EXPECTED_DIM_NAMES(2)
+        real :: EXPECTED_ZSUBAXIS_1(3)
+        real :: EXPECTED_ZSUBAXIS_2(1)
+        real :: EXPECTED_ZSUBAXIS_3(3)
 
         EXPECTED_DIM_NAMES(2) = "time"
         if (.not. open_file(fileobj, "test_multiple_zbounds.nc", "read")) then
@@ -91,8 +93,15 @@ program test_multiple_zbounds
         endif
 
         call check_dimension(fileobj, "time", EXPECTED_NTIMES)
-        call check_dimension(fileobj, "zaxis1_sub01", SUB1_SIZE)
-        call check_dimension(fileobj, "zaxis2_sub02", SUB2_SIZE)
+
+        EXPECTED_ZSUBAXIS_1 = (/3., 4., 5./)
+        call check_dimension(fileobj, "zaxis1_sub01", SUB1_SIZE, EXPECTED_ZSUBAXIS_1)
+
+        EXPECTED_ZSUBAXIS_2 = (/1./)
+        call check_dimension(fileobj, "zaxis2_sub02", SUB2_SIZE, EXPECTED_ZSUBAXIS_2)
+
+        EXPECTED_ZSUBAXIS_3 = (/5., 4., 3./)
+        call check_dimension(fileobj, "zaxis3_sub03", SUB1_SIZE, EXPECTED_ZSUBAXIS_3)
 
         EXPECTED_DIM_NAMES(1) = "zaxis1_sub01"
         call check_variable(fileobj, "ua_1", EXPECTED_DIM_NAMES)
@@ -121,17 +130,40 @@ program test_multiple_zbounds
 
     end subroutine check_variable
 
-    subroutine check_dimension(fileobj, dimension_name, expected_size)
+      !> @brief Check dimension data
+  subroutine check_data(err_msg, actual_data, expected_data)
+    character(len=*), intent(in) :: err_msg          !< Error message to append
+    real,             intent(in) :: actual_data(:)   !< Dimension data from file
+    real,             intent(in) :: expected_data(:) !< Expected data
+
+    integer :: i
+
+    do i = 1, size(actual_data)
+      if (actual_data(i) .ne. expected_data(i)) &
+        call mpp_error(FATAL, "The data is not expected for "//trim(err_msg))
+    enddo
+  end subroutine check_data
+
+    subroutine check_dimension(fileobj, dimension_name, expected_size, expected_data)
         type(FmsNetcdfFile_t), intent(in) :: fileobj
         character(len=*),      intent(in) :: dimension_name
         integer,               intent(in) :: expected_size
+        real, optional,        intent(in) :: expected_data(:)
 
         integer :: dim_size
+        real, allocatable :: z_data(:)
 
         call get_dimension_size(fileobj, dimension_name, dim_size)
         if (dim_size .ne. expected_size) then
             call mpp_error(FATAL, trim(dimension_name)//" is not the expected size!")
         endif
+
+        if (present(expected_data)) then
+            allocate(z_data(dim_size))
+            call read_data(fileobj, dimension_name, z_data)
+            call check_data(dimension_name, z_data, expected_data)
+        endif
+
 
     end subroutine
 end program test_multiple_zbounds

--- a/test_fms/diag_manager/test_multiple_zbounds.sh
+++ b/test_fms/diag_manager/test_multiple_zbounds.sh
@@ -47,6 +47,8 @@ diag_files:
     zbounds: 3 5
   - var_name: ua_2
     zbounds: 1 1
+  - var_name: ua_3
+    zbounds: 3 5
 _EOF
 
   test_expect_success "Test with multiple zbounds limits (modern diag manager)" '


### PR DESCRIPTION
**Description**
Fixes #1879 

1. Corrects the setting up starting/ending indices for sub axis to support decreasing/increasing arrays
2. Adds a select type before writing the data to correctly send subaxis data
3. Improves test by adding a test with a decreasing zaxis + adds checks to ensure the data was written correctly

**How Has This Been Tested?**
CI + Test case from Fabien

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

