### PR TITLE
Add configurable prefix/separator for diag_manager wildcard file names

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -695,6 +695,7 @@ if(UNIT_TESTS)
     test_fms/diag_manager/check_new_file_freq.F90
     test_fms/diag_manager/test_zbounds_limits.F90
     test_fms/diag_manager/test_multiple_zbounds.F90
+    test_fms/diag_manager/test_wildcard_filename.F90
     test_fms/drifters/test_cloud_interpolator.F90
     test_fms/drifters/test_drifters_io.F90
     test_fms/drifters/test_drifters_input.F90

--- a/diag_manager/diag_data.F90
+++ b/diag_manager/diag_data.F90
@@ -386,6 +386,12 @@ use platform_mod
   LOGICAL :: prepend_date = .TRUE. !< Should the history file have the start date prepended to the file name.
                                    !! <TT>.TRUE.</TT> is only supported if the diag_manager_init
                                    !! routine is called with the optional time_init parameter.
+  CHARACTER(len=16) :: wildcard_filename_prefix = '_' !< String inserted immediately before the first
+                                                      !! substituted time field when using a wildcard (%)
+                                                      !! file name.
+  CHARACTER(len=16) :: wildcard_filename_separator = '_' !< String inserted between each subsequent
+                                                         !! substituted time field when using a wildcard (%)
+                                                         !! file name.
   LOGICAL :: use_refactored_send = .false. !< Namelist flag to use refactored send_data math funcitons.
   LOGICAL :: use_modern_diag = .false. !< Namelist flag to use the modernized diag_manager code
   LOGICAL :: use_clock_average = .false. !< .TRUE. if the averaging of variable is done based on the clock

--- a/diag_manager/diag_manager.F90
+++ b/diag_manager/diag_manager.F90
@@ -195,6 +195,14 @@ use platform_mod
   !      This was usually done by FRE after the
   !     model run.
   !   </DATA>
+  !   <DATA NAME="wildcard_filename_prefix" TYPE="CHARACTER(len=16)" DEFAULT="'_'">
+  !     String inserted immediately before the first substituted time field when using a wildcard (%)
+  !     file name.
+  !   </DATA>
+  !   <DATA NAME="wildcard_filename_separator" TYPE="CHARACTER(len=16)" DEFAULT="'_'">
+  !     String inserted between each subsequent substituted time field when using a wildcard (%)
+  !     file name.
+  !   </DATA>
   !   <DATA NAME="region_out_use_alt_value" TYPE="LOGICAL" DEFAULT=".TRUE.">
   !     Will determine which value to use when checking a regional output if the region is the full axis or a sub-axis.
   !     The values are defined as <TT>GLO_REG_VAL</TT> (-999) and <TT>GLO_REG_VAL_ALT</TT>
@@ -231,7 +239,8 @@ use platform_mod
        & max_out_per_in_field, flush_nc_files, region_out_use_alt_value, max_field_attributes, output_field_type,&
        & max_file_attributes, max_axis_attributes, prepend_date, DIAG_FIELD_NOT_FOUND, diag_init_time, diag_data_init,&
        & use_refactored_send, &
-       & use_modern_diag, use_clock_average, diag_null, pack_size_str
+       & use_modern_diag, use_clock_average, diag_null, pack_size_str, &
+       & wildcard_filename_prefix, wildcard_filename_separator
   USE diag_data_mod, ONLY:  fileobj, fileobjU, fnum_for_domain, fileobjND
   USE diag_table_mod, ONLY: parse_diag_table
   USE diag_output_mod, ONLY: get_diag_global_att, set_diag_global_att
@@ -4096,7 +4105,8 @@ END FUNCTION register_static_field
          & max_num_axis_sets, max_files, use_cmor, issue_oor_warnings,&
          & oor_warnings_fatal, max_out_per_in_field, flush_nc_files, region_out_use_alt_value, max_field_attributes,&
          & max_file_attributes, max_axis_attributes, prepend_date, use_modern_diag, use_clock_average, &
-         & field_log_separator, use_refactored_send
+         & field_log_separator, use_refactored_send, &
+         & wildcard_filename_prefix, wildcard_filename_separator
 
     ! If the module was already initialized do nothing
     IF ( module_is_initialized ) RETURN
