### PR TITLE
Remove mpi_f08 opaque-type versions of MPP routines

### DIFF
--- a/mpp/include/mpp_domains_define.inc
+++ b/mpp/include/mpp_domains_define.inc
@@ -690,16 +690,16 @@
        pes = pelist
        if(from_mosaic) then
           allocate( pesall(0:mpp_npes()-1) )
-          call mpp_get_current_pelist(pesall, comm=cur_comm%mpi_val)
+          call mpp_get_current_pelist(pesall, commID=cur_comm%mpi_val)
        else
           allocate( pesall(0:size(pes(:))-1) )
           pesall = pes
-          call mpp_get_current_pelist(pesall, comm=cur_comm%mpi_val)
+          call mpp_get_current_pelist(pesall, commID=cur_comm%mpi_val)
        end if
     else
        allocate( pes(0:mpp_npes()-1) )
        allocate( pesall(0:mpp_npes()-1) )
-       call mpp_get_current_pelist(pes, comm=cur_comm%mpi_val)
+       call mpp_get_current_pelist(pes, commID=cur_comm%mpi_val)
        pesall = pes
     end if
 
@@ -1263,7 +1263,7 @@ end subroutine check_message_size
             'mpp_domains_define.inc: size of pelist is not equal mpp_npes')
        pes = pelist
     end if
-    call mpp_get_current_pelist(pes, comm=domain%comm%mpi_val)
+    call mpp_get_current_pelist(pes, commID=domain%comm%mpi_val)
     !--- pelist should be monotonic increasing by 1.
     do n = 1, nlist-1
        if(pes(n) - pes(n-1) .NE. 1) call mpp_error(FATAL, &
@@ -1396,7 +1396,7 @@ end subroutine check_message_size
        end do
        !--- set the tile communicator
        if (ANY(pelist_tile == pe)) then
-         call mpp_declare_pelist(pelist_tile, comm=domain%tile_comm%mpi_val)
+         call mpp_declare_pelist(pelist_tile, commID=domain%tile_comm%mpi_val)
        endif
        mask = .TRUE.
        if(present(maskmap))  mask = maskmap(1:layout(1,n), 1:layout(2,n), n)

--- a/mpp/include/mpp_domains_define.inc
+++ b/mpp/include/mpp_domains_define.inc
@@ -690,16 +690,16 @@
        pes = pelist
        if(from_mosaic) then
           allocate( pesall(0:mpp_npes()-1) )
-          call mpp_get_current_pelist(pesall, comm=cur_comm)
+          call mpp_get_current_pelist(pesall, comm=cur_comm%mpi_val)
        else
           allocate( pesall(0:size(pes(:))-1) )
           pesall = pes
-          call mpp_get_current_pelist(pesall, comm=cur_comm)
+          call mpp_get_current_pelist(pesall, comm=cur_comm%mpi_val)
        end if
     else
        allocate( pes(0:mpp_npes()-1) )
        allocate( pesall(0:mpp_npes()-1) )
-       call mpp_get_current_pelist(pes, comm=cur_comm)
+       call mpp_get_current_pelist(pes, comm=cur_comm%mpi_val)
        pesall = pes
     end if
 
@@ -1263,7 +1263,7 @@ end subroutine check_message_size
             'mpp_domains_define.inc: size of pelist is not equal mpp_npes')
        pes = pelist
     end if
