### PR TITLE
remove use_mpp_io namelist from FMS source code

### DIFF
--- a/amip_interp/amip_interp.F90
+++ b/amip_interp/amip_interp.F90
@@ -347,7 +347,6 @@ end type amip_interp_type
                                    !!      during forecast:  use_ncep_sst = .T.;  no_anom_sst = .F.
  logical :: use_ncep_ice = .false. !< For seasonal forecast: use_ncep_ice = .F.
  logical :: interp_oi_sst = .false. !< changed to false for regular runs
- logical :: use_mpp_io = .false. !< Set to .true. to use mpp_io, otherwise fms2io is used
 
  namelist /amip_interp_nml/ use_ncep_sst, no_anom_sst, use_ncep_ice,  tice_crit, &
                             interp_oi_sst, data_set, date_out_of_range,          &
@@ -356,8 +355,7 @@ end type amip_interp_type
                             sst_pert, sst_pert_type, do_sst_pert,                &
                             use_daily,                                           &
                             ! end add by JHC
-                            verbose, i_sst, j_sst, forecast_mode,                &
-                            use_mpp_io
+                            verbose, i_sst, j_sst, forecast_mode
 
 !-----------------------------------------------------------------------
 
@@ -384,12 +382,6 @@ contains
         write (iunit,nml=amip_interp_nml)
     endif
 
-    if (use_mpp_io) then
-            !! USE_MPP_IO_WARNING
-            call mpp_error ('amip_interp_mod', &
-             'MPP_IO is no longer supported.  Please remove use_mpp_io from amip_interp_nml',&
-              FATAL)
-    endif
     if ( .not. use_ncep_sst ) interp_oi_sst = .false.
 
 !   ---- freezing point of sea water in deg K ---

--- a/diag_manager/diag_data.F90
+++ b/diag_manager/diag_data.F90
@@ -386,7 +386,6 @@ use platform_mod
   LOGICAL :: prepend_date = .TRUE. !< Should the history file have the start date prepended to the file name.
                                    !! <TT>.TRUE.</TT> is only supported if the diag_manager_init
                                    !! routine is called with the optional time_init parameter.
-  LOGICAL :: use_mpp_io = .false. !< false is fms2_io (default); true is mpp_io
   LOGICAL :: use_refactored_send = .false. !< Namelist flag to use refactored send_data math funcitons.
   LOGICAL :: use_modern_diag = .false. !< Namelist flag to use the modernized diag_manager code
   LOGICAL :: use_clock_average = .false. !< .TRUE. if the averaging of variable is done based on the clock
@@ -426,7 +425,6 @@ use platform_mod
   TYPE(file_type), SAVE, ALLOCATABLE :: files(:)
   TYPE(input_field_type), ALLOCATABLE :: input_fields(:)
   TYPE(output_field_type), ALLOCATABLE :: output_fields(:)
-  ! used if use_mpp_io = .false.
   type(FmsNetcdfUnstructuredDomainFile_t),allocatable, target :: fileobjU(:)
   type(FmsNetcdfDomainFile_t),allocatable, target :: fileobj(:)
   type(FmsNetcdfFile_t),allocatable, target :: fileobjND(:)

--- a/diag_manager/diag_manager.F90
+++ b/diag_manager/diag_manager.F90
@@ -200,7 +200,6 @@ use platform_mod
   !     The values are defined as <TT>GLO_REG_VAL</TT> (-999) and <TT>GLO_REG_VAL_ALT</TT>
   !     (-1) in <TT>diag_data_mod</TT>.
   !   </DATA>
-  !   <DATA NAME="use_mpp_io" TYPE="LOGICAL" DEFAULT=".false.">
   !    Set to true, diag_manager uses mpp_io.  Default is fms2_io.
   !   </DATA>
   ! </NAMELIST>
@@ -233,7 +232,7 @@ use platform_mod
        & use_cmor, issue_oor_warnings, oor_warnings_fatal, oor_warning, pack_size,&
        & max_out_per_in_field, flush_nc_files, region_out_use_alt_value, max_field_attributes, output_field_type,&
        & max_file_attributes, max_axis_attributes, prepend_date, DIAG_FIELD_NOT_FOUND, diag_init_time, diag_data_init,&
-       & use_mpp_io, use_refactored_send, &
+       & use_refactored_send, &
        & use_modern_diag, use_clock_average, diag_null, pack_size_str
   USE diag_data_mod, ONLY:  fileobj, fileobjU, fnum_for_domain, fileobjND
   USE diag_table_mod, ONLY: parse_diag_table

