### PR TITLE
fix mpp_error output bug

### DIFF
--- a/mpp/include/mpp_util_mpi.inc
+++ b/mpp/include/mpp_util_mpi.inc
@@ -54,7 +54,7 @@ subroutine mpp_error_basic( errortype, errormsg )
      text_errortype = 'WARNING: non-existent errortype (must be NOTE|WARNING|FATAL)'
   end select
 
-  text = text_errortype 
+  text = text_errortype
   if( npes.GT.1 ) write( text,'(a,i6)' ) trim(text_errortype) // ' from PE', pe   !this is the mpp part
   if( PRESENT(errormsg) )text = trim(text) // ': ' // trim(errormsg)
 !$OMP CRITICAL (MPP_ERROR_CRITICAL)

--- a/mpp/include/mpp_util_mpi.inc
+++ b/mpp/include/mpp_util_mpi.inc
@@ -54,6 +54,7 @@ subroutine mpp_error_basic( errortype, errormsg )
      text_errortype = 'WARNING: non-existent errortype (must be NOTE|WARNING|FATAL)'
   end select
 
+  text = text_errortype 
   if( npes.GT.1 ) write( text,'(a,i6)' ) trim(text_errortype) // ' from PE', pe   !this is the mpp part
   if( PRESENT(errormsg) )text = trim(text) // ': ' // trim(errormsg)
 !$OMP CRITICAL (MPP_ERROR_CRITICAL)


### PR DESCRIPTION
**Description**
Fixes a un-initialized variable for GCC 15.

This bug was causing any strings output by mpp_error to be garbage non-ascii values, which is particularly annoying.

Fixes #1858 

**How Has This Been Tested?**
make check with gcc 15 on amd box

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