@@ -4168,6 +4178,17 @@ END FUNCTION register_static_field
        WRITE (err_msg_local,'(ES8.1E2)') CMOR_MISSING_VALUE
        CALL error_mesg('diag_manager_mod::diag_manager_init', 'Using CMOR missing value ('//TRIM(err_msg_local)// &
             & ').', NOTE)
+    END IF
+
+    ! wildcard_filename_prefix/separator are inserted directly into output file names, so must not
+    ! contain a directory separator
+    IF ( INDEX(TRIM(wildcard_filename_prefix), '/') > 0 ) THEN
+       CALL error_mesg('diag_manager_mod::diag_manager_init', 'DIAG_MANAGER_NML variable '//&
+            & 'wildcard_filename_prefix ("'//TRIM(wildcard_filename_prefix)//'") cannot contain "/"', FATAL)
+    END IF
+    IF ( INDEX(TRIM(wildcard_filename_separator), '/') > 0 ) THEN
+       CALL error_mesg('diag_manager_mod::diag_manager_init', 'DIAG_MANAGER_NML variable '//&
+            & 'wildcard_filename_separator ("'//TRIM(wildcard_filename_separator)//'") cannot contain "/"', FATAL)
     END IF
 
     ! How to handle Out of Range Warnings.

--- a/diag_manager/diag_yaml_format.md
+++ b/diag_manager/diag_yaml_format.md
@@ -134,6 +134,11 @@ ocn_2020_01_01_21.nc for time_bnds [18,24]
 
 **NOTE** If using the new_file_freq, there must be a way to distinguish each file, as it was done in the example above.
 
+**NOTE** The `_` shown before and between the substituted date/time fields above is the default,
+and can be changed via the `diag_manager_nml` namelist options `wildcard_filename_prefix` (inserted
+before the first substituted field) and `wildcard_filename_separator` (inserted between each
+subsequent field).
+
 - **file_duration** is a string that defines how long the file should receive data after start time in “file_duration_units”.  This optional field can only be used if the start_time field is present.  If this field is absent, then the file duration will be equal to the frequency for creating new files.
 - **global_meta** is a subsection that lists any additional global metadata to add to the file. This is a new feature that is not supported by the legacy ascii data_table.
 - **sub_region** is a subsection that defines the four corners of a subregional section to capture.

--- a/diag_manager/fms_diag_time_utils.F90
+++ b/diag_manager/fms_diag_time_utils.F90
@@ -28,7 +28,7 @@ module fms_diag_time_utils_mod
 use time_manager_mod, only: time_type, increment_date, increment_time, get_calendar_type, NO_CALENDAR, leap_year, &
                             get_date, get_time,  operator(>), operator(<), operator(-), set_date, set_time
 use diag_data_mod,    only: END_OF_RUN, EVERY_TIME, DIAG_SECONDS, DIAG_MINUTES, DIAG_HOURS, DIAG_DAYS, DIAG_MONTHS, &
-                            DIAG_YEARS, use_clock_average
+                            DIAG_YEARS, use_clock_average, wildcard_filename_prefix, wildcard_filename_separator
 USE constants_mod,    ONLY: SECONDS_PER_DAY, SECONDS_PER_HOUR, SECONDS_PER_MINUTE
 use fms_mod,          only: fms_error_handler
 use mpp_mod,          only: mpp_error, FATAL
@@ -235,17 +235,19 @@ contains
     INTEGER :: abs_sec              !< component of current_time
     INTEGER :: days_per_month(12) = (/31,28,31,30,31,30,31,31,30,31,30,31/)
     INTEGER :: julian_day, i, position, len, first_percent
+    LOGICAL :: field_written !< has a field already been appended to get_time_string
     CHARACTER(len=1) :: width  !< width of the field in format write
-    CHARACTER(len=10) :: format
+    CHARACTER(len=6) :: format
     CHARACTER(len=20) :: yr !< string of current time (output)
     CHARACTER(len=20) :: mo !< string of current time (output)
     CHARACTER(len=20) :: dy !< string of current time (output)
     CHARACTER(len=20) :: hr !< string of current time (output)
     CHARACTER(len=20) :: mi !< string of current time (output)
     CHARACTER(len=20) :: sc !< string of current time (output)
+    CHARACTER(len=20) :: fields(6) !< yr, mo, dy, hr, mi, sc, in order
     CHARACTER(len=128) :: filetail
 
-    format = '("_",i*.*)'
+    format = '(i*.*)'
     CALL get_date(current_time, yr1, mo1, dy1, hr1, mi1, sc1)
     len = LEN_TRIM(filename)
     first_percent = INDEX(filename, '%')
@@ -255,7 +257,7 @@ contains
     IF ( position > 0 ) THEN
        width = filetail(position-1:position-1)
        yr1_s = yr1
-       format(7:9) = width//'.'//width
+       format(3:5) = width//'.'//width
        WRITE(yr, format) yr1_s
        yr2 = 0
     ELSE
@@ -267,7 +269,7 @@ contains
     IF ( position > 0 ) THEN
        width = filetail(position-1:position-1)
        mo1_s = yr2*12 + mo1
-       format(7:9) = width//'.'//width
+       format(3:5) = width//'.'//width
        WRITE(mo, format) mo1_s
     ELSE
        mo = ' '
@@ -298,7 +300,7 @@ contains
     position = INDEX(filetail, 'dy')
     IF ( position > 0 ) THEN
        width = filetail(position-1:position-1)
-       FORMAT(7:9) = width//'.'//width
+       FORMAT(3:5) = width//'.'//width
        WRITE(dy, FORMAT) dy1_s
     ELSE
        dy = ' '
@@ -313,7 +315,7 @@ contains
     position = INDEX(filetail, 'hr')
     IF ( position > 0 ) THEN
        width = filetail(position-1:position-1)
-       format(7:9) = width//'.'//width
+       format(3:5) = width//'.'//width
        WRITE(hr, format) hr1_s
     ELSE
        hr = ' '
@@ -328,7 +330,7 @@ contains
     position = INDEX(filetail, 'mi')
     IF(position>0) THEN
        width = filetail(position-1:position-1)
-       format(7:9) = width//'.'//width
+       format(3:5) = width//'.'//width
        WRITE(mi, format) mi1_s
     ELSE
        mi = ' '
@@ -342,12 +344,26 @@ contains
     position = INDEX(filetail, 'sc')
     IF ( position > 0 ) THEN
        width = filetail(position-1:position-1)
-       format(7:9) = width//'.'//width
+       format(3:5) = width//'.'//width
        WRITE(sc, format) sc1_s
     ELSE
        sc = ' '
     ENDIF
-    get_time_string = TRIM(yr)//TRIM(mo)//TRIM(dy)//TRIM(hr)//TRIM(mi)//TRIM(sc)
+    ! join the present fields, using wildcard_filename_prefix before the first one and
+    ! wildcard_filename_separator between each subsequent one (both default to "_")
+    fields(1) = yr; fields(2) = mo; fields(3) = dy
+    fields(4) = hr; fields(5) = mi; fields(6) = sc
+    get_time_string = ''
+    field_written = .FALSE.
+    DO i = 1, SIZE(fields)
+       IF ( LEN_TRIM(fields(i)) == 0 ) CYCLE
+       IF ( field_written ) THEN
+          get_time_string = TRIM(get_time_string)//TRIM(wildcard_filename_separator)//TRIM(fields(i))
+       ELSE
+          get_time_string = TRIM(get_time_string)//TRIM(wildcard_filename_prefix)//TRIM(fields(i))
+          field_written = .TRUE.
+       END IF
+    END DO
   END FUNCTION get_time_string
 
   !> @brief Return the difference between two times in units.

--- a/docs/diag_table.md
+++ b/docs/diag_table.md
@@ -65,6 +65,11 @@ Thus, a file name of `file2_yr_dy%1yr%3dy` will have a base file name of
 `new_file_freq` and `new_file_freq_units` are used, otherwise a FMS `FATAL`
 error will occur.
 
+The `_` shown before and between the substituted fields above is the default,
+and can be changed via the `diag_manager_nml` namelist options
+`wildcard_filename_prefix` (inserted before the first substituted field) and
+`wildcard_filename_separator` (inserted between each subsequent field).
+
 #### `INTEGER :: output_freq`
 
 How often to write fields to file.

--- a/test_fms/diag_manager/Makefile.am
+++ b/test_fms/diag_manager/Makefile.am
@@ -34,7 +34,8 @@ check_PROGRAMS = test_diag_manager test_diag_manager_time \
  check_time_pow check_time_rms check_subregional test_cell_measures test_var_masks \
  check_var_masks test_multiple_send_data test_diag_out_yaml test_output_every_freq \
  test_dm_weights test_prepend_date test_ens_runs test_diag_multi_file test_diag_attribute_add \
- check_new_file_freq test_zbounds_limits test_multiple_zbounds test_diag_generalized_indices check_diag_generalized_indices
+ check_new_file_freq test_zbounds_limits test_multiple_zbounds test_diag_generalized_indices check_diag_generalized_indices \
+ test_wildcard_filename
 
 # This is the source code for the test.
 test_output_every_freq_SOURCES = test_output_every_freq.F90
@@ -73,6 +74,7 @@ test_zbounds_limits_SOURCES = test_zbounds_limits.F90
 test_multiple_zbounds_SOURCES = test_multiple_zbounds.F90
 test_diag_generalized_indices_SOURCES = testing_utils.F90 test_diag_generalized_indices.F90
 check_diag_generalized_indices_SOURCES = testing_utils.F90 check_diag_generalized_indices.F90
+test_wildcard_filename_SOURCES = test_wildcard_filename.F90
 
 TEST_EXTENSIONS = .sh
 SH_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
@@ -83,7 +85,8 @@ TESTS = test_diag_manager2.sh test_time_none.sh test_time_min.sh test_time_max.s
         test_time_avg.sh test_time_pow.sh test_time_rms.sh test_time_diurnal.sh test_cell_measures.sh \
         test_subregional.sh test_var_masks.sh test_multiple_send_data.sh test_output_every_freq.sh \
         test_dm_weights.sh test_flush_nc_file.sh test_prepend_date.sh test_ens_runs.sh test_diag_multi_file.sh \
-        test_diag_attribute_add.sh test_time_none_netcdf4.sh test_zbounds_limits.sh test_multiple_zbounds.sh
+        test_diag_attribute_add.sh test_time_none_netcdf4.sh test_zbounds_limits.sh test_multiple_zbounds.sh \
+        test_wildcard_filename.sh
 
 testing_utils.mod: testing_utils.$(OBJEXT)
 
@@ -93,7 +96,7 @@ EXTRA_DIST = test_diag_manager2.sh check_crashes.sh test_time_none.sh test_time_
              test_cell_measures.sh test_subregional.sh test_var_masks.sh test_multiple_send_data.sh \
              test_flush_nc_file.sh test_dm_weights.sh test_output_every_freq.sh test_prepend_date.sh \
              test_ens_runs.sh test_diag_multi_file.sh test_diag_attribute_add.sh test_time_none_netcdf4.sh \
-             test_zbounds_limits.sh test_multiple_zbounds.sh
+             test_zbounds_limits.sh test_multiple_zbounds.sh test_wildcard_filename.sh
 
 if USING_YAML
   parser_skip=""

--- a/test_fms/diag_manager/test_wildcard_filename.F90
+++ b/test_fms/diag_manager/test_wildcard_filename.F90
@@ -1,0 +1,97 @@
+!***********************************************************************
+!*                             Apache License 2.0
+!*
+!* This file is part of the GFDL Flexible Modeling System (FMS).
+!*
+!* Licensed under the Apache License, Version 2.0 (the "License");
+!* you may not use this file except in compliance with the License.
+!* You may obtain a copy of the License at
+!*
+!*     http://www.apache.org/licenses/LICENSE-2.0
+!*
+!* FMS is distributed in the hope that it will be useful, but WITHOUT
+!* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied;
+!* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+!* PARTICULAR PURPOSE. See the License for the specific language
+!* governing permissions and limitations under the License.
+!***********************************************************************
+
+!> @brief  This program tests diag_manager's wildcard (%) file name suffix, and confirms that
+!! diag_manager_nml::wildcard_filename_prefix/wildcard_filename_separator control how the
+!! substituted time fields are joined. It expects a diag_table.yaml with:
+!! - file_name: test_wildcard%4yr%2mo%2dy%2hr
+!!   freq: 6 hours
+!!   new_file_freq: 12 hours
+!!   file_duration: 18 hours
+!!   base_date: 2 1 1 0 0 0
+!! which, over a 48 hour run starting at 2-1-1 0:0:0, produces two files at hour 06 and hour 15.
+!! The expected suffixes for those two files are passed in via the test's own namelist so that the
+!! same program can be re-run with different wildcard_filename_prefix/separator settings.
+program test_wildcard_filename
+
+  use fms_mod,          only: fms_init, fms_end
+  use diag_manager_mod, only: send_data, diag_send_complete, diag_manager_set_time_end, &
+                              register_diag_field, diag_manager_init, diag_manager_end
+  use time_manager_mod, only: time_type, operator(+), JULIAN, set_time, set_calendar_type, set_date
+  use mpp_mod,          only: FATAL, mpp_error, input_nml_file
+  use fms2_io_mod,      only: FmsNetcdfFile_t, open_file, close_file
+
+  implicit none
+
+  integer         :: id_var0                       !< diag field id
+  logical         :: used                           !< for send_data calls
+  integer         :: ntimes = 48                    !< Number of hourly time steps (2 days)
+  type(time_type) :: Time                           !< "Model" time
+  type(time_type) :: Time_step                      !< Time step for the "simulation"
+  integer         :: i                              !< For do loops
+  integer         :: io_status                      !< Status when reading the namelist
+
+  !< Expected suffixes of the two files created by the 12 hour new_file_freq/18 hour file_duration
+  !! diag_table.yaml described above, given the wildcard_filename_prefix/separator that was set in
+  !! diag_manager_nml for this run. Defaults match the historical "_"-joined behavior.
+  character(len=32) :: expected_suffix1 = '_0002_01_01_06'
+  character(len=32) :: expected_suffix2 = '_0002_01_01_15'
+
+  namelist / test_wildcard_filename_nml / expected_suffix1, expected_suffix2
+
+  call fms_init
+
+  read (input_nml_file, test_wildcard_filename_nml, iostat=io_status)
+  if (io_status > 0) call mpp_error(FATAL, '=>test_wildcard_filename: Error reading input.nml')
+
+  call set_calendar_type(JULIAN)
+  call diag_manager_init()
+
+  Time = set_date(2,1,1,0,0,0)
+  Time_step = set_time(3600, 0) !< 1 hour
+  call diag_manager_set_time_end(set_date(2,1,3,0,0,0))
+
+  id_var0 = register_diag_field('ocn_mod', 'var0', Time)
+
+  do i = 1, ntimes
+    Time = Time + Time_step
+    used = send_data(id_var0, real(i), Time)
+    call diag_send_complete(Time_step)
+  enddo
+
+  call diag_manager_end(Time)
+
+  call check_output()
+  call fms_end
+
+  contains
+
+  !< @brief Confirm the two expected wildcard-named files were created
+  subroutine check_output()
+    type(FmsNetcdfFile_t) :: fileobj !< Fms2io fileobj
+
+    if (.not. open_file(fileobj, "test_wildcard"//trim(expected_suffix1)//".nc", "read")) &
+      call mpp_error(FATAL, "Error opening file: test_wildcard"//trim(expected_suffix1)//".nc")
+    call close_file(fileobj)
+
+    if (.not. open_file(fileobj, "test_wildcard"//trim(expected_suffix2)//".nc", "read")) &
+      call mpp_error(FATAL, "Error opening file: test_wildcard"//trim(expected_suffix2)//".nc")
+    call close_file(fileobj)
+  end subroutine check_output
+
+end program test_wildcard_filename

--- a/test_fms/diag_manager/test_wildcard_filename.sh
+++ b/test_fms/diag_manager/test_wildcard_filename.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+
+#***********************************************************************
+#*                             Apache License 2.0
+#*
+#* This file is part of the GFDL Flexible Modeling System (FMS).
+#*
+#* Licensed under the Apache License, Version 2.0 (the "License");
+#* you may not use this file except in compliance with the License.
+#* You may obtain a copy of the License at
+#*
+#*     http://www.apache.org/licenses/LICENSE-2.0
+#*
+#* FMS is distributed in the hope that it will be useful, but WITHOUT
+#* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied;
+#* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+#* PARTICULAR PURPOSE. See the License for the specific language
+#* governing permissions and limitations under the License.
+#***********************************************************************
+
+# Tests diag_manager_nml::wildcard_filename_prefix/wildcard_filename_separator, which control how
+# the time fields substituted into a wildcard (%) output file name are joined together.
+
+# Set common test settings.
+. ../test-lib.sh
+
+if [ -z "${parser_skip}" ]; then
+# create and enter directory for in/output files
+output_dir
+
+cat <<_EOF > diag_table.yaml
+title: test_wildcard_filename
+base_date: 2 1 1 0 0 0
+diag_files:
+- file_name: test_wildcard%4yr%2mo%2dy%2hr
+  freq: 6 hours
+  time_units: hours
+  unlimdim: time
+  new_file_freq: 12 hours
+  file_duration: 18 hours
+  varlist:
+  - module: ocn_mod
+    var_name: var0
+    reduction: none
+    kind: r4
+_EOF
+
+# remove any existing files that would result in false passes during checks
+rm -f *.nc
+
+my_test_count=1
+printf "&diag_manager_nml \n use_modern_diag=.true. \n/" | cat > input.nml
+test_expect_success "Default wildcard_filename_prefix/separator reproduce the historical '_' joined suffix (test $my_test_count)" '
+  mpirun -n 1 ../test_wildcard_filename
+'
+
+rm -f *.nc
+my_test_count=`expr $my_test_count + 1`
+printf "&diag_manager_nml \n use_modern_diag=.true. \n wildcard_filename_prefix='.' \n wildcard_filename_separator='-' \n/ \n &test_wildcard_filename_nml \n expected_suffix1='.0002-01-01-06' \n expected_suffix2='.0002-01-01-15' \n/" | cat > input.nml
+test_expect_success "Custom wildcard_filename_prefix/separator are used to join the substituted time fields (test $my_test_count)" '
+  mpirun -n 1 ../test_wildcard_filename
+'
+
+rm -f *.nc
+my_test_count=`expr $my_test_count + 1`
+printf "&diag_manager_nml \n use_modern_diag=.true. \n wildcard_filename_separator='/' \n/" | cat > input.nml
+test_expect_failure "wildcard_filename_separator containing '/' is rejected (test $my_test_count)" '
+  mpirun -n 1 ../test_wildcard_filename
+'
+
+fi
+test_done


### PR DESCRIPTION
**Description**
The diag_manager wildcard file name feature (e.g. `outputfile%4yr%2mo%2dy%2hr`) currently joins the substituted time fields with a hardcoded `_`, producing e.g. `outputfile_1900_01_01_00.nc`. This PR adds two new `diag_manager_nml` namelist options, `wildcard_filename_prefix` and `wildcard_filename_separator`, that control the string inserted before the first substituted field and between subsequent fields, respectively. Both default to `_`, so existing behaviour is preserved.

Fixes #1719

**How Has This Been Tested?**
Tests have been added to the test suite. These check that default behaviour is preserved, that providing an alternate prefix/separator produces the expected behaviour, and that an error is returned if there is a `/` in the prefix/separator.

```
$ ctest -R test_wildcard_filename --output-on-failure
Test project /.../build
    Start 39: test_wildcard_filename
1/1 Test #39: test_wildcard_filename ...........   Passed   10.56 sec

100% tests passed, 0 tests failed out of 1

Label Time Summary:
diag_manager    =  10.56 sec*proc (1 test)

Total Test time (real) =  10.57 sec
```

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [ ] `make distcheck` passes

