### PR TITLE
Move inverse_permutation to mpp_mod

### DIFF
--- a/interpolator/interpolator.F90
+++ b/interpolator/interpolator.F90
@@ -22,14 +22,15 @@
 
 module interpolator_mod
 
-use mpp_mod,           only : mpp_error, &
-                              FATAL,     &
-                              mpp_pe,    &
-                              mpp_init,  &
-                              mpp_exit,  &
-                              mpp_npes,  &
-                              WARNING,   &
-                              NOTE,      &
+use mpp_mod,           only : inverse_permutation, &
+                              mpp_error,           &
+                              FATAL,               &
+                              mpp_pe,              &
+                              mpp_init,            &
+                              mpp_exit,            &
+                              mpp_npes,            &
+                              WARNING,             &
+                              NOTE,                &
                               input_nml_file
 use mpp_domains_mod,   only : mpp_domains_init,      &
                               mpp_update_domains,    &
@@ -767,33 +768,6 @@ if (string(len:len) == CHAR(0)) len = len -1
 chomp = string(:len)
 
 end function chomp
-
-!> @brief Produce an inverse permutation. For example, transform [2, 3, 1, 4] into [3, 1, 2, 4].
-!!
-!! @param [in] <x> The original permutation vector
-!! @param [out] <x> The inverted permutation vector
-subroutine inverse_permutation(x, y)
-  use fms_string_utils_mod, only: string
-  integer, intent(in) :: x(:)
-  integer, intent(out) :: y(size(x))
-  integer :: i, n
-
-  y = 0
-
-  n = size(x)
-  do i=1,n
-    if (x(i).ge.1 .and. x(i).le.n) then
-      y(x(i)) = i
-    else
-      call mpp_error(FATAL, "interpolator_mod: Invalid dim_order. Values must be in the range from 1 through " &
-                            // string(n) // ".")
-    endif
-  enddo
-
-  if (any(y.eq.0)) then
-    call mpp_error(FATAL, "interpolator_mod: Invalid dim_order. Values must be non-repeating.")
-  endif
-end subroutine inverse_permutation
 !
 !########################################################################
 

--- a/mpp/include/mpp_util.inc
+++ b/mpp/include/mpp_util.inc
@@ -1571,7 +1571,6 @@ end function rarray_to_char
   !! @param [in] <x> The original permutation vector
   !! @param [out] <y> The inverted permutation vector
   subroutine inverse_permutation(x, y)
-    use fms_string_utils_mod, only: string
     integer, intent(in) :: x(:)
     integer, intent(out) :: y(size(x))
     integer :: i, n
@@ -1583,8 +1582,13 @@ end function rarray_to_char
       if (x(i).ge.1 .and. x(i).le.n) then
         y(x(i)) = i
       else
-        call mpp_error(FATAL, "inverse_permutation: Invalid dim_order. Values must be in the range from 1 through " &
-                              // string(n) // ".")
+        block
+          character(2) :: nstr
+
+          write (nstr, "(I0)") n
+          call mpp_error(FATAL, "inverse_permutation: Invalid dimension map. &
+                                 Values must be in the range from 1 to " // trim(nstr) // ".")
+        end block
       endif
     enddo
 

--- a/mpp/include/mpp_util.inc
+++ b/mpp/include/mpp_util.inc
@@ -1562,4 +1562,34 @@ end function rarray_to_char
     call mpp_broadcast(Content, LENGTH, from_pe, PELIST=PELIST)
 
   end subroutine read_ascii_file
+
+  !> @brief Produce an inverse permutation. For example, transform [2, 3, 1, 4] to [3, 1, 2, 4].
+  !!
+  !! The purpose of this subroutine is to convert between (memory dimension) -> (logical dimension) and
+  !! (logical dimension) -> (memory dimension) maps.
+  !!
+  !! @param [in] <x> The original permutation vector
+  !! @param [out] <y> The inverted permutation vector
+  subroutine inverse_permutation(x, y)
+    use fms_string_utils_mod, only: string
+    integer, intent(in) :: x(:)
+    integer, intent(out) :: y(size(x))
+    integer :: i, n
+
+    y = 0
+
+    n = size(x)
+    do i=1,n
+      if (x(i).ge.1 .and. x(i).le.n) then
+        y(x(i)) = i
+      else
+        call mpp_error(FATAL, "inverse_permutation: Invalid dim_order. Values must be in the range from 1 through " &
+                              // string(n) // ".")
+      endif
+    enddo
+
+    if (any(y.eq.0)) then
+      call mpp_error(FATAL, "inverse_permutation: Invalid dim_order. Values must be non-repeating.")
+    endif
+  end subroutine inverse_permutation
 !> @}

--- a/mpp/mpp.F90
+++ b/mpp/mpp.F90
@@ -211,7 +211,7 @@ private
   public :: read_ascii_file, read_input_nml, mpp_clock_begin, mpp_clock_end
   public :: get_ascii_file_num_lines, get_ascii_file_num_lines_and_length
   public :: mpp_record_time_start, mpp_record_time_end
-  public :: mpp_commID, mpp_comm
+  public :: mpp_commID, mpp_comm, inverse_permutation
 
   !--- public interface from mpp_comm.h ------------------------------
   public :: mpp_chksum, mpp_max, mpp_min, mpp_sum, mpp_transmit, mpp_send, mpp_recv


### PR DESCRIPTION
**Description**
Move `inverse_permutation` from `interpolator_mod` to `mpp_mod` so that it can be more cleanly reused by other parts of the codebase. The purpose of this subroutine is to convert between (memory dimension) --> (logical dimension) and (logical dimension) --> (memory dimension) maps.

**How Has This Been Tested?**
CI only.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes