### PR TITLE
Update mpp_do_redistribute.fh

### DIFF
--- a/mpp/include/mpp_do_redistribute.fh
+++ b/mpp/include/mpp_do_redistribute.fh
@@ -136,11 +136,6 @@ subroutine MPP_DO_REDISTRIBUTE_3D_( f_in, f_out, d_comm, d_type, axis_to_storage
          'MPP_DO_REDISTRIBUTE_3D_: chunk counts must be positive')
   endif
 
-  if (any(chunk_shape_in < 1) .OR. any(chunk_shape_out < 1)) then
-    call mpp_error(FATAL, &
-         'MPP_DO_REDISTRIBUTE_3D_: chunk extents must be positive')
-  endif
-
   total_chunks = sum(nchunks)
 
   !--------------------------------------------------------------------


### PR DESCRIPTION
**Description**
Removed new check on send/recv buffer extents. Some ranks participate on only one side of the redistribution, so a zero-sized local input or output chunk is expected. The underlying redistribution path already handles this case, but the new check rejected it before the communication logic.

Also, resolves previous test_mpp_redistribute_init failure in intel oneapi CI but still produces failures with test_time_interp2.

**How Has This Been Tested?**
Gaea fre/bronx-23

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [ ] `make distcheck` passes

