### PR TITLE
Fix divide by zero in time_manager

### DIFF
--- a/cmake/compiler_flags_IntelLLVM_Fortran.cmake
+++ b/cmake/compiler_flags_IntelLLVM_Fortran.cmake
@@ -11,5 +11,5 @@ set(CMAKE_Fortran_LINK_FLAGS "-fuse-ld=lld")
 
 # ufs flags to repoduce old behavior
 set(CMAKE_Fortran_SHARED_FLAGS "-fpp -fno-alias -auto -safe-cray-ptr -ftz -assume byterecl -align array64byte -nowarn -traceback")
-set(CMAKE_Fortran_FLAGS_RELEASEUFS "-O2 -debug minimal -nowarn -qoverride-limits -qno-opt-dynamic-align ${CMAKE_Fortran_SHARED_FLAGS}")
+set(CMAKE_Fortran_FLAGS_RELEASEUFS "-O2 -debug minimal -fp-model=precise -fp-speculation=safe -nowarn -qoverride-limits -qno-opt-dynamic-align ${CMAKE_Fortran_SHARED_FLAGS}")
 set(CMAKE_Fortran_FLAGS_DEBUGUFS "-g -O0 -check -check noarg_temp_created -check nopointer -warn -warn noerrors -fpe0 -ftrapuv ${CMAKE_Fortran_SHARED_FLAGS}")


### PR DESCRIPTION
**Description**

Add flags [-fp-model=precise](https://www.intel.com/content/www/us/en/docs/fortran-compiler/developer-guide-reference/2025-2/fp-model-fp.html) [-fp-speculation=safe](https://www.intel.com/content/www/us/en/docs/fortran-compiler/developer-guide-reference/2025-2/fp-speculation-qfp-speculation.html) for Intel OneAPI Fortran `ifx`

Fixes #1891

No dependencies required for this change.

**How Has This Been Tested?**

Testing:

- modifying the [spack-packages recipe for FMS](https://github.com/JCSDA/spack-packages/blob/release/2.1/repos/spack_repo/builtin/packages/fms/package.py) to [inject flags](https://github.com/JCSDA/spack-packages/blob/release/2.1/repos/spack_repo/builtin/packages/fms/package.py#L173-175) `-fp-model=precise -fp-speculation=safe` into the package build.  Subsequent UFS WM regression tests succeed / do not generate divide-by-zero errors.
- re-created [Dusan Jovic's reproducer test](https://github.com/NOAA-GFDL/FMS/issues/1891#issue-4625497604), and build / ran it against the updated spack-stack build noted above. See: `/gpfs/f6/epic/scratch/Richard.Grubin/test_time_manager`
  - compare with: `/gpfs/f6/drsa-hurr1/scratch/Dusan.Jovic/ufs/ss210/test_time_manager`
  - for both reproducer tests: run `build.sh`
- cloned [my repository fork for the bugfix branch](https://github.com/rickgrubin-noaa/FMS/tree/bugfix/time_manager)
  - configured and executed a `cmake` build
  - ran tests for `time_manager`
    - see attached file [test.time_manager.log](https://github.com/user-attachments/files/29868879/test.time_manager.log)

 

Host / compiler info:

- Host: gaea-c6
- OS
```
% cat /etc/os-release
NAME="SLES"
VERSION="15-SP6"
VERSION_ID="15.6"
PRETTY_NAME="SUSE Linux Enterprise Server 15 SP6"
ID="sles"
```
- Compiler: Intel oneAPI@2025.2.1


**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] `make distcheck` passes