-    call mpp_get_current_pelist(pes, comm=domain%comm)
+    call mpp_get_current_pelist(pes, comm=domain%comm%mpi_val)
     !--- pelist should be monotonic increasing by 1.
     do n = 1, nlist-1
        if(pes(n) - pes(n-1) .NE. 1) call mpp_error(FATAL, &
@@ -1396,7 +1396,7 @@ end subroutine check_message_size
        end do
        !--- set the tile communicator
        if (ANY(pelist_tile == pe)) then
-         call mpp_declare_pelist(pelist_tile, comm=domain%tile_comm)
+         call mpp_declare_pelist(pelist_tile, comm=domain%tile_comm%mpi_val)
        endif
        mask = .TRUE.
        if(present(maskmap))  mask = maskmap(1:layout(1,n), 1:layout(2,n), n)

--- a/mpp/include/mpp_transmit_mpi.fh
+++ b/mpp/include/mpp_transmit_mpi.fh
@@ -233,7 +233,7 @@
 
       if( .NOT.module_is_initialized )call mpp_error( FATAL, 'MPP_SCATTER: You must first call mpp_init.' )
 
-      call mpp_declare_pelist( pelist, comm=comm )
+      call mpp_declare_pelist( pelist, comm=comm%mpi_val )
       ! Rank number should be in reference to new comm
       root_pe2 = findloc(pelist, root_pe, dim=1) - 1
 
@@ -260,7 +260,7 @@
 
       if( .NOT.module_is_initialized )call mpp_error( FATAL, 'MPP_GATHER: You must first call mpp_init.' )
 
-      call mpp_declare_pelist( pelist, comm=comm )
+      call mpp_declare_pelist( pelist, comm=comm%mpi_val )
       ! Rank number should be in reference to new comm
       root_pe2 = findloc(pelist, root_pe, dim=1) - 1
 
@@ -282,7 +282,7 @@
       if( .NOT.module_is_initialized ) call mpp_error( FATAL, 'MPP_GATHERV: You must first call mpp_init.' )
 
 
-      call mpp_declare_pelist( pelist, comm=comm )
+      call mpp_declare_pelist( pelist, comm=comm%mpi_val )
       ! Rank number should be in reference to new comm
       root_pe2 = findloc(pelist, root_pe, dim=1) - 1
 

--- a/mpp/include/mpp_transmit_mpi.fh
+++ b/mpp/include/mpp_transmit_mpi.fh
@@ -233,7 +233,7 @@
 
       if( .NOT.module_is_initialized )call mpp_error( FATAL, 'MPP_SCATTER: You must first call mpp_init.' )
 
-      call mpp_declare_pelist( pelist, comm=comm%mpi_val )
+      call mpp_declare_pelist( pelist, commID=comm%mpi_val )
       ! Rank number should be in reference to new comm
       root_pe2 = findloc(pelist, root_pe, dim=1) - 1
 
@@ -260,7 +260,7 @@
 
       if( .NOT.module_is_initialized )call mpp_error( FATAL, 'MPP_GATHER: You must first call mpp_init.' )
 
-      call mpp_declare_pelist( pelist, comm=comm%mpi_val )
+      call mpp_declare_pelist( pelist, commID=comm%mpi_val )
       ! Rank number should be in reference to new comm
       root_pe2 = findloc(pelist, root_pe, dim=1) - 1
 
@@ -282,7 +282,7 @@
       if( .NOT.module_is_initialized ) call mpp_error( FATAL, 'MPP_GATHERV: You must first call mpp_init.' )
 
 
-      call mpp_declare_pelist( pelist, comm=comm%mpi_val )
+      call mpp_declare_pelist( pelist, commID=comm%mpi_val )
       ! Rank number should be in reference to new comm
       root_pe2 = findloc(pelist, root_pe, dim=1) - 1
 

--- a/mpp/include/mpp_util.inc
+++ b/mpp/include/mpp_util.inc
@@ -471,30 +471,20 @@ end function rarray_to_char
   !!
   !! This call implies synchronization across the PEs in the current
   !! pelist, of which <TT>pelist</TT> is a subset.
-  subroutine mpp_declare_pelist_f08( pelist, name, comm )
+  subroutine mpp_declare_pelist( pelist, name, commID )
     integer,                    intent(in) :: pelist(:) !> pelist you are declaring and storing within FMS
     character(len=*), intent(in), optional :: name      !> unique name for an input pelist
-    type(mpi_comm), intent(out), optional  :: comm      !> mpi_comm communicator handle
+    integer, intent(out), optional         :: commID    !> integral MPI communicator handle
     integer :: i
 
     if( .NOT.module_is_initialized )call mpp_error( FATAL, 'MPP_DECLARE_PELIST: You must first call mpp_init.' )
     i = get_peset(pelist)
     write( peset(i)%name,'(a,i2.2)' ) 'PElist', i !default name
     if( PRESENT(name) ) peset(i)%name = name
-    if( PRESENT(comm) ) then
-      comm = peset(i)%comm
+    if( PRESENT(commID) ) then
+      commID = peset(i)%comm%mpi_val
     endif
-  end subroutine mpp_declare_pelist_f08
-
-  subroutine mpp_declare_pelist_legacy( pelist, name, commID )
-    integer,                    intent(in) :: pelist(:) !> pelist you are declaring and storing within FMS
-    character(len=*), intent(in), optional :: name      !> unique name for an input pelist
-    integer, intent(out)                   :: commID    !> integral MPI communicator handle
-    type(mpi_comm) :: comm
-
-    call mpp_declare_pelist_f08(pelist, name, comm)
-    commID = comm%mpi_val
-  end subroutine mpp_declare_pelist_legacy
+  end subroutine mpp_declare_pelist
 
   !#####################################################################
 
@@ -544,29 +534,19 @@ end function rarray_to_char
 
   !this is created for use by mpp_define_domains within a pelist
   !will be published but not publicized
-  subroutine mpp_get_current_pelist_f08( pelist, name, comm )
+  subroutine mpp_get_current_pelist( pelist, name, commID )
     integer, intent(out)                    :: pelist(:) !> Array to copy the pelist into
     character(len=*), intent(out), optional :: name      !> Name of the pelist
-    type(mpi_comm), intent(out), optional   :: comm      !> mpi_comm communicator handle
+    integer, intent(out), optional          :: commID    !> Integral MPI communicator handle
 
     if( size(pelist(:)).NE.size(peset(current_peset_num)%list(:)) ) &
          call mpp_error( FATAL, 'MPP_GET_CURRENT_PELIST: size(pelist) is wrong.' )
     pelist(:) = peset(current_peset_num)%list(:)
     if( PRESENT(name) ) name = peset(current_peset_num)%name
-    if( PRESENT(comm) ) then
-      comm = peset(current_peset_num)%comm
+    if( PRESENT(commID) ) then
+      commID = peset(current_peset_num)%comm%mpi_val
     endif
-  end subroutine mpp_get_current_pelist_f08
-
-  subroutine mpp_get_current_pelist_legacy( pelist, name, commID )
-    integer, intent(out)                    :: pelist(:) !> Array to copy the pelist into
-    character(len=*), intent(out), optional :: name      !> Name of the pelist
-    integer, intent(out)                    :: commID    !> Integral MPI communicator handle
-    type(mpi_comm) :: comm
-
-    call mpp_get_current_pelist_f08(pelist, name, comm)
-    commID = comm%mpi_val
-  end subroutine mpp_get_current_pelist_legacy
+  end subroutine mpp_get_current_pelist
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   !                                                                             !

--- a/mpp/mpp.F90
+++ b/mpp/mpp.F90
@@ -417,24 +417,6 @@ private
      module procedure rarray_to_char
   end interface
 
-  !> Declare a pelist. The two flavors of this subroutine differ in the type
-  !! of their comm/commID argument: mpp_declare_pelist_f08 expects a type(mpi_comm)
-  !! as its comm argument, whereas mpp_declare_pelist_legacy expects an integer
-  !! as its commID argument.
-  interface mpp_declare_pelist
-    module procedure mpp_declare_pelist_f08
-    module procedure mpp_declare_pelist_legacy
-  end interface
-
-  !> Get the current pelist. The two flavors of this subroutine differ in the type
-  !! of their comm/commID argument: mpp_get_current_pelist_f08 expects a type(mpi_comm)
-  !! as its comm argument, whereas mpp_get_current_pelist_legacy expects an integer
-  !! as its commID argument.
-  interface mpp_get_current_pelist
-    module procedure mpp_get_current_pelist_f08
-    module procedure mpp_get_current_pelist_legacy
-  end interface
-
 !***********************************************************************
 !
 !    public interface from mpp_comm.h

--- a/mpp/mpp_pset.F90
+++ b/mpp/mpp_pset.F90
@@ -483,7 +483,7 @@ contains
        my_pelist = pelist
        my_comm = comm
     else
-       call mpp_get_current_pelist(my_pelist, comm = my_comm%mpi_val)
+       call mpp_get_current_pelist(my_pelist, commID = my_comm%mpi_val)
     endif
     do i = 0,npes/npset-1
        root_pelist(i) = my_pelist(npset*i)

--- a/mpp/mpp_pset.F90
+++ b/mpp/mpp_pset.F90
@@ -483,7 +483,7 @@ contains
        my_pelist = pelist
        my_comm = comm
     else
-       call mpp_get_current_pelist(my_pelist, comm = my_comm)
+       call mpp_get_current_pelist(my_pelist, comm = my_comm%mpi_val)
     endif
     do i = 0,npes/npset-1
        root_pelist(i) = my_pelist(npset*i)

--- a/offloading/metadata_transfer.F90
+++ b/offloading/metadata_transfer.F90
@@ -160,7 +160,7 @@ module metadata_transfer_mod
     end if
 
     allocate(broadcasting_pes(mpp_npes()))
-    call mpp_get_current_pelist(broadcasting_pes, comm=curr_comm)
+    call mpp_get_current_pelist(broadcasting_pes, comm=curr_comm%mpi_val)
 
     ! Broadcast the metadata transfer type to all processes
     select type(this)

--- a/offloading/metadata_transfer.F90
+++ b/offloading/metadata_transfer.F90
@@ -160,7 +160,7 @@ module metadata_transfer_mod
     end if
 
     allocate(broadcasting_pes(mpp_npes()))
-    call mpp_get_current_pelist(broadcasting_pes, comm=curr_comm%mpi_val)
+    call mpp_get_current_pelist(broadcasting_pes, commID=curr_comm%mpi_val)
 
     ! Broadcast the metadata transfer type to all processes
     select type(this)

--- a/test_fms/mpp/test_mpp.F90
+++ b/test_fms/mpp/test_mpp.F90
@@ -123,7 +123,7 @@ contains
     ! Get commID for current pelist (should be global pelist) via and compare with mpp_commID
     allocate(pelist(npes))
     pelist = (/ (i, i=0, npes-1) /)
-    call mpp_declare_pelist(pelist, comm = comm)
+    call mpp_declare_pelist(pelist, comm = comm%mpi_val)
 
     if (mpp_comm().ne.comm) then
       call mpp_error('test_mpp_comm', 'Test failed: mpp_comm() returned an unexpected mpi_comm handle', FATAL)

--- a/test_fms/mpp/test_mpp.F90
+++ b/test_fms/mpp/test_mpp.F90
@@ -123,7 +123,7 @@ contains
     ! Get commID for current pelist (should be global pelist) via and compare with mpp_commID
     allocate(pelist(npes))
     pelist = (/ (i, i=0, npes-1) /)
-    call mpp_declare_pelist(pelist, comm = comm%mpi_val)
+    call mpp_declare_pelist(pelist, commID = comm%mpi_val)
 
     if (mpp_comm().ne.comm) then
       call mpp_error('test_mpp_comm', 'Test failed: mpp_comm() returned an unexpected mpi_comm handle', FATAL)


### PR DESCRIPTION
**Description**
In #1828, new versions of `mpp_declare_pelist` and `mpp_get_current_pelist` were added to `mpp_mod`, which accept mpi_f08 opaque types as arguments. This PR reverts that change: the newly added interfaces and opaque-type versions of `mpp_declare_pelist` and `mpp_get_current_pelist` have been removed.

Fixes #1912

**How Has This Been Tested?**
Builds on C5 with ifx 2025.2.1. Relevant unit tests pass.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes