### PR TITLE
refactor time_interp test to fix CI failures

### DIFF
--- a/.github/workflows/github_autotools_gnu.yml
+++ b/.github/workflows/github_autotools_gnu.yml
@@ -26,6 +26,7 @@ jobs:
         # test_mpp_clock_begin_end_id is an expected fail that is passing, only happens in the CI
         # test_time_interp2 tests fail from file issues, only happens in the CI
         SKIP_TESTS: "test_time_none.10 test_time_sum.10 test_time_avg.10 test_time_min.10 test_time_max.10 test_time_pow.10 test_time_rms.10 test_mpp_clock_begin_end_id.10 test_time_interp2.7 test_time_interp2.8"
+        TEST_VERBOSE: 1
     steps:
     - name: Checkout code
       uses: actions/checkout@v6.0.1

--- a/.github/workflows/github_autotools_gnu.yml
+++ b/.github/workflows/github_autotools_gnu.yml
@@ -25,7 +25,7 @@ jobs:
         # diag manager openmp + logical mask tests fail with gcc, these are reproducible outside the CI
         # test_mpp_clock_begin_end_id is an expected fail that is passing, only happens in the CI
         # test_time_interp2 tests fail from file issues, only happens in the CI
-        SKIP_TESTS: "test_time_none.10 test_time_sum.10 test_time_avg.10 test_time_min.10 test_time_max.10 test_time_pow.10 test_time_rms.10 test_mpp_clock_begin_end_id.10 test_time_interp2.7 test_time_interp2.8"
+        SKIP_TESTS: "test_time_none.10 test_time_sum.10 test_time_avg.10 test_time_min.10 test_time_max.10 test_time_pow.10 test_time_rms.10 test_mpp_clock_begin_end_id.10"
         TEST_VERBOSE: 1
     steps:
     - name: Checkout code

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,8 +69,6 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "NVHPC")
   set(ENABLE_QUAD_PRECISION OFF)
   message(WARNING "NVHPC does not support building FMS with QUAD_PRECISION!")
 endif()
-# Testing-specific options
-set(OVERSUBSCRIBE_FLAG " --oversubscribe " CACHE STRING "Flag for mpirun to use more cores than available")
 
 if(32BIT)
   list(APPEND kinds "r4")
@@ -595,26 +593,50 @@ install(
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
-### Unit Testing
-include(CTest)
-
-# TODO autotools also checks if srun is available
-set(MPI_LAUNCHER "mpirun")
-# used in the test-lib.sh.in to make it behave differently when parsed by cmake
-set(USING_CMAKE "true")
-set(OVERSUBSCRIBE "${OVERSUBSCRIBE_FLAG}")
-message(STATUS "Using '${OVERSUBSCRIBE}' flag to oversubscribe ranks in test scripts")
-
-# set the fms library to link tests with based on whats built
-if(NOT kinds)
-  set(fmsLibraryName FMS::fms)
-elseif(64BIT)
-  set(fmsLibraryName FMS::fms_r8)
-elseif(32BIT)
-  set(fmsLibraryName FMS::fms_r4)
-endif()
 
 if(UNIT_TESTS)
+
+  # Testing-specific options
+  set(OVERSUBSCRIBE_FLAG "--oversubscribe" CACHE STRING "Flag for mpirun to use more cores than available")
+
+  ### Unit Testing
+  include(CTest)
+
+  set(MPI_LAUNCHER "${MPIEXEC_EXECUTABLE}")
+  if(NOT MPI_LAUNCHER)
+    set(MPI_LAUNCHER "mpirun")
+  endif()
+
+  # Open MPI requires an oversubscribe flag when tests launch more ranks than
+  # available slots; other launchers (e.g., MPICH Hydra) generally do not.
+  set(OVERSUBSCRIBE "")
+  execute_process(
+    COMMAND ${MPI_LAUNCHER} --version
+    OUTPUT_VARIABLE _mpi_version_out
+    ERROR_VARIABLE _mpi_version_err
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_STRIP_TRAILING_WHITESPACE
+    RESULT_VARIABLE _mpi_version_rc)
+  string(CONCAT _mpi_version_text "${_mpi_version_out}" "\n" "${_mpi_version_err}")
+  if(_mpi_version_rc EQUAL 0 AND _mpi_version_text MATCHES "(Open[ ]*MPI|OpenRTE)")
+    set(OVERSUBSCRIBE "${OVERSUBSCRIBE_FLAG}")
+    message(STATUS "Detected MPI launcher '${MPI_LAUNCHER}'; using oversubscribe flag '${OVERSUBSCRIBE}' for tests")
+  else()
+    message(STATUS "MPI launcher '${MPI_LAUNCHER}' does not require oversubscribe flag; leaving it unset for tests")
+  endif()
+
+  # used in the test-lib.sh.in to make it behave differently when parsed by cmake
+  set(USING_CMAKE "true")
+
+  # set the fms library to link tests with based on whats built
+  if(NOT kinds)
+    set(fmsLibraryName FMS::fms)
+  elseif(64BIT)
+    set(fmsLibraryName FMS::fms_r8)
+  elseif(32BIT)
+    set(fmsLibraryName FMS::fms_r4)
+  endif()
+
   # parse and add build info to test script util file
   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/test_fms/test-lib.sh.in ${CMAKE_CURRENT_SOURCE_DIR}/test-lib.sh
                 @ONLY)
@@ -804,6 +826,7 @@ if(UNIT_TESTS)
     test_fms/random_numbers/test_random_numbers.F90
     test_fms/sat_vapor_pres/test_sat_vapor_pres.F90
     test_fms/time_interp/test_time_interp.F90
+    test_fms/time_interp/test_time_interp_external_create_input.F90
     test_fms/time_interp/test_time_interp_external.F90
     test_fms/time_interp/test_time_interp_conservative_hi.F90
     test_fms/topography/test_topography.F90

--- a/test_fms/time_interp/Makefile.am
+++ b/test_fms/time_interp/Makefile.am
@@ -29,12 +29,15 @@ LDADD = $(top_builddir)/libFMS/libFMS.la
 
 # Build these test programs.
 check_PROGRAMS = test_time_interp_r4 test_time_interp_r8 \
+                 test_time_interp_external_create_input_r4 test_time_interp_external_create_input_r8 \
                  test_time_interp_external_r4 test_time_interp_external_r8 \
                  test_time_interp_conservative_hi_r4 test_time_interp_conservative_hi_r8
 
 # These are the sources for the tests.
 test_time_interp_r4_SOURCES = test_time_interp.F90
 test_time_interp_r8_SOURCES = test_time_interp.F90
+test_time_interp_external_create_input_r4_SOURCES = test_time_interp_external_create_input.F90
+test_time_interp_external_create_input_r8_SOURCES = test_time_interp_external_create_input.F90
 test_time_interp_external_r4_SOURCES = test_time_interp_external.F90
 test_time_interp_external_r8_SOURCES = test_time_interp_external.F90
 test_time_interp_conservative_hi_r4_SOURCES = test_time_interp_conservative_hi.F90
@@ -44,6 +47,8 @@ test_time_interp_conservative_hi_r8_SOURCES = test_time_interp_conservative_hi.F
 # adds r8 flag, otherwise no-flag default is 4
 test_time_interp_r4_CPPFLAGS=-DTEST_FMS_KIND_=4 -I$(MODDIR)
 test_time_interp_r8_CPPFLAGS=-DTEST_FMS_KIND_=8 -I$(MODDIR)
+test_time_interp_external_create_input_r4_CPPFLAGS=-DTEST_FMS_KIND_=4 -I$(MODDIR)
+test_time_interp_external_create_input_r8_CPPFLAGS=-DTEST_FMS_KIND_=8 -I$(MODDIR)
 test_time_interp_external_r4_CPPFLAGS=-DTEST_FMS_KIND_=4 -I$(MODDIR)
 test_time_interp_external_r8_CPPFLAGS=-DTEST_FMS_KIND_=8 -I$(MODDIR)
 test_time_interp_conservative_hi_r4_CPPFLAGS=-DTEST_FMS_KIND_=4 -I$(MODDIR)

--- a/test_fms/time_interp/test_time_interp2.sh
+++ b/test_fms/time_interp/test_time_interp2.sh
@@ -55,25 +55,28 @@ test_expect_success "create input files for time_interp_external with r8_kind" '
 test_expect_success "test time interpolation external with r8_kind (julian)" '
   mpirun -n 4 ./test_time_interp_external_r8
 '
+sed -i 's/julian/no_leap/' input.nml
+test_expect_success "test time interpolation external with r8_kind (no_leap)" '
+  mpirun -n 4 ./test_time_interp_external_r8
+'
+test_expect_success "test time interpolation external with conservative horizontal interp r8_kind" '
+  mpirun -n 4 ./test_time_interp_conservative_hi_r8
+'
+
 test_expect_success "create input files for time_interp_external with r4_kind" '
   mpirun -n 4 ./test_time_interp_external_create_input_r4
 '
 
+sed -i 's/no_leap/julian' input.nml
 test_expect_success "test time interpolation external with r4_kind (julian)" '
   mpirun -n 4 ./test_time_interp_external_r4
 '
 sed -i 's/julian/no_leap/' input.nml
 
-test_expect_success "test time interpolation external with r8_kind (no_leap)" '
-  mpirun -n 4 ./test_time_interp_external_r8
-'
 test_expect_success "test time interpolation external with r4_kind (no_leap)" '
   mpirun -n 4 ./test_time_interp_external_r4
 '
 
-test_expect_success "test time interpolation external with conservative horizontal interp r8_kind" '
-  mpirun -n 4 ./test_time_interp_conservative_hi_r8
-'
 test_expect_success "test time interpolation external with conservative horizontal interp r4_kind" '
   mpirun -n 4 ./test_time_interp_conservative_hi_r4
 '

--- a/test_fms/time_interp/test_time_interp2.sh
+++ b/test_fms/time_interp/test_time_interp2.sh
@@ -49,9 +49,16 @@ cal_type="julian"
 /
 _EOF
 
+test_expect_success "create input files for time_interp_external with r8_kind" '
+  mpirun -n 4 ./test_time_interp_external_create_input_r8
+'
 test_expect_success "test time interpolation external with r8_kind (julian)" '
   mpirun -n 4 ./test_time_interp_external_r8
 '
+test_expect_success "create input files for time_interp_external with r4_kind" '
+  mpirun -n 4 ./test_time_interp_external_create_input_r4
+'
+
 test_expect_success "test time interpolation external with r4_kind (julian)" '
   mpirun -n 4 ./test_time_interp_external_r4
 '

--- a/test_fms/time_interp/test_time_interp_external.F90
+++ b/test_fms/time_interp/test_time_interp_external.F90
@@ -22,7 +22,7 @@ program test_time_interp_external
 use constants_mod,             only : constants_init
 use fms_mod,                   only : check_nml_error
 use mpp_mod,                   only : mpp_init, mpp_exit, mpp_npes, stdout, stdlog, FATAL, mpp_error
-use mpp_mod,                   only : input_nml_file, mpp_pe, mpp_root_pe, mpp_sync
+use mpp_mod,                   only : input_nml_file
 use mpp_domains_mod,           only : mpp_domains_init, domain2d, mpp_define_layout, mpp_define_domains
 use mpp_domains_mod, only : mpp_global_sum, mpp_global_max, mpp_global_min, BITWISE_EXACT_SUM, mpp_get_compute_domain
 use mpp_domains_mod,           only : mpp_domains_set_stack_size
@@ -35,8 +35,7 @@ use time_manager_mod,          only : NOLEAP
 use horiz_interp_mod,          only : horiz_interp, horiz_interp_init, horiz_interp_new, horiz_interp_del, &
                                     & horiz_interp_type
 use axis_utils2_mod,           only : axis_edges
-use fms2_io_mod,               only : FmsNetcdfFile_t, fms2_io_init, open_file, close_file, write_data, register_axis
-use fms2_io_mod,               only : register_field, unlimited, register_variable_attribute
+use fms2_io_mod,               only : FmsNetcdfFile_t, fms2_io_init
 use platform_mod
 
 implicit none
@@ -68,8 +67,6 @@ real(TEST_FMS_KIND_)               :: lat_out(180,89) !< lon grid to interpolate
 integer            :: outunit !< stdout unit number
 type(FmsNetcdfFile_t) :: fileobj !< fileobj
 character(len=12)  :: axis_names(4) = (/ "lon ", "lat ", "time", "none"/) !< axis_names
-real(TEST_FMS_KIND_), allocatable  :: data_in(:,:)  !< data added to file
-real(TEST_FMS_KIND_), allocatable  :: data_in_1d(:)  !< data added to file
 
 namelist /test_time_interp_external_nml/ cal_type
 
@@ -83,9 +80,6 @@ call horiz_interp_init
 
 read (input_nml_file, test_time_interp_external_nml, iostat=ierr)
 ierr = check_nml_error (ierr, 'test_time_interp_external_nml')
-
-call create_input_files
-call create_input_files_1d
 
 select case (trim(cal_type))
 case ('julian')
@@ -106,91 +100,6 @@ call mpp_exit
 
 
  contains
-
-    !> Writes netcdf input files with fields to interpolate
-    subroutine create_input_files
-        !< Create a file to test with:
-        if (mpp_pe() .eq. mpp_root_pe()) then
-            if (open_file(fileobj, filename, "overwrite")) then
-                call register_axis(fileobj, "lon", 179)
-                call register_axis(fileobj, "lat", 89)
-                call register_axis(fileobj, "time", unlimited)
-
-                call register_field(fileobj, "lon", "double", dimensions=(/"lon"/))
-                call register_field(fileobj, "lat", "double", dimensions=(/"lat"/))
-                call register_field(fileobj, "time", "double", dimensions=(/"time"/))
-
-                call register_field(fileobj, fieldname, "double", dimensions=(/"lon ", "lat ", "time"/))
-                call register_field(fileobj, trim(fieldname)//"_random", "double", dimensions=(/"lon ","lat ","time"/))
-
-                call register_variable_attribute(fileobj, "lon", "cartesian_axis", "X", str_len=1)
-                call register_variable_attribute(fileobj, "lat", "cartesian_axis", "Y", str_len=1)
-
-                call register_variable_attribute(fileobj, "time", "cartesian_axis", "T", str_len=1)
-                call register_variable_attribute(fileobj, "time", "units", "days since 1800-01-01 00:00:00",str_len=30)
-                call register_variable_attribute(fileobj, "time", "calendar", "julian", str_len=6)
-
-                !call register_global_attribute(fileobj, "global_scalar", 1024.0_r8_kind)
-
-                call write_data(fileobj, "lat", (/(-90.0_kindl+i*2.0_kindl,i=1,89)/))
-                call write_data(fileobj, "lon", (/(-180.0_kindl+i*2.0_kindl,i=1,179)/))
-                call write_data(fileobj, "time", (/(1+i*2, i=0,2)/))
-
-                allocate(data_in(179, 89))
-                do i=0, 2
-                    data_in = real((1+i*2), TEST_FMS_KIND_)
-                    call write_data(fileobj, fieldname, data_in, unlim_dim_level=i+1)
-                    call random_number(data_in)
-                    call write_data(fileobj, trim(fieldname)//"_random", data_in, unlim_dim_level=i+1)
-                enddo
-                call close_file(fileobj)
-                deallocate(data_in)
-            endif
-        endif
-        !< Wait for the root pe to catch up
-        call mpp_sync()
-    end subroutine
-
-
-    !> Writes netcdf input files with fields to interpolate
-    subroutine create_input_files_1d
-        !< Create a file to test with:
-        if (mpp_pe() .eq. mpp_root_pe()) then
-            if (open_file(fileobj, filename_1d, "overwrite")) then
-                call register_axis(fileobj, "lon", 179)
-                call register_axis(fileobj, "time", unlimited)
-
-                call register_field(fileobj, "lon", "double", dimensions=(/"lon"/))
-                call register_field(fileobj, "time", "double", dimensions=(/"time"/))
-
-                call register_field(fileobj, fieldname_1d_band, "double", dimensions=(/"lon ", "time"/))
-                call register_field(fileobj, trim(fieldname_1d_band2), "double", dimensions=(/"lon ","time"/))
-
-                call register_variable_attribute(fileobj, "lon", "cartesian_axis", "X", str_len=1)
-
-                call register_variable_attribute(fileobj, "time", "cartesian_axis", "T", str_len=1)
-                call register_variable_attribute(fileobj, "time", "units", "days since 1800-01-01 00:00:00",str_len=30)
-                call register_variable_attribute(fileobj, "time", "calendar", "julian", str_len=6)
-
-                !call register_global_attribute(fileobj, "global_scalar", 1024.0_r8_kind)
-
-                call write_data(fileobj, "lon", (/(-180.0_kindl+i*2.0_kindl,i=1,179)/))
-                call write_data(fileobj, "time", (/(1+i*2, i=0,2)/))
-
-                allocate(data_in_1d(179))
-                do i=0, 2
-                    data_in_1d = real((1+i*2), TEST_FMS_KIND_)
-                    call write_data(fileobj, fieldname_1d_band, data_in_1d, unlim_dim_level=i+1)
-                    data_in_1d = - data_in_1d
-                    call write_data(fileobj, trim(fieldname_1d_band2), data_in_1d, unlim_dim_level=i+1)
-                enddo
-                call close_file(fileobj)
-                deallocate(data_in_1d)
-            endif
-        endif
-        !< Wait for the root pe to catch up
-        call mpp_sync()
-    end subroutine create_input_files_1d
 
     subroutine time_interpolate_3d_data
         real(TEST_FMS_KIND_), allocatable  :: data_d_3d(:,:,:) !< interpolated data in compute domain

--- a/test_fms/time_interp/test_time_interp_external_create_input.F90
+++ b/test_fms/time_interp/test_time_interp_external_create_input.F90
@@ -1,0 +1,131 @@
+!***********************************************************************
+!*                             Apache License 2.0
+!*
+!* This file is part of the GFDL Flexible Modeling System (FMS).
+!*
+!* Licensed under the Apache License, Version 2.0 (the "License");
+!* you may not use this file except in compliance with the License.
+!* You may obtain a copy of the License at
+!*
+!*     http://www.apache.org/licenses/LICENSE-2.0
+!*
+!* FMS is distributed in the hope that it will be useful, but WITHOUT
+!* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied;
+!* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+!* PARTICULAR PURPOSE. See the License for the specific language
+!* governing permissions and limitations under the License.
+!***********************************************************************
+
+program test_time_interp_external_create_input
+
+use constants_mod,   only : constants_init
+use mpp_mod,         only : mpp_init, mpp_exit, mpp_pe, mpp_root_pe, mpp_sync
+use mpp_domains_mod, only : mpp_domains_init
+use fms2_io_mod,     only : FmsNetcdfFile_t, fms2_io_init, open_file, close_file, write_data, register_axis
+use fms2_io_mod,     only : register_field, unlimited, register_variable_attribute
+use platform_mod,    only : r8_kind, r4_kind
+
+implicit none
+
+integer            :: i
+character(len=128) :: filename='INPUT/aerosol.climatology.nc'
+character(len=128) :: filename_1d='INPUT/solar_constant.nc'
+character(len=128) :: fieldname='so4_anthro'
+character(len=128) :: fieldname_1d_band='ssi_band'
+character(len=128) :: fieldname_1d_band2='ssi_band2'
+integer, parameter :: kindl = TEST_FMS_KIND_
+type(FmsNetcdfFile_t) :: fileobj
+real(TEST_FMS_KIND_), allocatable  :: data_in(:,:)
+real(TEST_FMS_KIND_), allocatable  :: data_in_1d(:)
+
+call mpp_init
+call constants_init
+call fms2_io_init
+call mpp_domains_init
+
+call create_input_files
+call create_input_files_1d
+
+call mpp_exit
+
+contains
+
+    !> Writes netcdf input files with fields to interpolate
+    subroutine create_input_files
+        if (mpp_pe() .eq. mpp_root_pe()) then
+            if (open_file(fileobj, filename, "overwrite")) then
+                call register_axis(fileobj, "lon", 179)
+                call register_axis(fileobj, "lat", 89)
+                call register_axis(fileobj, "time", unlimited)
+
+                call register_field(fileobj, "lon", "double", dimensions=(/"lon"/))
+                call register_field(fileobj, "lat", "double", dimensions=(/"lat"/))
+                call register_field(fileobj, "time", "double", dimensions=(/"time"/))
+
+                call register_field(fileobj, fieldname, "double", dimensions=(/"lon ", "lat ", "time"/))
+                call register_field(fileobj, trim(fieldname)//"_random", "double", dimensions=(/"lon ","lat ","time"/))
+
+                call register_variable_attribute(fileobj, "lon", "cartesian_axis", "X", str_len=1)
+                call register_variable_attribute(fileobj, "lat", "cartesian_axis", "Y", str_len=1)
+
+                call register_variable_attribute(fileobj, "time", "cartesian_axis", "T", str_len=1)
+                call register_variable_attribute(fileobj, "time", "units", "days since 1800-01-01 00:00:00",str_len=30)
+                call register_variable_attribute(fileobj, "time", "calendar", "julian", str_len=6)
+
+                call write_data(fileobj, "lat", (/(-90.0_kindl+i*2.0_kindl,i=1,89)/))
+                call write_data(fileobj, "lon", (/(-180.0_kindl+i*2.0_kindl,i=1,179)/))
+                call write_data(fileobj, "time", (/(1+i*2, i=0,2)/))
+
+                allocate(data_in(179, 89))
+                do i=0, 2
+                    data_in = real((1+i*2), TEST_FMS_KIND_)
+                    call write_data(fileobj, fieldname, data_in, unlim_dim_level=i+1)
+                    call random_number(data_in)
+                    call write_data(fileobj, trim(fieldname)//"_random", data_in, unlim_dim_level=i+1)
+                enddo
+                call close_file(fileobj)
+                deallocate(data_in)
+            endif
+        endif
+
+        call mpp_sync()
+    end subroutine create_input_files
+
+    !> Writes netcdf input files with fields to interpolate
+    subroutine create_input_files_1d
+        if (mpp_pe() .eq. mpp_root_pe()) then
+            if (open_file(fileobj, filename_1d, "overwrite")) then
+                call register_axis(fileobj, "lon", 179)
+                call register_axis(fileobj, "time", unlimited)
+
+                call register_field(fileobj, "lon", "double", dimensions=(/"lon"/))
+                call register_field(fileobj, "time", "double", dimensions=(/"time"/))
+
+                call register_field(fileobj, fieldname_1d_band, "double", dimensions=(/"lon ", "time"/))
+                call register_field(fileobj, trim(fieldname_1d_band2), "double", dimensions=(/"lon ","time"/))
+
+                call register_variable_attribute(fileobj, "lon", "cartesian_axis", "X", str_len=1)
+
+                call register_variable_attribute(fileobj, "time", "cartesian_axis", "T", str_len=1)
+                call register_variable_attribute(fileobj, "time", "units", "days since 1800-01-01 00:00:00",str_len=30)
+                call register_variable_attribute(fileobj, "time", "calendar", "julian", str_len=6)
+
+                call write_data(fileobj, "lon", (/(-180.0_kindl+i*2.0_kindl,i=1,179)/))
+                call write_data(fileobj, "time", (/(1+i*2, i=0,2)/))
+
+                allocate(data_in_1d(179))
+                do i=0, 2
+                    data_in_1d = real((1+i*2), TEST_FMS_KIND_)
+                    call write_data(fileobj, fieldname_1d_band, data_in_1d, unlim_dim_level=i+1)
+                    data_in_1d = - data_in_1d
+                    call write_data(fileobj, trim(fieldname_1d_band2), data_in_1d, unlim_dim_level=i+1)
+                enddo
+                call close_file(fileobj)
+                deallocate(data_in_1d)
+            endif
+        endif
+
+        call mpp_sync()
+    end subroutine create_input_files_1d
+
+end program test_time_interp_external_create_input


### PR DESCRIPTION
**Description**
This just refactors one of the tests so that the input files are created by a separate executable, instead of being written and later read in by the same program. I think this should fix CI failures that pop up from time to time, seems like it hits some kind of race condition and the test hangs but only occasionally.

I also included a small fix for the cmake build to better handle the oversubscribe flag. Now it will do some checks to see if its needed instead of using it automatically using it since that can give errors.

Fixes #1862 

**How Has This Been Tested?**
Tested with intel 2026.1 on the amd box with both build systems

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

