### PR TITLE
Return if the fields were never allocated by the field manager.

### DIFF
--- a/field_manager/field_manager.F90
+++ b/field_manager/field_manager.F90
@@ -1392,6 +1392,8 @@ integer :: j
 
 module_is_initialized = .false.
 
+if (.NOT. allocated(fields)) return
+
 do j=1,size(fields)
   if(allocated(fields(j)%methods)) deallocate(fields(j)%methods)
 end do


### PR DESCRIPTION
**Description**
Return if the fields were never allocated by the field manager.

Fixes #1901

**How Has This Been Tested?**
CI

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

