### PR TITLE
cmake: report default mixed-precision CMake target

### DIFF
--- a/cmake/FMSConfig.cmake.in
+++ b/cmake/FMSConfig.cmake.in
@@ -7,8 +7,9 @@
 #  * R8 - 64-bit library
 #
 # Imported interface targets provided:
-#  * FMS::fms_r4 - real32 library target
-#  * FMS::fms_r8 - real64 library target
+#  * FMS::fms    - default mixed-precision library target
+#  * FMS::fms_r4 - real32 library target when built with 32BIT
+#  * FMS::fms_r8 - real64 library target when built with 64BIT
 
 # Include targets file.  This will create IMPORTED target fms
 include("${CMAKE_CURRENT_LIST_DIR}/fms-targets.cmake")
@@ -39,10 +40,6 @@ foreach(_comp ${_possible_fms_components})
   set(_name_${_comp} ${_comp})
 endforeach()
 
-#R4 is the default component
-if(NOT FMS_FIND_COMPONENTS)
-  list(APPEND _search_fms_components "R4")
-endif()
 foreach(_comp ${FMS_FIND_COMPONENTS})
   list(APPEND _search_fms_components ${_comp})
   if(NOT _name_${_comp})
@@ -72,6 +69,9 @@ check_required_components("FMS")
 
 message(STATUS "Found FMS: \"${FMS_INSTALL_PREFIX}\" (Version: \"${FMSVersion}\")")
 message( STATUS "FMS targets:" )
+if(TARGET FMS::fms)
+  message(STATUS "  - FMS::fms")
+endif()
 foreach(component ${_search_fms_components})
   string( TOLOWER "${component}" _component )
   if(FMS_${component}_FOUND)


### PR DESCRIPTION
**Description**

The default FMS build exports the mixed-precision `FMS::fms` target, but `FMSConfig.cmake.in` implicitly checked for the `R4` component when no components were requested. This resulted in a misleading diagnostic such as:

```text
FMS::fms_r4 [COMPONENT R4 NOT FOUND]
```
for a successful default `find_package(FMS REQUIRED)` lookup.

This change:
- Documents the default `FMS::fms` exported target.
- Removes the implicit R4 component request.
- Reports `FMS::fms` when that target is available.
- Retains explicit R4 and R8 component handling.

Fixes #1910

NOTE: This patch was figured out with the help of GPT 5.6 Terra, but I did the testing

**How Has This Been Tested?**

Manually verified downstream GEOSgcm configuration against a default mixed-precision FMS installation after applying the generated-config equivalent. The package lookup reports:
```
-- FMS targets:
--   - FMS::fms
```

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [ ] `make distcheck` passes