--- a/diag_manager/diag_manager.F90
+++ b/diag_manager/diag_manager.F90
@@ -200,8 +200,6 @@ use platform_mod
   !     The values are defined as <TT>GLO_REG_VAL</TT> (-999) and <TT>GLO_REG_VAL_ALT</TT>
   !     (-1) in <TT>diag_data_mod</TT>.
   !   </DATA>
-  !    Set to true, diag_manager uses mpp_io.  Default is fms2_io.
-  !   </DATA>
   ! </NAMELIST>
 
   USE time_manager_mod, ONLY: set_time, set_date, get_time, time_type, OPERATOR(>=), OPERATOR(>),&

--- a/exchange/xgrid.F90
+++ b/exchange/xgrid.F90
@@ -165,12 +165,9 @@ integer :: nsubset = 0 !< Number of processors to read exchange grid information
                        !! processor count. Try to set nsubset = mpp_npes/MPI_rank_per_node.
 logical :: do_alltoall = .true.
 logical :: do_alltoallv = .false.
-logical :: use_mpp_io = .false.!< use_mpp_io Default = .false. When true, uses mpp_io for IO.
-                               !! When false, uses fms2_io for IO.
 !> @brief xgrid nml
 namelist /xgrid_nml/ make_exchange_reproduce, interp_method, debug_stocks, xgrid_clocks_on, &
-    monotonic_exchange, nsubset, do_alltoall, do_alltoallv, &
-    use_mpp_io
+    monotonic_exchange, nsubset, do_alltoall, do_alltoallv
 
 integer :: remapping_method
 
@@ -537,12 +534,6 @@ subroutine xgrid_init(remap_method)
   out_unit = stdout()
   if ( mpp_pe() == mpp_root_pe() ) write (iunit,nml=xgrid_nml)
 
-  if (use_mpp_io) then
-          ! FATAL error if trying to use mpp_io
-        call error_mesg('xgrid_init', &
-             'MPP_IO is no longer supported.  Please remove use_mpp_io from namelists',&
-              FATAL)
-  endif
 !--------- check interp_method has suitable value
 !--- when monotonic_exchange is true, interp_method must be second order.
 
@@ -2116,7 +2107,7 @@ end subroutine setup_xmap
 function get_nest_contact_fms2_io(fileobj, tile_nest_out, tile_parent_out, is_nest_out, &
                           ie_nest_out, js_nest_out, je_nest_out, is_parent_out, &
                           ie_parent_out, js_parent_out, je_parent_out) &
-                        result(get_nest_contact) !< This is needed for use_mpp_io
+                        result(get_nest_contact)
 type(FmsNetcdfFile_t), intent(in)  :: fileobj
 integer,               intent(out) :: tile_nest_out, tile_parent_out
 integer,               intent(out) :: is_nest_out, ie_nest_out

--- a/interpolator/include/interpolator.inc
+++ b/interpolator/include/interpolator.inc
@@ -134,10 +134,6 @@ if (mpp_pe() == mpp_root_pe() ) write (stdlog(), nml=interpolator_nml)
 module_is_initialized = .true.
 
 endif !> if (module_is_initilized)
-if (use_mpp_io) then
-   call mpp_error(FATAL, "Interpolator::nml=interpolator_nml " //&
-           'MPP_IO is no longer supported.  Please remove from use_mpp_io from interpolator_nml')
-endif
 
 clim_type%FMS_INTP_TYPE_%is_allocated = .true.
 

--- a/interpolator/interpolator.F90
+++ b/interpolator/interpolator.F90
@@ -400,10 +400,9 @@ logical :: read_all_on_init = .false.          !< No description
 integer :: verbose = 0                         !< No description
 logical :: conservative_interp = .true.        !< No description
 logical :: retain_cm3_bug = .false.            !< No description
-logical :: use_mpp_io = .false. !< Set to true to use mpp_io, otherwise fms2io is used
 
 namelist /interpolator_nml/    &
-                             read_all_on_init, verbose, conservative_interp, retain_cm3_bug, use_mpp_io
+                             read_all_on_init, verbose, conservative_interp, retain_cm3_bug
 
 contains
 


### PR DESCRIPTION
**Description**
removes the deprecated use_mpp_io namelist parameter and associated code blocks from the FMS source code. 

Fixes #1881 

**How Has This Been Tested?**


**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] `make distcheck` passes

